### PR TITLE
Updating Definition of Acre as 'state' rather than territory

### DIFF
--- a/src/xml/wn-noun.group.xml
+++ b/src/xml/wn-noun.group.xml
@@ -26314,6 +26314,7 @@
       <SynsetRelation relType="hyponym" target="ewn-08194876-n"/> <!-- city-state, city state -->
       <SynsetRelation relType="hyponym" target="ewn-08322872-n"/> <!-- ally -->
       <SynsetRelation relType="instance_hyponym" target="ewn-08737725-n"/> <!-- Tamil Eelam, Eelam -->
+      <SynsetRelation relType="hyponym" target="ewn-08873717-n"/>
       <Example>&quot;the state has elected a new president&quot;</Example>
       <Example>&quot;African nations&quot;</Example>
       <Example>&quot;students who had come to the nation&apos;s capitol&quot;</Example>

--- a/src/xml/wn-noun.location.xml
+++ b/src/xml/wn-noun.location.xml
@@ -36533,9 +36533,10 @@
     </Synset>
     <!-- Acre -->
     <Synset id="ewn-08873717-n" ili="i83347" partOfSpeech="n" dc:subject="noun.location">
-      <Definition>a territory of western Brazil bordering on Bolivia and Peru</Definition>
+      <Definition>a state in western Brazil bordering on Bolivia and Peru</Definition>
       <SynsetRelation relType="instance_hypernym" target="ewn-08569713-n"/> <!-- dominion, territory, district, territorial dominion -->
       <SynsetRelation relType="holo_part" target="ewn-08872733-n"/> <!-- Federative Republic of Brazil, Brazil, Brasil -->
+      <SynsetRelation relType="hypernym" target="ewn-08185877-n"/> <!-- state, land, commonwealth, body politic, res publica, country, nation -->
     </Synset>
     <!-- St. Mary of Bethlehem, Para, Feliz Lusitania, Belem, Santa Maria de Belem -->
     <Synset id="ewn-08873847-n" ili="i83348" partOfSpeech="n" dc:subject="noun.location">

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -19275,7 +19275,9 @@
   partOfSpeech: n
 08873717-n:
   definition:
-  - a territory of western Brazil bordering on Bolivia and Peru
+  - a state in western Brazil bordering on Bolivia and Peru
+  hypernym:
+  - 08185877-n
   ili: i83347
   instance_hypernym:
   - 08569713-n


### PR DESCRIPTION
Fixes #533

-Rather than keep the old Synset for 'Acre' and create a new one, it seems more appropriate to update the existing definition and adjust the relations accordingly.