### PR TITLE
Add synsets for 'COVID-19', 'MERS', 'coronavirus disease'

### DIFF
--- a/src/wn-noun.state.xml
+++ b/src/wn-noun.state.xml
@@ -27028,6 +27028,66 @@
       <Lemma writtenForm="prostration" partOfSpeech="n"/>
       <Sense id="ewn-prostration-n-14089685-02" n="0" synset="ewn-14089685-n" dc:identifier="prostration%1:26:00::"/>
     </LexicalEntry>
+    <LexicalEntry id="ewn-coronavirus_disease-n">
+      <Lemma writtenForm="coronavirus disease" partOfSpeech="n"/>
+      <Sense id="ewn-coronavirus_disease-n-85935644-01" n="0" synset="ewn-85935644-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-severe_acute_respiratory_syndrome-n">
+      <Lemma writtenForm="severe acute respiratory syndrome" partOfSpeech="n"/>
+      <Sense id="ewn-severe_acute_respiratory_syndrome-n-14203428-02" n="0" synset="ewn-14203428-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-MERS-n">
+      <Lemma writtenForm="MERS" partOfSpeech="n"/>
+      <Sense id="ewn-MERS-n-89373281-01" n="0" synset="ewn-89373281-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-Middle_East_respiratory_syndrome-n">
+      <Lemma writtenForm="Middle East respiratory syndrome" partOfSpeech="n"/>
+      <Sense id="ewn-Middle_East_respiratory_syndrome-n-89373281-02" n="0" synset="ewn-89373281-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-camel_flu-n">
+      <Lemma writtenForm="camel flu" partOfSpeech="n"/>
+      <Sense id="ewn-camel_flu-n-89373281-03" n="0" synset="ewn-89373281-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-COVID-19-n">
+      <Lemma writtenForm="COVID-19" partOfSpeech="n"/>
+      <Sense id="ewn-COVID-19-n-82230893-01" n="0" synset="ewn-82230893-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-coronavirus_disease_-2019-n">
+      <Lemma writtenForm="coronavirus disease 2019" partOfSpeech="n"/>
+      <Sense id="ewn-coronavirus_disease_-20192019-n-82230893-02" n="0" synset="ewn-82230893-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-2019-nCoV_acute_respiratory_disease-n">
+      <Lemma writtenForm="2019-nCoV acute respiratory disease" partOfSpeech="n"/>
+      <Sense id="ewn-2019-nCoV_acute_respiratory_disease-n-82230893-03" n="0" synset="ewn-82230893-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-novel_coronavirus_pneumonia-n">
+      <Lemma writtenForm="novel coronavirus pneumonia" partOfSpeech="n"/>
+      <Sense id="ewn-novel_coronavirus_pneumonia-n-82230893-04" n="0" synset="ewn-82230893-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-Wuhan_coronavirus-n">
+      <Lemma writtenForm="Wuhan coronavirus" partOfSpeech="n"/>
+      <Sense id="ewn-Wuhan_coronavirus-n-82230893-05" n="0" synset="ewn-82230893-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-Wuhan_virus-n">
+      <Lemma writtenForm="Wuhan virus" partOfSpeech="n"/>
+      <Sense id="ewn-Wuhan_virus-n-82230893-06" n="0" synset="ewn-82230893-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-Wuhan_pneumonia-n">
+      <Lemma writtenForm="Wuhan pneumonia" partOfSpeech="n"/>
+      <Sense id="ewn-Wuhan_pneumonia-n-82230893-07" n="0" synset="ewn-82230893-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-Wuhan_flu-n">
+      <Lemma writtenForm="Wuhan flu" partOfSpeech="n"/>
+      <Sense id="ewn-Wuhan_flu-n-82230893-08" n="0" synset="ewn-82230893-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-coronavirus-n">
+      <Lemma writtenForm="coronavirus" partOfSpeech="n"/>
+      <Sense id="ewn-coronavirus-n-82230893-09" n="0" synset="ewn-82230893-n"/>
+    </LexicalEntry>
+    <LexicalEntry id="ewn-corona-n">
+      <Lemma writtenForm="corona" partOfSpeech="n"/>
+      <Sense id="ewn-corona-n-82230893-10" n="0" synset="ewn-82230893-n"/>
+    </LexicalEntry>
     <!-- cleavage -->
     <Synset id="ewn-13943045-n" ili="i110105" partOfSpeech="n" dc:subject="noun.state">
       <Definition>the state of being split or cleft</Definition>
