### PR TITLE
Deleting 'container' as hypernym for 'wheeled vehicle'

### DIFF
--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -118992,7 +118992,6 @@
     around 3500 BC"'
   hypernym:
   - 04531608-n
-  - 03099154-n
   ili: i61100
   members:
   - wheeled vehicle


### PR DESCRIPTION
Closes #479