### PR TITLE
Fixes #578

### DIFF
--- a/src/xml/wn-verb.possession.xml
+++ b/src/xml/wn-verb.possession.xml
@@ -15053,8 +15053,8 @@
       <SynsetRelation relType="hypernym" target="ewn-02250775-v"/> <!-- deal -->
     </Synset>
     <Synset id="ewn-85549043-v" ili="in" partOfSpeech="v" dc:subject="verb.possession">
-      <Definition>the official distribution of a new product or service to the public</Definition>
-      <ILIDefinition>the official distribution of a new product or service to the public</ILIDefinition>
+      <Definition>officially distribute a new product or service to the public</Definition>
+      <ILIDefinition>officially distribute a new product or service to the public</ILIDefinition>
       <SynsetRelation relType="hypernym" target="ewn-02299397-v"/> <!-- dispense, dole out, deal, deal out, mete out, parcel out, distribute, administer, allot, lot, dish out, shell out -->
       <Example>&quot;Israel has been the fastest to roll out inoculations.&quot;</Example>
     </Synset>

--- a/src/xml/wn-verb.possession.xml
+++ b/src/xml/wn-verb.possession.xml
@@ -8998,6 +8998,10 @@
       <Lemma writtenForm="fine" partOfSpeech="v"/>
       <Sense id="ewn-fine-v-02312392-02" n="2" synset="ewn-02312392-v" dc:identifier="fine%2:40:01::"/>
     </LexicalEntry>
+    <LexicalEntry id="ewn-roll_out-v">
+      <Lemma writtenForm="roll out" partOfSpeech="v"/>
+      <Sense id="ewn-roll_out-v-85549043-01" n="4" synset="ewn-85549043-v" dc:identifier="roll_out%2:40:04::"/>
+    </LexicalEntry>
     <!-- give -->
     <Synset id="ewn-02204104-v" ili="i32755" partOfSpeech="v" dc:subject="verb.possession">
       <Definition>transfer possession of something concrete or abstract to somebody</Definition>
@@ -12340,6 +12344,7 @@
       <SynsetRelation relType="hyponym" target="ewn-02233683-v"/> <!-- reallot -->
       <SynsetRelation relType="hyponym" target="ewn-02251238-v"/> <!-- deal -->
       <SynsetRelation relType="hyponym" target="ewn-02314145-v"/> <!-- apply, give -->
+      <SynsetRelation relType="hyponym" target="ewn-85549043-v"/>
       <Example>&quot;administer critical remarks to everyone present&quot;</Example>
       <Example>&quot;dole out some money&quot;</Example>
       <Example>&quot;shell out pocket money for the children&quot;</Example>
@@ -15046,6 +15051,12 @@
       <Definition>to sell marijuana on a street corner</Definition>
       <ILIDefinition>to sell marijuana on a street corner</ILIDefinition>
       <SynsetRelation relType="hypernym" target="ewn-02250775-v"/> <!-- deal -->
+    </Synset>
+    <Synset id="ewn-85549043-v" ili="in" partOfSpeech="v" dc:subject="verb.possession">
+      <Definition>the official distribution of a new product or service to the public</Definition>
+      <ILIDefinition>the official distribution of a new product or service to the public</ILIDefinition>
+      <SynsetRelation relType="hypernym" target="ewn-02299397-v"/> <!-- dispense, dole out, deal, deal out, mete out, parcel out, distribute, administer, allot, lot, dish out, shell out -->
+      <Example>&quot;Israel has been the fastest to roll out inoculations.&quot;</Example>
     </Synset>
   </Lexicon>
 </LexicalResource>

--- a/src/yaml/entries-r.yaml
+++ b/src/yaml/entries-r.yaml
@@ -46570,6 +46570,10 @@ roll off:
       - vtai
       synset: 00947680-v
 roll out:
+  n:
+    sense:
+    - id: 'roll_out%1:04:01::'
+      synset: 80754254-n
   v:
     sense:
     - id: 'roll_out%2:35:01::'
@@ -46582,6 +46586,10 @@ roll out:
       synset: 01489811-v
     - id: 'roll_out%2:35:03::'
       synset: 01382265-v
+    - id: 'roll_out%2:40:04::'
+      synset: 85549043-v
+    - id: 'roll_out%2:40:04::'
+      synset: 85549043-v
 roll over:
   v:
     sense:

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -72023,6 +72023,14 @@
   - 01299188-n
   - 01301715-n
   partOfSpeech: n
+80754254-n:
+  definition:
+  - the act of oficially distributing a new product or service to the public
+  hypernym:
+  - 00369128-n
+  members:
+  - roll out
+  partOfSpeech: n
 83885718-n:
   definition:
   - a variant of three-card monte played with 4 cards

--- a/src/yaml/verb.possession.yaml
+++ b/src/yaml/verb.possession.yaml
@@ -9931,7 +9931,7 @@
   partOfSpeech: v
 85549043-v:
   definition:
-  - the official distribution of a new product or service to the public
+  - officially distribute a new product or service to the public
   example:
   - '"Israel has been the fastest to roll out inoculations."'
   hypernym:

--- a/src/yaml/verb.possession.yaml
+++ b/src/yaml/verb.possession.yaml
@@ -9929,6 +9929,16 @@
   members:
   - headquarter
   partOfSpeech: v
+85549043-v:
+  definition:
+  - the official distribution of a new product or service to the public
+  example:
+  - '"Israel has been the fastest to roll out inoculations."'
+  hypernym:
+  - 02299397-v
+  members:
+  - roll out
+  partOfSpeech: v
 90000191-v:
   definition:
   - to return someone's following of you on a social media platform


### PR DESCRIPTION
added two new synsets (one verb and one noun) for roll out. I added "Israel has been the fastest to roll out inoculations." as example for the verb synset.