### PR TITLE
trivial patches for two verb synsets.

### DIFF
--- a/src/wn31-verb.contact.xml
+++ b/src/wn31-verb.contact.xml
@@ -33408,7 +33408,7 @@
     </Synset>
     <!-- foul out -->
     <Synset id="ewn-01407428-v" ili="i28750" partOfSpeech="v" dc:subject="verb.contact">
-      <Definition>baseball: hit a ball such that it is caught from an out in foul territory</Definition>
+      <Definition>baseball: hit a ball such that it is caught in foul territory</Definition>
       <SynsetRelation relType="hypernym" target="ewn-01150321-v"/> <!-- foul -->
     </Synset>
     <!-- pop -->
@@ -40270,7 +40270,7 @@
     <Synset id="ewn-01597283-v" ili="i29705" partOfSpeech="v" dc:subject="verb.contact">
       <Definition>crush or grind with a heavy instrument</Definition>
       <SynsetRelation relType="hypernym" target="ewn-01596858-v"/> <!-- squeeze, squelch, squash, crush, mash -->
-      <Example>&quot;stamp fruit extract the juice&quot;</Example>
+      <Example>&quot;stamp fruit to extract the juice&quot;</Example>
     </Synset>
     <!-- steamroller -->
     <Synset id="ewn-01597435-v" ili="i29706" partOfSpeech="v" dc:subject="verb.contact">


### PR DESCRIPTION
foul_out:
{ref:wikit} says of foul_out => "To become out by hitting a foul ball which is
caught." Original def have some troubles and just simplified it.

stamp:
Simple typo. added "to".