### PR TITLE
Fix #902: Update version year

### DIFF
--- a/scripts/merge.py
+++ b/scripts/merge.py
@@ -70,7 +70,7 @@ def wn_merge():
            language="en"
            email="english-wordnet@googlegroups.com"
            license="https://creativecommons.org/licenses/by/4.0/"
-           version="2021"
+           version="2022"
            citation = "John P. McCrae, Alexandre Rademaker, Francis Bond, Ewa Rudnicka and Christiane Fellbaum (2019) English WordNet 2019 – An Open-Source WordNet for English, *Proceedings of the 10th Global WordNet Conference* – GWC 2019"
            url="https://github.com/globalwordnet/english-wordnet">""")
         lex_entries = {}

--- a/scripts/wordnet_yaml.py
+++ b/scripts/wordnet_yaml.py
@@ -136,7 +136,7 @@ def load():
     wn = Lexicon("oewn", "Engish WordNet", "en",
                  "english-wordnet@googlegroups.com",
                  "https://creativecommons.org/licenses/by/4.0",
-                 "2021",
+                 "2022",
                  "https://github.com/globalwordnet/english-wordnet")
     with open("src/yaml/frames.yaml", encoding="utf-8") as inp:
         frames = yaml.load(inp, Loader=CLoader)


### PR DESCRIPTION
Trying to move #902 along. This PR changes the `version` from `2021` to `2022` in both `merge.py` and `wordnet_yaml.py`. The resulting XML file passes both `xmllint` and `validate.py`.

In producing this PR, I noticed a few opportunities for improved documentation:
- `pyyaml` is a dependency, but it is not mentioned anywhere and there is no `requirements.txt`
- `CONTRIBUTING.md` is missing the `from-yaml.py` step for building the XML (it is mentioned in the README, however)
- `CONTRIBUTING.md` and `README.md` both refer to `wn31.xml` instead of `wn.xml`

I'm happy to push a commit to address these issues but they are not directly relevant to this PR.