@@ -33970,6 +34030,7 @@
       <SynsetRelation relType="hyponym" target="ewn-14147714-n"/> <!-- pox -->
       <SynsetRelation relType="hyponym" target="ewn-14148413-n"/> <!-- Vincent's angina, trench mouth, Vincent's infection -->
       <SynsetRelation relType="hyponym" target="ewn-14156641-n"/> <!-- Cupid's itch, venereal disease, dose, sexually transmitted disease, STD, Cupid's disease, VD, social disease, venereal infection, Venus's curse -->
+      <SynsetRelation relType="hyponym" target="ewn-85935644-n"/>
     </Synset>
     <!-- flu, grippe, influenza -->
     <Synset id="ewn-14145979-n" ili="i111145" partOfSpeech="n" dc:subject="noun.state">
@@ -34625,8 +34686,8 @@
       <SynsetRelation relType="hyponym" target="ewn-14171992-n"/> <!-- interstitial pneumonia -->
       <SynsetRelation relType="hyponym" target="ewn-14173445-n"/> <!-- pneumonoconiosis, pneumoconiosis -->
       <SynsetRelation relType="hyponym" target="ewn-14174222-n"/> <!-- hyaline membrane disease, respiratory distress syndrome, respiratory distress syndrome of the newborn -->
-      <SynsetRelation relType="hyponym" target="ewn-14203428-n"/> <!-- SARS, severe acute respiratory syndrome -->
       <SynsetRelation relType="mero_part" target="ewn-14382579-n"/> <!-- cough, coughing -->
+      <SynsetRelation relType="hyponym" target="ewn-85935644-n"/>
     </Synset>
     <!-- cold, common cold -->
     <Synset id="ewn-14168983-n" ili="i111251" partOfSpeech="n" dc:subject="noun.state">
@@ -35632,7 +35693,7 @@
     <!-- SARS, severe acute respiratory syndrome -->
     <Synset id="ewn-14203428-n" ili="i111411" partOfSpeech="n" dc:subject="noun.state">
       <Definition>a respiratory disease of unknown etiology that apparently originated in mainland China in 2003; characterized by fever and coughing or difficulty breathing or hypoxia; can be fatal</Definition>
-      <SynsetRelation relType="hypernym" target="ewn-14168577-n"/> <!-- respiratory illness, respiratory disorder, respiratory disease -->
+      <SynsetRelation relType="hypernym" target="ewn-85935644-n"/> <!-- respiratory illness, respiratory disorder, respiratory disease -->
     </Synset>
     <!-- upper respiratory infection -->
     <Synset id="ewn-14203695-n" ili="i111412" partOfSpeech="n" dc:subject="noun.state">
@@ -49777,6 +49838,22 @@
       <SynsetRelation relType="hypernym" target="ewn-00024900-n"/> <!-- state -->
       <Example>&quot;the judicial system suffered from too much technicality and formality&quot;</Example>
       <Example>&quot;It is a tribute to the tribunals that the technicality at the heart of the appellate process in these tribunals can and does coexist with the relative informality in atmosphere and with procedural flexibility.&quot;</Example>
+    </Synset>
+    <Synset id="ewn-85935644-n" ili="in" partOfSpeech="n" dc:subject="noun.state">
+      <Definition>acute disease caused by a virus of the family Orthocoronavirinae</Definition>
+      <SynsetRelation relType="hypernym" target="ewn-14145717-n"/> <!-- contagious disease, contagion -->
+      <SynsetRelation relType="hypernym" target="ewn-14168577-n"/> <!-- respiratory illness, respiratory disorder, respiratory disease -->
+      <SynsetRelation relType="hyponym" target="ewn-14203428-n"/>
+      <SynsetRelation relType="hyponym" target="ewn-89373281-n"/>
+      <SynsetRelation relType="hyponym" target="ewn-82230893-n"/>
+    </Synset>
+    <Synset id="ewn-89373281-n" ili="in" partOfSpeech="n" dc:subject="noun.state">
+      <Definition>a viral disease caused by MERS-CoV that is typically transmitted from camels</Definition>
+      <SynsetRelation relType="hypernym" target="ewn-85935644-n"/>
+    </Synset>
+    <Synset id="ewn-82230893-n" ili="in" partOfSpeech="n" dc:subject="noun.state">
+      <Definition>a viral disease caused by SARS-CoV-2 that caused a global pandemic in 2020</Definition>
+      <SynsetRelation relType="hypernym" target="ewn-85935644-n"/>
     </Synset>
   </Lexicon>
 </LexicalResource>


### PR DESCRIPTION
This PR adds synsets for COVID-19 and terminology variants as on
Wikipedia. It also adds a new super-concept 'coronavirus disease' which
includes the existing 'SARS' synset and a synset for 'MERS'.

While this PR slightly contradicts the rule of avoiding synsets that are
already in Wikipedia, in this case it may be important enough to break
the rule.