### PR TITLE
Make changes to gender-neutral and gender-specific terms

### DIFF
--- a/src/yaml/entries-a.yaml
+++ b/src/yaml/entries-a.yaml
@@ -39732,6 +39732,11 @@ agony column:
     sense:
     - id: 'agony_column%1:10:00::'
       synset: 06282167-n
+agony uncle:
+  n:
+    sense:
+    - id: 'agony_uncle%1:18:01::'
+      synset: 87143696-n
 agora:
   n-1:
     form:
@@ -40973,6 +40978,11 @@ air hose:
     sense:
     - id: 'air_hose%1:06:00::'
       synset: 02693129-n
+air host:
+  n:
+    sense:
+    - id: 'air_host%1:18:01::'
+      synset: 87595983-n
 air hostess:
   n:
     sense:
@@ -41681,19 +41691,16 @@ airmailer:
       synset: 02693574-n
 airman:
   n:
-    pronunciation:
-    - value: ˈeə.mən
-      variety: US
     sense:
     - derivation:
       - 'airmanship%1:09:00::'
-      id: 'airman%1:18:00::'
-      synset: 09845606-n
+      id: 'airman%1:18:01::'
+      synset: 85242186-n
 airmanship:
   n:
     sense:
     - derivation:
-      - 'airman%1:18:00::'
+      - 'airman%1:18:01::'
       id: 'airmanship%1:09:00::'
       synset: 05643033-n
 airplane:
@@ -48197,20 +48204,16 @@ alumna:
   n:
     form:
     - alumnae
-    pronunciation:
-    - value: əˈlʌmnə
     sense:
-    - id: 'alumna%1:18:00::'
-      synset: 09805779-n
+    - id: 'alumna%1:18:01::'
+      synset: 86032704-n
 alumnus:
   n:
     form:
     - alumni
-    pronunciation:
-    - value: əˈlʌmnəs
     sense:
-    - id: 'alumnus%1:18:00::'
-      synset: 09805779-n
+    - id: 'alumnus%1:18:01::'
+      synset: 80186365-n
 alumroot:
   n:
     sense:

--- a/src/yaml/entries-b.yaml
+++ b/src/yaml/entries-b.yaml
@@ -11637,6 +11637,11 @@ baby oil:
     sense:
     - id: 'baby_oil%1:06:00::'
       synset: 02769966-n
+baby papa:
+  n:
+    sense:
+    - id: 'baby_papa%1:18:01::'
+      synset: 85626490-n
 baby powder:
   n:
     sense:
@@ -19495,8 +19500,8 @@ barman:
     - value: ˈbɑɹmæn
       variety: US
     sense:
-    - id: 'barman%1:18:00::'
-      synset: 09860576-n
+    - id: 'barman%1:18:01::'
+      synset: 86986461-n
 barmbrack:
   n:
     sense:
@@ -37112,13 +37117,13 @@ bionic:
 bionic man:
   n:
     sense:
-    - id: 'bionic_man%1:18:00::'
-      synset: 10005508-n
+    - id: 'bionic_man%1:18:01::'
+      synset: 84232664-n
 bionic woman:
   n:
     sense:
-    - id: 'bionic_woman%1:18:00::'
-      synset: 10005508-n
+    - id: 'bionic_woman%1:18:01::'
+      synset: 80220778-n
 bionics:
   n:
     pronunciation:
@@ -44769,10 +44774,15 @@ blond:
     - value: blɑnd
       variety: US
     sense:
-    - id: 'blond%1:18:00::'
-      synset: 09879912-n
     - id: 'blond%1:07:00::'
       synset: 04973194-n
+    - id: 'blond%1:18:01::'
+      synset: 86947054-n
+blond person:
+  n:
+    sense:
+    - id: 'blond_person%1:18:01::'
+      synset: 09879912-n
 blonde:
   a:
     pronunciation:
@@ -44790,10 +44800,10 @@ blonde:
     - value: blɑnd
       variety: US
     sense:
-    - id: 'blonde%1:18:00::'
-      synset: 09879912-n
     - id: 'blonde%1:07:00::'
       synset: 04973194-n
+    - id: 'blonde%1:18:01::'
+      synset: 85758093-n
 blonde lilian:
   n:
     sense:
@@ -50918,19 +50928,24 @@ bondsman:
     sense:
     - id: 'bondsman%1:18:01::'
       synset: 09884297-n
-    - id: 'bondsman%1:18:00::'
-      synset: 09884685-n
     - id: 'bondsman%1:18:02::'
       synset: 09884374-n
+    - id: 'bondsman%1:18:03::'
+      synset: 85259651-n
+bondsperson:
+  n:
+    sense:
+    - id: 'bondsperson%1:18:01::'
+      synset: 09884685-n
 bondswoman:
   n:
     sense:
-    - id: 'bondswoman%1:18:00::'
-      synset: 09884685-n
     - id: 'bondswoman%1:18:02::'
       synset: 09884568-n
     - id: 'bondswoman%1:18:01::'
       synset: 09884474-n
+    - id: 'bondswoman%1:18:03::'
+      synset: 88561238-n
 bonduc:
   n:
     sense:
@@ -56165,6 +56180,11 @@ boy:
       synset: 10643436-n
     - id: 'boy%1:18:01::'
       synset: 84496658-n
+boy Friday:
+  n:
+    sense:
+    - id: 'boy_friday%1:18:01::'
+      synset: 83935783-n
 boy scout:
   n:
     sense:

--- a/src/yaml/entries-c.yaml
+++ b/src/yaml/entries-c.yaml
@@ -45183,7 +45183,7 @@ chairman:
       - 'chairmanship%1:04:00::'
       - 'chairman%2:41:00::'
       id: 'chairman%1:18:01::'
-      synset: 10488547-n
+      synset: 83179919-n
   v:
     pronunciation:
     - value: ˈtʃɛːmən
@@ -45218,7 +45218,7 @@ chairwoman:
   n:
     sense:
     - id: 'chairwoman%1:18:01::'
-      synset: 10488547-n
+      synset: 81797116-n
 chaise:
   n:
     pronunciation:
@@ -48461,6 +48461,11 @@ charm quark:
     sense:
     - id: 'charm_quark%1:17:00::'
       synset: 09265138-n
+charman:
+  n:
+    sense:
+    - id: 'charman%1:18:01::'
+      synset: 85556310-n
 charmed:
   a:
     pronunciation:
@@ -61871,13 +61876,13 @@ clannishness:
 clansman:
   n:
     sense:
-    - id: 'clansman%1:18:00::'
-      synset: 10327942-n
+    - id: 'clansman%1:18:01::'
+      synset: 81650724-n
 clanswoman:
   n:
     sense:
-    - id: 'clanswoman%1:18:00::'
-      synset: 10327942-n
+    - id: 'clanswoman%1:18:01::'
+      synset: 80679038-n
 clap:
   n:
     sense:
@@ -64259,6 +64264,11 @@ cleaning lady:
     sense:
     - id: 'cleaning_lady%1:18:00::'
       synset: 09930684-n
+cleaning man:
+  n:
+    sense:
+    - id: 'cleaning_man%1:18:01::'
+      synset: 81448123-n
 cleaning pad:
   n:
     sense:
@@ -92592,13 +92602,13 @@ congressional district:
 congressman:
   n:
     sense:
-    - id: 'congressman%1:18:00::'
-      synset: 09975260-n
+    - id: 'congressman%1:18:01::'
+      synset: 83115757-n
 congresswoman:
   n:
     sense:
-    - id: 'congresswoman%1:18:00::'
-      synset: 09975260-n
+    - id: 'congresswoman%1:18:01::'
+      synset: 80278004-n
 congruence:
   n:
     pronunciation:
@@ -103117,6 +103127,10 @@ coq au vin:
     - id: 'coq_au_vin%1:13:00::'
       synset: 07877533-n
 coquet:
+  n:
+    sense:
+    - id: 'coquet%1:18:01::'
+      synset: 82846014-n
   v:
     form:
     - coquetted
@@ -108942,8 +108956,8 @@ counterirritant:
 counterman:
   n:
     sense:
-    - id: 'counterman%1:18:00::'
-      synset: 09989248-n
+    - id: 'counterman%1:18:01::'
+      synset: 89433552-n
 countermand:
   n:
     pronunciation:
@@ -109402,8 +109416,8 @@ counterweight:
 counterwoman:
   n:
     sense:
-    - id: 'counterwoman%1:18:00::'
-      synset: 09989248-n
+    - id: 'counterwoman%1:18:01::'
+      synset: 81007314-n
 countess:
   n:
     pronunciation:
@@ -110780,6 +110794,11 @@ cover:
       subcat:
       - vtai
       synset: 00048350-v
+cover boy:
+  n:
+    sense:
+    - id: 'cover_boy%1:18:01::'
+      synset: 87519584-n
 cover charge:
   n:
     sense:
@@ -111284,12 +111303,12 @@ cowboy:
     pronunciation:
     - value: ˈkaʊˌbɔɪ
     sense:
-    - id: 'cowboy%1:18:00::'
-      synset: 09992191-n
     - id: 'cowboy%1:18:03::'
       synset: 09992602-n
     - id: 'cowboy%1:18:02::'
       synset: 09992476-n
+    - id: 'cowboy%1:18:04::'
+      synset: 86290056-n
 cowboy boot:
   n:
     sense:

--- a/src/yaml/entries-c.yaml
+++ b/src/yaml/entries-c.yaml
@@ -111449,8 +111449,8 @@ cowling:
 cowman:
   n:
     sense:
-    - id: 'cowman%1:18:00::'
-      synset: 09992191-n
+    - id: 'cowman%1:18:01::'
+      synset: 86290056-n
 cownose ray:
   n:
     sense:

--- a/src/yaml/entries-f.yaml
+++ b/src/yaml/entries-f.yaml
@@ -4910,8 +4910,8 @@ Frenchify:
 Frenchman:
   n:
     sense:
-    - id: 'frenchman%1:18:00::'
-      synset: 09727801-n
+    - id: 'frenchman%1:18:01::'
+      synset: 86250495-n
 Frenchness:
   n:
     pronunciation:
@@ -4922,8 +4922,8 @@ Frenchness:
 Frenchwoman:
   n:
     sense:
-    - id: 'frenchwoman%1:18:00::'
-      synset: 09727801-n
+    - id: 'frenchwoman%1:18:01::'
+      synset: 88429598-n
 Freon:
   n:
     sense:
@@ -16476,6 +16476,11 @@ fanbase:
     sense:
     - id: 'fanbase%1:14:01::'
       synset: 91000501-n
+fanboy:
+  n:
+    sense:
+    - id: 'fanboy%1:18:01::'
+      synset: 86461832-n
 fancam:
   n:
     sense:
@@ -31346,6 +31351,11 @@ first gear:
     sense:
     - id: 'first_gear%1:06:00::'
       synset: 03354857-n
+first gentleman:
+  n:
+    sense:
+    - id: 'first_gentleman%1:18:01::'
+      synset: 89782767-n
 first half:
   n:
     sense:
@@ -39090,6 +39100,11 @@ flower bed:
     sense:
     - id: 'flower_bed%1:06:00::'
       synset: 03373198-n
+flower boy:
+  n:
+    sense:
+    - id: 'flower_boy%1:18:01::'
+      synset: 85582747-n
 flower bud:
   n:
     sense:
@@ -52011,8 +52026,8 @@ freeborn:
 freedman:
   n:
     sense:
-    - id: 'freedman%1:18:00::'
-      synset: 10129754-n
+    - id: 'freedman%1:18:01::'
+      synset: 86419394-n
 freedom:
   n:
     pronunciation:
@@ -52111,11 +52126,16 @@ freedom to bear arms:
     sense:
     - id: 'freedom_to_bear_arms%1:07:00::'
       synset: 05191581-n
+freedperson:
+  n:
+    sense:
+    - id: 'freedperson%1:18:01::'
+      synset: 10129754-n
 freedwoman:
   n:
     sense:
