### PR TITLE
Fix merge conflict in README.md and typos in scripts/change-relation.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,42 +53,22 @@ WordNet is released under [CC-BY 4.0](LICENSE.md)
 
 The canonical citation for English Wordnet is:
 
-* John P. McCrae, Alexandre Rademaker, Francis Bond, Ewa Rudnicka and Christiane Fellbaum (2019) [English WordNet 2019 -- An Open-Source WordNet for English](https://aclanthology.org/2019.gwc-1.31/), *Proceedings of the 10th Global WordNet Conference – GWC 2019*, Wrocław
+* John P. McCrae, Alexandre Rademaker, Francis Bond, Ewa Rudnicka and Christiane Fellbaum (2019) [English WordNet 2019 – An Open-Source WordNet for English](https://aclanthology.org/2019.gwc-1.31/). In *Proceedings of the 10th Global WordNet Conference – GWC 2019*, Wrocław
 
 More recent papers describing it include:
 
 * John Philip McCrae, Alexandre Rademaker, Ewa Rudnicka, Francis Bond (2020)
-[English WordNet 2020: Improving and Extending a WordNet for English using an Open-Source Methodology](https://aclanthology.org/2020.mmw-1.3/) *In Proceedings of the 11th Global Wordnet Conference (GWC2021)*, University of South Africa (UNISA)
+[English WordNet 2020: Improving and Extending a WordNet for English using an Open-Source Methodology](https://aclanthology.org/2020.mmw-1.3/). In *Proceedings of the LREC 2020 Workshop on Multimodal Wordnets (MMW2020)*, Marseille
 
-* John P. McCrae, Michael Wayne Goodman, Francis Bond, Alexandre Rademaker, Ewa Rudnicka, Luis Morgado Da Costa (2020) [The GlobalWordNet Formats: Updates for 2020](https://aclanthology.org/2021.gwc-1.11/)  *In Proceedings of the 11th Global Wordnet Conference (GWC2021)*, University of South Africa (UNISA)
+* John P. McCrae, Michael Wayne Goodman, Francis Bond, Alexandre Rademaker, Ewa Rudnicka, Luis Morgado Da Costa (2020) [The GlobalWordNet Formats: Updates for 2020](https://aclanthology.org/2021.gwc-1.11/). In *Proceedings of the 11th Global Wordnet Conference (GWC2021)*, University of South Africa (UNISA)
 
 It incorporates material from:
 
 * Christiane Fellbaum, editor (1998) *WordNet: An Electronic Lexical Database*. The MIT Press, Cambridge, MA.
-* Merrick Choo Yeu Herng and Francis Bond (2021) [Taboo wordnet](https://aclanthology.org/2021.gwc-1.5/). *In Proceedings of the 11th Global Wordnet Conference (GWC2021)*, University of South Africa (UNISA).
+* Merrick Choo Yeu Herng and Francis Bond (2021) [Taboo wordnet](https://aclanthology.org/2021.gwc-1.5/). In *Proceedings of the 11th Global Wordnet Conference (GWC2021)*, University of South Africa (UNISA).
 
 
 ## Contributors
-
-<<<<<<< HEAD
-* John P. McCrae
-* Alexandre Rademaker
-* Ewa Rudnicka
-* Bernard Bou
-* Daiki Nomura
-* David Cillessen
-* Ciara O'Loughlin
-* Cathal McGovern
-* Francis Bond
-* Eric Kafe
-* Michael Wayne Goodman
-
-## Publications
-John P. McCrae, Alexandre Rademaker, Francis Bond, Ewa Rudnicka, and Christiane Fellbaum (2019) [English WordNet 2019 – An Open-Source WordNet for English](https://aclanthology.org/2019.gwc-1.31/). In Proceedings of the 10th Global Wordnet Conference, pages 245–252, Wroclaw, Poland. Global Wordnet Association.
-
-John P. McCrae, Alexandre Rademaker, Ewa Rudnicka, and Francis Bond (2020) [English WordNet 2020: Improving and Extending a WordNet for English using an Open-Source Methodology](https://aclanthology.org/2020.mmw-1.3/). In Proceedings of the LREC 2020 Workshop on Multimodal Wordnets (MMW2020), pages 14–19, Marseille, France. The European Language Resources Association (ELRA).
-
-John P. McCrae, Michael Wayne Goodman, Francis Bond, Alexandre Rademaker, Ewa Rudnicka, and Luis Morgado Da Costa (2021) [The GlobalWordNet Formats: Updates for 2020](https://aclanthology.org/2021.gwc-1.11/). In Proceedings of the 11th Global Wordnet Conference, pages 91–99, University of South Africa (UNISA). Global Wordnet Association.
 
 * John P. **McCrae**
 * Alexandre **Rademaker**
@@ -100,5 +80,6 @@ John P. McCrae, Michael Wayne Goodman, Francis Bond, Alexandre Rademaker, Ewa Ru
 * Cathal **McGovern**
 * Francis **Bond**
 * Eric **Kafe**
+* Michael Wayne **Goodman**
 * Merrick **Choo** Yeu Herng
 * Enejda **Nasaj**

--- a/scripts/change-relation.py
+++ b/scripts/change-relation.py
@@ -196,14 +196,14 @@ def main():
                     print("Target sense %d does not exist" % args.target_id)
                     sys.exit(-1)
                 if args.source_id == args.target_id:
-                    print("Won;t link sense %d to itself" % args.source_id)
+                    print("Won't link sense %d to itself" % args.source_id)
                     sys.exit(-1) 
                 change_manager.add_sense_relation(
                     wn, args.source_id, args.target_id, wordnet.SenseRelType(
                         args.new_relation))
             else:
                 if source_synset == target_synset:
-                    print("Won't link synset %s to itself" % source_id)
+                    print("Won't link synset %s to itself" % source_synset)
                     sys.exit(-1) 
                 change_manager.add_relation(
                     wn,


### PR DESCRIPTION
Hi,

I spotted some minor errors and tried to fix them.

Regards,
Tom Levy

---

Commit cacaa91 (Add changes from Francis Bond's repo, 2022-08-11) resulted in a duplicate contributor list and a duplicate Publications/References section.

This commit fixes the duplication and some other typos.

---

I also spotted likely bugs in scripts/change-relation.py: it uses the `%d` format specifier to format `args.source_id` in many places, e.g. `print("Source sense %d does not exist" % args.source_id)`, but it looks like `args.source_id` is a string rather than a number. I didn't attempt to fix this.