### PR TITLE
Fix 522 gathering

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -85,10 +85,10 @@ def check_no_loops(wn):
             for c in hypernyms[synset.id]:
                 hypernyms[synset.id] = hypernyms[synset.id].union(
                     hypernyms.get(c, []))
+                if synset.id in hypernyms[synset.id]:
+                    return ["Loop for %s <-> %s" % (synset.id, c)]
             if len(hypernyms[synset.id]) != n_size:
                 changed = True
-            if synset.id in hypernyms[synset.id]:
-                return ["Loop for %s" % (synset.id)]
     return []
 
 def check_no_domain_loops(wn):

--- a/src/xml/wn-noun.Tops.xml
+++ b/src/xml/wn-noun.Tops.xml
@@ -1866,7 +1866,6 @@
       <SynsetRelation relType="hyponym" target="ewn-90008911-n"/>
       <SynsetRelation relType="hypernym" target="ewn-00002137-n"/> <!-- abstract entity, abstraction -->
       <SynsetRelation relType="hyponym" target="ewn-07298313-n"/>
-      <SynsetRelation relType="hypernym" target="ewn-08324519-n"/>
     </Synset>
     <!-- physical process, process -->
     <Synset id="ewn-00029976-n" ili="i35587" partOfSpeech="n" dc:subject="noun.Tops">

--- a/src/xml/wn-noun.group.xml
+++ b/src/xml/wn-noun.group.xml
@@ -29673,7 +29673,8 @@
     </Synset>
     <!-- party -->
     <Synset id="ewn-08269523-n" ili="i80500" partOfSpeech="n" dc:subject="noun.group">
-      <Definition>a group of people gathered together for pleasure</Definition>
+      <Definition>a gathering of people for pleasure</Definition>
+      <ILIDefinition>a group of people gathered together for pleasure</ILIDefinition>
       <SynsetRelation relType="hypernym" target="ewn-08269132-n"/> <!-- social affair, social gathering -->
       <SynsetRelation relType="hyponym" target="ewn-08269966-n"/> <!-- shindig, shindy -->
       <SynsetRelation relType="hyponym" target="ewn-08270062-n"/> <!-- dance -->

--- a/src/xml/wn-noun.group.xml
+++ b/src/xml/wn-noun.group.xml
@@ -19627,14 +19627,11 @@
       <SynsetRelation relType="hyponym" target="ewn-08254784-n"/> <!-- dramatis personae, cast, cast of characters -->
       <SynsetRelation relType="hyponym" target="ewn-08255384-n"/> <!-- course, class, grade, form -->
       <SynsetRelation relType="hyponym" target="ewn-08255581-n"/> <!-- class, year -->
-      <SynsetRelation relType="hyponym" target="ewn-08269132-n"/> <!-- social affair, social gathering -->
       <SynsetRelation relType="hyponym" target="ewn-08290764-n"/> <!-- crowd, crew, bunch, gang -->
       <SynsetRelation relType="hyponym" target="ewn-08327239-n"/> <!-- covey -->
       <SynsetRelation relType="hyponym" target="ewn-08374919-n"/> <!-- quorum -->
-      <SynsetRelation relType="hyponym" target="ewn-08375259-n"/> <!-- mass meeting, rally -->
       <SynsetRelation relType="hyponym" target="ewn-08392296-n"/> <!-- commune -->
       <SynsetRelation relType="hyponym" target="ewn-08419179-n"/> <!-- convocation -->
-      <SynsetRelation relType="hyponym" target="ewn-08425514-n"/> <!-- fair -->
       <SynsetRelation relType="hyponym" target="ewn-08432731-n"/> <!-- bevy -->
       <SynsetRelation relType="hyponym" target="ewn-08446124-n"/> <!-- cortege, suite, retinue, entourage -->
       <SynsetRelation relType="hyponym" target="ewn-08495029-n"/> <!-- camp -->
@@ -19642,8 +19639,6 @@
       <SynsetRelation relType="hyponym" target="ewn-08496806-n"/> <!-- rap group -->
       <SynsetRelation relType="hyponym" target="ewn-08496905-n"/> <!-- rave-up -->
       <SynsetRelation relType="hyponym" target="ewn-08497146-n"/> <!-- table -->
-      <SynsetRelation relType="hyponym" target="ewn-08503199-n"/> <!-- wine tasting -->
-      <SynsetRelation relType="hyponym" target="ewn-08324519-n"/> <!-- group meeting, meeting -->
     </Synset>
     <!-- bee -->
     <Synset id="ewn-07992356-n" ili="i79221" partOfSpeech="n" dc:subject="noun.group">
@@ -29661,7 +29656,6 @@
     <!-- social affair, social gathering -->
     <Synset id="ewn-08269132-n" ili="i80498" partOfSpeech="n" dc:subject="noun.group">
       <Definition>a gathering for the purpose of promoting fellowship</Definition>
-      <SynsetRelation relType="hypernym" target="ewn-07991473-n"/> <!-- assemblage, gathering -->
       <SynsetRelation relType="hyponym" target="ewn-07992356-n"/> <!-- bee -->
       <SynsetRelation relType="hyponym" target="ewn-07993172-n"/> <!-- love feast -->
       <SynsetRelation relType="hyponym" target="ewn-08201779-n"/> <!-- company -->
@@ -29669,6 +29663,7 @@
       <SynsetRelation relType="hyponym" target="ewn-08269523-n"/> <!-- party -->
       <SynsetRelation relType="hyponym" target="ewn-08273488-n"/> <!-- supper -->
       <SynsetRelation relType="hyponym" target="ewn-08327319-n"/> <!-- meeting, get together -->
+      <SynsetRelation relType="hypernym" target="ewn-01232427-n"/>
     </Synset>
     <!-- function -->
     <Synset id="ewn-08269388-n" ili="i80499" partOfSpeech="n" dc:subject="noun.group">
@@ -31633,7 +31628,7 @@
       <SynsetRelation relType="hyponym" target="ewn-08329289-n"/> <!-- summit meeting, summit -->
       <SynsetRelation relType="hyponym" target="ewn-08329392-n"/> <!-- town meeting -->
       <SynsetRelation relType="hyponym" target="ewn-00029677-n"/>
-      <SynsetRelation relType="hypernym" target="ewn-07991473-n"/> <!-- assemblage, gathering -->
+      <SynsetRelation relType="hypernym" target="ewn-01232427-n"/>
       <Example>next year the meeting will be in Chicago</Example>
       <Example>the meeting elected a chairperson</Example>
     </Synset>
@@ -33298,9 +33293,9 @@
     <!-- mass meeting, rally -->
     <Synset id="ewn-08375259-n" ili="i81033" partOfSpeech="n" dc:subject="noun.group">
       <Definition>a large gathering of people intended to arouse enthusiasm</Definition>
-      <SynsetRelation relType="hypernym" target="ewn-07991473-n"/> <!-- assemblage, gathering -->
       <SynsetRelation relType="hyponym" target="ewn-08375419-n"/> <!-- pep rally -->
       <SynsetRelation relType="hyponym" target="ewn-08402874-n"/> <!-- revival meeting, revival -->
+      <SynsetRelation relType="hypernym" target="ewn-01232427-n"/>
     </Synset>
     <!-- pep rally -->
     <Synset id="ewn-08375419-n" ili="i81034" partOfSpeech="n" dc:subject="noun.group">
@@ -35114,9 +35109,9 @@
     <!-- fair -->
     <Synset id="ewn-08425514-n" ili="i81293" partOfSpeech="n" dc:subject="noun.group">
       <Definition>gathering of producers to promote business</Definition>
-      <SynsetRelation relType="hypernym" target="ewn-07991473-n"/> <!-- assemblage, gathering -->
       <SynsetRelation relType="hyponym" target="ewn-08425375-n"/> <!-- bookfair, book fair -->
       <SynsetRelation relType="hyponym" target="ewn-00523201-n"/>
+      <SynsetRelation relType="hypernym" target="ewn-01232427-n"/>
       <Example>world fair</Example>
       <Example>trade fair</Example>
       <Example>book fair</Example>
@@ -38082,7 +38077,7 @@
     <!-- wine tasting -->
     <Synset id="ewn-08503199-n" ili="i81651" partOfSpeech="n" dc:subject="noun.group">
       <Definition>a gathering of people to taste and compare different wines</Definition>
-      <SynsetRelation relType="hypernym" target="ewn-07991473-n"/> <!-- assemblage, gathering -->
+      <SynsetRelation relType="hypernym" target="ewn-01232427-n"/>
     </Synset>
     <!-- wing -->
     <Synset id="ewn-08503316-n" ili="i81652" partOfSpeech="n" dc:subject="noun.group">

--- a/src/xml/wn-noun.group.xml
+++ b/src/xml/wn-noun.group.xml
@@ -29674,7 +29674,6 @@
     <!-- party -->
     <Synset id="ewn-08269523-n" ili="i80500" partOfSpeech="n" dc:subject="noun.group">
       <Definition>a gathering of people for pleasure</Definition>
-      <ILIDefinition>a group of people gathered together for pleasure</ILIDefinition>
       <SynsetRelation relType="hypernym" target="ewn-08269132-n"/> <!-- social affair, social gathering -->
       <SynsetRelation relType="hyponym" target="ewn-08269966-n"/> <!-- shindig, shindy -->
       <SynsetRelation relType="hyponym" target="ewn-08270062-n"/> <!-- dance -->
@@ -31628,7 +31627,6 @@
       <SynsetRelation relType="hyponym" target="ewn-08327098-n"/> <!-- stockholders meeting -->
       <SynsetRelation relType="hyponym" target="ewn-08329289-n"/> <!-- summit meeting, summit -->
       <SynsetRelation relType="hyponym" target="ewn-08329392-n"/> <!-- town meeting -->
-      <SynsetRelation relType="hyponym" target="ewn-00029677-n"/>
       <SynsetRelation relType="hypernym" target="ewn-01232427-n"/>
       <Example>next year the meeting will be in Chicago</Example>
       <Example>the meeting elected a chairperson</Example>

--- a/src/yaml/noun.Tops.yaml
+++ b/src/yaml/noun.Tops.yaml
@@ -486,7 +486,6 @@
   - something that happens at a given place and time
   hypernym:
   - 00002137-n
-  - 08324519-n
   ili: i35586
   members:
   - event

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -2624,7 +2624,6 @@
   members:
   - insider trading
   partOfSpeech: n
-  wikidata: Q854623
 00081294-n:
   definition:
   - a put or call option for which the seller or buyer has no underlying security
@@ -2939,7 +2938,6 @@
   members:
   - expropriation
   partOfSpeech: n
-  wikidata: Q86757
 00087117-n:
   definition:
   - placing private property in the custody of an officer of the law
@@ -3678,7 +3676,6 @@
   members:
   - valet parking
   partOfSpeech: n
-  wikidata: Q1423019
 00100087-n:
   definition:
   - the act of performing a drama
@@ -4209,7 +4206,6 @@
   - breaking ball
   - bender
   partOfSpeech: n
-  wikidata: Q44891
 00108901-n:
   definition:
   - a pitch thrown deliberately close to the batter
@@ -4247,7 +4243,6 @@
   - knuckleball
   - knuckler
   partOfSpeech: n
-  wikidata: Q44459
 00109365-n:
   definition:
   - a baseball pitch in which the hand moves above the shoulder
@@ -4635,7 +4630,6 @@
   - haul
   - haulage
   partOfSpeech: n
-  wikidata: Q4174178
 00116112-n:
   definition:
   - the act of hauling something (as a vehicle) by means of a hitch or rope
@@ -4774,7 +4768,6 @@
   - burping
   - eructation
   partOfSpeech: n
-  wikidata: Q209789
 00118630-n:
   definition:
   - the forceful expulsion of something from inside
@@ -4865,7 +4858,6 @@
   - hematemesis
   - haematemesis
   partOfSpeech: n
-  wikidata: Q1570161
 00120117-n:
   definition:
   - severe and excessive vomiting
@@ -5400,7 +5392,6 @@
   members:
   - fair ball
   partOfSpeech: n
