### PR TITLE
added a patch for Immigration and Naturalization Service.

### DIFF
--- a/src/wn31-noun.group.xml
+++ b/src/wn31-noun.group.xml
@@ -24619,7 +24619,7 @@
     </Synset>
     <!-- INS, Immigration and Naturalization Service -->
     <Synset id="ewn-08153484-n" ili="i79925" partOfSpeech="n" dc:subject="noun.group">
-      <Definition>an agency in the Department of Justice that enforces laws and regulations for the admission of foreign-born persons to the United States</Definition>
+      <Definition>a former agency in the Department of Justice that enforces laws and regulations for the admission of foreign-born persons to the United States</Definition>
       <SynsetRelation relType="hypernym" target="ewn-08354251-n"/> <!-- authority, agency, government agency, bureau, federal agency, office -->
       <SynsetRelation relType="holo_part" target="ewn-08151789-n"/> <!-- Homeland Security, Department of Homeland Security -->
       <SynsetRelation relType="mero_part" target="ewn-08153749-n"/> <!-- US Border Patrol, United States Border Patrol -->


### PR DESCRIPTION
INS was transferred from the Department of Justice to Department of Homeland
Security in 2003. The holonym of this synset is already Department of Homeland
Security but def says it is in the Department of Justice. This is an inconsistency.
As lexicographers sometimes do, adding "former" solves this problem.
{enwiki:Immigration and Naturalization Service}
{enwiki:United States Department of Justice}
{enwiki:United States Department of Homeland Security}