### PR TITLE
Disambiguate definition of Montezuma cypress (tree)

### DIFF
--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -97643,7 +97643,7 @@
   partOfSpeech: n
 84172907-n:
   definition:
-  - cypress of river valleys of Mexican highlands
+  - cypress tree of river valleys of Mexican highlands
   hypernym:
   - 11650940-n
   members:


### PR DESCRIPTION
Complement PR #358 (issue #78), by adding the word "tree" in the definition of the new synset ewn-80820791-n, thus avoiding to just carry over the ambiguous definition that was previously used for the "wood" sense of Montezuma cypress.