-  wikidata: Q1141278
 00128911-n:
   definition:
   - (baseball) a ball struck with the bat so that it does not stay between the lines
@@ -5547,7 +5538,6 @@
   members:
   - putout
   partOfSpeech: n
-  wikidata: Q1046690
 00131167-n:
   definition:
   - an out resulting from the batter getting three strikes
@@ -6077,7 +6067,6 @@
   members:
   - corner kick
   partOfSpeech: n
-  wikidata: Q242415
 00138697-n:
   definition:
   - (football) kicking (as for a field goal) in which the football is dropped and
@@ -6419,7 +6408,6 @@
   members:
   - ophthalmoscopy
   partOfSpeech: n
-  wikidata: Q837188
 00144705-n:
   definition:
   - a method of examination in which the examiner feels the size or shape or firmness
@@ -6504,7 +6492,6 @@
   - connection
   - connexion
   partOfSpeech: n
-  wikidata: Q1480529
 00146599-n:
   definition:
   - a connection made via the internet to another website
@@ -8605,7 +8592,6 @@
   members:
   - referendum
   partOfSpeech: n
-  wikidata: Q43109
 00182630-n:
   definition:
   - a vote to select the winner of a position or political office
@@ -8647,7 +8633,6 @@
   - primary
   - primary election
   partOfSpeech: n
-  wikidata: Q669262
 00183572-n:
   definition:
   - a primary where voters directly select the candidates who will run for office
@@ -8689,7 +8674,6 @@
   - by-election
   - bye-election
   partOfSpeech: n
-  wikidata: Q1057954
 00184206-n:
   definition:
   - a final election to resolve an earlier election that did not produce a winner
@@ -10689,7 +10673,6 @@
   members:
   - honor killing
   partOfSpeech: n
-  wikidata: Q2691275
 00221276-n:
   definition:
   - homicide without malice aforethought
@@ -10769,7 +10752,6 @@
   members:
   - mariticide
   partOfSpeech: n
-  wikidata: Q6647198
 00222686-n:
   definition:
   - the murder of your mother
@@ -10943,7 +10925,6 @@
   - carnage
   - butchery
   partOfSpeech: n
-  wikidata: Q750215
 00225127-n:
   definition:
   - indiscriminate slaughter
@@ -11137,7 +11118,6 @@
   members:
   - carjacking
   partOfSpeech: n
-  wikidata: Q632327
 00228462-n:
   definition:
   - the act of killing (an animal or person) in order to propitiate a deity
@@ -11284,7 +11264,6 @@
   members:
   - layoff
   partOfSpeech: n
-  wikidata: Q1462531
 00230801-n:
   definition:
   - the act of extinguishing; causing to stop burning
@@ -11790,7 +11769,6 @@
   - groundbreaking
   - groundbreaking ceremony
   partOfSpeech: n
-  wikidata: Q1068633
 00240533-n:
   definition:
   - the act of starting to construct a house
@@ -12701,7 +12679,6 @@
   - haircare
   - hairdressing
   partOfSpeech: n
-  wikidata: Q3633540
 00258335-n:
   definition:
   - the act of interweaving a hairpiece with your own hair
@@ -12900,7 +12877,6 @@
   members:
   - land reform
   partOfSpeech: n
-  wikidata: Q208128
 00261872-n:
   definition:
   - the act of relieving ills and changing for the better
@@ -13150,7 +13126,6 @@
   - redevelopment
   - overhaul
   partOfSpeech: n
-  wikidata: Q1441983
 00266316-n:
   definition:
   - a renovation that improves the outward appearance (as of a building) but usually
@@ -13748,7 +13723,6 @@
   members:
   - dyeing
   partOfSpeech: n
-  wikidata: Q1164991
 00276416-n:
   definition:
   - (histology) the use of a dye to color specimens for microscopic study
@@ -14433,7 +14407,6 @@
   members:
   - piaffe
   partOfSpeech: n
-  wikidata: Q1751413
 00289330-n:
   definition:
   - a smooth three-beat gait; between a trot and a gallop
@@ -15230,7 +15203,6 @@
   members:
   - international flight
   partOfSpeech: n
-  wikidata: Q6054674
 00302827-n:
   definition:
   - a flight made without intermediate stops between source and destination
@@ -15279,7 +15251,6 @@
   - stunting
   - stunt flying
   partOfSpeech: n
-  wikidata: Q373557
 00303875-n:
   definition:
   - using only instruments for flying an aircraft because you cannot see through clouds
@@ -15379,7 +15350,6 @@
   - parasailing
   - paragliding
   partOfSpeech: n