-    - id: 'freedwoman%1:18:00::'
-      synset: 10129754-n
+    - id: 'freedwoman%1:18:01::'
+      synset: 81117668-n
 freehand:
   a:
     sense:
@@ -52254,13 +52274,18 @@ freemail:
 freeman:
   n:
     sense:
-    - id: 'freeman%1:18:00::'
-      synset: 10130792-n
+    - id: 'freeman%1:18:01::'
+      synset: 80035492-n
 freemasonry:
   n:
     sense:
     - id: 'freemasonry%1:26:00::'
       synset: 13953106-n
+freeperson:
+  n:
+    sense:
+    - id: 'freeperson%1:18:01::'
+      synset: 10130792-n
 freesia:
   n:
     pronunciation:
@@ -52376,8 +52401,8 @@ freewill:
 freewoman:
   n:
     sense:
-    - id: 'freewoman%1:18:00::'
-      synset: 10130792-n
+    - id: 'freewoman%1:18:01::'
+      synset: 83017536-n
 freeze:
   n:
     sense:

--- a/src/yaml/entries-g.yaml
+++ b/src/yaml/entries-g.yaml
@@ -46647,6 +46647,11 @@ golf widow:
     sense:
     - id: 'golf_widow%1:18:00::'
       synset: 10157018-n
+golf widower:
+  n:
+    sense:
+    - id: 'golf_widower%1:18:01::'
+      synset: 83226323-n
 golf-club:
   n:
     sense:

--- a/src/yaml/entries-h.yaml
+++ b/src/yaml/entries-h.yaml
@@ -38139,17 +38139,17 @@ horseman:
     - value: ˈhɔːsmən
       variety: GB
     sense:
-    - derivation:
-      - 'horsemanship%1:09:00::'
-      id: 'horseman%1:18:00::'
-      synset: 10205412-n
     - id: 'horseman%1:18:01::'
       synset: 10205301-n
+    - derivation:
+      - 'horsemanship%1:09:00::'
+      id: 'horseman%1:18:02::'
+      synset: 87171397-n
 horsemanship:
   n:
     sense:
     - derivation:
-      - 'horseman%1:18:00::'
+      - 'horseman%1:18:02::'
       id: 'horsemanship%1:09:00::'
       synset: 05646219-n
 horsemeat:

--- a/src/yaml/entries-j.yaml
+++ b/src/yaml/entries-j.yaml
@@ -13522,13 +13522,13 @@ jury-rigged:
 juryman:
   n:
     sense:
-    - id: 'juryman%1:18:00::'
-      synset: 10247948-n
+    - id: 'juryman%1:18:01::'
+      synset: 83347365-n
 jurywoman:
   n:
     sense:
-    - id: 'jurywoman%1:18:00::'
-      synset: 10247948-n
+    - id: 'jurywoman%1:18:01::'
+      synset: 86950860-n
 jus civile:
   n:
     sense:

--- a/src/yaml/entries-k.yaml
+++ b/src/yaml/entries-k.yaml
@@ -6253,6 +6253,11 @@ kept:
     sense:
     - id: 'kept%3:00:00::'
       synset: 00290665-a
+kept man:
+  n:
+    sense:
+    - id: 'kept_man%1:18:01::'
+      synset: 82904005-n
 kept up:
   a:
     sense:
@@ -8787,8 +8792,6 @@ king:
       - 'kingship%1:26:00::'
       id: 'king%1:18:00::'
       synset: 10251212-n
-    - id: 'king%1:18:02::'
-      synset: 10254721-n
     - id: 'king%1:18:01::'
       synset: 09859605-n
     - id: 'king%1:26:00::'
@@ -8799,6 +8802,10 @@ king:
       synset: 03623428-n
     - id: 'king%1:06:00::'
       synset: 03623310-n
+    - id: 'king%1:18:06::'
+      synset: 88005275-n
+    - id: 'king%1:18:07::'
+      synset: 89388690-n
 king begonia:
   n:
     sense:

--- a/src/yaml/entries-l.yaml
+++ b/src/yaml/entries-l.yaml
@@ -37348,6 +37348,11 @@ lollipop lady:
     sense:
     - id: 'lollipop_lady%1:18:00::'
       synset: 10290165-n
+lollipop man:
+  n:
+    sense:
+    - id: 'lollipop_man%1:18:01::'
+      synset: 81269373-n
 lollipop woman:
   n:
     sense:
@@ -39227,6 +39232,11 @@ loose end:
     sense:
     - id: 'loose_end%1:04:00::'
       synset: 00582922-n
+loose man:
+  n:
+    sense:
+    - id: 'loose_man%1:18:01::'
+      synset: 88456890-n
 loose off:
   v:
     sense:

--- a/src/yaml/entries-m.yaml
+++ b/src/yaml/entries-m.yaml
@@ -15717,8 +15717,8 @@ madly:
 madman:
   n:
     sense:
-    - id: 'madman%1:18:00::'
-      synset: 10296461-n
+    - id: 'madman%1:18:01::'
+      synset: 84605489-n
 madnep:
   n:
     sense:

--- a/src/yaml/entries-n.yaml
+++ b/src/yaml/entries-n.yaml
@@ -11657,6 +11657,11 @@ needlelike:
     sense:
     - id: needlelike%5:00:00:pointed:00
       synset: 01815474-s
+needleman:
+  n:
+    sense:
+    - id: 'needleman%1:18:01::'
+      synset: 87565945-n
 needlenose pliers:
   n:
     sense:
@@ -15937,8 +15942,8 @@ newsletter:
 newsman:
   n:
     sense:
-    - id: 'newsman%1:18:00::'
-      synset: 10541255-n
+    - id: 'newsman%1:18:01::'
+      synset: 82640040-n
 newsmonger:
   n:
     sense:
@@ -16020,13 +16025,13 @@ newspapering:
 newspaperman:
   n:
     sense:
-    - id: 'newspaperman%1:18:00::'
-      synset: 09986240-n
+    - id: 'newspaperman%1:18:01::'
+      synset: 87306750-n
 newspaperwoman:
   n:
     sense:
-    - id: 'newspaperwoman%1:18:00::'
-      synset: 09986240-n
+    - id: 'newspaperwoman%1:18:01::'
+      synset: 84863880-n
 newspeak:
   n:
     pronunciation:

--- a/src/yaml/entries-o.yaml
+++ b/src/yaml/entries-o.yaml
@@ -4474,13 +4474,13 @@ oarsman:
     sense:
     - derivation:
       - 'oarsmanship%1:09:00::'
-      id: 'oarsman%1:18:00::'
-      synset: 10388619-n
+      id: 'oarsman%1:18:01::'
+      synset: 89928249-n
 oarsmanship:
   n:
     sense:
     - derivation:
-      - 'oarsman%1:18:00::'
+      - 'oarsman%1:18:01::'
       id: 'oarsmanship%1:09:00::'
       synset: 05647401-n
 oarswoman:
@@ -24763,7 +24763,12 @@ outdoors:
 outdoorsman:
   n:
     sense:
-    - id: 'outdoorsman%1:18:00::'
+    - id: 'outdoorsman%1:18:01::'
+      synset: 89964369-n
+outdoorsperson:
+  n:
+    sense:
+    - id: 'outdoorsperson%1:18:01::'
       synset: 10406317-n
 outdoorswoman:
   n:

--- a/src/yaml/entries-p.yaml
+++ b/src/yaml/entries-p.yaml
@@ -62411,8 +62411,8 @@ policeman:
     pronunciation:
     - value: pəˈliːsmən
     sense:
-    - id: 'policeman%1:18:00::'
-      synset: 10468557-n
+    - id: 'policeman%1:18:01::'
+      synset: 80600405-n
 policeman bird:
   n:
     sense:

--- a/src/yaml/entries-p.yaml
+++ b/src/yaml/entries-p.yaml
@@ -78268,10 +78268,10 @@ pressingly:
 pressman:
   n:
     sense:
-    - id: 'pressman%1:18:00::'
-      synset: 10494882-n
     - id: 'pressman%1:18:01::'
       synset: 09986240-n
+    - id: 'pressman%1:18:02::'
+      synset: 87306750-n
 pressmark:
   n:
     sense:

--- a/src/yaml/entries-q.yaml
+++ b/src/yaml/entries-q.yaml
@@ -3069,8 +3069,6 @@ queen:
       synset: 10519442-n
     - id: 'queen%1:18:04::'
       synset: 10519802-n
-    - id: 'queen%1:18:03::'
-      synset: 10254721-n
     - id: 'queen%1:18:02::'
       synset: 10095821-n
     - id: 'queen%1:06:01::'
@@ -3084,6 +3082,8 @@ queen:
       synset: 02372587-n
     - id: 'queen%1:05:03::'
       synset: 02125530-n
+    - id: 'queen%1:18:05::'
+      synset: 85801071-n
   v:
     pronunciation:
     - value: kwiːn

--- a/src/yaml/entries-s.yaml
+++ b/src/yaml/entries-s.yaml
@@ -5719,8 +5719,8 @@ Scotch woodcock:
 Scotchman:
   n:
     sense:
-    - id: 'scotchman%1:18:00::'
-      synset: 09749875-n
+    - id: 'scotchman%1:18:01::'
+      synset: 88770907-n
 Scotchwoman:
   n:
     sense:
@@ -5782,8 +5782,8 @@ Scotsman:
     - value: ˈskɑts.mən
       variety: US
     sense:
-    - id: 'scotsman%1:18:00::'
-      synset: 09749875-n
+    - id: 'scotsman%1:18:01::'
+      synset: 88770907-n
 Scotswoman:
   n:
     sense:
@@ -39770,6 +39770,11 @@ seductively:
       pertainym:
       - 'seductive%3:00:00::'
       synset: 00450023-r
+seductor:
+  n:
+    sense:
+    - id: 'seductor%1:18:01::'
+      synset: 85717860-n
 seductress:
   n:
     sense:
@@ -44076,6 +44081,11 @@ sempiternity:
     sense:
     - id: 'sempiternity%1:07:00::'
       synset: 05060678-n
+sempster:
+  n:
+    sense:
+    - id: 'sempster%1:18:01::'
+      synset: 87565945-n
 sempstress:
   n:
     pronunciation:
@@ -59866,6 +59876,11 @@ showboat:
     sense:
     - id: 'showboat%1:06:00::'
       synset: 04215827-n
+showboy:
+  n:
+    sense:
+    - id: 'showboy%1:18:01::'
+      synset: 83222719-n
 showcase:
   n:
     pronunciation:
@@ -101044,8 +101059,8 @@ sportsman:
     sense:
     - derivation:
       - 'sportsmanship%1:07:00::'
-      id: 'sportsman%1:18:00::'
-      synset: 10658320-n
+      id: 'sportsman%1:18:01::'
+      synset: 88651493-n
 sportsmanlike:
   a:
     sense:
@@ -101055,7 +101070,7 @@ sportsmanship:
   n:
     sense:
     - derivation:
-      - 'sportsman%1:18:00::'
+      - 'sportsman%1:18:01::'
       id: 'sportsmanship%1:07:00::'
       synset: 04846786-n
 sportswear:
@@ -101066,8 +101081,8 @@ sportswear:
 sportswoman:
   n:
     sense:
-    - id: 'sportswoman%1:18:00::'
-      synset: 10658320-n
+    - id: 'sportswoman%1:18:01::'
+      synset: 84238586-n
 sportswriter:
   n:
     sense:
@@ -110641,8 +110656,8 @@ statesman:
     - derivation:
       - 'statesmanly%3:00:00::'
       - 'statesmanship%1:07:00::'
-      id: 'statesman%1:18:00::'
-      synset: 10669601-n
+      id: 'statesman%1:18:01::'
+      synset: 85404693-n
 statesmanlike:
   a:
     sense:
