### PR TITLE
Add ñ forms of Spanish forms of address

### DIFF
--- a/src/yaml/entries-s.yaml
+++ b/src/yaml/entries-s.yaml
@@ -7998,6 +7998,21 @@ Seymour:
     sense:
     - id: 'seymour%1:18:00::'
       synset: 11314670-n
+Señor:
+  n:
+    sense:
+    - id: 'señor%1:10:01::'
+      synset: 06353232-n
+Señora:
+  n:
+    sense:
+    - id: 'señora%1:10:01::'
+      synset: 06353385-n
+Señorita:
+  n:
+    sense:
+    - id: 'señorita%1:10:01::'
+      synset: 06353552-n
 Sfax:
   n:
     sense:
@@ -49567,11 +49582,6 @@ sezession:
     sense:
     - id: 'sezession%1:14:00::'
       synset: 08487045-n
-señorita:
-  n:
-    sense:
-    - id: 'señorita%1:10:01::'
-      synset: 06353552-n
 sforzando:
   n:
     sense:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -4900,6 +4900,7 @@
   ili: i69805
   members:
   - Senor
+  - Señor
   partOfSpeech: n
 06353385-n:
   definition:
@@ -4912,6 +4913,7 @@
   ili: i69806
   members:
   - Senora
+  - Señora
   partOfSpeech: n
 06353552-n:
   definition:
@@ -4924,7 +4926,7 @@
   ili: i69807
   members:
   - Senorita
-  - señorita
+  - Señorita
   partOfSpeech: n
 06353732-n:
   definition:

--- a/src/yaml/verb.contact.yaml
+++ b/src/yaml/verb.contact.yaml
@@ -13866,7 +13866,8 @@
   example:
   - Adam knew Eve
   - Were you ever intimate with this man?
-  - Most healthcare providers recommend that individuals get tested for STI's before sleeping with a new partner
+  - Most healthcare providers recommend that individuals get tested for STI's before
+    sleeping with a new partner
   hypernym:
   - 01431486-v
   ili: i28863


### PR DESCRIPTION
Adding the tilde forms. As this is a dictionary of English we include both with and without accents.

Fixes #886 