-  wikidata: Q178380
 00305268-n:
   definition:
   - a flight by an aircraft over a particular area (especially over an area in foreign
@@ -16110,7 +16080,6 @@
   - commutation
   - commuting
   partOfSpeech: n
-  wikidata: Q48442
 00316656-n:
   definition:
   - to move something from its natural environment
@@ -16432,7 +16401,6 @@
   - catheterization
   - catheterisation
   partOfSpeech: n
-  wikidata: Q2312472
 00322557-n:
   definition:
   - the introduction of a liquid (by pouring or injection) drop by drop
@@ -16485,7 +16453,6 @@
   - encasement
   - incasement
   partOfSpeech: n
-  wikidata: Q3053713
 00323460-n:
   definition:
   - the forceful insertion of a substance under pressure
@@ -16523,7 +16490,6 @@
   members:
   - intramuscular injection
   partOfSpeech: n
-  wikidata: Q432083
 00323978-n:
   definition:
   - an injection into a vein
@@ -16533,7 +16499,6 @@
   members:
   - intravenous injection
   partOfSpeech: n
-  wikidata: Q1369403
 00324088-n:
   definition:
   - something craved, especially an intravenous injection of a narcotic drug
@@ -19134,7 +19099,6 @@
   members:
   - contracture
   partOfSpeech: n
-  wikidata: Q1480291
 00370340-n:
   definition:
   - act of stretching or straightening out a flexed limb
@@ -19525,7 +19489,6 @@
   - smashing
   - shattering
   partOfSpeech: n
-  wikidata: Q7490719
 00377802-n:
   definition:
   - the act of cracking something
@@ -20031,7 +19994,6 @@
   members:
   - bisection
   partOfSpeech: n
-  wikidata: Q3128632
 00387361-n:
   definition:
   - dividing into four equal parts
@@ -20451,7 +20413,6 @@
   members:
   - autotomy
   partOfSpeech: n
-  wikidata: Q465891
 00395293-n:
   definition:
   - the removal of contaminants
@@ -20837,7 +20798,6 @@
   members:
   - vocational rehabilitation
   partOfSpeech: n
-  wikidata: Q6130303
 00402267-n:
   definition:
   - the act of restoring someone to a previous position
@@ -21838,7 +21798,6 @@
   members:
   - blaxploitation
   partOfSpeech: n
-  wikidata: Q883179
 00420477-n:
   definition:
   - the commercial exploitation of sex or sexuality or explicit sexual material
@@ -22790,7 +22749,6 @@
   members:
   - headstand
   partOfSpeech: n
-  wikidata: Q2281572
 00438728-n:
   definition:
   - an acrobatic feat of rolling or turning end over end
@@ -22874,7 +22832,6 @@
   - stock split
   - split up
   partOfSpeech: n
-  wikidata: Q1154798
 00440224-n:
   definition:
   - a decrease in the number of outstanding shares of a corporation without changing
@@ -22998,7 +22955,6 @@
   members:
   - ski jumping
   partOfSpeech: n
-  wikidata: Q7718
 00442175-n:
   definition:
   - a standing turn made in skiing; one ski is raised to the vertical and pivoted
@@ -23073,7 +23029,6 @@
   members:
   - sea bathing
   partOfSpeech: n
-  wikidata: Q1132965
 00443639-n:
   definition:
   - a naked swim
@@ -23232,7 +23187,6 @@
   - snorkeling
   - snorkel diving
   partOfSpeech: n
-  wikidata: Q2471422
 00446040-n:
   definition:
   - the sport of riding a surfboard toward the shore on the crest of a wave
@@ -23306,7 +23260,6 @@
   members:
   - professional boxing
   partOfSpeech: n
-  wikidata: Q2631720
 00447396-n:
   definition:
   - boxing at close quarters
@@ -23477,7 +23430,6 @@
   members:
   - figure skating
   partOfSpeech: n
-  wikidata: Q38108
 00449857-n:
   definition:
   - skating using Rollerblades
@@ -23496,7 +23448,6 @@
   members:
   - roller skating
   partOfSpeech: n
-  wikidata: Q1707432
 00450039-n:
   definition:
   - the sport of skating on a skateboard
@@ -23669,7 +23620,6 @@
   members:
   - motorcycling
   partOfSpeech: n
-  wikidata: Q608003
 00452754-n:
   definition:
   - bicycling or motorcycling on sand dunes
@@ -23758,7 +23708,6 @@
   members:
   - coursing
   partOfSpeech: n
-  wikidata: Q515302
 00454337-n:
   definition:
   - hunting deer
@@ -24049,7 +23998,6 @@
   - opening
   - chess opening
   partOfSpeech: n
-  wikidata: Q103632
 00459118-n:
   definition:
   - (chess) an attack that is intended to counter the opponent's advantage in another
@@ -24539,7 +24487,6 @@
   members:
   - croquet
   partOfSpeech: n
-  wikidata: Q193387
 00468190-n:
   definition:
   - a game that simulates military combat; players on one team try to eliminate players
@@ -24592,7 +24539,6 @@
   - field hockey
   - hockey
   partOfSpeech: n
-  wikidata: Q1455
 00469374-n:
   definition:
   - a simple version of hockey played by children on the streets (or on ice or on
@@ -24958,7 +24904,6 @@
   - dribble
   - dribbling
   partOfSpeech: n
-  wikidata: Q1215228
 00479866-n:
   definition:
   - an illegal dribble in basketball (the player uses both hands to dribble or the
@@ -25063,7 +25008,6 @@
   - battledore
   - battledore and shuttlecock
   partOfSpeech: n
-  wikidata: Q354176
 00482004-n:
   definition:
   - a game played on a court by two opposing teams of 5 players; points are scored
@@ -25219,7 +25163,6 @@
   - real tennis
   - court tennis
   partOfSpeech: n
-  wikidata: Q2360406
 00484859-n:
   definition:
   - an Italian game similar to tennis
@@ -25571,7 +25514,6 @@
   - auction
   - auction bridge
   partOfSpeech: n
-  wikidata: Q5370841
 00492377-n:
   definition:
   - a variety of bridge in which the bidder receives points toward game only for the
@@ -25741,7 +25683,6 @@
   - penuchle
   - bezique
   partOfSpeech: n
-  wikidata: Q1019517
 00495304-n:
   definition:
   - a card game for two players using a reduced pack of 32 cards
@@ -25976,7 +25917,6 @@
   - stud
   - stud poker
   partOfSpeech: n
-  wikidata: Q953223
 00499438-n:
   definition:
   - a form of all fours in which the players bid for the privilege of naming trumps
@@ -26233,7 +26173,6 @@
   mero_part:
   - 03015175-n
   partOfSpeech: n
-  wikidata: Q1293
 00504248-n:
   definition:
   - a board game for two players who move their 16 pieces according to specific rules;
@@ -26259,7 +26198,6 @@
   - Chinese checkers
   - Chinese chequers
   partOfSpeech: n
-  wikidata: Q1045090
 00505220-n:
   definition:
   - a game in which small pointed missiles are thrown at a dartboard
@@ -26370,7 +26308,6 @@
   members:
   - Parcheesi
   partOfSpeech: n
-  wikidata: Q1511387
 00506737-n:
   definition:
   - a form of chess played on a board of 81 squares; each player has 20 pieces
@@ -26382,7 +26319,6 @@
   members:
   - shogi
   partOfSpeech: n
-  wikidata: Q131375
 00506882-n:
   definition:
   - a game in which coins or discs are slid by hand across a board toward a mark
@@ -26916,7 +26852,6 @@
   members:
   - word play
   partOfSpeech: n
-  wikidata: Q998840
 00515052-n:
   definition:
   - an unkind or aggressive trick
@@ -27138,7 +27073,6 @@
   members:
   - eisteddfod
   partOfSpeech: n
-  wikidata: Q670265
 00518474-n:
   definition:
   - a cinematic festival that features films (usually films produced during the past
@@ -27149,7 +27083,6 @@
   members:
   - film festival
   partOfSpeech: n
-  wikidata: Q220505
 00518620-n:
   definition:
   - (in Spanish speaking regions) a local festival or fair, usually in honor of some
@@ -27194,7 +27127,6 @@
   - Kwanzaa
   - Kwanza
   partOfSpeech: n
-  wikidata: Q746851
 00519359-n:
   definition:
   - an autumn festival that involves merrymaking and drinking beer
@@ -28319,7 +28251,6 @@
   - morris dance
   - morris dancing
   partOfSpeech: n
-  wikidata: Q1900271
 00539547-n:
   definition:
   - any of various dances by men who step nimbly over swords or flourish them in the
@@ -28827,7 +28758,6 @@
   - scat
   - scat singing
   partOfSpeech: n
-  wikidata: Q623202
 00548491-n:
   definition:
   - the act of whistling a tune
@@ -29073,7 +29003,6 @@
   - hamming
   - overacting
   partOfSpeech: n
-  wikidata: Q2042275
 00552751-n:
   definition:
   - ostentatious or vainglorious or extravagant or melodramatic conduct
@@ -29975,7 +29904,6 @@
   - tennis stroke
   - tennis shot
   partOfSpeech: n
-  wikidata: Q849132
 00567335-n:
   definition:
   - a tennis stroke that sends the ball back to the other player
@@ -30230,7 +30158,6 @@
   mero_part:
   - 00575467-n
   partOfSpeech: n
-  wikidata: Q828185
 00571609-n:
   definition:
   - an elementary swimming stroke imitating a swimming dog
@@ -30277,7 +30204,6 @@
   mero_part:
   - 00575645-n
   partOfSpeech: n
-  wikidata: Q326163
 00572320-n:
   definition:
   - a swimming stroke that resembles the crawl except the swimmer lies on his or her
@@ -30483,7 +30409,6 @@
   members:
   - frog kick
   partOfSpeech: n
-  wikidata: Q5505237
 00575827-n:
   definition:
   - a swimming kick; an up and down kick of the feet together
@@ -30768,7 +30693,6 @@
   members:
   - socage
   partOfSpeech: n
-  wikidata: Q1369542
 00581014-n:
   definition:
   - land tenure by service in the lord's army
@@ -32546,7 +32470,6 @@
   - woodworking
   - woodwork
   partOfSpeech: n
-  wikidata: Q816871
 00609152-n:
   definition:
   - the craft of drawing blueprints
@@ -32655,7 +32578,6 @@
   members:
   - papermaking
   partOfSpeech: n
-  wikidata: Q335415
 00610774-n:
   definition:
   - the occupation of a pilot
@@ -32888,7 +32810,6 @@
   - secret writing
   - steganography
   partOfSpeech: n
-  wikidata: Q15032
 00616017-n:
   definition:
   - the activity of writing by hand
@@ -33072,7 +32993,6 @@
   - shoe repairing
   - cobbling
   partOfSpeech: n
-  wikidata: Q6408486
 00619229-n:
   definition:
   - the craft of a roofer
@@ -33170,7 +33090,6 @@
   - bookkeeping
   - clerking
   partOfSpeech: n
-  wikidata: Q3707847
 00620659-n:
   definition:
   - a simple bookkeeping system; transactions are entered in only one account
@@ -33315,7 +33234,6 @@
   - travail
   - sweat
   partOfSpeech: n
-  wikidata: Q723375
 00623308-n:
   definition:
   - strenuous effort
@@ -33553,7 +33471,6 @@
   - muscle building
   - musclebuilding
   partOfSpeech: n
-  wikidata: Q124100
 00627428-n:
   definition:
   - bodybuilding by exercise that involves lifting weights
@@ -33604,7 +33521,6 @@
   mero_part:
   - 00627663-n
   partOfSpeech: n
-  wikidata: Q6531690
 00628253-n:
   definition:
   - a weightlift in which the barbell is lifted to shoulder height and then smoothly
@@ -33616,7 +33532,6 @@
   - press
   - military press
   partOfSpeech: n
-  wikidata: Q2029261
 00628436-n:
   definition:
   - a weightlift in which the barbell is lifted overhead in one rapid motion
@@ -34639,7 +34554,6 @@
   - time study
   - work study
   partOfSpeech: n
-  wikidata: Q114642
 00646865-n:
   definition:
   - a form of microscopic examination of living material by scattered light; specimens
@@ -35521,7 +35435,6 @@
   members:
   - diathermy
   partOfSpeech: n
-  wikidata: Q533734
 00663439-n:
   definition:
   - the therapeutic use of aromatic plant extracts and essential oils in baths or
@@ -35632,7 +35545,6 @@
   - electromotive drug administration
   - EMDA
   partOfSpeech: n
-  wikidata: Q1528394
 00665353-n:
   definition:
   - the act of treating with medicines or remedies
@@ -35800,7 +35712,6 @@
   members:
   - angioplasty
   partOfSpeech: n
-  wikidata: Q539795
 00667843-n:
   definition:
   - the surgical fixation of a joint which is intended to result in bone fusion
@@ -35941,7 +35852,6 @@
   members:
   - cholecystectomy
   partOfSpeech: n
-  wikidata: Q638774
 00670398-n:
   definition:
   - excision of the clitoris
@@ -36005,7 +35915,6 @@
   members:
   - decortication
   partOfSpeech: n
-  wikidata: Q1183720
 00671493-n:
   definition:
   - a surgical procedure usually performed under local anesthesia in which the cervix
@@ -36151,7 +36060,6 @@
   - eye operation
   - eye surgery
   partOfSpeech: n
-  wikidata: Q760348
 00675401-n:
   definition:
   - plastic surgery to remove wrinkles and other signs of aging from your face; an
@@ -36763,7 +36671,6 @@
   members:
   - lumpectomy
   partOfSpeech: n
-  wikidata: Q542022
 00686090-n:
   definition:
   - any surgical procedure that involves anesthesia or respiratory assistance
@@ -36914,7 +36821,6 @@
   - orchidectomy
   - orchiectomy
   partOfSpeech: n
-  wikidata: Q1806228
 00688280-n:
   definition:
   - surgical removal of part or all of the pancreas
@@ -36998,7 +36904,6 @@
   members:
   - sympathectomy
   partOfSpeech: n
-  wikidata: Q6128790
 00689351-n:
   definition:
   - surgical removal of a blood clot (thrombus) from a blood vessel
@@ -37035,7 +36940,6 @@
   members:
   - myotomy
   partOfSpeech: n
-  wikidata: Q1956720
 00689810-n:
   definition:
   - surgical removal of the eardrum
@@ -37112,7 +37016,6 @@
   members:
   - osteotomy
   partOfSpeech: n
-  wikidata: Q2167748
 00690803-n:
   definition:
   - surgical procedure that creates an artificial opening for the elimination of bodily
@@ -37185,7 +37088,6 @@
   members:
   - polypectomy
   partOfSpeech: n
-  wikidata: Q7226727
 00692186-n:
   definition:
   - reconstructive surgery of the anus or rectum
@@ -37289,7 +37191,6 @@
   - fixing
   - altering
   partOfSpeech: n
-  wikidata: Q3482590
 00693979-n:
   definition:
   - neutering a female by removing the ovaries
@@ -38916,7 +38817,6 @@
   members:
   - gender role
   partOfSpeech: n
-  wikidata: Q2672163
 00723730-n:
   definition:
   - (in team sports) the role assigned to an individual player
@@ -39408,7 +39308,6 @@
   - da'wah
   - dawah
   partOfSpeech: n
-  wikidata: Q1075838
 00732520-n:
   definition:
   - a special assignment that is given to a person or group
@@ -42864,7 +42763,6 @@
   - MOT test
   - Ministry of Transportation test
   partOfSpeech: n
-  wikidata: Q3933942
 00797013-n:
   definition:
   - activity planned as a test or trial
@@ -43161,7 +43059,6 @@
   mero_member:
   - 10104404-n
   partOfSpeech: n
-  wikidata: Q8031205
 00802318-n:
   definition:
   - the movement aimed at liberating homosexuals from legal or social or economic
@@ -43446,7 +43343,6 @@
   - deregulation
   - deregulating
   partOfSpeech: n
-  wikidata: Q902410
 00807185-n:
   definition:
   - an official lowering of a nation's currency; a decrease in the value of a country's
@@ -44990,7 +44886,6 @@
   - Heimlich maneuver
   - Heimlich manoeuvre
   partOfSpeech: n
-  wikidata: Q857300
 00834957-n:
   definition:
   - breathing in which most of the respiratory effort is done by the abdominal muscles
@@ -45720,7 +45615,6 @@
   mero_part:
   - 00846839-n
   partOfSpeech: n
-  wikidata: Q5873
 00847651-n:
   definition:
   - slang for sexual intercourse
@@ -45801,7 +45695,6 @@
   - statutory rape
   - carnal abuse
   partOfSpeech: n
-  wikidata: Q1968926
 00848797-n:
   definition:
   - any lascivious contact by an adult with the sexual organs of a child (especially
@@ -45913,7 +45806,6 @@
   - pulling out
   - onanism
   partOfSpeech: n
-  wikidata: Q182207
 00850924-n:
   definition:
   - intercourse via the anus, committed by a man with a man or woman
@@ -45926,7 +45818,6 @@
   - anal sex
   - anal intercourse
   partOfSpeech: n
-  wikidata: Q8398
 00851153-n:
   definition:
   - the sexual activity of conceiving and bearing offspring
@@ -46041,7 +45932,6 @@
   members:
   - inbreeding
   partOfSpeech: n
-  wikidata: Q38978
 00853319-n:
   definition:
   - any of several methods of family planning that do not involve sterilization or
@@ -46229,7 +46119,6 @@
   - cunnilingus
   - cunnilinctus
   partOfSpeech: n
-  wikidata: Q8402
 00856798-n:
   also:
   - 90001611-n
@@ -46410,7 +46299,6 @@
   - heterosexualism
   - straightness
   partOfSpeech: n
-  wikidata: Q1035954
 00859501-n:
   definition:
   - sexual relations between a man and a boy (usually anal intercourse with the boy
@@ -46423,7 +46311,6 @@
   - pederasty
   - paederasty
   partOfSpeech: n
-  wikidata: Q211354
 00859689-n:
   definition:
   - sexual activity between a person and an animal
@@ -46711,7 +46598,6 @@
   members:
   - chemotaxis
   partOfSpeech: n
-  wikidata: Q658145
 00864695-n:
   definition:
   - movement away from a chemical stimulus
@@ -47217,7 +47103,6 @@
   - exponentiation
   - involution
   partOfSpeech: n
-  wikidata: Q33456
 00874219-n:
   definition:
   - a mathematical operation involving numbers
@@ -47407,7 +47292,6 @@
   - value judgment
   - value judgement
   partOfSpeech: n
-  wikidata: Q1969661
 00877740-n:
   definition:
   - judgments about another person's morality
@@ -47449,7 +47333,6 @@
   members:
   - auscultation
   partOfSpeech: n
-  wikidata: Q779054
 00878415-n:
   definition:
   - activity intended to achieve a particular sensory result
@@ -48540,7 +48423,6 @@
   members:
   - fire drill
   partOfSpeech: n
-  wikidata: Q3243704
 00896833-n:
   definition:
   - (military) a prescribed drill in handling a rifle
@@ -49110,7 +48992,6 @@
   members:
   - angiography
   partOfSpeech: n
-  wikidata: Q468414
 00907226-n:
   definition:
   - roentgenographic examination of lymph nodes and lymph vessels after injection
@@ -49180,7 +49061,6 @@
   members:
   - myelography
   partOfSpeech: n
-  wikidata: Q2122468
 00908362-n:
   definition:
   - roentgenography of the kidney and ureters (usually after injection with a radiopaque
@@ -49723,7 +49603,6 @@
   members:
   - horse breeding
   partOfSpeech: n
-  wikidata: Q1265288
 00917553-n:
   definition:
   - (agriculture) production of food by preparing the land to grow crops (especially
@@ -50261,7 +50140,6 @@
   members:
   - forging
   partOfSpeech: n
-  wikidata: Q193057
 00927546-n:
   definition:
   - the activity of making things out of metal in a skillful manner
@@ -50585,7 +50463,6 @@
   - novelization
   - novelisation
   partOfSpeech: n
-  wikidata: Q2421000
 00933423-n:
   definition:
   - the act of putting something in writing
@@ -50863,7 +50740,6 @@
   members:
   - printmaking
   partOfSpeech: n
-  wikidata: Q271588
 00939472-n:
   definition:
   - creating figures or designs in three dimensions
@@ -51315,7 +51191,6 @@
   members:
   - venipuncture
   partOfSpeech: n
-  wikidata: Q886549
 00947021-n:
   definition:
   - the activity of selecting the scenes to be shown and putting them together to
@@ -51327,7 +51202,6 @@
   - film editing
   - cutting
   partOfSpeech: n
-  wikidata: Q237893
 00947217-n:
   definition:
   - the activity of looking thoroughly in order to find something or someone
@@ -51518,7 +51392,6 @@
   members:
   - land development
   partOfSpeech: n
-  wikidata: Q6484056
 00950553-n:
   definition:
   - making an area of water more useful
@@ -51714,7 +51587,6 @@
   - commercialization
   - commercialisation
   partOfSpeech: n
-  wikidata: Q5152592
 00954325-n:
   definition:
   - an estimation of the value of a business
@@ -51864,7 +51736,6 @@
   - operation
   - military operation
   partOfSpeech: n
-  wikidata: Q645883
 00957676-n:
   definition:
   - a military operation carried out cooperatively by two or more allied nations or
@@ -51934,7 +51805,6 @@
   members:
   - pitched battle
   partOfSpeech: n
-  wikidata: Q743488
 00960588-n:
   definition:
   - a pitched battle between naval fleets
@@ -52122,7 +51992,6 @@
   - chemical defense
   - chemical defence
   partOfSpeech: n
-  wikidata: Q5090452
 00964073-n:
   definition:
   - laying explosive mines in concealed places to destroy enemy personnel and equipment
@@ -52233,7 +52102,6 @@
   - Peasant's Revolt
   - Great Revolt
   partOfSpeech: n
-  wikidata: Q498871
 00966454-n:
   definition:
   - an engagement fought between two military forces
@@ -52445,7 +52313,6 @@
   - biologic attack
   - bioattack
   partOfSpeech: n
-  wikidata: Q8242560
 00970097-n:
   definition:
   - defense against biological warfare
@@ -52471,7 +52338,6 @@
   - campaign
   - military campaign
   partOfSpeech: n
-  wikidata: Q831663
 00970583-n:
   definition:
   - a military campaign designed to achieve a specific objective in a foreign country
@@ -52504,7 +52370,6 @@
   members:
   - First Crusade
   partOfSpeech: n
-  wikidata: Q51649
 00971329-n:
   definition:
   - a Crusade from 1145 to 1147 that failed because of internal disagreements among
@@ -52515,7 +52380,6 @@
   members:
   - Second Crusade
   partOfSpeech: n
-  wikidata: Q51654
 00971525-n:
   definition:
   - a Crusade from 1189 to 1192 led by Richard I and the king of France that failed
@@ -52527,7 +52391,6 @@
   members:
   - Third Crusade
   partOfSpeech: n
-  wikidata: Q51655
 00971788-n:
   definition:
   - a Crusade from 1202 to 1204 that was diverted into a battle for Constantinople
@@ -53283,7 +53146,6 @@
   members:
   - clandestine operation
   partOfSpeech: n
-  wikidata: Q3354903
 00985897-n:
   definition:
   - a clandestine rescue operation to bring a defector or refugee or an operative
@@ -53325,7 +53187,6 @@
   members:
   - black operation
   partOfSpeech: n
-  wikidata: Q3394581
 00986576-n:
   definition:
   - the collection of intelligence openly without concealment
@@ -53439,7 +53300,6 @@
   members:
   - counterintelligence
   partOfSpeech: n
-  wikidata: Q501700
 00988749-n:
   definition:
   - the aspect of counterintelligence designed to detect and prevent subversive activities
@@ -53521,7 +53381,6 @@
   - volley
   - burst
   partOfSpeech: n
-  wikidata: Q5510053
 00990642-n:
   definition:
   - fire delivered on a specific target in response to a request from the supported
@@ -54198,7 +54057,6 @@
   members:
   - equal temperament
   partOfSpeech: n
-  wikidata: Q723441
 01002785-n:
   definition:
   - the adjustment of a radio receiver or other circuit to a required frequency
@@ -54650,7 +54508,6 @@
   - Thematic Apperception Test
   - TAT
   partOfSpeech: n
-  wikidata: Q29320
 01010213-n:
   definition:
   - one of a battery of related tests
@@ -54975,7 +54832,6 @@
   - assembling
   - aggregation
   partOfSpeech: n
-  wikidata: Q208165
 01016432-n:
   definition:
   - the act of collecting in a mass; the act of agglomerating
@@ -55280,7 +55136,6 @@
   members:
   - copying
   partOfSpeech: n
-  wikidata: Q1156791
 01021645-n:
   definition:
   - the act of copying or making a duplicate (or duplicates) of something
@@ -55974,7 +55829,6 @@
   - transvestitism
   - cross dressing
   partOfSpeech: n
-  wikidata: Q486680
 01034072-n:
   definition:
   - the act of public worship following prescribed rules
@@ -56448,7 +56302,6 @@
   members:
   - sanctification
   partOfSpeech: n
-  wikidata: Q956444
 01042160-n:
   definition:
   - (Roman Catholic Church) an act of the Pope who declares that a deceased person
@@ -56634,7 +56487,6 @@
   members:
   - bhakti
   partOfSpeech: n
-  wikidata: Q507417
 01045221-n:
   definition:
   - a Roman Catholic devotion consisting of prayers on nine consecutive days
@@ -56845,7 +56697,6 @@
   - astrolatry
   - worship of heavenly bodies
   partOfSpeech: n
-  wikidata: Q3627640
 01047848-n:
   definition:
   - the worship of the cosmos
@@ -58811,7 +58662,6 @@
   members:
   - tax avoidance
   partOfSpeech: n
-  wikidata: Q329303
 01081986-n:
   definition:
   - (law) the disqualification of a judge or jury by reason of prejudice or conflict
@@ -59752,7 +59602,6 @@
   members:
   - corporate finance
   partOfSpeech: n
-  wikidata: Q1134763
 01101014-n:
   definition:
   - the act of financing
@@ -60303,7 +60152,6 @@
   - conveyancing
   - conveying
   partOfSpeech: n
-  wikidata: Q759815
 01110546-n:
   definition:
   - act of transferring a title or right or claim to another
@@ -60523,7 +60371,6 @@
   members:
   - smuggling
   partOfSpeech: n
-  wikidata: Q184840
 01114194-n:
   definition:
   - the smuggling of guns and ammunition into a country secretly and illegally
@@ -61309,7 +61156,6 @@
   - legislating
   - lawmaking
   partOfSpeech: n
-  wikidata: Q1725430
 01128280-n:
   definition:
   - legislation that makes something illegal
@@ -61445,7 +61291,6 @@
   members:
   - law enforcement
   partOfSpeech: n
-  wikidata: Q44554
 01130587-n:
   definition:
   - the actions of a vigilance committee in trying to enforce the laws
@@ -61563,7 +61408,6 @@
   members:
   - moral obligation
   partOfSpeech: n
-  wikidata: Q31011
 01133056-n:
   definition:
   - the obligation of those of high rank to be honorable and generous
@@ -61672,7 +61516,6 @@
   members:
   - foster care
   partOfSpeech: n
-  wikidata: Q1430789
 01134469-n:
   definition:
   - more attention and consideration than is normally bestowed by prudent persons
@@ -62533,7 +62376,6 @@
   members:
   - false imprisonment
   partOfSpeech: n
-  wikidata: Q694752
 01149860-n:
   definition:
   - holding by the police
@@ -63131,7 +62973,6 @@
   - draft
   - selective service
   partOfSpeech: n
-  wikidata: Q580750
 01160551-n:
   definition:
   - the act of drafting into military service
@@ -64220,7 +64061,6 @@
   members:
   - single combat
   partOfSpeech: n
-  wikidata: Q1046469
 01179421-n:
   definition:
   - deliberate interference
@@ -64388,7 +64228,6 @@
   - disobedience
   - noncompliance
   partOfSpeech: n
-  wikidata: Q4047355
 01182417-n:
   definition:
   - a group's refusal to obey a law because they believe the law is immoral (as in
@@ -65168,7 +65007,6 @@
   members:
   - acquittal
   partOfSpeech: n
-  wikidata: Q1454723
 01196511-n:
   definition:
   - conviction for murder
@@ -65348,7 +65186,6 @@
   members:
   - Scopes trial
   partOfSpeech: n
-  wikidata: Q642342
 01199609-n:
   definition:
   - a trial held for show; the guilt of the accused person has been decided in advance
@@ -65393,7 +65230,6 @@
   members:
   - judicial review
   partOfSpeech: n
-  wikidata: Q898871
 01200418-n:
   definition:
   - an answer indicating why a suit should be dismissed
@@ -65653,7 +65489,6 @@
   - integrating
   - desegregation
   partOfSpeech: n
-  wikidata: Q48532
 01205155-n:
   definition:
   - advocacy of a policy of strict separation of church and state
@@ -66124,7 +65959,6 @@
   - daycare
   - day care
   partOfSpeech: n
-  wikidata: Q364005
 01213037-n:
   definition:
   - a service that provides information and assistance to the users of a computer
@@ -66887,7 +66721,6 @@
   members:
   - bohemianism
   partOfSpeech: n
-  wikidata: Q207175
 01226255-n:
   definition:
   - conduct that is unfair or unethical or unsportsmanlike
@@ -67369,7 +67202,6 @@
   members:
   - service call
   partOfSpeech: n
-  wikidata: Q7455665
 01234000-n:
   definition:
   - a secret rendezvous (especially between lovers)
@@ -68041,7 +67873,6 @@
   - nonviolent resistance
   - nonviolence
   partOfSpeech: n
-  wikidata: Q754479
 01245509-n:
   definition:
   - a voluntary fast undertaken as a means of protest
@@ -68285,7 +68116,6 @@
   members:
   - terrorist attack
   partOfSpeech: n
-  wikidata: Q5710433
 01249473-n:
   definition:
   - the act of concealing yourself and lying in wait to attack by surprise
@@ -68403,7 +68233,6 @@
   - matriculation
   - matric
   partOfSpeech: n
-  wikidata: Q1193162
 01251299-n:
   definition:
   - the act of marrying again
@@ -68491,7 +68320,6 @@
   - hooliganism
   - malicious mischief
   partOfSpeech: n
-  wikidata: Q219954
 01252578-n:
   definition:
   - the act of ceding back
@@ -69709,7 +69537,6 @@
   - Battle of the Alamo
   - Alamo
   partOfSpeech: n
-  wikidata: Q235344
 01272126-n:
   definition:
   - a siege in which Federal troops under Sherman cut off the railroads supplying
@@ -69737,7 +69564,6 @@
   - Austerlitz
   - battle of Austerlitz
   partOfSpeech: n
-  wikidata: Q134114
 01272646-n:
   definition:
   - a battle in which the Scots under Robert the Bruce defeated the English and assured
@@ -69822,7 +69648,6 @@
   - Chateau-Thierry
   - Marne River
   partOfSpeech: n
-  wikidata: Q876417
 01274162-n:
   definition:
   - a naval battle in World War II; Allied land-based bombers destroyed a Japanese
@@ -69849,7 +69674,6 @@
   - Battle of Blenheim
   - Blenheim
   partOfSpeech: n
-  wikidata: Q154635
 01274627-n:
   definition:
   - Napoleon defeated the Russians in 1812 in a pitched battle at a village in western
@@ -69943,7 +69767,6 @@
   - Bull Run
   - Battle of Bull Run
   partOfSpeech: n
-  wikidata: Q221469
 01276228-n:
   definition:
   - the first important battle of the American War of Independence (1775) which was
@@ -69957,7 +69780,6 @@
   - Bunker Hill
   - battle of Bunker Hill
   partOfSpeech: n
-  wikidata: Q334029
 01276493-n:
   definition:
   - ancient city in southeastern Italy where Hannibal defeated the Romans in 216 BC
@@ -69994,7 +69816,6 @@
   - Battle of the Caudine Forks
   - Caudine Forks
   partOfSpeech: n
-  wikidata: Q1357977
 01277024-n:
   definition:
   - a battle in which Philip II of Macedon defeated the Athenians and Thebans (338
@@ -70035,7 +69856,6 @@
   - Battle of Chancellorsville
   - Chancellorsville
   partOfSpeech: n
-  wikidata: Q745979
 01277635-n:
   definition:
   - a pitched battle in the Mexican War that resulted in a major victory for American
@@ -70064,7 +69884,6 @@
   - Chattanooga
   - battle of Chattanooga
   partOfSpeech: n
-  wikidata: Q2443807
 01278190-n:
   definition:
   - a Confederate victory in the American Civil War (1863); Confederate forces under
@@ -70145,7 +69964,6 @@
   - Cunaxa
   - battle of Cunaxa
   partOfSpeech: n
-  wikidata: Q431205
 01279558-n:
   definition:
   - the battle that ended the second Macedonian War (197 BC); the Romans defeated
@@ -70173,7 +69991,6 @@
   - Dardanelles
   - Dardanelles campaign
   partOfSpeech: n
-  wikidata: Q164983
 01280033-n:
   definition:
   - the French military base fell after a siege by Vietnam troops that lasted 56 days;
@@ -70214,7 +70031,6 @@
   - Dunkirk
   - Dunkerque
   partOfSpeech: n
-  wikidata: Q911972
 01280725-n:
   definition:
   - a pitched battle in World War II (1942) resulting in a decisive Allied victory
@@ -70283,7 +70099,6 @@
   - Fort Ticonderoga
   - Ticonderoga
   partOfSpeech: n
-  wikidata: Q1546173
 01281835-n:
   definition:
   - an important battle in the American Civil War (1862); the Union Army under A.
@@ -70324,7 +70139,6 @@
   - Granicus
   - Battle of Granicus River
   partOfSpeech: n
-  wikidata: Q192938
 01282548-n:
   definition:
   - a battle in World War II in the Pacific (1942-1943); the island was occupied by
@@ -70352,7 +70166,6 @@
   - Battle of Hampton Roads
   - Hampton Roads
   partOfSpeech: n
-  wikidata: Q868481
 01283007-n:
   definition:
   - the decisive battle in which William the Conqueror (duke of Normandy) defeated
@@ -70378,7 +70191,6 @@
   - Hohenlinden
   - battle of Hohenlinden
   partOfSpeech: n
-  wikidata: Q705813
 01283483-n:
   definition:
   - a battle in the Korean War (1950); United States forces landed at Inchon
@@ -70391,7 +70203,6 @@
   - Battle of Inchon
   - Inchon
   partOfSpeech: n
-  wikidata: Q483039
 01283647-n:
   definition:
   - discontent with British administration in India led to numerous mutinies in 1857
@@ -70407,7 +70218,6 @@
   - Indian Mutiny
   - Sepoy Mutiny
   partOfSpeech: n
-  wikidata: Q129864
 01283920-n:
   definition:
   - a battle between the successors of Alexander the Great (301 BC); Lysimachus and
@@ -70421,7 +70231,6 @@
   - Ipsus
   - battle of Ipsus
   partOfSpeech: n
-  wikidata: Q319124
 01284131-n:
   definition:
   - a battle (333 BC) in which Alexander the Great defeated the Persians under Darius
@@ -70613,7 +70422,6 @@
   - Battle of the Little Bighorn
   - Custer's Last Stand
   partOfSpeech: n
-  wikidata: Q205422
 01287421-n:
   definition:
   - the British residents of Lucknow were besieged by Indian insurgents during the
@@ -70640,7 +70448,6 @@
   - Lule Burgas
   - battle of Lule Burgas
   partOfSpeech: n
-  wikidata: Q1445532
 01287798-n:
   definition:
   - a battle in the Thirty Years' War (1632); Swedes under Gustavus Adolphus defeated
@@ -70767,7 +70574,6 @@
   - Battle of the Metaurus
   - Metaurus River
   partOfSpeech: n
-  wikidata: Q848056
 01289924-n:
   definition:
   - an American operation in World War I (1918); American troops under Pershing drove
@@ -70815,7 +70621,6 @@
   - Minden
   - battle of Minden
   partOfSpeech: n
-  wikidata: Q683044
 01290765-n:
   definition:
   - a pitched battle in New Jersey during the American Revolution (1778) that ended
@@ -70886,7 +70691,6 @@
   - Omdurman
   - battle of Omdurman
   partOfSpeech: n
-  wikidata: Q1137302
 01292124-n:
   definition:
   - an operation as part of the Gulf War in 1991, where the United States and its
@@ -71195,7 +70999,6 @@
   - Sempach
   - battle of Sempach
   partOfSpeech: n
-  wikidata: Q661759
 01296993-n:
   definition:
   - the second great battle of the American Civil War (1862); the battle ended with
@@ -71210,7 +71013,6 @@
   - battle of Shiloh
   - battle of Pittsburgh Landing
   partOfSpeech: n
-  wikidata: Q943277
 01297282-n:
   definition:
   - a battle in World War I (May 1918); the Germans tried to attack before the American
@@ -71329,7 +71131,6 @@
   - Tannenberg
   - battle of Tannenberg
   partOfSpeech: n
-  wikidata: Q153858
 01299188-n:
   definition:
   - battles in World War II in the Pacific (November 1943); United States Marines
@@ -71345,7 +71146,6 @@
   - Makin
   - Tarawa-Makin
   partOfSpeech: n
-  wikidata: Q250309
 01299437-n:
   definition:
   - a battle in France in 687 among the descendants of Clovis
@@ -71358,7 +71158,6 @@
   - Tertry
   - battle of Tertry
   partOfSpeech: n
-  wikidata: Q784296
 01299586-n:
   definition:
   - a battle in 9 AD in which the Germans under Arminius annihilated three Roman Legions
@@ -71438,7 +71237,6 @@
   - Battle of Tsushima
   - Tsushima
   partOfSpeech: n
-  wikidata: Q208127
 01300862-n:
   definition:
   - the French defeated the Austrian and Prussian troops in 1792 (with a famous cannonade
@@ -71452,7 +71250,6 @@
   - Valmy
   - battle of Valmy
   partOfSpeech: n
-  wikidata: Q4411
 01301064-n:
   definition:
   - a battle in World War I (1916); in some of the bloodiest fighting in World War
@@ -71505,7 +71302,6 @@
   - Battle of Wake
   - Battle of Wake Island
   partOfSpeech: n
-  wikidata: Q1141380
 01301967-n:
   definition:
   - the battle on 18 June 1815 in which Prussian and British forces under Blucher
@@ -71534,7 +71330,6 @@
   mero_part:
   - 01298409-n
   partOfSpeech: n
-  wikidata: Q739644
 01302485-n:
   definition:
   - a battle in the Korean War (November 1950); when UN troops advanced north to the
@@ -71605,7 +71400,6 @@
   - battle of Ypres
   - third battle of Ypres
   partOfSpeech: n
-  wikidata: Q426227
 01303914-n:
   definition:
   - the battle in 202 BC in which Scipio decisively defeated Hannibal at the end of
@@ -71666,7 +71460,6 @@
   - 01296620-n
   - 01302733-n
   partOfSpeech: n
-  wikidata: Q40949
 01304940-n:
   definition:
   - tension between Arabs and Israeli erupted into a brief war in June 1967; Israel
@@ -71709,7 +71502,6 @@
   mero_part:
   - 01287594-n
   partOfSpeech: n
-  wikidata: Q165725
 01305743-n:
   definition:
   - 'either of two wars: the first when the Boers fought England in order to regain
@@ -71805,7 +71597,6 @@
   members:
   - French and Indian War
   partOfSpeech: n
-  wikidata: Q154697
 01307498-n:
   definition:
   - the revolution in France against the Bourbons; 1789-1799
@@ -71828,7 +71619,6 @@
   mero_part:
   - 01279127-n
   partOfSpeech: n
-  wikidata: Q12551
 01307801-n:
   definition:
   - a dispute over control of the waterway between Iraq and Iran broke out into open
@@ -72060,7 +71850,6 @@
   - 01287798-n
   - 01295228-n
   partOfSpeech: n
-  wikidata: Q2487
 01311886-n:
   definition:
   - (Greek mythology) a great war fought between Greece and Troy; the Greeks sailed
@@ -72103,7 +71892,6 @@
   - Greek War of Independence
   - War of Greek Independence
   partOfSpeech: n
-  wikidata: Q182062
 01312838-n:
   definition:
   - Prussia and Austria fought over Silesia and most of the rest of Europe took sides;
@@ -72142,7 +71930,6 @@
   mero_part:
   - 01274408-n
   partOfSpeech: n
-  wikidata: Q150701
 01313536-n:
   definition:
   - struggle for the English throne (1455-1485) between the house of York (white rose)
@@ -72197,7 +71984,6 @@
   - 01303273-n
   - 01303571-n
   partOfSpeech: n
-  wikidata: Q361
 01314587-n:
   definition:
   - a war between the Allies (Australia, Belgium, Bolivia, Brazil, Canada, China,
@@ -72250,11 +72036,10 @@
     order to slow the spread of infectious diseases. Large-scale measures include
     canceling group events or closing schools, workplaces and public spaces.
   example:
-  - To practice social or physical distancing, stay at least 6 feet (about 2 arm
-    lengths) from other people who are not from your household in both indoor and
-    outdoor spaces.
-  - Physical distancing can prevent the virus from transferring to one another;
-    it doesn't mean that socially we have to disconnect from our loved ones.
+  - To practice social or physical distancing, stay at least 6 feet (about 2 arm lengths)
+    from other people who are not from your household in both indoor and outdoor spaces.
+  - Physical distancing can prevent the virus from transferring to one another; it
+    doesn't mean that socially we have to disconnect from our loved ones.
   hypernym:
   - 01081219-n
   members:
@@ -72392,7 +72177,6 @@
   - waterboarding
   partOfSpeech: n
   source: Colloquial WordNet
-  wikidata: Q2552748
 90002791-n:
   definition:
   - The hobby of playing or collecting older video games and computer games.
@@ -72545,7 +72329,6 @@
   - paywall
   partOfSpeech: n
   source: Colloquial WordNet
-  wikidata: Q910845
 90016241-n:
   definition:
   - To play a game or sport in a manner that is effective but requires little skill

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -17232,7 +17232,7 @@
   partOfSpeech: n
 08269523-n:
   definition:
-  - a group of people gathered together for pleasure
+  - a gathering of people for pleasure
   example:
   - she joined the party after dinner
   hypernym:

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -713,7 +713,6 @@
   members:
   - social group
   partOfSpeech: n
-  wikidata: Q874405
 07968050-n:
   definition:
   - several things grouped together or considered as a whole
@@ -1704,7 +1703,6 @@
   - pressure group
   - third house
   partOfSpeech: n
-  wikidata: Q431603
 07985639-n:
   definition:
   - groups that seek to control a social system or activity from which they derive
@@ -1885,7 +1883,6 @@
   - feudalism
   - feudal system
   partOfSpeech: n
-  wikidata: Q37739
 07989121-n:
   definition:
   - a form of social organization in which a male is the family head and title is
@@ -1991,7 +1988,6 @@
   - social class
   - socio-economic class
   partOfSpeech: n
-  wikidata: Q187588
 07991213-n:
   definition:
   - people in the same age range
@@ -2217,7 +2213,6 @@
   members:
   - Greek mythology
   partOfSpeech: n
-  wikidata: Q34726
 07999593-n:
   definition:
   - the mythology of the ancient Romans
@@ -2227,7 +2222,6 @@
   members:
   - Roman mythology
   partOfSpeech: n
-  wikidata: Q122173
 08000298-n:
   definition:
   - the mythology of Scandinavia (shared in part by Britain and Germany) until the
@@ -2240,7 +2234,6 @@
   members:
   - Norse mythology
   partOfSpeech: n
-  wikidata: Q128285
 08001247-n:
   definition:
   - a collection of 13 ancient papyrus codices translated from Greek into Coptic that
@@ -2253,7 +2246,6 @@
   - Nag Hammadi
   - Nag Hammadi Library
   partOfSpeech: n
-  wikidata: Q222999
 08001577-n:
   definition:
   - a set containing a single member
@@ -3139,7 +3131,6 @@
   members:
   - violin family
   partOfSpeech: n
-  wikidata: Q1365097
 08014892-n:
   definition:
   - (music) the family of woodwind instruments
@@ -3326,7 +3317,6 @@
   members:
   - null set
   partOfSpeech: n
-  wikidata: Q1201815
 08017883-n:
   definition:
   - a set of complex numbers that has a highly convoluted fractal boundary when plotted;
@@ -3353,7 +3343,6 @@
   - mathematical space
   - topological space
   partOfSpeech: n
-  wikidata: Q179899
 08018457-n:
   definition:
   - a company that manages tv or radio stations
@@ -3567,7 +3556,6 @@
   members:
   - Euclidean space
   partOfSpeech: n
-  wikidata: Q17295
 08021565-n:
   definition:
   - a metric space that is linear and complete and (usually) infinite-dimensional
@@ -3971,7 +3959,6 @@
   - al-Gama'a al-Islamiyya
   - Islamic Group
   partOfSpeech: n
-  wikidata: Q285185
 08029116-n:
   definition:
   - a fundamentalist Islamic group in Somalia who initially did fundraising for al-Qaeda;
@@ -4249,7 +4236,6 @@
   - Asbat al-Ansar
   - Band of Partisans
   partOfSpeech: n
-  wikidata: Q721306
 08034367-n:
   definition:
   - a terrorist organization whose goal is to take over Japan and then the world;
@@ -4268,7 +4254,6 @@
   - Aum
   - Supreme Truth
   partOfSpeech: n
-  wikidata: Q217408
 08034727-n:
   definition:
   - a radical left-wing revolutionary terrorist group active in Germany from 1968
@@ -4353,7 +4338,6 @@
   - CIRA
   - Continuity Army Council
   partOfSpeech: n
-  wikidata: Q1128945
 08036276-n:
   definition:
   - a Marxist-Leninist group that believes Palestinian goals can only be achieved
@@ -4373,7 +4357,6 @@
   - Popular Democratic Front for the Liberation of Palestine
   - PDFLP
   partOfSpeech: n
-  wikidata: Q818618
 08036666-n:
   definition:
   - a group of Uighur Muslims fighting Chinese control of Xinjiang; declared by China
@@ -4524,7 +4507,6 @@
   - Harakat ul-Jihad-I-Islami
   - HUJI
   partOfSpeech: n
-  wikidata: Q1422667
 08039725-n:
   definition:
   - an Islamic fundamentalist group in Pakistan that fought the Soviet Union in Afghanistan
@@ -4570,7 +4552,6 @@
   - Revolutionary Justice Organization
   - Organization of the Oppressed on Earth
   partOfSpeech: n
-  wikidata: Q1621312
 08040596-n:
   definition:
   - the most popular and feared Islamic extremist group in central Asia; advocates
@@ -4617,7 +4598,6 @@
   - People's Republican Army
   - Catholic Reaction Force
   partOfSpeech: n
-  wikidata: Q1146230
 08041485-n:
   definition:
   - a militant organization of Irish nationalists who used terrorism and guerilla
@@ -4711,7 +4691,6 @@
   - JEM
   - Army of Muhammad
   partOfSpeech: n
-  wikidata: Q286627
 08043292-n:
   definition:
   - an Islamic terrorist group organized in the 1980s; seeks to purify Islam through
@@ -4748,7 +4727,6 @@
   - JRA
   - Anti-Imperialist International Brigade
   partOfSpeech: n
-  wikidata: Q333954
 08044067-n:
   definition:
   - an indigenous Islamic terrorist group in Azerbaijan that attempted to bomb the
@@ -4863,7 +4841,6 @@
   - Party of Democratic Kampuchea
   - Communist Party of Kampuchea
   partOfSpeech: n
-  wikidata: Q191764
 08046174-n:
   definition:
   - a secret society of white Southerners in the United States; was formed in the
@@ -4986,7 +4963,6 @@
   - Army of the Pure
   - Army of the Righteous
   partOfSpeech: n
-  wikidata: Q736955
 08048139-n:
   definition:
   - a paramilitary terrorist organization of militant Muslims in Indonesia; wages
@@ -5104,7 +5080,6 @@
   - Maktab al-Khidmat
   - MAK
   partOfSpeech: n
-  wikidata: Q1411386
 08050582-n:
   definition:
   - a terrorist group formed in 1983 as the armed wing of the Chilean Communist Party
@@ -5265,7 +5240,6 @@
   mero_member:
   - 10400198-n
   partOfSpeech: n
-  wikidata: Q1345321
 08053601-n:
   definition:
   - a terrorist group of Protestants who oppose any political settlement with Irish
@@ -5364,7 +5338,6 @@
   - Popular Front for the Liberation of Palestine
   - PFLP
   partOfSpeech: n
-  wikidata: Q212884
 08055500-n:
   definition:
   - a Marxist-Leninist terrorist organization that conducted several attacks in western
@@ -5513,7 +5486,6 @@
   - Red Army Faction
   - RAF
   partOfSpeech: n
-  wikidata: Q102734
 08058236-n:
   definition:
   - a Marxist-Leninist terrorist organization that arose out of a student protest
@@ -5846,7 +5818,6 @@
   - Tammany Society
   - Tammany
   partOfSpeech: n
-  wikidata: Q432139
 08065052-n:
   definition:
   - a nongovernmental organization of Pakistani scientists that has been a supporter
@@ -6080,7 +6051,6 @@
   members:
   - federal government
   partOfSpeech: n
-  wikidata: Q1006644
 08069442-n:
   definition:
   - a temporary government moved to or formed in a foreign land by exiles who hope
@@ -6091,7 +6061,6 @@
   members:
   - government-in-exile
   partOfSpeech: n
-  wikidata: Q678116
 08069626-n:
   definition:
   - the government of a local area
@@ -6608,7 +6577,6 @@
   - consulting firm
   - consulting company
   partOfSpeech: n
-  wikidata: Q2089936
 08079459-n:
   definition:
   - a firm in the publishing business
@@ -6940,7 +6908,6 @@
   members:
   - computer industry
   partOfSpeech: n
-  wikidata: Q1067601
 08084519-n:
   definition:
   - an industry that builds housing
@@ -6962,7 +6929,6 @@
   mero_member:
   - 08019477-n
   partOfSpeech: n
-  wikidata: Q5358497
 08084787-n:
   definition:
   - 'those involved in providing entertainment: radio and television and films and
@@ -6987,7 +6953,6 @@
   - film industry
   - movie industry
   partOfSpeech: n
-  wikidata: Q1415395
 08085211-n:
   definition:
   - the film industry of India
@@ -7047,7 +7012,6 @@
   - munitions industry
   - arms industry
   partOfSpeech: n
-  wikidata: Q392933
 08085886-n:
   definition:
   - an industry that produces and delivers oil and oil products
@@ -7124,7 +7088,6 @@
   mero_member:
   - 09796453-n
   partOfSpeech: n
-  wikidata: Q2073644
 08086966-n:
   definition:
   - an unethical or overly aggressive brokerage firm
@@ -7960,7 +7923,6 @@
   - Cathars
   - Cathari
   partOfSpeech: n
-  wikidata: Q2511685
 08102274-n:
   definition:
   - a Christian Church in the Middle East that followed Nestorianism; there is still
@@ -8164,7 +8126,6 @@
   members:
   - Church of Ireland
   partOfSpeech: n
-  wikidata: Q875668
 08105758-n:
   definition:
   - an autonomous branch of the Anglican Communion in Scotland
@@ -8350,7 +8311,6 @@
   mero_member:
   - 10268074-n
   partOfSpeech: n
-  wikidata: Q35269
 08108710-n:
   definition:
   - the Protestant denomination adhering to the views of Martin Luther
@@ -9117,7 +9077,6 @@
   members:
   - superorder
   partOfSpeech: n
-  wikidata: Q5868144
 08124465-n:
   definition:
   - (biology) a taxonomic group containing one or more genera
@@ -9175,7 +9134,6 @@
   members:
   - subfamily
   partOfSpeech: n
-  wikidata: Q2455704
 08125750-n:
   definition:
   - (biology) a taxonomic category between a genus and a subfamily
@@ -9871,7 +9829,6 @@
   - corrections
   - department of corrections
   partOfSpeech: n
-  wikidata: Q5260216
 08137885-n:
   definition:
   - a department responsible for the security of the institution's property and workers
@@ -10095,7 +10052,6 @@
   - 08142402-n
   - 08142704-n
   partOfSpeech: n
-  wikidata: Q37230
 08142402-n:
   definition:
   - an agency that helps the Director of Central Intelligence coordinate counterterrorist
@@ -10203,7 +10159,6 @@
   mero_part:
   - 08144539-n
   partOfSpeech: n
-  wikidata: Q668687
 08144539-n:
   definition:
   - the primary law enforcement arm of the United States Postal Service
@@ -10643,7 +10598,6 @@
   - Federal Bureau of Investigation
   - FBI
   partOfSpeech: n
-  wikidata: Q8333
 08153484-n:
   definition:
   - a former agency in the Department of Justice that enforces laws and regulations
@@ -10657,7 +10611,6 @@
   mero_part:
   - 08153749-n
   partOfSpeech: n
-  wikidata: Q194984
 08153749-n:
   definition:
   - the mobile law enforcement arm of the Immigration and Naturalization Service that
@@ -10680,7 +10633,6 @@
   - Federal Law Enforcement Training Center
   - FLETC
   partOfSpeech: n
-  wikidata: Q1400052
 08154251-n:
   definition:
   - a law enforcement agency of the Treasury Department responsible for establishing
@@ -10807,7 +10759,6 @@
   members:
   - National Park Service
   partOfSpeech: n
-  wikidata: Q308439
 08156795-n:
   definition:
   - the federal department that collects revenue and administers federal finances;
@@ -10943,7 +10894,6 @@
   - US Marshals Service
   - Marshals
   partOfSpeech: n
-  wikidata: Q934866
 08159801-n:
   definition:
   - the agency of the Treasury Department responsible for controlling the currency
@@ -10974,7 +10924,6 @@
   members:
   - Bureau of Engraving and Printing
   partOfSpeech: n
-  wikidata: Q1010519
 08160321-n:
   definition:
   - the bureau of the Treasury Department responsible for tax collections
@@ -11312,7 +11261,6 @@
   mero_member:
   - 10798013-n
   partOfSpeech: n
-  wikidata: Q131479
 08166321-n:
   definition:
   - a Roman Catholic order founded by Saint Francis of Assisi in the 13th century
@@ -11376,7 +11324,6 @@
   mero_member:
   - 10605181-n
   partOfSpeech: n
-  wikidata: Q1370167
 08167777-n:
   definition:
   - a charismatic Protestant denomination in the United States
@@ -11602,7 +11549,6 @@
   mero_member:
   - 09915972-n
   partOfSpeech: n
-  wikidata: Q133602
 08171447-n:
   definition:
   - a dynasty of Roman Emperors from 69 to 96 including Vespasian and his sons Titus
@@ -11613,7 +11559,6 @@
   members:
   - Flavian dynasty
   partOfSpeech: n
-  wikidata: Q200565
 08171602-n:
   definition:
   - imperial dynasty that ruled China (most of the time from 206 BC to AD 220) and
@@ -11692,7 +11637,6 @@
   - 11062477-n
   - 11062686-n
   partOfSpeech: n
-  wikidata: Q105278
 08172953-n:
   definition:
   - the dynasty that ruled much of Manchuria and northeastern China from 947 to 1125
@@ -11716,7 +11660,6 @@
   mero_member:
   - 10330071-n
   partOfSpeech: n
-  wikidata: Q59488
 08173291-n:
   definition:
   - the imperial dynasty of China from 1368 to 1644
@@ -11844,7 +11787,6 @@
   - Shang
   - Shang dynasty
   partOfSpeech: n
-  wikidata: Q128938
 08175359-n:
   definition:
   - the royal family that ruled Scotland from 1371-1714 and ruled England from 1603
@@ -11952,7 +11894,6 @@
   - 11015846-n
   - 11016086-n
   partOfSpeech: n
-  wikidata: Q81589
 08176823-n:
   definition:
   - the English royal house (a branch of the Plantagenet line) that reigned from 1461
@@ -12369,7 +12310,6 @@
   members:
   - developing country
   partOfSpeech: n
-  wikidata: Q177323
 08184148-n:
   definition:
   - one of the self-governing nations in the British Commonwealth
@@ -12634,7 +12574,6 @@
   members:
   - Central Powers
   partOfSpeech: n
-  wikidata: Q152283
 08188491-n:
   definition:
   - the alliance of nations that fought the Axis in World War II and which (with subsequent
@@ -12698,7 +12637,6 @@
   - 09066665-n
   - 09187354-n
   partOfSpeech: n
-  wikidata: Q7172
 08189594-n:
   definition:
   - the nations of the European continent collectively
@@ -13043,7 +12981,6 @@
   - puppet state
   - pupet regime
   partOfSpeech: n
-  wikidata: Q208164
 08195465-n:
   definition:
   - the group of people comprising the government of a sovereign state
@@ -13533,7 +13470,6 @@
   members:
   - bank holding company
   partOfSpeech: n
-  wikidata: Q2512624
 08202561-n:
   definition:
   - a bank holding company owning several banks
@@ -13555,7 +13491,6 @@
   - public utility company
   - public-service corporation
   partOfSpeech: n
-  wikidata: Q1951366
 08202965-n:
   definition:
   - a company or agency that performs a public service; subject to government regulation
@@ -13707,7 +13642,6 @@
   - chorus
   - Greek chorus
   partOfSpeech: n
-  wikidata: Q770974
 08205165-n:
   definition:
   - a group of musicians playing or singing together
@@ -13987,7 +13921,6 @@
   mero_part:
   - 08211486-n
   partOfSpeech: n
-  wikidata: Q11218
 08210152-n:
   definition:
   - the principal agency of the United States Navy for research and development for
@@ -14044,7 +13977,6 @@
   - United States Naval Academy
   - US Naval Academy
   partOfSpeech: n
-  wikidata: Q559549
 08211206-n:
   definition:
   - the military intelligence agency that provides for the intelligence and counterintelligence
@@ -14056,7 +13988,6 @@
   - Office of Naval Intelligence
   - ONI
   partOfSpeech: n
-  wikidata: Q1967781
 08211486-n:
   definition:
   - an agency of the United States Marine Corps that provides responsive and broad
@@ -14088,7 +14019,6 @@
   - United States Air Force Academy
   - US Air Force Academy
   partOfSpeech: n
-  wikidata: Q1331280
 08212072-n:
   definition:
   - the airforce of Great Britain
@@ -14177,7 +14107,6 @@
   - 08214089-n
   - 08214326-n
   partOfSpeech: n
-  wikidata: Q11223
 08213562-n:
   definition:
   - a command that is the primary provider of air combat weapon systems to the United
@@ -14283,7 +14212,6 @@
   mero_member:
   - 10602198-n
   partOfSpeech: n
-  wikidata: Q176799
 08215965-n:
   definition:
   - the military forces of a nation
@@ -14394,7 +14322,6 @@
   - Fedayeen Saddam
   - Saddam's Martyrs
   partOfSpeech: n
-  wikidata: Q1142173
 08224784-n:
   definition:
   - a group of people having the power of effective action
@@ -14626,7 +14553,6 @@
   members:
   - Gestapo
   partOfSpeech: n
-  wikidata: Q43250
 08228845-n:
   definition:
   - special police force in Nazi Germany founded as a personal bodyguard for Adolf
@@ -14640,7 +14566,6 @@
   mero_part:
   - 08228681-n
   partOfSpeech: n
-  wikidata: Q44687
 08229067-n:
   definition:
   - Nazi militia created by Hitler in 1921 that helped him to power but was eclipsed
@@ -14695,7 +14620,6 @@
   - Women's Army Corps
   - WAC
   partOfSpeech: n
-  wikidata: Q2918601
 08229841-n:
   definition:
   - a training program to prepare college students to be commissioned officers
@@ -15011,7 +14935,6 @@
   - percussion
   - rhythm section
   partOfSpeech: n
-  wikidata: Q1456785
 08234659-n:
   definition:
   - the section of a band or orchestra that plays trumpets or cornets
@@ -15740,7 +15663,6 @@
   mero_member:
   - 10769021-n
   partOfSpeech: n
-  wikidata: Q3556413
 08246196-n:
   definition:
   - a club of people to play chess
@@ -16004,7 +15926,6 @@
   members:
   - bowling league
   partOfSpeech: n
-  wikidata: Q4951251
 08249417-n:
   definition:
   - a league of football teams
@@ -16061,7 +15982,6 @@
   - trades union
   - brotherhood
   partOfSpeech: n
-  wikidata: Q178790
 08250347-n:
   definition:
   - a labor union that admits all workers in a given industry irrespective of their
@@ -16103,7 +16023,6 @@
   - American Federation of Labor
   - AFL
   partOfSpeech: n
-  wikidata: Q464242
 08251024-n:
   definition:
   - the largest federation of North American labor unions; formed in 1955
@@ -16250,7 +16169,6 @@
   mero_member:
   - 10559173-n
   partOfSpeech: n
-  wikidata: Q109179
 08253359-n:
   definition:
   - an association of companies for some definite purpose
@@ -16314,7 +16232,6 @@
   members:
   - Cali cartel
   partOfSpeech: n
-  wikidata: Q1026717
 08254620-n:
   definition:
   - a cartel of companies or nations formed to control the production and distribution
@@ -16636,7 +16553,6 @@
   members:
   - professional association
   partOfSpeech: n
-  wikidata: Q829080
 08259720-n:
   definition:
   - an organized group of workmen
@@ -16847,7 +16763,6 @@
   mero_member:
   - 10300192-n
   partOfSpeech: n
-  wikidata: Q1458155
 08262723-n:
   definition:
   - a crime syndicate in the United States; organized in families; believed to have
@@ -17298,7 +17213,7 @@
   definition:
   - a gathering for the purpose of promoting fellowship
   hypernym:
-  - 07991473-n
+  - 01232427-n
   ili: i80498
   members:
   - social gathering
@@ -17601,7 +17516,6 @@
   - party
   - political party
   partOfSpeech: n
-  wikidata: Q7278
 08274700-n:
   definition:
   - a former political party in the United States; formed in 1936 in New York when
@@ -17733,7 +17647,6 @@
   members:
   - Free Soil Party
   partOfSpeech: n
-  wikidata: Q1346993
 08277141-n:
   definition:
   - the French moderate political party that was in power (1791-1793) during the French
@@ -17777,7 +17690,6 @@
   - Kuomintang
   - Guomindang
   partOfSpeech: n
-  wikidata: Q31113
 08277882-n:
   definition:
   - a left-of-center political party formed to represent the interest of ordinary
@@ -18174,7 +18086,6 @@
   members:
   - periodic table
   partOfSpeech: n
-  wikidata: Q10693
 08284561-n:
   definition:
   - (mathematics) a rectangular array of quantities or expressions set out by rows
@@ -18269,7 +18180,6 @@
   - identity matrix
   - unit matrix
   partOfSpeech: n
-  wikidata: Q193794
 08286317-n:
   definition:
   - a square matrix used to solve simultaneous equations
@@ -18400,7 +18310,6 @@
   - spiral galaxy
   - spiral nebula
   partOfSpeech: n
-  wikidata: Q2488
 08288577-n:
   definition:
   - a spiral galaxy in the constellation of Andromeda that is visible to the naked
@@ -19062,7 +18971,6 @@
   - dental school
   - school of dentistry
   partOfSpeech: n
-  wikidata: Q5259432
 08299030-n:
   definition:
   - a private school for girls that emphasizes training in cultural and social activities
@@ -19090,7 +18998,6 @@
   members:
   - junior college
   partOfSpeech: n
-  wikidata: Q370258
 08299463-n:
   definition:
   - a nonresidential junior college offering a curriculum fitted to the needs of the
@@ -19280,7 +19187,6 @@
   - polytechnic
   - engineering school
   partOfSpeech: n
-  wikidata: Q1663017
 08302515-n:
   definition:
   - a secondary school teaching the skilled trades
@@ -19583,7 +19489,6 @@
   - Minoan civilisation
   - Minoan culture
   partOfSpeech: n
-  wikidata: Q134178
 08307849-n:
   definition:
   - the Bronze Age civilization on the Cyclades islands in the southern Aegean Sea
@@ -19838,7 +19743,6 @@
   - 09043873-n
   - 09044635-n
   partOfSpeech: n
-  wikidata: Q7779
 08312501-n:
   definition:
   - an organization of independent states formed in 1945 to promote international
@@ -19886,7 +19790,6 @@
   members:
   - United Nations Secretariat
   partOfSpeech: n
-  wikidata: Q220563
 08313253-n:
   definition:
   - a permanent council of the United Nations; responsible for preserving world peace
@@ -20116,7 +20019,6 @@
   - International Civil Aviation Organization
   - ICAO
   partOfSpeech: n
-  wikidata: Q125761
 08318076-n:
   definition:
   - an agency of the United Nations affiliated with the World Bank
@@ -20127,7 +20029,6 @@
   - International Development Association
   - IDA
   partOfSpeech: n
-  wikidata: Q827525
 08318228-n:
   definition:
   - a United Nations agency that invests directly in companies and guarantees loans
@@ -20313,7 +20214,6 @@
   - 09035723-n
   - 09036436-n
   partOfSpeech: n
-  wikidata: Q42908
 08321674-n:
   definition:
   - the union of Greece and Cyprus (which is the goal of a group of Greek Cypriots)
@@ -20492,7 +20392,7 @@
   - next year the meeting will be in Chicago
   - the meeting elected a chairperson
   hypernym:
-  - 07991473-n
+  - 01232427-n
   ili: i80791
   members:
   - meeting
@@ -20527,7 +20427,6 @@
   members:
   - caucus
   partOfSpeech: n
-  wikidata: Q751892
 08325340-n:
   definition:
   - a confidential or secret meeting
@@ -20828,7 +20727,6 @@
   - Nicaea
   - First Council of Nicaea
   partOfSpeech: n
-  wikidata: Q133331
 08330720-n:
   definition:
   - the second ecumenical council in 381 which added wording about the Holy Spirit
@@ -20862,7 +20760,6 @@
   - Chalcedon
   - Council of Chalcedon
   partOfSpeech: n
-  wikidata: Q170531
 08331257-n:
   definition:
   - the fifth ecumenical council in 553 which held Origen's writings to be heretic
@@ -20884,7 +20781,6 @@
   - Constantinople
   - Third Council of Constantinople
   partOfSpeech: n
-  wikidata: Q208037
 08331645-n:
   definition:
   - the seventh ecumenical council in 787 which refuted iconoclasm and regulated the
@@ -21068,7 +20964,6 @@
   - Second Vatican Council
   - Vatican II
   partOfSpeech: n
-  wikidata: Q169789
 08335353-n:
   definition:
   - the legislative assembly composed of delegates from the rebel colonies who met
@@ -21457,7 +21352,6 @@
   members:
   - election commission
   partOfSpeech: n
-  wikidata: Q935741
 08342167-n:
   definition:
   - a commission delegated to ensure opportunities for the expression of opposing
@@ -21752,7 +21646,6 @@
   - appeals court
   - court of appeals
   partOfSpeech: n
-  wikidata: Q4959031
 08347225-n:
   definition:
   - one of the twelve federal United States courts of appeals that cover a group of
@@ -22110,7 +22003,6 @@
   - state supreme court
   - high court
   partOfSpeech: n
-  wikidata: Q7603882
 08353282-n:
   definition:
   - a court that has power to prosecute for traffic offenses
@@ -22133,7 +22025,6 @@
   members:
   - trial court
   partOfSpeech: n
-  wikidata: Q3125101
 08353554-n:
   definition:
   - a collection of works (plays, songs, operas, ballets) that an artist or company
@@ -22189,7 +22080,6 @@
   - office
   - authority
   partOfSpeech: n
-  wikidata: Q327333
 08355774-n:
   definition:
   - an agency of the United States government that is created by an act of Congress
@@ -22290,7 +22180,6 @@
   - Defense Intelligence Agency
   - DIA
   partOfSpeech: n
-  wikidata: Q612276
 08358257-n:
   definition:
   - a logistics combat support agency in the Department of Defense; provides worldwide
@@ -22325,7 +22214,6 @@
   - Defense Technical Information Center
   - DTIC
   partOfSpeech: n
-  wikidata: Q5251426
 08358966-n:
   definition:
   - an intelligence agency outside the United States
@@ -22348,7 +22236,6 @@
   - Canadian Security Intelligence Service
   - CSIS
   partOfSpeech: n
-  wikidata: Q1032405
 08359597-n:
   definition:
   - the United Kingdom's central unit for the tasking and coordination and funding
@@ -22584,7 +22471,6 @@
   - MI
   - Military Intelligence Section 6
   partOfSpeech: n
-  wikidata: Q184560
 08363832-n:
   definition:
   - an agency of the Canadian government that oversees the activities of the Criminal
@@ -22668,7 +22554,6 @@
   - Secret Service
   - SS
   partOfSpeech: n
-  wikidata: Q503224
 08365742-n:
   definition:
   - an agency responsible for insuring obedience to the laws
@@ -22791,7 +22676,6 @@
   mero_part:
   - 08368307-n
   partOfSpeech: n
-  wikidata: Q786713
 08368307-n:
   definition:
   - the investigative arm of the Federal Trade Commission
@@ -22865,7 +22749,6 @@
   - office
   - office staff
   partOfSpeech: n
-  wikidata: Q1021663
 08369400-n:
   definition:
   - a group of associated research workers in a university or library or laboratory
@@ -22934,7 +22817,6 @@
   - regulatory agency
   - regulatory authority
   partOfSpeech: n
-  wikidata: Q1639780
 08370490-n:
   definition:
   - an independent federal agency that administers compulsory military service
@@ -23073,7 +22955,6 @@
   members:
   - travel agency
   partOfSpeech: n
-  wikidata: Q217107
 08372718-n:
   definition:
   - the executive and legislative and judicial branches of the federal government
@@ -23236,7 +23117,7 @@
   definition:
   - a large gathering of people intended to arouse enthusiasm
   hypernym:
-  - 07991473-n
+  - 01232427-n
   ili: i81033
   members:
   - rally
@@ -23475,7 +23356,6 @@
   - mobocracy
   - ochlocracy
   partOfSpeech: n
-  wikidata: Q191031
 08379382-n:
   definition:
   - a political system governed by a few people
@@ -23489,7 +23369,6 @@
   members:
   - oligarchy
   partOfSpeech: n
-  wikidata: Q79751
 08379702-n:
   definition:
   - a political system governed by the wealthy people
@@ -23621,7 +23500,6 @@
   - private enterprise
   - laissez-faire economy
   partOfSpeech: n
-  wikidata: Q179522
 08382149-n:
   definition:
   - an economic system that combines private and state enterprises
@@ -23631,7 +23509,6 @@
   members:
   - mixed economy
   partOfSpeech: n
-  wikidata: Q191675
 08382271-n:
   definition:
   - an economy that is not a market economy
@@ -23726,7 +23603,6 @@
   - 07983333-n
   - 08381475-n
   partOfSpeech: n
-  wikidata: Q273005
 08384027-n:
   definition:
   - a non-market economy in which government intervention is important in allocating
@@ -24391,7 +24267,6 @@
   members:
   - racial segregation
   partOfSpeech: n
-  wikidata: Q59816
 08396186-n:
   definition:
   - racial segregation enforced primarily in public transportation and hotels and
@@ -24475,7 +24350,6 @@
   - directorate
   - board of directors
   partOfSpeech: n
-  wikidata: Q188628
 08397706-n:
   definition:
   - a board of directors a portion of whose members are elected each year instead
@@ -24829,7 +24703,6 @@
   - upper class
   - upper crust
   partOfSpeech: n
-  wikidata: Q1155605
 08403286-n:
   definition:
   - a group or class of persons enjoying superior intellectual or social or economic
@@ -25278,7 +25151,6 @@
   members:
   - Union Army
   partOfSpeech: n
-  wikidata: Q1752901
 08411614-n:
   definition:
   - the southern army during the American Civil War
@@ -25346,7 +25218,6 @@
   - United States Military Academy
   - US Military Academy
   partOfSpeech: n
-  wikidata: Q9219
 08412639-n:
   definition:
   - an agency of the United States Army responsible for providing timely and relevant
@@ -25384,7 +25255,6 @@
   - Defense Information Systems Agency
   - DISA
   partOfSpeech: n
-  wikidata: Q5251388
 08413494-n:
   definition:
   - a combat support agency that provides geographic intelligence in support of national
@@ -25396,7 +25266,6 @@
   - National Geospatial-Intelligence Agency
   - NGA
   partOfSpeech: n
-  wikidata: Q1296491
 08413717-n:
   definition:
   - an agency in the Department of Defense that is a national center for research
@@ -25421,7 +25290,6 @@
   - Army National Guard
   - ARNG
   partOfSpeech: n
-  wikidata: Q689764
 08414212-n:
   definition:
   - soldiers collectively
@@ -25804,7 +25672,6 @@
   mero_member:
   - 09840488-n
   partOfSpeech: n
-  wikidata: Q213283
 08419785-n:
   definition:
   - an ambassador and his entourage collectively
@@ -26148,7 +26015,6 @@
   members:
   - art exhibition
   partOfSpeech: n
-  wikidata: Q667276
 08424926-n:
   definition:
   - an exhibition of a representative selection of an artist's life work
@@ -26198,7 +26064,7 @@
   - trade fair
   - book fair
   hypernym:
-  - 07991473-n
+  - 01232427-n
   ili: i81293
   members:
   - fair
@@ -26511,7 +26377,6 @@
   - school board
   - board of education
   partOfSpeech: n
-  wikidata: Q7432149
 08430486-n:
   definition:
   - a board of officials who divide an area into zones that are subject to different
@@ -26897,7 +26762,6 @@
   - merchant bank
   - acquirer
   partOfSpeech: n
-  wikidata: Q1921438
 08436311-n:
   definition:
   - the financial institution that dispenses cash in automated teller machines and
@@ -27070,7 +26934,6 @@
   members:
   - building society
   partOfSpeech: n
-  wikidata: Q449067
 08440014-n:
   definition:
   - a thrift institution in the northeastern United States; since deregulation in
@@ -28434,7 +28297,6 @@
   members:
   - tax law
   partOfSpeech: n
-  wikidata: Q856251
 08473738-n:
   definition:
   - nonelective government officials
@@ -28665,7 +28527,6 @@
   members:
   - arithmetic progression
   partOfSpeech: n
-  wikidata: Q170008
 08478183-n:
   definition:
   - (mathematics) a progression in which each term is multiplied by a constant in
@@ -29049,7 +28910,6 @@
   members:
   - fauvism
   partOfSpeech: n
-  wikidata: Q166593
 08485095-n:
   definition:
   - an artistic movement in Italy around 1910 that tried to express the energy and
@@ -29071,7 +28931,6 @@
   - Hudson River school
   - romantic realism
   partOfSpeech: n
-  wikidata: Q943853
 08485510-n:
   definition:
   - a movement by American and English poets early in the 20th century in reaction
@@ -29083,7 +28942,6 @@
   members:
   - imagism
   partOfSpeech: n
-  wikidata: Q746727
 08485732-n:
   definition:
   - English poets at the beginning of the 19th century who lived in the Lake District
@@ -29287,7 +29145,6 @@
   members:
   - falun gong
   partOfSpeech: n
-  wikidata: Q185802
 08489346-n:
   definition:
   - a group of people working together to achieve a political goal
@@ -29515,7 +29372,6 @@
   mero_member:
   - 09878139-n
   partOfSpeech: n
-  wikidata: Q220222
 08493840-n:
   definition:
   - the cultural movement of the Renaissance; based on classical studies
@@ -29534,7 +29390,6 @@
   members:
   - analytical cubism
   partOfSpeech: n
-  wikidata: Q3006706
 08494088-n:
   definition:
   - the late phase of cubism
@@ -29544,7 +29399,6 @@
   members:
   - synthetic cubism
   partOfSpeech: n
-  wikidata: Q3006708
 08494175-n:
   definition:
   - people who have not confessed
@@ -29721,7 +29575,6 @@
   - Chow
   - Chow dynasty
   partOfSpeech: n
-  wikidata: Q35216
 08496626-n:
   definition:
   - a gathering of military personnel for duty
@@ -29786,7 +29639,6 @@
   members:
   - World Council of Churches
   partOfSpeech: n
-  wikidata: Q283639
 08497523-n:
   definition:
   - a select company of people
@@ -29971,7 +29823,6 @@
   members:
   - chosen people
   partOfSpeech: n
-  wikidata: Q926707
 08500276-n:
   definition:
   - an ethnic group living in Azerbaijan
@@ -30138,7 +29989,6 @@
   - FSB
   - Federal Security Service
   partOfSpeech: n
-  wikidata: Q58792
 08502840-n:
   definition:
   - an administrative agency of the Russian government
@@ -30170,7 +30020,7 @@
   definition:
   - a gathering of people to taste and compare different wines
   hypernym:
-  - 07991473-n
+  - 01232427-n
   ili: i81651
   members:
   - wine tasting
@@ -30218,7 +30068,6 @@
   - World Trade Organization
   - WTO
   partOfSpeech: n
-  wikidata: Q7825
 08504159-n:
   definition:
   - an association of people to promote the welfare of senior citizens
@@ -31232,7 +31081,6 @@
   - pseudometric space
   partOfSpeech: n
   source: plWordNet 4.0
-  wikidata: Q1397059
 92444944-n:
   definition:
   - Term used in Germany for neo-expressionism, the re-emergence of expressive painting


### PR DESCRIPTION
This PR proposes a minimal solution to the core problem of issue #522, by changing non-group hyponyms of gathering (group) to gathering (act): specifically 'fair', 'wine_tasting', 'social gathering', 'rally' and 'meeting'.This was achieved by using EWE to delete the incorrect hyponym links from gathering (group), and add them to gathering (act). 'rave-up' was not touched, since it is already handled by #680.

As a consequence, the many (@rwingerter55 counts  a few hundred) transititive hyponyms of the moved hyponyms also inherit the correct hypernymy relation to gathering (act). Specifically, this also applies to 'party', thereby also solving #526.

However, what EWE _does not do_, is to move all these hundreds of synsets from the wn-noun.group.xml lexical file to wn-noun.act.xml, as would have happened in PWN, where a similar change also would have entailed changing the lexfile number in all the involved sense keys, and attributing new word numbers in the noun.act lexical file if needed. Also, the "dc:subject" attribute of all the involved synsets should be changed from "noun.group" to "noun.act", but EWE does not handle that neither.