@@ -110654,14 +110669,14 @@ statesmanly:
   a:
     sense:
     - derivation:
-      - 'statesman%1:18:00::'
+      - 'statesman%1:18:01::'
       id: 'statesmanly%3:00:00::'
       synset: 00756614-a
 statesmanship:
   n:
     sense:
     - derivation:
-      - 'statesman%1:18:00::'
+      - 'statesman%1:18:01::'
       id: 'statesmanship%1:07:00::'
       synset: 04898060-n
 stateswoman:
@@ -125628,8 +125643,8 @@ stunt kite:
 stunt man:
   n:
     sense:
-    - id: 'stunt_man%1:18:00::'
-      synset: 10686285-n
+    - id: 'stunt_man%1:18:01::'
+      synset: 83734211-n
 stunt pilot:
   n:
     sense:
@@ -125638,8 +125653,8 @@ stunt pilot:
 stunt woman:
   n:
     sense:
-    - id: 'stunt_woman%1:18:00::'
-      synset: 10686285-n
+    - id: 'stunt_woman%1:18:01::'
+      synset: 84393389-n
 stunted:
   a:
     sense:
@@ -135398,6 +135413,11 @@ supercritical:
     sense:
     - id: supercritical%5:00:00:critical:04
       synset: 00655373-s
+superdad:
+  n:
+    sense:
+    - id: 'superdad%1:18:01::'
+      synset: 86495725-n
 superego:
   n:
     pronunciation:

--- a/src/yaml/entries-t.yaml
+++ b/src/yaml/entries-t.yaml
@@ -55920,6 +55920,11 @@ trophy case:
     sense:
     - id: 'trophy_case%1:06:00::'
       synset: 04495458-n
+trophy husband:
+  n:
+    sense:
+    - id: 'trophy_husband%1:18:01::'
+      synset: 80620228-n
 trophy wife:
   n:
     sense:

--- a/src/yaml/entries-w.yaml
+++ b/src/yaml/entries-w.yaml
@@ -8957,6 +8957,11 @@ washing-up:
     sense:
     - id: 'washing-up%1:04:00::'
       synset: 00256989-n
+washman:
+  n:
+    sense:
+    - id: 'washman%1:18:01::'
+      synset: 87970505-n
 washout:
   n:
     pronunciation:
@@ -27363,6 +27368,11 @@ wonder flower:
     sense:
     - id: 'wonder_flower%1:20:00::'
       synset: 12480813-n
+wonder man:
+  n:
+    sense:
+    - id: 'wonder_man%1:18:01::'
+      synset: 83000076-n
 wonder woman:
   n:
     pronunciation:

--- a/src/yaml/entries-y.yaml
+++ b/src/yaml/entries-y.yaml
@@ -1144,13 +1144,18 @@ yachting cap:
 yachtsman:
   n:
     sense:
-    - id: 'yachtsman%1:18:00::'
+    - id: 'yachtsman%1:18:01::'
+      synset: 87657220-n
+yachtsperson:
+  n:
+    sense:
+    - id: 'yachtsperson%1:18:01::'
       synset: 10821647-n
 yachtswoman:
   n:
     sense:
-    - id: 'yachtswoman%1:18:00::'
-      synset: 10821647-n
+    - id: 'yachtswoman%1:18:01::'
+      synset: 83067869-n
 yack:
   n:
     pronunciation:

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -124124,6 +124124,8 @@
   - 03005231-n
   members:
   - voyeuse
+  masculine:
+  - 10780994-n
   partOfSpeech: n
   source: plWordNet 4.0
 92449711-n:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -17915,6 +17915,8 @@
 05938456-n:
   definition:
   - the principal character in a play or movie or novel or poem
+  feminine:
+  - 10192976-n
   hypernym:
   - 05937794-n
   ili: i67991

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -29436,7 +29436,6 @@
   members:
   - cowpuncher
   - puncher
-  - cowman
   - cattleman
   - cowpoke
   - cowhand
@@ -60610,7 +60609,6 @@
   ili: i92253
   members:
   - printer
-  - pressman
   partOfSpeech: n
 10495169-n:
   definition:
@@ -120525,6 +120523,7 @@
   - 09992191-n
   members:
   - cowboy
+  - cowman
   partOfSpeech: n
 86294295-n:
   definition:
@@ -120639,6 +120638,7 @@
   - 09986240-n
   members:
   - newspaperman
+  - pressman
   partOfSpeech: n
 87519584-n:
   definition:

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -193,6 +193,8 @@
   definition:
   - an imaginary figure of superhuman size and strength; appears in folklore and fairy
     tales
+  feminine:
+  - 09513887-n
   hypernym:
   - 09506868-n
   ili: i86481
@@ -7725,6 +7727,8 @@
 09629201-n:
   definition:
   - a person who enjoys taking risks
+  feminine:
+  - 09792592-n
   hypernym:
   - 09786620-n
   ili: i87153
@@ -9009,6 +9013,8 @@
 09661981-n:
   definition:
   - a man who is White
+  feminine:
+  - 09662109-n
   hypernym:
   - 10306910-n
   - 09660255-n
@@ -9025,6 +9031,8 @@
   ili: i87290
   members:
   - white woman
+  masculine:
+  - 09661981-n
   partOfSpeech: n
 09662205-n:
   definition:
@@ -11282,6 +11290,8 @@
 09701687-n:
   definition:
   - a believer in or follower of Islam
+  feminine:
+  - 10361304-n
   hypernym:
   - 09651570-n
   ili: i87523
@@ -12404,6 +12414,8 @@
 09720999-n:
   definition:
   - a man who is a native or inhabitant of England
+  feminine:
+  - 09721229-n
   hypernym:
   - 09720544-n
   ili: i87640
@@ -12418,6 +12430,8 @@
   ili: i87641
   members:
   - Englishwoman
+  masculine:
+  - 09720999-n
   partOfSpeech: n
 09721373-n:
   definition:
@@ -12538,6 +12552,8 @@
 09723205-n:
   definition:
   - a man who is a native or inhabitant of Cornwall
+  feminine:
+  - 09723328-n
   hypernym:
   - 09720999-n
   ili: i87653
@@ -12552,6 +12568,8 @@
   ili: i87654
   members:
   - Cornishwoman
+  masculine:
+  - 09723205-n
   partOfSpeech: n
 09723453-n:
   definition:
@@ -12865,13 +12883,15 @@
 09727801-n:
   definition:
   - a person of French nationality
+  feminine:
+  - 88429598-n
   hypernym:
   - 09705914-n
   ili: i87687
   members:
-  - Frenchman
-  - Frenchwoman
   - French person
+  masculine:
+  - 86250495-n
   partOfSpeech: n
 09728044-n:
   definition:
@@ -13305,6 +13325,8 @@
 09734561-n:
   definition:
   - a man who is a native or inhabitant of Ireland
+  feminine:
+  - 09734699-n
   hypernym:
   - 09734348-n
   ili: i87732
@@ -13319,6 +13341,8 @@
   ili: i87733
   members:
   - Irishwoman
+  masculine:
+  - 09734561-n
   partOfSpeech: n
 09734823-n:
   definition:
@@ -14286,13 +14310,15 @@
 09749875-n:
   definition:
   - a native or inhabitant of Scotland
+  feminine:
+  - 09750074-n
   hypernym:
   - 09705914-n
   ili: i87833
   members:
   - Scot
-  - Scotsman
-  - Scotchman
+  masculine:
+  - 88770907-n
   partOfSpeech: n
 09750074-n:
   definition:
@@ -15989,11 +16015,15 @@
   - abbess
   - mother superior
   - prioress
+  masculine:
+  - 09773735-n
   partOfSpeech: n
   wikidata: Q1646408
 09773735-n:
   definition:
   - the superior of an abbey of monks
+  feminine:
+  - 09773548-n
   hypernym:
   - 10695315-n
   ili: i88008
@@ -16628,6 +16658,8 @@
 09784701-n:
   definition:
   - a theatrical performer
+  feminine:
+  - 09787123-n
   hypernym:
   - 10435383-n
   ili: i88068
@@ -16903,6 +16935,8 @@
   - someone who commits adultery or fornication
   exemplifies:
   - 06730109-n
+  feminine:
+  - 09792353-n
   hypernym:
   - 10277344-n
   ili: i88093
@@ -16930,6 +16964,8 @@
   - slut
   - strumpet
   - trollop
+  masculine:
+  - 88456890-n
   partOfSpeech: n
 09792499-n:
   definition:
@@ -17261,6 +17297,8 @@
   ili: i88126
   members:
   - agony aunt
+  masculine:
+  - 87143696-n
   partOfSpeech: n
 09799064-n:
   definition:
@@ -17721,15 +17759,17 @@
 09805779-n:
   definition:
   - a person who has received a degree from a school (high school or college or university)
+  feminine:
+  - 86032704-n
   hypernym:
   - 10577282-n
   ili: i88171
   members:
-  - alumnus
-  - alumna
   - alum
   - graduate
   - grad
+  masculine:
+  - 80186365-n
   partOfSpeech: n
 09806026-n:
   definition:
@@ -17795,6 +17835,8 @@
   definition:
   - a diplomat of the highest rank; accredited as representative from one country
     to another
+  feminine:
+  - 09807319-n
   hypernym:
   - 10033672-n
   ili: i88178
@@ -19307,6 +19349,8 @@
 09833786-n:
   definition:
   - someone who is a member of a legislative assembly
+  feminine:
+  - 09833893-n
   hypernym:
   - 10541628-n
   ili: i88325
@@ -19321,6 +19365,8 @@
   ili: i88326
   members:
   - assemblywoman
+  masculine:
+  - 09833786-n
   partOfSpeech: n
 09833972-n:
   definition:
@@ -19841,15 +19887,18 @@
 09845606-n:
   definition:
   - someone who operates an aircraft
+  feminine:
+  - 09846007-n
   hypernym:
   - 10625393-n
   ili: i88373
   members:
   - aviator
   - aeronaut
-  - airman
   - flier
   - flyer
+  masculine:
+  - 85242186-n
   partOfSpeech: n
 09846007-n:
   definition:
@@ -20056,6 +20105,9 @@
 09849169-n:
   definition:
   - a man who has never been married
+  feminine:
+  - 10655886-n
+  - 10759169-n
   hypernym:
   - 10306910-n
   ili: i88393
@@ -20412,6 +20464,8 @@
   members:
   - ballerina
   - danseuse
+  masculine:
+  - 10010944-n
   partOfSpeech: n
 09854087-n:
   definition:
@@ -20878,15 +20932,18 @@
 09860576-n:
   definition:
   - an employee who mixes and serves alcoholic drinks at a bar
+  feminine:
+  - 09859090-n
   hypernym:
   - 10073616-n
   ili: i88473
   members:
   - bartender
-  - barman
   - barkeep
   - barkeeper
   - mixologist
+  masculine:
+  - 86986461-n
   partOfSpeech: n
 09860788-n:
   definition:
@@ -21334,6 +21391,8 @@
 09866675-n:
   definition:
   - a man who is a beggar
+  feminine:
+  - 09866752-n
   hypernym:
   - 09866418-n
   ili: i88516
@@ -21348,6 +21407,8 @@
   ili: i88517
   members:
   - beggarwoman
+  masculine:
+  - 09866675-n
   partOfSpeech: n
 09866833-n:
   definition:
@@ -21631,6 +21692,8 @@
 09870873-n:
   definition:
   - the principal groomsman at a wedding
+  feminine:
+  - 09894328-n
   hypernym:
   - 10167685-n
   ili: i88545
@@ -22171,12 +22234,15 @@
 09879912-n:
   definition:
   - a person with fair skin and hair
+  feminine:
+  - 85758093-n
   hypernym:
   - 00007846-n
   ili: i88598
   members:
-  - blond
-  - blonde
+  - blond person
+  masculine:
+  - 86947054-n
   partOfSpeech: n
 09880059-n:
   definition:
