### PR TITLE
Fix #189

### DIFF
--- a/src/wn-noun.feeling.xml
+++ b/src/wn-noun.feeling.xml
@@ -3467,9 +3467,6 @@
     <LexicalEntry id="ewn-mellowness-n">
       <Lemma writtenForm="mellowness" partOfSpeech="n"/>
       <Sense id="ewn-mellowness-n-07569690-01" n="0" synset="ewn-07569690-n" dc:identifier="mellowness%1:12:00::">
-        <SenseRelation relType="pertainym" target="ewn-mellow-s-01159816-01"/> <!-- mellowed, mellow -->
-        <SenseRelation relType="pertainym" target="ewn-mellow-s-02416807-02"/> <!-- laid-back, mellow -->
-        <SenseRelation relType="pertainym" target="ewn-mellow-s-00802795-02"/> <!-- high, mellow -->
         <SenseRelation relType="derivation" target="ewn-mellow-s-01159816-01"/> <!-- mellowed, mellow -->
         </Sense>
     </LexicalEntry>


### PR DESCRIPTION
Remove erroneous pertainyms to from a noun to an adjective as this
is in the wrong direction and not correct anyway