### PR TITLE
Update the year in license text

### DIFF
--- a/WNDB_License.txt
+++ b/WNDB_License.txt
@@ -2,7 +2,7 @@
   2 the Open English Wordnet team under the Creative Commons Attribution 4.0  
   3 International License (CC-BY 4.0).  
   4                  
-  5 Open English Wordnet 2021 Copyright 2021 by the Open English Wordnet team.  
+  5 Open English Wordnet 2022 Copyright 2022 by the Open English Wordnet team.  
   6   
   7 Permission to use, copy, modify and distribute this software and  
   8 database and its documentation for any purpose and without fee or  


### PR DESCRIPTION
Fix the recurrent issue #603. In order to be able to distinguish between different Wordnet versions, some libraries (for ex. NLTK) extract the version of the current database from the copyright statement in the license text. 
This PR updates the year to 2022 in _WNDB_License.txt_ (cf. #604).