@@ -22482,6 +22548,8 @@
 09884297-n:
   definition:
   - a male slave
+  feminine:
+  - 09884474-n
   hypernym:
   - 10628841-n
   ili: i88628
@@ -22492,6 +22560,8 @@
 09884374-n:
   definition:
   - a male bound to serve without wages
+  feminine:
+  - 09884568-n
   hypernym:
   - 09884804-n
   ili: i88629
@@ -22509,6 +22579,8 @@
   - bondwoman
   - bondswoman
   - bondmaid
+  masculine:
+  - 09884297-n
   partOfSpeech: n
 09884568-n:
   definition:
@@ -22520,16 +22592,21 @@
   - bondwoman
   - bondswoman
   - bondmaid
+  masculine:
+  - 09884374-n
   partOfSpeech: n
 09884685-n:
   definition:
   - someone who signs a bond as surety for someone else
+  feminine:
+  - 88561238-n
   hypernym:
   - 09631739-n
   ili: i88632
   members:
-  - bondsman
-  - bondswoman
+  - bondsperson
+  masculine:
+  - 85259651-n
   partOfSpeech: n
 09884804-n:
   definition:
@@ -22933,6 +23010,8 @@
   example:
   - if I'd known he was her boyfriend I wouldn't have asked
   - When the law changed, Pet could finally married his long-time boyfriend Jim
+  feminine:
+  - 10150206-n
   hypernym:
   - 10306910-n
   - 09645472-n
@@ -23174,6 +23253,8 @@
   ili: i88696
   members:
   - bride
+  masculine:
+  - 10167455-n
   partOfSpeech: n
 09894191-n:
   definition:
@@ -23183,6 +23264,8 @@
   ili: i88697
   members:
   - bride
+  masculine:
+  - 10167555-n
   partOfSpeech: n
 09894328-n:
   definition:
@@ -23194,6 +23277,9 @@
   members:
   - bridesmaid
   - maid of honor
+  masculine:
+  - 10167685-n
+  - 09870873-n
   partOfSpeech: n
 09894491-n:
   definition:
@@ -23689,6 +23775,8 @@
   definition:
   - a person engaged in commercial or industrial business (especially an owner or
     executive)
+  feminine:
+  - 09902067-n
   hypernym:
   - 09902168-n
   ili: i88744
@@ -23704,6 +23792,8 @@
   ili: i88745
   members:
   - businesswoman
+  masculine:
+  - 09901459-n
   partOfSpeech: n
 09902168-n:
   definition:
@@ -25514,6 +25604,8 @@
 09928311-n:
   definition:
   - a man paid to drive a privately owned car
+  feminine:
+  - 09928444-n
   hypernym:
   - 10054631-n
   ili: i88917
@@ -25679,6 +25771,9 @@
   - char
   - cleaning woman
   - cleaning lady
+  masculine:
+  - 85556310-n
+  - 81448123-n
   partOfSpeech: n
 09930923-n:
   definition:
@@ -26190,6 +26285,8 @@
   - chorus girl
   - showgirl
   - chorine
+  masculine:
+  - 83222719-n
   partOfSpeech: n
 09940492-n:
   definition:
@@ -27046,6 +27143,8 @@
 09954232-n:
   definition:
   - a man hairdresser
+  feminine:
+  - 09954304-n
   hypernym:
   - 10175409-n
   ili: i89063
@@ -27060,6 +27159,8 @@
   ili: i89064
   members:
   - coiffeuse
+  masculine:
+  - 09954232-n
   partOfSpeech: n
 09954379-n:
   definition:
@@ -27602,6 +27703,8 @@
 09963816-n:
   definition:
   - a man who is a member of committee
+  feminine:
+  - 09963909-n
   hypernym:
   - 09963639-n
   ili: i89115
@@ -27616,6 +27719,8 @@
   ili: i89116
   members:
   - committeewoman
+  masculine:
+  - 09963816-n
   partOfSpeech: n
 09964008-n:
   definition:
@@ -27631,6 +27736,8 @@
 09964156-n:
   definition:
   - a man who is a council member
+  feminine:
+  - 09964410-n
   hypernym:
   - 09964242-n
   ili: i89118
@@ -27655,6 +27762,8 @@
   ili: i89120
   members:
   - councilwoman
+  masculine:
+  - 09964156-n
   partOfSpeech: n
 09964500-n:
   definition:
@@ -27953,6 +28062,8 @@
   - courtesan
   - doxy
   - paramour
+  masculine:
+  - 09991369-n
   partOfSpeech: n
   wikidata: Q2719946
 09972018-n:
@@ -27969,6 +28080,8 @@
 09972531-n:
   definition:
   - the person who collects fares on a public conveyance
+  feminine:
+  - 09972754-n
   hypernym:
   - 09955820-n
   ili: i89151
@@ -28164,13 +28277,15 @@
 09975260-n:
   definition:
   - a member of the United States House of Representatives
+  feminine:
+  - 80278004-n
   hypernym:
   - 10273692-n
   ili: i89170
   members:
-  - congressman
-  - congresswoman
   - representative
+  masculine:
+  - 83115757-n
   partOfSpeech: n
 09975423-n:
   definition:
@@ -28766,6 +28881,8 @@
   - minx
   - tease
   - prickteaser
+  masculine:
+  - 82846014-n
   partOfSpeech: n
 09984954-n:
   definition:
@@ -28866,15 +28983,17 @@
 09986240-n:
   definition:
   - a journalist employed to provide news stories for newspapers or broadcast media
+  feminine:
+  - 84863880-n
   hypernym:
   - 10244248-n
   ili: i89238
   members:
   - correspondent
-  - newspaperman
-  - newspaperwoman
   - newswriter
   - pressman
+  masculine:
+  - 87306750-n
   partOfSpeech: n
 09986471-n:
   definition:
@@ -29040,6 +29159,8 @@
 09988748-n:
   definition:
   - a nobleman (in various countries) having rank equal to a British earl
+  feminine:
+  - 09989932-n
   hypernym:
   - 10291374-n
   ili: i89255
@@ -29076,13 +29197,15 @@
 09989248-n:
   definition:
   - someone who attends a counter (as in a diner)
+  feminine:
+  - 81007314-n
   hypernym:
   - 10783051-n
   ili: i89259
   members:
   - counterperson
-  - counterwoman
-  - counterman
+  masculine:
+  - 89433552-n
   partOfSpeech: n
 09989399-n:
   definition:
@@ -29131,6 +29254,8 @@
   ili: i89264
   members:
   - countess
+  masculine:
+  - 09988748-n
   partOfSpeech: n
 09990023-n:
   definition:
@@ -29167,6 +29292,8 @@
 09990493-n:
   definition:
   - a man from your own country
+  feminine:
+  - 09990577-n
   hypernym:
   - 09990229-n
   ili: i89268
@@ -29181,10 +29308,14 @@
   ili: i89269
   members:
   - countrywoman
+  masculine:
+  - 09990493-n
   partOfSpeech: n
 09990665-n:
   definition:
   - a man who lives in the country and has country ways
+  feminine:
+  - 09990803-n
   hypernym:
   - 10563789-n
   ili: i89270
@@ -29200,6 +29331,8 @@
   ili: i89271
   members:
   - countrywoman
+  masculine:
+  - 09990665-n
   partOfSpeech: n
 09990915-n:
   definition:
@@ -29235,6 +29368,8 @@
 09991369-n:
   definition:
   - an attendant at the court of a sovereign
+  feminine:
+  - 09971872-n
   hypernym:
   - 09841233-n
   ili: i89275
@@ -29276,6 +29411,8 @@
   - cover girl
   - pin-up
   - lovely
+  masculine:
+  - 87519584-n
   partOfSpeech: n
 09992117-n:
   definition:
@@ -29291,11 +29428,12 @@
 09992191-n:
   definition:
   - a hired hand who tends cattle and performs other duties on horseback
+  feminine:
+  - 09992952-n
   hypernym:
   - 10526137-n
   ili: i89280
   members:
-  - cowboy
   - cowpuncher
   - puncher
   - cowman
@@ -29303,6 +29441,8 @@
   - cowpoke
   - cowhand
   - cowherd
+  masculine:
+  - 86290056-n
   partOfSpeech: n
 09992476-n:
   definition:
@@ -30115,13 +30255,15 @@
     devices
   example:
   - a cyborg is a cybernetic organism
+  feminine:
+  - 80220778-n
   hypernym:
   - 10298363-n
   ili: i89358
   members:
   - cyborg
-  - bionic man
-  - bionic woman
+  masculine:
+  - 84232664-n
   partOfSpeech: n
 10005719-n:
   definition:
@@ -30373,6 +30515,8 @@
   - ma'am
   - lady
   - gentlewoman
+  masculine:
+  - 10146810-n
   partOfSpeech: n
 10009040-n:
   definition:
@@ -30457,6 +30601,8 @@
 10010944-n:
   definition:
   - a male ballet dancer who is the partner of a ballerina
+  feminine:
+  - 09853980-n
   hypernym:
   - 09854087-n
   ili: i89388
@@ -31949,6 +32095,8 @@
 10034684-n:
   definition:
   - someone who controls resources and expenditures
+  feminine:
+  - 10309123-n
   hypernym:
   - 09790372-n
   ili: i89528
@@ -32958,6 +33106,9 @@
   - needlewoman
   - seamstress
   - sempstress
+  masculine:
+  - 10709060-n
+  - 87565945-n
   partOfSpeech: n
 10053297-n:
   definition:
@@ -33258,6 +33409,8 @@
   ili: i89650
   members:
   - duchess
+  masculine:
+  - 10058503-n
   partOfSpeech: n
 10058272-n:
   definition:
@@ -33280,6 +33433,8 @@
 10058503-n:
   definition:
   - a nobleman (in various countries) of high rank
+  feminine:
+  - 10058134-n
   hypernym:
   - 10291374-n
   ili: i89653
@@ -34138,6 +34293,8 @@
 10072812-n:
   definition:
   - the male ruler of an empire
+  feminine:
+  - 10073247-n
   hypernym:
   - 10648006-n
   ili: i89736
@@ -34211,6 +34368,8 @@
 10074893-n:
   definition:
   - a sorcerer or magician
+  feminine:
+  - 10075105-n
   hypernym:
   - 10645222-n
   ili: i89744
@@ -34237,6 +34396,8 @@
   members:
   - enchantress
   - witch
+  masculine:
+  - 10074893-n
   partOfSpeech: n
 10075218-n:
   definition:
@@ -34254,6 +34415,8 @@
   - siren
   - Delilah
   - femme fatale
+  masculine:
+  - 10719401-n
   partOfSpeech: n
 10075374-n:
   definition:
@@ -34437,6 +34600,8 @@
 10078393-n:
   definition:
   - a male enlisted person in the armed forces
+  feminine:
+  - 10078770-n
   hypernym:
   - 10078585-n
   ili: i89765
@@ -34460,6 +34625,8 @@
   ili: i89767
   members:
   - enlisted woman
+  masculine:
+  - 10078393-n
   partOfSpeech: n
 10078875-n:
   definition:
@@ -35874,6 +36041,8 @@
 10101439-n:
   definition:
   - a man who takes over all the functions of the real father
+  feminine:
+  - 10352757-n
   hypernym:
   - 10306910-n
   ili: i89904
@@ -36155,6 +36324,8 @@
 10105638-n:
   definition:
   - a man who is engaged to be married
+  feminine:
+  - 10105739-n
   hypernym:
   - 09870983-n
   ili: i89931
@@ -36171,6 +36342,8 @@
   members:
   - fiancee
   - bride-to-be
+  masculine:
+  - 10105638-n
   partOfSpeech: n
 10105843-n:
   definition:
@@ -36552,6 +36725,8 @@
   ili: i89967
   members:
   - first lady
+  masculine:
+  - 89782767-n
   partOfSpeech: n
 10112649-n:
   definition:
@@ -36934,6 +37109,8 @@
   ili: i90005
   members:
   - flower girl
+  masculine:
+  - 85582747-n
   partOfSpeech: n
 10117764-n:
   definition:
@@ -37318,6 +37495,8 @@
   - a person who exercises control over workers
   example:
   - if you want to leave early you have to ask the foreman
+  feminine:
+  - 10124657-n
   hypernym:
   - 10696316-n
   ili: i90042
@@ -37331,6 +37510,8 @@
 10124256-n:
   definition:
   - a man who is foreperson of a jury
+  feminine:
+  - 10124752-n
   hypernym:
   - 10124361-n
   ili: i90043
@@ -37365,6 +37546,8 @@
   ili: i90046
   members:
   - forewoman
+  masculine:
+  - 10123978-n
   partOfSpeech: n
 10124752-n:
   definition:
@@ -37375,6 +37558,8 @@
   members:
   - forewoman
   - forelady
+  masculine:
+  - 10124256-n
   partOfSpeech: n
 10124854-n:
   definition:
@@ -37537,6 +37722,8 @@
   - a person who founds or establishes some institution
   example:
   - George Washington is the father of his country
+  feminine:
+  - 10127787-n
   hypernym:
   - 10403515-n
   ili: i90063
@@ -37731,12 +37918,15 @@
 10129754-n:
   definition:
   - a person who has been freed from slavery
+  feminine:
+  - 81117668-n
   hypernym:
   - 10130792-n
   ili: i90082
   members:
-  - freedman
-  - freedwoman
+  - freedperson
+  masculine:
+  - 86419394-n
   partOfSpeech: n
 10129862-n:
   definition:
@@ -37794,12 +37984,15 @@
 10130792-n:
   definition:
   - a person who is not a serf or a slave
+  feminine:
+  - 83017536-n
   hypernym:
   - 09943131-n
   ili: i90088
   members:
-  - freeman
-  - freewoman
+  - freeperson
+  masculine:
+  - 80035492-n
   partOfSpeech: n
 10130913-n:
   definition:
@@ -37902,6 +38095,8 @@
 10132841-n:
   definition:
   - a man who lives on the frontier
+  feminine:
+  - 10133018-n
   hypernym:
   - 10454188-n
   ili: i90099
@@ -37918,6 +38113,8 @@
   ili: i90100
   members:
   - frontierswoman
+  masculine:
+  - 10132841-n
   partOfSpeech: n
 10133131-n:
   definition:
@@ -38807,6 +39004,8 @@
 10146810-n:
   definition:
   - a man of refinement
+  feminine:
+  - 10008828-n
   hypernym:
   - 10306910-n
   ili: i90189
@@ -38986,6 +39185,8 @@
   - young lady
   - young woman
   - fille
+  masculine:
+  - 10823891-n
   partOfSpeech: n
 10149967-n:
   definition:
@@ -39006,6 +39207,8 @@
   ili: i90208
   members:
   - girl Friday
+  masculine:
+  - 83935783-n
   partOfSpeech: n
 10150206-n:
   definition:
@@ -39020,6 +39223,8 @@
   - girlfriend
   - girl
   - lady friend
+  masculine:
+  - 09890770-n
   partOfSpeech: n
 10150397-n:
   definition:
@@ -39504,6 +39709,8 @@
   ili: i90255
   members:
   - golf widow
+  masculine:
+  - 83226323-n
   partOfSpeech: n
 10157152-n:
   definition:
@@ -40258,6 +40465,8 @@
 10167455-n:
   definition:
   - a man who has recently been married
+  feminine:
+  - 09894084-n
   hypernym:
   - 10375765-n
   ili: i90331
@@ -40268,6 +40477,8 @@
 10167555-n:
   definition:
   - a man participant in his own marriage ceremony
+  feminine:
+  - 09894191-n
   hypernym:
   - 10421528-n
   ili: i90332
@@ -40278,6 +40489,8 @@
 10167685-n:
   definition:
   - a male attendant of the bridegroom at a wedding
+  feminine:
+  - 09894328-n
   hypernym:
   - 09841233-n
   ili: i90333
@@ -41416,6 +41629,9 @@
 10183826-n:
   definition:
   - presiding officer of a school
+  feminine:
+  - 10183990-n
+  - 10579268-n
   hypernym:
   - 10494230-n
   ili: i90438
@@ -41432,6 +41648,8 @@
   ili: i90439
   members:
   - headmistress
+  masculine:
+  - 10183826-n
   partOfSpeech: n
 10184085-n:
   definition:
@@ -41708,6 +41926,8 @@
   definition:
   - a person who is entitled by law or by the terms of a will to inherit the estate
     of another
+  feminine:
+  - 10188740-n
   hypernym:
   - 09651094-n
   ili: i90467
@@ -42012,6 +42232,8 @@
     exploits; often the offspring of a mortal and a god
   domain_topic:
   - 07995347-n
+  feminine:
+  - 10192976-n
   hypernym:
   - 09507794-n
   ili: i90494
@@ -42026,6 +42248,9 @@
   ili: i90495
   members:
   - heroine
+  masculine:
+  - 10192757-n
+  - 05938456-n
   partOfSpeech: n
 10193081-n:
   definition:
@@ -42035,6 +42260,8 @@
   ili: i90496
   members:
   - heroine
+  masculine:
+  - 10344679-n
   partOfSpeech: n
 10193250-n:
   definition:
@@ -42808,13 +43035,16 @@
 10205412-n:
   definition:
   - a man skilled in equitation
+  feminine:
+  - 10205762-n
   hypernym:
   - 10549540-n
   ili: i90570
   members:
-  - horseman
   - equestrian
   - horseback rider
+  masculine:
+  - 87171397-n
   partOfSpeech: n
 10205687-n:
   definition:
@@ -42876,6 +43106,8 @@
 10206393-n:
   definition:
   - the owner or manager of an inn
+  feminine:
+  - 10206678-n
   hypernym:
   - 10428069-n
   ili: i90577
@@ -42908,6 +43140,8 @@
   definition:
   - a person who invites guests to a social event (such as a party in his or her own
     home) and who is responsible for them while they are there
+  feminine:
+  - 10207110-n
   hypernym:
   - 09786620-n
   ili: i90580
@@ -43005,6 +43239,8 @@
 10207988-n:
   definition:
   - a man in charge of children in an institution
+  feminine:
+  - 10208678-n
   hypernym:
   - 10306910-n
   ili: i90589
@@ -43066,6 +43302,8 @@
   ili: i90595
   members:
   - housemother
+  masculine:
+  - 10207988-n
   partOfSpeech: n
 10208798-n:
   definition:
@@ -43369,6 +43607,8 @@
 10213586-n:
   definition:
   - a married man; a woman's partner in marriage
+  feminine:
+  - 10800308-n
   hypernym:
   - 10660018-n
   ili: i90626
@@ -45490,13 +45730,15 @@
 10247948-n:
   definition:
   - someone who serves (or waits to be called to serve) on a jury
+  feminine:
+  - 86950860-n
   hypernym:
   - 10415805-n
   ili: i90826
   members:
   - juror
-  - juryman
-  - jurywoman
+  masculine:
+  - 83347365-n
   partOfSpeech: n
 10248138-n:
   definition:
@@ -45716,6 +45958,8 @@
 10251212-n:
   definition:
   - a male sovereign; ruler of a kingdom
+  feminine:
+  - 10518940-n
   hypernym:
   - 10648006-n
   ili: i90847
@@ -45767,13 +46011,15 @@
 10254721-n:
   definition:
   - a competitor who holds a preeminent position
+  feminine:
+  - 85801071-n
   hypernym:
   - 10552570-n
   ili: i90852
   members:
-  - king
-  - queen
   - world-beater
+  masculine:
+  - 88005275-n
   partOfSpeech: n
 10254839-n:
   definition:
@@ -45881,6 +46127,8 @@
 10256643-n:
   definition:
   - a male relative
+  feminine:
+  - 10256766-n
   hypernym:
   - 10255246-n
   ili: i90862
@@ -45895,6 +46143,8 @@
   ili: i90863
   members:
   - kinswoman
+  masculine:
+  - 10256643-n
   partOfSpeech: n
 10256893-n:
   definition:
@@ -46262,6 +46512,8 @@
   - Lady
   - noblewoman
   - peeress
+  masculine:
+  - 10291374-n
   partOfSpeech: n
 10262834-n:
   definition:
@@ -46440,6 +46692,8 @@
 10264933-n:
   definition:
   - a landowner who leases to others
+  feminine:
+  - 10264853-n
   hypernym:
   - 10265336-n
   ili: i90917
@@ -46830,10 +47084,14 @@
   ili: i90955
   members:
   - leading lady
+  masculine:
+  - 10271214-n
   partOfSpeech: n
 10271214-n:
   definition:
   - actor who plays the leading male role
+  feminine:
+  - 10271114-n
   hypernym:
   - 09784701-n
   ili: i90956
@@ -47065,6 +47323,8 @@
   - lesbian
   - tribade
   - gay woman
+  masculine:
+  - 83837368-n
   partOfSpeech: n
 10274793-n:
   definition:
@@ -48070,6 +48330,8 @@
   members:
   - lollipop lady
   - lollipop woman
+  masculine:
+  - 81269373-n
   partOfSpeech: n
 10290325-n:
   definition:
@@ -48153,6 +48415,8 @@
 10291374-n:
   definition:
   - a titled peer of the realm
+  feminine:
+  - 10262488-n
   hypernym:
   - 10304832-n
   ili: i91084
@@ -48481,13 +48745,16 @@
   - an insane person
   exemplifies:
   - 06730109-n
+  feminine:
+  - 10299661-n
   hypernym:
   - 10615055-n
   ili: i91113
   members:
   - lunatic
-  - madman
   - maniac
+  masculine:
+  - 84605489-n
   partOfSpeech: n
 10296639-n:
   definition:
@@ -49209,6 +49476,8 @@
   - an adult person who is male (as opposed to a woman)
   example:
   - there were two women and six men on the bus
+  feminine:
+  - 10807146-n
   hypernym:
   - 09647338-n
   - 09628463-n
@@ -49227,6 +49496,8 @@
   - she takes good care of her man
   exemplifies:
   - 07089193-n
+  feminine:
+  - 10808492-n
   hypernym:
   - 09647338-n
   - 09645915-n
@@ -49877,6 +50148,8 @@
 10317869-n:
   definition:
   - a male massager
+  feminine:
+  - 10317938-n
   hypernym:
   - 10317650-n
   ili: i91245
@@ -49891,6 +50164,8 @@
   ili: i91246
   members:
   - masseuse
+  masculine:
+  - 10317869-n
   partOfSpeech: n
 10318010-n:
   definition:
@@ -49916,6 +50191,8 @@
 10318314-n:
   definition:
   - directs the work of others
+  feminine:
+  - 10343292-n
   hypernym:
   - 10074465-n
   ili: i91249
@@ -50109,6 +50386,8 @@
   members:
   - matriarch
   - materfamilias
+  masculine:
+  - 10426510-n
   partOfSpeech: n
 10322367-n:
   definition:
@@ -50479,13 +50758,15 @@
 10327942-n:
   definition:
   - a member of a clan
+  feminine:
+  - 80679038-n
   hypernym:
   - 10326901-n
   ili: i91304
   members:
-  - clansman
-  - clanswoman
   - clan member
+  masculine:
+  - 81650724-n
   partOfSpeech: n
 10328061-n:
   definition:
@@ -50931,6 +51212,8 @@
   members:
   - midwife
   - accoucheuse
+  masculine:
+  - 10389398-n
   partOfSpeech: n
   wikidata: Q185196
 10334610-n:
@@ -51174,6 +51457,8 @@
   ili: i91372
   members:
   - millionairess
+  masculine:
+  - 10549130-n
   partOfSpeech: n
 10338344-n:
   definition:
