### PR TITLE
Spell Wordnet with lowercase "n" in WNDB license

### DIFF
--- a/WNDB_License.txt
+++ b/WNDB_License.txt
@@ -1,8 +1,8 @@
   1 This software and database is being provided to you, the LICENSEE, by  
-  2 the Open English WordNet team under the Creative Commons Attribution 4.0  
+  2 the Open English Wordnet team under the Creative Commons Attribution 4.0  
   3 International License (CC-BY 4.0).  
-  4                 
-  5 Open English WordNet 2021. Copyright 2021 by the Open English WordNet team.  
+  4                  
+  5 Open English Wordnet 2021 Copyright 2021 by the Open English Wordnet team.  
   6   
   7 Permission to use, copy, modify and distribute this software and  
   8 database and its documentation for any purpose and without fee or  


### PR DESCRIPTION
Avoid trademark problem (https://github.com/bond-lab/omw-data/issues/5#issuecomment-925058271) by spelling Wordnet with lowercase "n" in the WNDB license.