### PR TITLE
Fix classification loop

### DIFF
--- a/src/xml/wn-noun.cognition.xml
+++ b/src/xml/wn-noun.cognition.xml
@@ -41720,7 +41720,6 @@
       <Definition>the branch of engineering science that studies (with the aid of computers) computable processes and structures</Definition>
       <SynsetRelation relType="hypernym" target="ewn-06134474-n"/> <!-- engineering science, technology, engineering, applied science -->
       <SynsetRelation relType="holo_part" target="ewn-06151569-n"/> <!-- information processing, IP, informatics, information science -->
-      <SynsetRelation relType="domain_topic" target="ewn-03086983-n"/> <!-- computer, data processor, computing machine, electronic computer, computing device, information processing system -->
       <SynsetRelation relType="has_domain_topic" target="ewn-00185232-s"/> <!-- addressable -->
       <SynsetRelation relType="has_domain_topic" target="ewn-01654843-a"/> <!-- on-line, online -->
       <SynsetRelation relType="has_domain_topic" target="ewn-01655194-a"/> <!-- off-line -->
@@ -41743,7 +41742,6 @@
       <SynsetRelation relType="has_domain_topic" target="ewn-02920030-n"/> <!-- bulletin board system, bulletin board, bbs, electronic bulletin board -->
       <SynsetRelation relType="has_domain_topic" target="ewn-02938401-n"/> <!-- cache, memory cache -->
       <SynsetRelation relType="has_domain_topic" target="ewn-02998952-n"/> <!-- processor, C.P.U., central processing unit, CPU, mainframe, central processor -->
-      <SynsetRelation relType="has_domain_topic" target="ewn-03086983-n"/> <!-- computer, data processor, computing machine, electronic computer, computing device, information processing system -->
       <SynsetRelation relType="has_domain_topic" target="ewn-03088462-n"/> <!-- computer circuit -->
       <SynsetRelation relType="has_domain_topic" target="ewn-03089375-n"/> <!-- computer network -->
       <SynsetRelation relType="has_domain_topic" target="ewn-03102324-n"/> <!-- command key, control key -->
@@ -41943,6 +41941,7 @@
       <SynsetRelation relType="has_domain_topic" target="ewn-90013991-n"/>
       <SynsetRelation relType="has_domain_topic" target="ewn-89845378-s"/>
       <SynsetRelation relType="has_domain_topic" target="ewn-82841156-s"/>
+      <SynsetRelation relType="has_domain_topic" target="ewn-03086983-n"/> <!-- computer, data processor, computing machine, electronic computer, computing device, information processing system -->
     </Synset>
     <!-- object -->
     <Synset id="ewn-06142175-n" ili="i68813" partOfSpeech="n" dc:subject="noun.cognition">

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -54759,7 +54759,6 @@
   ili: i54950
   members:
   - hot line
-  - hotline
   partOfSpeech: n
 03548292-n:
   definition:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -26824,8 +26824,6 @@
   definition:
   - the branch of engineering science that studies (with the aid of computers) computable
     processes and structures
-  domain_topic:
-  - 03086983-n
   hypernym:
   - 06134474-n
   ili: i68812


### PR DESCRIPTION
Fix issue #439.

EWE first removes both symmetric classification links between 'computer_science' and 'computer', so the correct one ('computer' is a sub-topic of 'computer_science') had to be re-inserted afterwards.