@@ -51498,6 +51783,8 @@
   ili: i91404
   members:
   - mistress
+  masculine:
+  - 10318314-n
   partOfSpeech: n
 10343410-n:
   definition:
@@ -51511,6 +51798,8 @@
   - mistress
   - kept woman
   - fancy woman
+  masculine:
+  - 82904005-n
   partOfSpeech: n
 10343657-n:
   definition:
@@ -51571,6 +51860,8 @@
   - a person distinguished by exceptional courage and nobility and strength
   example:
   - RAF pilots were the heroes of the Battle of Britain
+  feminine:
+  - 10193081-n
   hypernym:
   - 09646208-n
   ili: i91411
@@ -52124,6 +52415,8 @@
   ili: i91465
   members:
   - mother figure
+  masculine:
+  - 10101439-n
   partOfSpeech: n
 10352878-n:
   definition:
@@ -52521,6 +52814,8 @@
     of another human being)
   exemplifies:
   - 06730109-n
+  feminine:
+  - 10358892-n
   hypernym:
   - 09997190-n
   - 10250784-n
@@ -54392,12 +54687,15 @@
 10388619-n:
   definition:
   - someone who rows a boat
+  feminine:
+  - 10388794-n
   hypernym:
   - 09881352-n
   ili: i91685
   members:
-  - oarsman
   - rower
+  masculine:
+  - 89928249-n
   partOfSpeech: n
   wikidata: Q893169
 10388794-n:
@@ -54452,6 +54750,8 @@
 10389398-n:
   definition:
   - a physician specializing in obstetrics
+  feminine:
+  - 10334494-n
   hypernym:
   - 10651974-n
   ili: i91691
@@ -54791,6 +55091,8 @@
 10395205-n:
   definition:
   - a man who is very old
+  feminine:
+  - 10396720-n
   hypernym:
   - 10396222-n
   - 10306910-n
@@ -54858,6 +55160,8 @@
   ili: i91730
   members:
   - old woman
+  masculine:
+  - 10395205-n
   partOfSpeech: n
 10396884-n:
   definition:
@@ -55460,11 +55764,15 @@
 10406317-n:
   definition:
   - a person who spends time outdoors (e.g., hunting or fishing)
+  feminine:
+  - 10406453-n
   hypernym:
   - 09786620-n
   ili: i91790
   members:
-  - outdoorsman
+  - outdoorsperson
+  masculine:
+  - 89964369-n
   partOfSpeech: n
 10406453-n:
   definition:
@@ -55629,6 +55937,8 @@
   - 08458195-n
   example:
   - he is the owner of a chain of restaurants
+  feminine:
+  - 10478085-n
   hypernym:
   - 09901459-n
   ili: i91807
@@ -56572,6 +56882,8 @@
 10426510-n:
   definition:
   - the male head of family or tribe
+  feminine:
+  - 10322243-n
   hypernym:
   - 10306910-n
   - 10184198-n
@@ -58626,6 +58938,8 @@
 10463768-n:
   definition:
   - a writer of poems (the term is usually reserved for writers of good poetry)
+  feminine:
+  - 10466829-n
   hypernym:
   - 10813654-n
   ili: i92096
@@ -58698,6 +59012,8 @@
   - someone who is the forefront of an important enterprise
   example:
   - he is the president's point man on economic issues
+  feminine:
+  - 10468029-n
   hypernym:
   - 09646208-n
   ili: i92103
@@ -58723,6 +59039,8 @@
   ili: i92105
   members:
   - point woman
+  masculine:
+  - 10467731-n
   partOfSpeech: n
 10468142-n:
   definition:
@@ -58758,13 +59076,16 @@
   - a member of a police force
   example:
   - it was an accident, officer
+  feminine:
+  - 10468986-n
   hypernym:
   - 10269156-n
   ili: i92109
   members:
-  - policeman
   - police officer
   - officer
+  masculine:
+  - 80600405-n
   partOfSpeech: n
 10468986-n:
   definition:
@@ -59111,6 +59432,8 @@
   - a person who habitually pretends to be something he is not
   exemplifies:
   - 06730109-n
+  feminine:
+  - 10475636-n
   hypernym:
   - 10090518-n
   ili: i92142
@@ -59182,6 +59505,8 @@
 10476440-n:
   definition:
   - a male poster child
+  feminine:
+  - 10476780-n
   hypernym:
   - 10476516-n
   ili: i92149
@@ -59208,6 +59533,8 @@
   ili: i92151
   members:
   - poster girl
+  masculine:
+  - 10476440-n
   partOfSpeech: n
 10476859-n:
   definition:
@@ -59363,6 +59690,8 @@
 10479141-n:
   definition:
   - the person in charge of a post office
+  feminine:
+  - 10479253-n
   hypernym:
   - 10318314-n
   ili: i92167
@@ -59907,15 +60236,17 @@
   - the officer who presides at the meetings of an organization
   example:
   - address your remarks to the chairperson
+  feminine:
+  - 81797116-n
   hypernym:
   - 10488931-n
   ili: i92219
   members:
   - president
-  - chairman
-  - chairwoman
   - chair
   - chairperson
+  masculine:
+  - 83179919-n
   partOfSpeech: n
 10488931-n:
   definition:
@@ -60026,6 +60357,8 @@
 10490835-n:
   definition:
   - a person who performs religious duties and ceremonies in a non-Christian religion
+  feminine:
+  - 10491155-n
   hypernym:
   - 09528285-n
   ili: i92230
@@ -60041,6 +60374,8 @@
   ili: i92231
   members:
   - priestess
+  masculine:
+  - 10490835-n
   partOfSpeech: n
 10491225-n:
   definition:
@@ -60133,6 +60468,8 @@
   definition:
   - a male member of a royal family other than the sovereign (especially the son of
     a sovereign)
+  feminine:
+  - 10493649-n
   hypernym:
   - 09827177-n
   ili: i92240
@@ -60204,6 +60541,8 @@
   ili: i92247
   members:
   - princess
+  masculine:
+  - 10492384-n
   partOfSpeech: n
 10493928-n:
   definition:
@@ -60747,6 +61086,8 @@
 10503115-n:
   definition:
   - an authoritative person who divines the future
+  feminine:
+  - 10503384-n
   hypernym:
   - 10039756-n
   ili: i92299
@@ -61741,6 +62082,8 @@
   - queen
   - queen regnant
   - female monarch
+  masculine:
+  - 10251212-n
   partOfSpeech: n
 10519216-n:
   definition:
@@ -61759,6 +62102,8 @@
   ili: i92395
   members:
   - queen
+  masculine:
+  - 89388690-n
   partOfSpeech: n
 10519802-n:
   definition:
@@ -61772,6 +62117,8 @@
   ili: i92396
   members:
   - queen
+  masculine:
+  - 14459136-n
   partOfSpeech: n
 10520004-n:
   definition:
@@ -63156,13 +63503,16 @@
 10541255-n:
   definition:
   - a person who investigates and reports or edits news stories
+  feminine:
+  - 10541446-n
   hypernym:
   - 09633690-n
   ili: i92531
   members:
   - reporter
-  - newsman
   - newsperson
+  masculine:
+  - 82640040-n
   partOfSpeech: n
 10541446-n:
   definition:
@@ -63585,6 +63935,8 @@
 10549130-n:
   definition:
   - a person whose material wealth is valued at more than a million dollars
+  feminine:
+  - 10338265-n
   hypernym:
   - 10548806-n
   ili: i92572
@@ -64817,10 +65169,14 @@
   - salesgirl
   - saleswoman
   - saleslady
+  masculine:
+  - 10568094-n
   partOfSpeech: n
 10568094-n:
   definition:
   - a man salesperson
+  feminine:
+  - 10567976-n
   hypernym:
   - 10568238-n
   ili: i92691
@@ -65514,6 +65870,8 @@
 10578620-n:
   definition:
   - a boy attending school
+  feminine:
+  - 10579031-n
   hypernym:
   - 10305010-n
   - 10578716-n
@@ -65549,6 +65907,8 @@
   ili: i92759
   members:
   - schoolgirl
+  masculine:
+  - 10578620-n
   partOfSpeech: n
 10579111-n:
   definition:
@@ -65571,10 +65931,15 @@
   - schoolma'am
   - schoolmistress
   - mistress
+  masculine:
+  - 10183826-n
+  - 10579424-n
   partOfSpeech: n
 10579424-n:
   definition:
   - any person (or institution) who acts as an educator
+  feminine:
+  - 10579268-n
   hypernym:
   - 10065521-n
   ili: i92762
@@ -65975,6 +66340,8 @@
 10585500-n:
   definition:
   - an artist who creates sculptures
+  feminine:
+  - 10586321-n
   hypernym:
   - 09831743-n
   ili: i92801
@@ -66500,6 +66867,8 @@
   ili: i92849
   members:
   - seductress
+  masculine:
+  - 85717860-n
   partOfSpeech: n
 10594907-n:
   definition:
@@ -66588,6 +66957,8 @@
 10596128-n:
   definition:
   - a male elected member of a board of officials who run New England towns
+  feminine:
+  - 10596270-n
   hypernym:
   - 10068644-n
   ili: i92858
@@ -66602,6 +66973,8 @@
   ili: i92859
   members:
   - selectwoman
+  masculine:
+  - 10596128-n
   partOfSpeech: n
 10596414-n:
   definition:
@@ -67336,6 +67709,8 @@
 10607765-n:
   definition:
   - the leader of an Arab village or family
+  feminine:
+  - 10607927-n
   hypernym:
   - 10560786-n
   ili: i92929
@@ -67355,6 +67730,8 @@
   members:
   - sheika
   - sheikha
+  masculine:
+  - 10607765-n
   partOfSpeech: n
 10608009-n:
   definition:
@@ -69573,6 +69950,8 @@
 10643672-n:
   definition:
   - a person who sings with skill
+  feminine:
+  - 10643799-n
   hypernym:
   - 10619214-n
   ili: i93144
@@ -69659,6 +70038,8 @@
 10645222-n:
   definition:
   - one who practices magic or sorcery
+  feminine:
+  - 10645902-n
   hypernym:
   - 10390080-n
   ili: i93153
@@ -70221,6 +70602,8 @@
   members:
   - spinster
   - old maid
+  masculine:
+  - 09849169-n
   partOfSpeech: n
 10655996-n:
   definition:
@@ -70339,6 +70722,8 @@
 10657708-n:
   definition:
   - a male spokesperson
+  feminine:
+  - 10658132-n
   hypernym:
   - 10657783-n
   ili: i93217
@@ -70368,6 +70753,8 @@
   ili: i93219
   members:
   - spokeswoman
+  masculine:
+  - 10657708-n
   partOfSpeech: n
 10658211-n:
   definition:
@@ -70381,13 +70768,15 @@
 10658320-n:
   definition:
   - someone who engages in sports
+  feminine:
+  - 84238586-n
   hypernym:
   - 09839665-n
   ili: i93221
   members:
   - sport
-  - sportsman
-  - sportswoman
+  masculine:
+  - 88651493-n
   partOfSpeech: n
 10658445-n:
   definition:
@@ -71143,13 +71532,16 @@
 10669601-n:
   definition:
   - a man who is a respected leader in national or international affairs
+  feminine:
+  - 10671950-n
   hypernym:
   - 10469877-n
   ili: i93293
   members:
-  - statesman
   - solon
   - national leader
+  masculine:
+  - 85404693-n
   partOfSpeech: n
 10671950-n:
   definition:
@@ -71377,6 +71769,8 @@
 10675033-n:
   definition:
   - an attendant on an airplane
+  feminine:
+  - 10675314-n
   hypernym:
   - 09841233-n
   ili: i93316
@@ -71403,6 +71797,8 @@
   - stewardess
   - air hostess
   - hostess
+  masculine:
+  - 87595983-n
   partOfSpeech: n
 10675425-n:
   definition:
