### PR TITLE
Add 'exact' as member rather than definition by synonym

### DIFF
--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -268,12 +268,13 @@
   - 00005838-s
 00005472-s:
   definition:
-  - lacking compromising or mitigating elements; exact
+  - lacking compromising or mitigating elements
   example:
   - the direct opposite
   ili: i23
   members:
   - direct
+  - exact
   partOfSpeech: s
   similar:
   - 00005204-a

--- a/src/yaml/entries-e.yaml
+++ b/src/yaml/entries-e.yaml
@@ -36829,6 +36829,8 @@ exact:
       - 'exactness%1:07:00::'
       id: exact%5:00:00:correct:00
       synset: 00634639-s
+    - id: exact%5:00:01:absolute:00
+      synset: 00005472-s
   v:
     pronunciation:
     - value: ɪɡˈzækt


### PR DESCRIPTION
Fix #855 