### PR TITLE
Fixes #557

### DIFF
--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -27450,7 +27450,7 @@
   definition:
   - a socialist who advocates communism
   hypernym:
-  - 10638364-n
+  - 09794206-n
   ili: i89123
   members:
   - communist
@@ -35395,7 +35395,7 @@
   definition:
   - an adherent of fascism or other authoritarian views
   hypernym:
-  - 09628463-n
+  - 09794206-n
   ili: i89895
   members:
   - fascist


### PR DESCRIPTION
Removed ewn-10638364-n as hypernym of ewn-09964798-n. Added ewn-09794206-n as hypernym of ewn-09964798-n. Removed ewn-09628463-n as hypernym of ewn-10099673-n. Added ewn-09794206-n as hypernym of ewn-10099673-n.