@@ -72137,13 +72533,15 @@
   - a stand-in for movie stars to perform dangerous stunts
   example:
   - his first job in Hollywood was as a double for Clark Gable
+  feminine:
+  - 84393389-n
   hypernym:
   - 10667676-n
   ili: i93388
   members:
   - double
-  - stunt man
-  - stunt woman
+  masculine:
+  - 83734211-n
   partOfSpeech: n
 10686480-n:
   definition:
@@ -72754,6 +73152,8 @@
   ili: i93446
   members:
   - supermom
+  masculine:
+  - 86495725-n
   partOfSpeech: n
 10696008-n:
   definition:
@@ -73568,6 +73968,8 @@
 10709060-n:
   definition:
   - a person whose occupation is making and altering garments
+  feminine:
+  - 10053137-n
   hypernym:
   - 10140473-n
   ili: i93526
@@ -73763,6 +74165,8 @@
 10711765-n:
   definition:
   - someone who imposes hard or continuous work
+  feminine:
+  - 10711901-n
   hypernym:
   - 10696316-n
   ili: i93545
@@ -74258,6 +74662,8 @@
   - a person who tempts others
   example:
   - Satan is the great tempter of mankind
+  feminine:
+  - 10075218-n
   hypernym:
   - 09786620-n
   ili: i93590
@@ -76293,6 +76699,8 @@
   ili: i93789
   members:
   - trophy wife
+  masculine:
+  - 80620228-n
   partOfSpeech: n
 10750670-n:
   definition:
@@ -76887,6 +77295,8 @@
   ili: i93848
   members:
   - unmarried woman
+  masculine:
+  - 09849169-n
   partOfSpeech: n
 10759293-n:
   definition:
@@ -77502,6 +77912,8 @@
 10768557-n:
   definition:
   - a man who is a member of a church vestry
+  feminine:
+  - 10768672-n
   hypernym:
   - 09942257-n
   ili: i93906
@@ -77516,6 +77928,8 @@
   ili: i93907
   members:
   - vestrywoman
+  masculine:
+  - 10768557-n
   partOfSpeech: n
 10768791-n:
   definition:
@@ -77969,6 +78383,8 @@
 10775483-n:
   definition:
   - a British peer who ranks below an earl and above a baron
+  feminine:
+  - 10775594-n (new synset)
   hypernym:
   - 10432655-n
   ili: i93951
@@ -77996,6 +78412,8 @@
 10775816-n:
   definition:
   - (in various countries) a son or younger brother or a count
+  feminine:
+  - 10775594-n (new synset)
   hypernym:
   - 10291374-n
   ili: i93954
@@ -78330,6 +78748,8 @@
 10780994-n:
   definition:
   - a viewer who enjoys seeing the sex acts or sex organs of others
+  feminine:
+  - 92449602-n
   hypernym:
   - 10652848-n
   ili: i93987
@@ -78896,6 +79316,8 @@
 10788752-n:
   definition:
   - operates industrial washing machine
+  feminine:
+  - 10788856-n
   hypernym:
   - 10788571-n
   ili: i94043
@@ -78914,6 +79336,9 @@
   - washerwoman
   - laundrywoman
   - laundress
+  masculine:
+  - 10788752-n
+  - 87970505-n
   partOfSpeech: n
 10788989-n:
   definition:
@@ -79694,10 +80119,14 @@
   members:
   - widow
   - widow woman
+  masculine:
+  - 10800182-n
   partOfSpeech: n
 10800182-n:
   definition:
   - a man whose wife is dead especially one who has not remarried
+  feminine:
+  - 10799960-n
   hypernym:
   - 10306910-n
   ili: i94122
@@ -79715,6 +80144,8 @@
   members:
   - wife
   - married woman
+  masculine:
+  - 10213586-n
   partOfSpeech: n
 10800912-n:
   definition:
@@ -80186,6 +80617,8 @@
   members:
   - woman
   - adult female
+  masculine:
+  - 10306910-n
   mero_part:
   - 05227400-n
   partOfSpeech: n
@@ -80202,6 +80635,8 @@
   ili: i94169
   members:
   - woman
+  masculine:
+  - 10308177-n
   partOfSpeech: n
 10808758-n:
   definition:
@@ -80257,6 +80692,8 @@
   ili: i94174
   members:
   - wonder woman
+  masculine:
+  - 83000076-n
   partOfSpeech: n
 10809603-n:
   definition:
@@ -80519,6 +80956,8 @@
 10813654-n:
   definition:
   - writes (books or stories or articles or the like) professionally (for pay)
+  feminine:
+  - 09843467-n
   hypernym:
   - 09633690-n
   ili: i94200
@@ -80581,12 +81020,15 @@
 10821647-n:
   definition:
   - a person who owns or sails a yacht
+  feminine:
+  - 83067869-n
   hypernym:
   - 10566190-n
   ili: i94206
   members:
-  - yachtsman
-  - yachtswoman
+  - yachtsperson
+  masculine:
+  - 87657220-n
   partOfSpeech: n
 10821751-n:
   definition:
@@ -80756,6 +81198,8 @@
 10823891-n:
   definition:
   - a teenager or a young adult male
+  feminine:
+  - 10149362-n
   hypernym:
   - 09791452-n
   - 10306910-n
@@ -119502,6 +119946,14 @@
   mero_member:
   - 09660255-n
   partOfSpeech: n
+80035492-n:
+  definition:
+  - a male person who is not a serf or a slave
+  hypernym:
+  - 10130792-n
+  members:
+  - freeman
+  partOfSpeech: n
 80147706-n:
   definition:
   - a servile black character in a novel by Harriet Beecher Stowe
@@ -119509,6 +119961,32 @@
   - 09610740-n
   members:
   - Uncle Tom
+  partOfSpeech: n
+80186365-n:
+  definition:
+  - a male person who has received a degree from a school (high school or college
+    or university)
+  hypernym:
+  - 09805779-n
+  members:
+  - alumnus
+  partOfSpeech: n
+80220778-n:
+  definition:
+  - a female human being whose body has been taken over in whole or in part by electromechanical
+    devices
+  hypernym:
+  - 10005508-n
+  members:
+  - bionic woman
+  partOfSpeech: n
+80278004-n:
+  definition:
+  - a female member of the United States House of Representatives
+  hypernym:
+  - 09975260-n
+  members:
+  - congresswoman
   partOfSpeech: n
 80570446-n:
   definition:
@@ -119520,6 +119998,71 @@
   - 84278296-n
   members:
   - yellow woman
+  masculine:
+  - 86740061-n
+  partOfSpeech: n
+80600405-n:
+  definition:
+  - a male member of a police force
+  hypernym:
+  - 10468557-n
+  members:
+  - policeman
+  partOfSpeech: n
+80620228-n:
+  definition:
+  - a husband who is an attractive young man; seldom the first husband of an affluent
+    older woman
+  feminine:
+  - 10750477-n
+  hypernym:
+  - 10800308-n
+  members:
+  - trophy husband
+  partOfSpeech: n
+80679038-n:
+  definition:
+  - a female member of a clan
+  hypernym:
+  - 10327942-n
+  members:
+  - clanswoman
+  partOfSpeech: n
+81007314-n:
+  definition:
+  - a female who attends a counter (as in a diner)
+  hypernym:
+  - 09989248-n
+  members:
+  - counterwoman
+  partOfSpeech: n
+81117668-n:
+  definition:
+  - a female person who has been freed from slavery
+  hypernym:
+  - 10129754-n
+  members:
+  - freedwoman
+  partOfSpeech: n
+81269373-n:
+  definition:
+  - a man hired to help children cross a road safely near a school
+  feminine:
+  - 10290165-n
+  hypernym:
+  - 10000188-n
+  members:
+  - lollipop man
+  partOfSpeech: n
+81448123-n:
+  definition:
+  - a human female employed to do housework
+  feminine:
+  - 09930684-n
+  hypernym:
+  - 09946547-n
+  members:
+  - cleaning man
   partOfSpeech: n
 81621166-n:
   definition:
@@ -119534,6 +120077,22 @@
   - 09660255-n
   members:
   - paleface
+  partOfSpeech: n
+81650724-n:
+  definition:
+  - a male member of a clan
+  hypernym:
+  - 10327942-n
+  members:
+  - clansman
+  partOfSpeech: n
+81797116-n:
+  definition:
+  - the female officer who presides at the meetings of an organization
+  hypernym:
+  - 10488547-n
+  members:
+  - chairwoman
   partOfSpeech: n
 81875840-n:
   definition:
@@ -119591,6 +120150,53 @@
   - Uncle Tom
   - Tom
   partOfSpeech: n
+82640040-n:
+  definition:
+  - a male person who investigates and reports or edits news stories
+  hypernym:
+  - 10541255-n
+  members:
+  - newsman
+  partOfSpeech: n
+82846014-n:
+  definition:
+  - a seductive man who uses his sex appeal to exploit women
+  feminine:
+  - 09984664-n
+  hypernym:
+  - 10807146-n
+  members:
+  - coquet
+  partOfSpeech: n
+82904005-n:
+  definition:
+  - an adulterous man; a man who has an ongoing extramarital sexual relationship with
+    a woman
+  feminine:
+  - 10343410-n
+  hypernym:
+  - 10807146-n
+  members:
+  - kept man
+  partOfSpeech: n
+83000076-n:
+  definition:
+  - a man who can be a succesful husband and care for his children
+  feminine:
+  - 10809460-n
+  hypernym:
+  - 10807146-n
+  members:
+  - wonder man
+  partOfSpeech: n
+83017536-n:
+  definition:
+  - a female person who is not a serf or a slave
+  hypernym:
+  - 10130792-n
+  members:
+  - freewoman
+  partOfSpeech: n
 83027659-n:
   definition:
   - a person who has a large following on one or more social media platform that works
@@ -119600,6 +120206,30 @@
   members:
   - influencer
   partOfSpeech: n
+83067869-n:
+  definition:
+  - a female person who owns or sails a yacht
+  hypernym:
+  - 10821647-n
+  members:
+  - yachtswoman
+  partOfSpeech: n
+83115757-n:
+  definition:
+  - a male member of the United States House of Representatives
+  hypernym:
+  - 09975260-n
+  members:
+  - congressman
+  partOfSpeech: n
+83179919-n:
+  definition:
+  - the male officer who presides at the meetings of an organization
+  hypernym:
+  - 10488547-n
+  members:
+  - chairman
+  partOfSpeech: n
 83192005-n:
   definition:
   - someone who tunes a musical instrument
@@ -119608,14 +120238,62 @@
   members:
   - tuner
   partOfSpeech: n
+83222719-n:
+  definition:
+  - a man who dances in a chorus line
+  feminine:
+  - 09940359-n
+  hypernym:
+  - 10009040-n
+  members:
+  - showboy
+  partOfSpeech: n
+83226323-n:
+  definition:
+  - a husband who is left alone much of the time because his wife is playing golf
+  feminine:
+  - 10157018-n
+  hypernym:
+  - 10800308-n
+  members:
+  - golf widower
+  partOfSpeech: n
+83347365-n:
+  definition:
+  - a male who serves (or waits to be called to serve) on a jury
+  hypernym:
+  - 10247948-n
+  members:
+  - juryman
+  partOfSpeech: n
+83734211-n:
+  definition:
+  - a male stand-in for movie stars to perform dangerous stunts
+  hypernym:
+  - 10686285-n
+  members:
+  - stunt man
+  partOfSpeech: n
 83837368-n:
   definition:
   - a homosexual man
+  feminine:
+  - 10274662-n
   hypernym:
   - 10202544-n
   members:
   - gay man
   - shirtlifter
+  partOfSpeech: n
+83935783-n:
+  definition:
+  - a male assistant who has a range of duties
+  feminine:
+  - 10150104-n
+  hypernym:
+  - 09835195-n
+  members:
+  - boy Friday
   partOfSpeech: n
 84046311-n:
   definition:
@@ -119626,6 +120304,23 @@
   - African American
   - Black American
   - Afro-American
+  partOfSpeech: n
+84232664-n:
+  definition:
+  - a male human being whose body has been taken over in whole or in part by electromechanical
+    devices
+  hypernym:
+  - 10005508-n
+  members:
+  - bionic man
+  partOfSpeech: n
+84238586-n:
+  definition:
+  - a female who engages in sports
+  hypernym:
+  - 10658320-n
+  members:
+  - sportswoman
   partOfSpeech: n
 84278296-n:
   definition:
@@ -119642,6 +120337,8 @@
 84362169-n:
   definition:
   - a man who is Black
+  feminine:
+  - 84388951-n
   hypernym:
   - 86294295-n
   - 10306910-n
@@ -119658,6 +120355,16 @@
   - 86294295-n
   members:
   - Black woman
+  masculine:
+  - 84362169-n
+  partOfSpeech: n
+84393389-n:
+  definition:
+  - a female stand-in for movie stars to perform dangerous stunts
+  hypernym:
+  - 10686285-n
+  members:
+  - stunt woman
   partOfSpeech: n
 84496658-n:
   definition:
@@ -119672,6 +120379,39 @@
   members:
   - boy
   partOfSpeech: n
+84605489-n:
+  definition:
+  - a male insane person
+  hypernym:
+  - 10296461-n
+  members:
+  - madman
+  partOfSpeech: n
+84863880-n:
+  definition:
+  - a female journalist employed to provide news stories for newspapers or broadcast
+    media
+  hypernym:
+  - 09986240-n
+  members:
+  - newspaperwoman
+  partOfSpeech: n
+85242186-n:
+  definition:
+  - a male who operates an aircraft
+  hypernym:
+  - 09845606-n
+  members:
+  - airman
+  partOfSpeech: n
+85259651-n:
+  definition:
+  - a male who signs a bond as surety for someone else
+  hypernym:
+  - 09884685-n
+  members:
+  - bondsman
+  partOfSpeech: n
 85394298-n:
   definition:
   - a dark-skinned race
@@ -119685,6 +120425,79 @@
   - 86294295-n
   - 09659490-n
   partOfSpeech: n
+85404693-n:
+  definition:
+  - a male person  who is a respected leader in national or international affairs
+  hypernym:
+  - 10669601-n
+  members:
+  - statesman
+  partOfSpeech: n
+85556310-n:
+  definition:
+  - a human male employed to do housework
+  feminine:
+  - 09930684-n
+  hypernym:
+  - 09946547-n
+  members:
+  - charman
+  partOfSpeech: n
+85582747-n:
+  definition:
+  - a young boy who carries flowers in a (wedding) procession
+  feminine:
+  - 10117611-n
+  hypernym:
+  - 10104064-n
+  members:
+  - flower boy
+  partOfSpeech: n
+85626490-n:
+  definition:
+  - the father of at least one of your children
+  feminine:
+  - 90019431-n
+  hypernym:
+  - 10807146-n
+  members:
+  - baby papa
+  partOfSpeech: n
+85717860-n:
+  definition:
+  - a man who seduces
+  feminine:
+  - 10594831-n
+  hypernym:
+  - 10594685-n
+  members:
+  - seductor
+  partOfSpeech: n
+85758093-n:
+  definition:
+  - a female person with fair skin and hair
+  hypernym:
+  - 09879912-n
+  members:
+  - blonde
+  partOfSpeech: n
+85801071-n:
+  definition:
+  - a female competitor who holds a preeminent position
+  hypernym:
+  - 10254721-n
+  members:
+  - queen
+  partOfSpeech: n
+86032704-n:
+  definition:
+  - a female person who has received a degree from a school (high school or college
+    or university)
+  hypernym:
+  - 09805779-n
+  members:
+  - alumna
+  partOfSpeech: n
 86191087-n:
   definition:
   - an Asian race
@@ -119696,6 +120509,22 @@
   - Yellow race
   mero_member:
   - 84278296-n
+  partOfSpeech: n
+86250495-n:
+  definition:
+  - a male person of French nationality
+  hypernym:
+  - 09727801-n
+  members:
+  - Frenchman
+  partOfSpeech: n
+86290056-n:
+  definition:
+  - a male hired hand who tends cattle and performs other duties on horseback
+  hypernym:
+  - 09992191-n
+  members:
+  - cowboy
   partOfSpeech: n
 86294295-n:
   definition:
@@ -119717,16 +120546,120 @@
   members:
   - Abo
   partOfSpeech: n
+86419394-n:
+  definition:
+  - a male person who has been freed from slavery
+  hypernym:
+  - 10129754-n
+  members:
+  - freedman
+  partOfSpeech: n
+86461832-n:
+  definition:
+  - A male fan who is obsessive about a particular subject (especially, someone or
+    something in popular entertainment media
+  feminine:
+  - 90009741-n
+  hypernym:
+  - 10097373-n
+  members:
+  - fanboy
+  partOfSpeech: n
+86495725-n:
+  definition:
+  - an informal term for a father who can combine childcare and full-time employment
+  feminine:
+  - 10695873-n
+  hypernym:
+  - 10352098-n
+  members:
+  - superdad
+  partOfSpeech: n
 86740061-n:
   definition:
   - offensive term for an Asian man
   exemplifies:
   - 06730109-n
+  feminine:
+  - 80570446-n
   hypernym:
   - 10306910-n
   - 84278296-n
   members:
   - yellow man
+  partOfSpeech: n
+86947054-n:
+  definition:
+  - a male person with fair skin and hair
+  hypernym:
+  - 09879912-n
+  members:
+  - blond
+  partOfSpeech: n
+86950860-n:
+  definition:
+  - a female who serves (or waits to be called to serve) on a jury
+  hypernym:
+  - 10247948-n
+  members:
+  - jurywoman
+  partOfSpeech: n
+86986461-n:
+  definition:
+  - a male employee who mixes and serves alcoholic drinks at a bar
+  hypernym:
+  - 09860576-n
+  members:
+  - barman
+  partOfSpeech: n
+87143696-n:
+  definition:
+  - a male newspaper columnist who answers questions and offers advice on personal
+    problems to people who write in
+  feminine:
+  - 09798902-n
+  hypernym:
+  - 10376291-n
+  members:
+  - agony uncle
+  partOfSpeech: n
+87171397-n:
+  definition:
+  - a male person  skilled in equitation
+  hypernym:
+  - 10205412-n
+  members:
+  - horseman
+  partOfSpeech: n
+87306750-n:
+  definition:
+  - a male journalist employed to provide news stories for newspapers or broadcast
+    media
+  hypernym:
+  - 09986240-n
+  members:
+  - newspaperman
+  partOfSpeech: n
+87519584-n:
+  definition:
+  - a very pretty boy who works as a photographer's model
+  feminine:
+  - 09991988-n
+  hypernym:
+  - 10446867-n
+  members:
+  - cover boy
+  partOfSpeech: n
+87565945-n:
+  definition:
+  - a man who makes or mends dresses
+  feminine:
+  - 10053137-n
+  hypernym:
+  - 10140473-n
+  members:
+  - needleman
+  - sempster
   partOfSpeech: n
 87584402-n:
   definition:
@@ -119735,6 +120668,24 @@
   - 09824747-n
   members:
   - arbalist
+  partOfSpeech: n
+87595983-n:
+  definition:
+  - a male steward on an airplane
+  feminine:
+  - 10675314-n
+  hypernym:
+  - 10675033-n
+  members:
+  - air host
+  partOfSpeech: n
+87657220-n:
+  definition:
+  - a male person who owns or sails a yacht
+  hypernym:
+  - 10821647-n
+  members:
+  - yachtsman
   partOfSpeech: n
 87736171-n:
   definition:
@@ -119757,6 +120708,24 @@
   - mentee
   - mentoree
   partOfSpeech: n
+87970505-n:
+  definition:
+  - a working woman who takes in washing
+  feminine:
+  - 10788856-n
+  hypernym:
+  - 10788571-n
+  members:
+  - washman
+  partOfSpeech: n
+88005275-n:
+  definition:
+  - a male competitor who holds a preeminent position
+  hypernym:
+  - 10254721-n
+  members:
+  - king
+  partOfSpeech: n
 88020193-n:
   definition:
   - a graduate at an Ivy League school
@@ -119773,6 +120742,24 @@
   members:
   - Red Indian
   partOfSpeech: n
+88429598-n:
+  definition:
+  - a female person of French nationality
+  hypernym:
+  - 09727801-n
+  members:
+  - Frenchwoman
+  partOfSpeech: n
+88456890-n:
+  definition:
+  - a male adulterer
+  feminine:
+  - 09792353-n
+  hypernym:
+  - 09792169-n
+  members:
+  - loose man
+  partOfSpeech: n
 88458300-n:
   definition:
   - (ethnic slur) offensive term for Black people
@@ -119787,6 +120774,31 @@
   - darkie
   - darkey
   partOfSpeech: n
+88561238-n:
+  definition:
+  - a female who signs a bond as surety for someone else
+  hypernym:
+  - 09884685-n
+  members:
+  - bondswoman
+  partOfSpeech: n
+88651493-n:
+  definition:
+  - a male who engages in sports
+  hypernym:
+  - 10658320-n
+  members:
+  - sportsman
+  partOfSpeech: n
+88770907-n:
+  definition:
+  - a male native or inhabitant of Scotland
+  hypernym:
+  - 09749875-n
+  members:
+  - Scotchman
+  - Scotsman
+  partOfSpeech: n
 89085804-n:
   definition:
   - a United States term for Blacks that is now considered offensive
@@ -119800,6 +120812,50 @@
   - colored
   - coloured person
   - coloured
+  partOfSpeech: n
+89388690-n:
+  definition:
+  - the husband or widower of a queen
+  feminine:
+  - 10519442-n
+  hypernym:
+  - 10103592-n
+  members:
+  - king
+  partOfSpeech: n
+89433552-n:
+  definition:
+  - a male who attends a counter (as in a diner)
+  hypernym:
+  - 09989248-n
+  members:
+  - counterman
+  partOfSpeech: n
+89782767-n:
+  definition:
+  - the husband of a chief executive
+  feminine:
+  - 10112563-n
+  hypernym:
+  - 10800308-n
+  members:
+  - first gentleman
+  partOfSpeech: n
+89928249-n:
+  definition:
+  - a male who rows a boat
+  hypernym:
+  - 10388619-n
+  members:
+  - oarsman
+  partOfSpeech: n
+89964369-n:
+  definition:
+  - a male person who spends time outdoors (e.g., hunting or fishing)
+  hypernym:
+  - 10406317-n
+  members:
+  - outdoorsman
   partOfSpeech: n
 90000141-n:
   definition:
@@ -120006,6 +121062,8 @@
   - 09642198-n
   members:
   - fangirl
+  masculine:
+  - 86461832-n
   partOfSpeech: n
   source: Colloquial WordNet
 90010941-n:
@@ -120109,6 +121167,8 @@
   - 10352098-n
   members:
   - baby mama
+  masculine:
+  - 85626490-n
   partOfSpeech: n
   source: Colloquial WordNet
 90019741-n:

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -29508,6 +29508,8 @@
   - preeminence in a particular category or group or field
   example:
   - the lion is the king of beasts
+  feminine:
+  - 10519802-n
   hypernym:
   - 14458911-n
   ili: i112868


### PR DESCRIPTION
Fix #883 

This introduces two new properties, `masculine` and `feminine` as synset relations that indicate a masculine or feminine form.

If the hypernym is a gender-neutral the `feminine` link points from the gender-neutral term

```
actress ==hypernym=> actor
actor ==feminine=> actress
```

If there is both a masculine and a feminine term both are linked from the gender-neutral term

```
representative ==feminine=> congresswoman
congresswoman ==hypernym=> representative
representative ==masculine=> congressman
congressman ==hypernym=> representative
```