### PR TITLE
Clear methodology for masculine and feminine forms of words

### DIFF
--- a/src/yaml/entries-a.yaml
+++ b/src/yaml/entries-a.yaml
@@ -39732,6 +39732,11 @@ agony column:
     sense:
     - id: 'agony_column%1:10:00::'
       synset: 06282167-n
+agony uncle:
+  n:
+    sense:
+    - id: 'agony_uncle%1:18:01::'
+      synset: 87143696-n
 agora:
   n-1:
     form:
@@ -40973,6 +40978,11 @@ air hose:
     sense:
     - id: 'air_hose%1:06:00::'
       synset: 02693129-n
+air host:
+  n:
+    sense:
+    - id: 'air_host%1:18:01::'
+      synset: 87595983-n
 air hostess:
   n:
     sense:
@@ -41687,13 +41697,13 @@ airman:
     sense:
     - derivation:
       - 'airmanship%1:09:00::'
-      id: 'airman%1:18:00::'
-      synset: 09845606-n
+      id: 'airman%1:18:01::'
+      synset: 85242186-n
 airmanship:
   n:
     sense:
     - derivation:
-      - 'airman%1:18:00::'
+      - 'airman%1:18:01::'
       id: 'airmanship%1:09:00::'
       synset: 05643033-n
 airplane:
@@ -48200,8 +48210,8 @@ alumna:
     pronunciation:
     - value: əˈlʌmnə
     sense:
-    - id: 'alumna%1:18:00::'
-      synset: 09805779-n
+    - id: 'alumna%1:18:01::'
+      synset: 86032704-n
 alumnus:
   n:
     form:
@@ -48209,8 +48219,8 @@ alumnus:
     pronunciation:
     - value: əˈlʌmnəs
     sense:
-    - id: 'alumnus%1:18:00::'
-      synset: 09805779-n
+    - id: 'alumnus%1:18:01::'
+      synset: 80186365-n
 alumroot:
   n:
     sense:

--- a/src/yaml/entries-b.yaml
+++ b/src/yaml/entries-b.yaml
@@ -11637,6 +11637,11 @@ baby oil:
     sense:
     - id: 'baby_oil%1:06:00::'
       synset: 02769966-n
+baby papa:
+  n:
+    sense:
+    - id: 'baby_papa%1:18:01::'
+      synset: 85626490-n
 baby powder:
   n:
     sense:
@@ -19495,8 +19500,8 @@ barman:
     - value: ˈbɑɹmæn
       variety: US
     sense:
-    - id: 'barman%1:18:00::'
-      synset: 09860576-n
+    - id: 'barman%1:18:01::'
+      synset: 86986461-n
 barmbrack:
   n:
     sense:
@@ -37112,13 +37117,13 @@ bionic:
 bionic man:
   n:
     sense:
-    - id: 'bionic_man%1:18:00::'
-      synset: 10005508-n
+    - id: 'bionic_man%1:18:01::'
+      synset: 84232664-n
 bionic woman:
   n:
     sense:
-    - id: 'bionic_woman%1:18:00::'
-      synset: 10005508-n
+    - id: 'bionic_woman%1:18:01::'
+      synset: 80220778-n
 bionics:
   n:
     pronunciation:
@@ -44769,10 +44774,15 @@ blond:
     - value: blɑnd
       variety: US
     sense:
-    - id: 'blond%1:18:00::'
-      synset: 09879912-n
     - id: 'blond%1:07:00::'
       synset: 04973194-n
+    - id: 'blond%1:18:01::'
+      synset: 86947054-n
+blond person:
+  n:
+    sense:
+    - id: 'blond_person%1:18:01::'
+      synset: 09879912-n
 blonde:
   a:
     pronunciation:
@@ -44790,10 +44800,10 @@ blonde:
     - value: blɑnd
       variety: US
     sense:
-    - id: 'blonde%1:18:00::'
-      synset: 09879912-n
     - id: 'blonde%1:07:00::'
       synset: 04973194-n
+    - id: 'blonde%1:18:01::'
+      synset: 85758093-n
 blonde lilian:
   n:
     sense:
@@ -50918,19 +50928,24 @@ bondsman:
     sense:
     - id: 'bondsman%1:18:01::'
       synset: 09884297-n
-    - id: 'bondsman%1:18:00::'
-      synset: 09884685-n
     - id: 'bondsman%1:18:02::'
       synset: 09884374-n
+    - id: 'bondsman%1:18:03::'
+      synset: 85259651-n
+bondsperson:
+  n:
+    sense:
+    - id: 'bondsperson%1:18:01::'
+      synset: 09884685-n
 bondswoman:
   n:
     sense:
-    - id: 'bondswoman%1:18:00::'
-      synset: 09884685-n
     - id: 'bondswoman%1:18:02::'
       synset: 09884568-n
     - id: 'bondswoman%1:18:01::'
       synset: 09884474-n
+    - id: 'bondswoman%1:18:03::'
+      synset: 88561238-n
 bonduc:
   n:
     sense:
@@ -56163,6 +56178,11 @@ boy:
       synset: 10643436-n
     - id: 'boy%1:18:01::'
       synset: 84496658-n
+boy Friday:
+  n:
+    sense:
+    - id: 'boy_friday%1:18:01::'
+      synset: 83935783-n
 boy scout:
   n:
     sense:

--- a/src/yaml/entries-c.yaml
+++ b/src/yaml/entries-c.yaml
@@ -45153,7 +45153,7 @@ chairman:
       - 'chairmanship%1:04:00::'
       - 'chairman%2:41:00::'
       id: 'chairman%1:18:01::'
-      synset: 10488547-n
+      synset: 83179919-n
   v:
     pronunciation:
     - value: ˈtʃɛːmən
@@ -45188,7 +45188,7 @@ chairwoman:
   n:
     sense:
     - id: 'chairwoman%1:18:01::'
-      synset: 10488547-n
+      synset: 81797116-n
 chaise:
   n:
     pronunciation:
@@ -48429,6 +48429,11 @@ charm quark:
     sense:
     - id: 'charm_quark%1:17:00::'
       synset: 09265138-n
+charman:
+  n:
+    sense:
+    - id: 'charman%1:18:01::'
+      synset: 85556310-n
 charmed:
   a:
     pronunciation:
@@ -61831,13 +61836,13 @@ clannishness:
 clansman:
   n:
     sense:
-    - id: 'clansman%1:18:00::'
-      synset: 10327942-n
+    - id: 'clansman%1:18:01::'
+      synset: 81650724-n
 clanswoman:
   n:
     sense:
-    - id: 'clanswoman%1:18:00::'
-      synset: 10327942-n
+    - id: 'clanswoman%1:18:01::'
+      synset: 80679038-n
 clap:
   n:
     sense:
@@ -64219,6 +64224,11 @@ cleaning lady:
     sense:
     - id: 'cleaning_lady%1:18:00::'
       synset: 09930684-n
+cleaning man:
+  n:
+    sense:
+    - id: 'cleaning_man%1:18:01::'
+      synset: 81448123-n
 cleaning pad:
   n:
     sense:
@@ -92547,13 +92557,13 @@ congressional district:
 congressman:
   n:
     sense:
-    - id: 'congressman%1:18:00::'
-      synset: 09975260-n
+    - id: 'congressman%1:18:01::'
+      synset: 83115757-n
 congresswoman:
   n:
     sense:
-    - id: 'congresswoman%1:18:00::'
-      synset: 09975260-n
+    - id: 'congresswoman%1:18:01::'
+      synset: 80278004-n
 congruence:
   n:
     pronunciation:
@@ -103072,6 +103082,10 @@ coq au vin:
     - id: 'coq_au_vin%1:13:00::'
       synset: 07877533-n
 coquet:
+  n:
+    sense:
+    - id: 'coquet%1:18:01::'
+      synset: 82846014-n
   v:
     form:
     - coquetted
@@ -108897,8 +108911,8 @@ counterirritant:
 counterman:
   n:
     sense:
-    - id: 'counterman%1:18:00::'
-      synset: 09989248-n
+    - id: 'counterman%1:18:01::'
+      synset: 89433552-n
 countermand:
   n:
     pronunciation:
@@ -109357,8 +109371,8 @@ counterweight:
 counterwoman:
   n:
     sense:
-    - id: 'counterwoman%1:18:00::'
-      synset: 09989248-n
+    - id: 'counterwoman%1:18:01::'
+      synset: 81007314-n
 countess:
   n:
     pronunciation:
@@ -110735,6 +110749,11 @@ cover:
       subcat:
       - vtai
       synset: 00048350-v
+cover boy:
+  n:
+    sense:
+    - id: 'cover_boy%1:18:01::'
+      synset: 87519584-n
 cover charge:
   n:
     sense:
@@ -111239,12 +111258,12 @@ cowboy:
     pronunciation:
     - value: ˈkaʊˌbɔɪ
     sense:
-    - id: 'cowboy%1:18:00::'
-      synset: 09992191-n
     - id: 'cowboy%1:18:03::'
       synset: 09992602-n
     - id: 'cowboy%1:18:02::'
       synset: 09992476-n
+    - id: 'cowboy%1:18:04::'
+      synset: 86290056-n
 cowboy boot:
   n:
     sense:

--- a/src/yaml/entries-c.yaml
+++ b/src/yaml/entries-c.yaml
@@ -39281,8 +39281,8 @@ cattleman:
     sense:
     - id: 'cattleman%1:18:01::'
       synset: 09921470-n
-    - id: 'cattleman%1:18:00::'
-      synset: 09992191-n
+    - id: 'cattleman%1:18:02::'
+      synset: 86290056-n
 cattleship:
   n:
     sense:
@@ -111404,8 +111404,8 @@ cowling:
 cowman:
   n:
     sense:
-    - id: 'cowman%1:18:00::'
-      synset: 09992191-n
+    - id: 'cowman%1:18:01::'
+      synset: 86290056-n
 cownose ray:
   n:
     sense:

--- a/src/yaml/entries-d.yaml
+++ b/src/yaml/entries-d.yaml
@@ -62925,7 +62925,7 @@ dressmaker:
       variety: US
     sense:
     - id: 'dressmaker%1:18:00::'
-      synset: 10053137-n
+      synset: 10140473-n
 dressmaker's model:
   n:
     sense:

--- a/src/yaml/entries-f.yaml
+++ b/src/yaml/entries-f.yaml
@@ -4910,8 +4910,8 @@ Frenchify:
 Frenchman:
   n:
     sense:
-    - id: 'frenchman%1:18:00::'
-      synset: 09727801-n
+    - id: 'frenchman%1:18:01::'
+      synset: 86250495-n
 Frenchness:
   n:
     pronunciation:
@@ -4922,8 +4922,8 @@ Frenchness:
 Frenchwoman:
   n:
     sense:
-    - id: 'frenchwoman%1:18:00::'
-      synset: 09727801-n
+    - id: 'frenchwoman%1:18:01::'
+      synset: 88429598-n
 Freon:
   n:
     sense:
@@ -16476,6 +16476,11 @@ fanbase:
     sense:
     - id: 'fanbase%1:14:01::'
       synset: 91000501-n
+fanboy:
+  n:
+    sense:
+    - id: 'fanboy%1:18:01::'
+      synset: 86461832-n
 fancam:
   n:
     sense:
@@ -31343,6 +31348,11 @@ first gear:
     sense:
     - id: 'first_gear%1:06:00::'
       synset: 03354857-n
+first gentleman:
+  n:
+    sense:
+    - id: 'first_gentleman%1:18:01::'
+      synset: 89782767-n
 first half:
   n:
     sense:
@@ -39087,6 +39097,11 @@ flower bed:
     sense:
     - id: 'flower_bed%1:06:00::'
       synset: 03373198-n
+flower boy:
+  n:
+    sense:
+    - id: 'flower_boy%1:18:01::'
+      synset: 85582747-n
 flower bud:
   n:
     sense:
@@ -52008,8 +52023,8 @@ freeborn:
 freedman:
   n:
     sense:
-    - id: 'freedman%1:18:00::'
-      synset: 10129754-n
+    - id: 'freedman%1:18:01::'
+      synset: 86419394-n
 freedom:
   n:
     pronunciation:
@@ -52108,11 +52123,16 @@ freedom to bear arms:
     sense:
     - id: 'freedom_to_bear_arms%1:07:00::'
       synset: 05191581-n
+freedperson:
+  n:
+    sense:
+    - id: 'freedperson%1:18:01::'
+      synset: 10129754-n
 freedwoman:
   n:
     sense:
-    - id: 'freedwoman%1:18:00::'
-      synset: 10129754-n
+    - id: 'freedwoman%1:18:01::'
+      synset: 81117668-n
 freehand:
   a:
     sense:
@@ -52251,13 +52271,18 @@ freemail:
 freeman:
   n:
     sense:
-    - id: 'freeman%1:18:00::'
-      synset: 10130792-n
+    - id: 'freeman%1:18:01::'
+      synset: 80035492-n
 freemasonry:
   n:
     sense:
     - id: 'freemasonry%1:26:00::'
       synset: 13953106-n
+freeperson:
+  n:
+    sense:
+    - id: 'freeperson%1:18:01::'
+      synset: 10130792-n
 freesia:
   n:
     pronunciation:
@@ -52373,8 +52398,8 @@ freewill:
 freewoman:
   n:
     sense:
-    - id: 'freewoman%1:18:00::'
-      synset: 10130792-n
+    - id: 'freewoman%1:18:01::'
+      synset: 83017536-n
 freeze:
   n:
     sense:

--- a/src/yaml/entries-g.yaml
+++ b/src/yaml/entries-g.yaml
@@ -46647,6 +46647,11 @@ golf widow:
     sense:
     - id: 'golf_widow%1:18:00::'
       synset: 10157018-n
+golf widower:
+  n:
+    sense:
+    - id: 'golf_widower%1:18:01::'
+      synset: 83226323-n
 golf-club:
   n:
     sense:

--- a/src/yaml/entries-h.yaml
+++ b/src/yaml/entries-h.yaml
@@ -38132,17 +38132,17 @@ horseman:
     - value: ˈhɔːsmən
       variety: GB
     sense:
-    - derivation:
-      - 'horsemanship%1:09:00::'
-      id: 'horseman%1:18:00::'
-      synset: 10205412-n
     - id: 'horseman%1:18:01::'
       synset: 10205301-n
+    - derivation:
+      - 'horsemanship%1:09:00::'
+      id: 'horseman%1:18:02::'
+      synset: 82609402-n
 horsemanship:
   n:
     sense:
     - derivation:
-      - 'horseman%1:18:00::'
+      - 'horseman%1:18:02::'
       id: 'horsemanship%1:09:00::'
       synset: 05646219-n
 horsemeat:

--- a/src/yaml/entries-j.yaml
+++ b/src/yaml/entries-j.yaml
@@ -13520,13 +13520,13 @@ jury-rigged:
 juryman:
   n:
     sense:
-    - id: 'juryman%1:18:00::'
-      synset: 10247948-n
+    - id: 'juryman%1:18:01::'
+      synset: 83347365-n
 jurywoman:
   n:
     sense:
-    - id: 'jurywoman%1:18:00::'
-      synset: 10247948-n
+    - id: 'jurywoman%1:18:01::'
+      synset: 86950860-n
 jus civile:
   n:
     sense:

--- a/src/yaml/entries-k.yaml
+++ b/src/yaml/entries-k.yaml
@@ -6253,6 +6253,11 @@ kept:
     sense:
     - id: 'kept%3:00:00::'
       synset: 00290665-a
+kept man:
+  n:
+    sense:
+    - id: 'kept_man%1:18:01::'
+      synset: 82904005-n
 kept up:
   a:
     sense:
@@ -8784,8 +8789,6 @@ king:
       - 'kingship%1:26:00::'
       id: 'king%1:18:00::'
       synset: 10251212-n
-    - id: 'king%1:18:02::'
-      synset: 10254721-n
     - id: 'king%1:18:01::'
       synset: 09859605-n
     - id: 'king%1:26:00::'
@@ -8796,6 +8799,10 @@ king:
       synset: 03623428-n
     - id: 'king%1:06:00::'
       synset: 03623310-n
+    - id: 'king%1:18:06::'
+      synset: 88005275-n
+    - id: 'king%1:18:07::'
+      synset: 89388690-n
 king begonia:
   n:
     sense:

--- a/src/yaml/entries-l.yaml
+++ b/src/yaml/entries-l.yaml
@@ -37348,6 +37348,11 @@ lollipop lady:
     sense:
     - id: 'lollipop_lady%1:18:00::'
       synset: 10290165-n
+lollipop man:
+  n:
+    sense:
+    - id: 'lollipop_man%1:18:01::'
+      synset: 81269373-n
 lollipop woman:
   n:
     sense:
@@ -39227,6 +39232,11 @@ loose end:
     sense:
     - id: 'loose_end%1:04:00::'
       synset: 00582922-n
+loose man:
+  n:
+    sense:
+    - id: 'loose_man%1:18:01::'
+      synset: 88456890-n
 loose off:
   v:
     sense:

--- a/src/yaml/entries-m.yaml
+++ b/src/yaml/entries-m.yaml
@@ -15717,8 +15717,8 @@ madly:
 madman:
   n:
     sense:
-    - id: 'madman%1:18:00::'
-      synset: 10296461-n
+    - id: 'madman%1:18:01::'
+      synset: 84605489-n
 madnep:
   n:
     sense:

--- a/src/yaml/entries-n.yaml
+++ b/src/yaml/entries-n.yaml
@@ -15931,8 +15931,8 @@ newsletter:
 newsman:
   n:
     sense:
-    - id: 'newsman%1:18:00::'
-      synset: 10541255-n
+    - id: 'newsman%1:18:01::'
+      synset: 82640040-n
 newsmonger:
   n:
     sense:
@@ -16014,13 +16014,13 @@ newspapering:
 newspaperman:
   n:
     sense:
-    - id: 'newspaperman%1:18:00::'
-      synset: 09986240-n
+    - id: 'newspaperman%1:18:01::'
+      synset: 87306750-n
 newspaperwoman:
   n:
     sense:
-    - id: 'newspaperwoman%1:18:00::'
-      synset: 09986240-n
+    - id: 'newspaperwoman%1:18:01::'
+      synset: 84863880-n
 newspeak:
   n:
     pronunciation:

--- a/src/yaml/entries-o.yaml
+++ b/src/yaml/entries-o.yaml
@@ -4474,13 +4474,13 @@ oarsman:
     sense:
     - derivation:
       - 'oarsmanship%1:09:00::'
-      id: 'oarsman%1:18:00::'
-      synset: 10388619-n
+      id: 'oarsman%1:18:01::'
+      synset: 89928249-n
 oarsmanship:
   n:
     sense:
     - derivation:
-      - 'oarsman%1:18:00::'
+      - 'oarsman%1:18:01::'
       id: 'oarsmanship%1:09:00::'
       synset: 05647401-n
 oarswoman:
@@ -24763,7 +24763,12 @@ outdoors:
 outdoorsman:
   n:
     sense:
-    - id: 'outdoorsman%1:18:00::'
+    - id: 'outdoorsman%1:18:01::'
+      synset: 89964369-n
+outdoorsperson:
+  n:
+    sense:
+    - id: 'outdoorsperson%1:18:01::'
       synset: 10406317-n
 outdoorswoman:
   n:

--- a/src/yaml/entries-p.yaml
+++ b/src/yaml/entries-p.yaml
@@ -78268,7 +78268,7 @@ pressman:
     - id: 'pressman%1:18:00::'
       synset: 10494882-n
     - id: 'pressman%1:18:01::'
-      synset: 09986240-n
+      synset: 87306750-n
 pressmark:
   n:
     sense:

--- a/src/yaml/entries-p.yaml
+++ b/src/yaml/entries-p.yaml
@@ -62408,8 +62408,8 @@ policeman:
     pronunciation:
     - value: pəˈliːsmən
     sense:
-    - id: 'policeman%1:18:00::'
-      synset: 10468557-n
+    - id: 'policeman%1:18:01::'
+      synset: 80600405-n
 policeman bird:
   n:
     sense:

--- a/src/yaml/entries-q.yaml
+++ b/src/yaml/entries-q.yaml
@@ -3069,8 +3069,6 @@ queen:
       synset: 10519442-n
     - id: 'queen%1:18:04::'
       synset: 10519802-n
-    - id: 'queen%1:18:03::'
-      synset: 10254721-n
     - id: 'queen%1:18:02::'
       synset: 10095821-n
     - id: 'queen%1:06:01::'
@@ -3084,6 +3082,8 @@ queen:
       synset: 02372587-n
     - id: 'queen%1:05:03::'
       synset: 02125530-n
+    - id: 'queen%1:18:05::'
+      synset: 85801071-n
   v:
     pronunciation:
     - value: kwiːn

--- a/src/yaml/entries-s.yaml
+++ b/src/yaml/entries-s.yaml
@@ -5719,8 +5719,8 @@ Scotch woodcock:
 Scotchman:
   n:
     sense:
-    - id: 'scotchman%1:18:00::'
-      synset: 09749875-n
+    - id: 'scotchman%1:18:01::'
+      synset: 88770907-n
 Scotchwoman:
   n:
     sense:
@@ -5782,8 +5782,8 @@ Scotsman:
     - value: ˈskɑts.mən
       variety: US
     sense:
-    - id: 'scotsman%1:18:00::'
-      synset: 09749875-n
+    - id: 'scotsman%1:18:01::'
+      synset: 88770907-n
 Scotswoman:
   n:
     sense:
@@ -59864,6 +59864,11 @@ showboat:
     sense:
     - id: 'showboat%1:06:00::'
       synset: 04215827-n
+showboy:
+  n:
+    sense:
+    - id: 'showboy%1:18:01::'
+      synset: 83222719-n
 showcase:
   n:
     pronunciation:
@@ -101042,8 +101047,8 @@ sportsman:
     sense:
     - derivation:
       - 'sportsmanship%1:07:00::'
-      id: 'sportsman%1:18:00::'
-      synset: 10658320-n
+      id: 'sportsman%1:18:01::'
+      synset: 88651493-n
 sportsmanlike:
   a:
     sense:
@@ -101053,7 +101058,7 @@ sportsmanship:
   n:
     sense:
     - derivation:
-      - 'sportsman%1:18:00::'
+      - 'sportsman%1:18:01::'
       id: 'sportsmanship%1:07:00::'
       synset: 04846786-n
 sportswear:
@@ -101064,8 +101069,8 @@ sportswear:
 sportswoman:
   n:
     sense:
-    - id: 'sportswoman%1:18:00::'
-      synset: 10658320-n
+    - id: 'sportswoman%1:18:01::'
+      synset: 84238586-n
 sportswriter:
   n:
     sense:
@@ -110636,8 +110641,8 @@ statesman:
     - derivation:
       - 'statesmanly%3:00:00::'
       - 'statesmanship%1:07:00::'
-      id: 'statesman%1:18:00::'
-      synset: 10669601-n
+      id: 'statesman%1:18:01::'
+      synset: 85900704-n
 statesmanlike:
   a:
     sense:
@@ -110649,14 +110654,14 @@ statesmanly:
   a:
     sense:
     - derivation:
-      - 'statesman%1:18:00::'
+      - 'statesman%1:18:01::'
       id: 'statesmanly%3:00:00::'
       synset: 00756614-a
 statesmanship:
   n:
     sense:
     - derivation:
-      - 'statesman%1:18:00::'
+      - 'statesman%1:18:01::'
       id: 'statesmanship%1:07:00::'
       synset: 04898060-n
 stateswoman:
@@ -125617,8 +125622,8 @@ stunt kite:
 stunt man:
   n:
     sense:
-    - id: 'stunt_man%1:18:00::'
-      synset: 10686285-n
+    - id: 'stunt_man%1:18:01::'
+      synset: 83734211-n
 stunt pilot:
   n:
     sense:
@@ -125627,8 +125632,8 @@ stunt pilot:
 stunt woman:
   n:
     sense:
-    - id: 'stunt_woman%1:18:00::'
-      synset: 10686285-n
+    - id: 'stunt_woman%1:18:01::'
+      synset: 84393389-n
 stunted:
   a:
     sense:
@@ -135387,6 +135392,11 @@ supercritical:
     sense:
     - id: supercritical%5:00:00:critical:04
       synset: 00655373-s
+superdad:
+  n:
+    sense:
+    - id: 'superdad%1:18:01::'
+      synset: 86495725-n
 superego:
   n:
     pronunciation:

--- a/src/yaml/entries-t.yaml
+++ b/src/yaml/entries-t.yaml
@@ -55916,6 +55916,11 @@ trophy case:
     sense:
     - id: 'trophy_case%1:06:00::'
       synset: 04495458-n
+trophy husband:
+  n:
+    sense:
+    - id: 'trophy_husband%1:18:01::'
+      synset: 80620228-n
 trophy wife:
   n:
     sense:

--- a/src/yaml/entries-w.yaml
+++ b/src/yaml/entries-w.yaml
@@ -8957,6 +8957,11 @@ washing-up:
     sense:
     - id: 'washing-up%1:04:00::'
       synset: 00256989-n
+washman:
+  n:
+    sense:
+    - id: 'washman%1:18:01::'
+      synset: 87970505-n
 washout:
   n:
     pronunciation:
@@ -27363,6 +27368,11 @@ wonder flower:
     sense:
     - id: 'wonder_flower%1:20:00::'
       synset: 12480813-n
+wonder man:
+  n:
+    sense:
+    - id: 'wonder_man%1:18:01::'
+      synset: 83000076-n
 wonder woman:
   n:
     pronunciation:

--- a/src/yaml/entries-y.yaml
+++ b/src/yaml/entries-y.yaml
@@ -1144,13 +1144,18 @@ yachting cap:
 yachtsman:
   n:
     sense:
-    - id: 'yachtsman%1:18:00::'
+    - id: 'yachtsman%1:18:01::'
+      synset: 87657220-n
+yachtsperson:
+  n:
+    sense:
+    - id: 'yachtsperson%1:18:01::'
       synset: 10821647-n
 yachtswoman:
   n:
     sense:
-    - id: 'yachtswoman%1:18:00::'
-      synset: 10821647-n
+    - id: 'yachtswoman%1:18:01::'
+      synset: 83067869-n
 yack:
   n:
     pronunciation:

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -78078,6 +78078,7 @@
   - a noblewoman holding the rank of viscount in her own right
   hypernym:
   - 10432655-n
+  - 10807146-n
   ili: i93952
   members:
   - viscountess

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -17263,8 +17263,8 @@
   partOfSpeech: n
 09798902-n:
   definition:
-  - a newspaper columnist who answers questions and offers advice on personal problems
-    to people who write in
+  - a female newspaper columnist who answers questions and offers advice on personal
+    problems to people who write in
   hypernym:
   - 10376291-n
   - 10807146-n
@@ -28901,7 +28901,6 @@
   members:
   - correspondent
   - newswriter
-  - pressman
   partOfSpeech: n
 09986471-n:
   definition:
@@ -78994,7 +78993,7 @@
   partOfSpeech: n
 10788752-n:
   definition:
-  - operates industrial washing machine
+  - a man who operates an industrial washing machine
   hypernym:
   - 10788571-n
   - 10306910-n
@@ -120290,6 +120289,7 @@
   - 09986240-n
   members:
   - newspaperman
+  - pressman
   partOfSpeech: n
 87519584-n:
   definition:

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -311,6 +311,7 @@
   - a female giant
   hypernym:
   - 09511841-n
+  - 10807146-n
   ili: i86492
   members:
   - giantess
@@ -12408,6 +12409,7 @@
   - a man who is a native or inhabitant of England
   hypernym:
   - 09720544-n
+  - 10306910-n
   ili: i87640
   members:
   - Englishman
@@ -12417,6 +12419,7 @@
   - a woman who is a native or inhabitant of England
   hypernym:
   - 09720544-n
+  - 10807146-n
   ili: i87641
   members:
   - Englishwoman
@@ -12871,8 +12874,6 @@
   - 09705914-n
   ili: i87687
   members:
-  - Frenchman
-  - Frenchwoman
   - French person
   partOfSpeech: n
 09728044-n:
@@ -13309,6 +13310,7 @@
   - a man who is a native or inhabitant of Ireland
   hypernym:
   - 09734348-n
+  - 10306910-n
   ili: i87732
   members:
   - Irishman
@@ -13318,6 +13320,7 @@
   - a woman who is a native or inhabitant of Ireland
   hypernym:
   - 09734348-n
+  - 10807146-n
   ili: i87733
   members:
   - Irishwoman
@@ -14293,14 +14296,13 @@
   ili: i87833
   members:
   - Scot
-  - Scotsman
-  - Scotchman
   partOfSpeech: n
 09750074-n:
   definition:
   - a woman who is a Scot
   hypernym:
   - 09749875-n
+  - 10807146-n
   ili: i87834
   members:
   - Scotswoman
@@ -15986,6 +15988,7 @@
   - the superior of a group of nuns
   hypernym:
   - 10695315-n
+  - 10807146-n
   ili: i88007
   members:
   - abbess
@@ -15998,6 +16001,7 @@
   - the superior of an abbey of monks
   hypernym:
   - 10695315-n
+  - 10306910-n
   ili: i88008
   members:
   - abbot
@@ -16670,6 +16674,7 @@
   - a female actor
   hypernym:
   - 09784701-n
+  - 10807146-n
   ili: i88071
   members:
   - actress
@@ -16922,6 +16927,7 @@
   - 07139048-n
   hypernym:
   - 09792169-n
+  - 10807146-n
   ili: i88094
   members:
   - adulteress
@@ -16947,6 +16953,7 @@
   - a woman adventurer
   hypernym:
   - 09629201-n
+  - 10807146-n
   ili: i88096
   members:
   - adventuress
@@ -17260,6 +17267,7 @@
     to people who write in
   hypernym:
   - 10376291-n
+  - 10807146-n
   ili: i88126
   members:
   - agony aunt
@@ -17727,8 +17735,6 @@
   - 10577282-n
   ili: i88171
   members:
-  - alumnus
-  - alumna
   - alum
   - graduate
   - grad
@@ -17820,6 +17826,7 @@
   - a woman ambassador
   hypernym:
   - 09806975-n
+  - 10807146-n
   ili: i88180
   members:
   - ambassadress
@@ -19311,6 +19318,7 @@
   - someone who is a member of a legislative assembly
   hypernym:
   - 10541628-n
+  - 10306910-n
   ili: i88325
   members:
   - assemblyman
@@ -19320,6 +19328,7 @@
   - a woman assemblyman
   hypernym:
   - 10541628-n
+  - 10807146-n
   ili: i88326
   members:
   - assemblywoman
@@ -19712,6 +19721,7 @@
   - a woman author
   hypernym:
   - 10813654-n
+  - 10807146-n
   ili: i88361
   members:
   - authoress
@@ -19849,7 +19859,6 @@
   members:
   - aviator
   - aeronaut
-  - airman
   - flier
   - flyer
   partOfSpeech: n
@@ -19858,6 +19867,7 @@
   - a woman aviator
   hypernym:
   - 09845606-n
+  - 10807146-n
   ili: i88374
   members:
   - aviatrix
@@ -20410,6 +20420,7 @@
   - a female ballet dancer
   hypernym:
   - 09854087-n
+  - 10807146-n
   ili: i88426
   members:
   - ballerina
@@ -20766,6 +20777,7 @@
   - a female bartender
   hypernym:
   - 09860576-n
+  - 10807146-n
   ili: i88463
   members:
   - barmaid
@@ -20885,7 +20897,6 @@
   ili: i88473
   members:
   - bartender
-  - barman
   - barkeep
   - barkeeper
   - mixologist
@@ -21338,6 +21349,7 @@
   - a man who is a beggar
   hypernym:
   - 09866418-n
+  - 10306910-n
   ili: i88516
   members:
   - beggarman
@@ -21347,6 +21359,7 @@
   - a woman who is a beggar
   hypernym:
   - 09866418-n
+  - 10807146-n
   ili: i88517
   members:
   - beggarwoman
@@ -22177,8 +22190,7 @@
   - 00007846-n
   ili: i88598
   members:
-  - blond
-  - blonde
+  - blond person
   partOfSpeech: n
 09880059-n:
   definition:
@@ -22486,6 +22498,7 @@
   - a male slave
   hypernym:
   - 10628841-n
+  - 10306910-n
   ili: i88628
   members:
   - bondman
@@ -22496,6 +22509,7 @@
   - a male bound to serve without wages
   hypernym:
   - 09884804-n
+  - 10306910-n
   ili: i88629
   members:
   - bondman
@@ -22506,6 +22520,7 @@
   - a female slave
   hypernym:
   - 10628841-n
+  - 10807146-n
   ili: i88630
   members:
   - bondwoman
@@ -22517,6 +22532,7 @@
   - a female bound to serve without wages
   hypernym:
   - 09884804-n
+  - 10807146-n
   ili: i88631
   members:
   - bondwoman
@@ -22530,8 +22546,7 @@
   - 09631739-n
   ili: i88632
   members:
-  - bondsman
-  - bondswoman
+  - bondsperson
   partOfSpeech: n
 09884804-n:
   definition:
@@ -23173,6 +23188,7 @@
   - a woman who has recently been married
   hypernym:
   - 10375765-n
+  - 10807146-n
   ili: i88696
   members:
   - bride
@@ -23182,6 +23198,7 @@
   - a woman participant in her own marriage ceremony
   hypernym:
   - 10421528-n
+  - 10807146-n
   ili: i88697
   members:
   - bride
@@ -23693,6 +23710,7 @@
     executive)
   hypernym:
   - 09902168-n
+  - 10306910-n
   ili: i88744
   members:
   - businessman
@@ -23703,6 +23721,7 @@
   - a female businessperson
   hypernym:
   - 09902168-n
+  - 10807146-n
   ili: i88745
   members:
   - businesswoman
@@ -25515,7 +25534,7 @@
   partOfSpeech: n
 09928311-n:
   definition:
-  - a man paid to drive a privately owned car
+  - a person paid to drive a privately owned car
   hypernym:
   - 10054631-n
   ili: i88917
@@ -25527,6 +25546,7 @@
   - a woman chauffeur
   hypernym:
   - 09928311-n
+  - 10807146-n
   ili: i88918
   members:
   - chauffeuse
@@ -25675,6 +25695,7 @@
     text: Oh, good. The cleaning lady came, so I don't have to be embarrassed.
   hypernym:
   - 09946547-n
+  - 10807146-n
   ili: i88932
   members:
   - charwoman
@@ -26187,6 +26208,7 @@
   - a woman who dances in a chorus line
   hypernym:
   - 10009040-n
+  - 10807146-n
   ili: i88979
   members:
   - chorus girl
@@ -27050,6 +27072,7 @@
   - a man hairdresser
   hypernym:
   - 10175409-n
+  - 10306910-n
   ili: i89063
   members:
   - coiffeur
@@ -27059,6 +27082,7 @@
   - a woman hairdresser
   hypernym:
   - 10175409-n
+  - 10807146-n
   ili: i89064
   members:
   - coiffeuse
@@ -27606,6 +27630,7 @@
   - a man who is a member of committee
   hypernym:
   - 09963639-n
+  - 10306910-n
   ili: i89115
   members:
   - committeeman
@@ -27615,6 +27640,7 @@
   - a woman who is a member of a committee
   hypernym:
   - 09963639-n
+  - 10807146-n
   ili: i89116
   members:
   - committeewoman
@@ -27635,6 +27661,7 @@
   - a man who is a council member
   hypernym:
   - 09964242-n
+  - 10306910-n
   ili: i89118
   members:
   - councilman
@@ -27654,6 +27681,7 @@
   - a woman who is a council member
   hypernym:
   - 09964242-n
+  - 10807146-n
   ili: i89120
   members:
   - councilwoman
@@ -27991,6 +28019,7 @@
   - a woman conductor
   hypernym:
   - 09972531-n
+  - 10807146-n
   ili: i89153
   members:
   - conductress
@@ -28170,8 +28199,6 @@
   - 10273692-n
   ili: i89170
   members:
-  - congressman
-  - congresswoman
   - representative
   partOfSpeech: n
 09975423-n:
@@ -28873,8 +28900,6 @@
   ili: i89238
   members:
   - correspondent
-  - newspaperman
-  - newspaperwoman
   - newswriter
   - pressman
   partOfSpeech: n
@@ -29083,8 +29108,6 @@
   ili: i89259
   members:
   - counterperson
-  - counterwoman
-  - counterman
   partOfSpeech: n
 09989399-n:
   definition:
@@ -29171,6 +29194,7 @@
   - a man from your own country
   hypernym:
   - 09990229-n
+  - 10306910-n
   ili: i89268
   members:
   - countryman
@@ -29180,6 +29204,7 @@
   - a woman from your own country
   hypernym:
   - 09990229-n
+  - 10807146-n
   ili: i89269
   members:
   - countrywoman
@@ -29189,6 +29214,7 @@
   - a man who lives in the country and has country ways
   hypernym:
   - 10563789-n
+  - 10306910-n
   ili: i89270
   members:
   - countryman
@@ -29199,6 +29225,7 @@
   - a woman who lives in the country and has country ways
   hypernym:
   - 10563789-n
+  - 10807146-n
   ili: i89271
   members:
   - countrywoman
@@ -29239,6 +29266,7 @@
   - an attendant at the court of a sovereign
   hypernym:
   - 09841233-n
+  - 10306910-n
   ili: i89275
   members:
   - courtier
@@ -29273,6 +29301,7 @@
   - a very pretty girl who works as a photographer's model
   hypernym:
   - 10446867-n
+  - 10807146-n
   ili: i89278
   members:
   - cover girl
@@ -29297,11 +29326,8 @@
   - 10526137-n
   ili: i89280
   members:
-  - cowboy
   - cowpuncher
   - puncher
-  - cowman
-  - cattleman
   - cowpoke
   - cowhand
   - cowherd
@@ -29342,6 +29368,7 @@
   - a woman cowboy
   hypernym:
   - 09992191-n
+  - 10807146-n
   ili: i89284
   members:
   - cowgirl
@@ -30122,8 +30149,6 @@
   ili: i89358
   members:
   - cyborg
-  - bionic man
-  - bionic woman
   partOfSpeech: n
 10005719-n:
   definition:
@@ -30461,6 +30486,7 @@
   - a male ballet dancer who is the partner of a ballerina
   hypernym:
   - 09854087-n
+  - 10306910-n
   ili: i89388
   members:
   - danseur
@@ -32950,12 +32976,12 @@
   partOfSpeech: n
 10053137-n:
   definition:
-  - someone who makes or mends dresses
+  - a woman who makes or mends dresses
   hypernym:
   - 10140473-n
+  - 10807146-n
   ili: i89621
   members:
-  - dressmaker
   - modiste
   - needlewoman
   - seamstress
@@ -34151,6 +34177,7 @@
   - a woman emperor or the wife of an emperor
   hypernym:
   - 10072812-n
+  - 10807146-n
   ili: i89737
   members:
   - empress
@@ -34215,6 +34242,7 @@
   - a sorcerer or magician
   hypernym:
   - 10645222-n
+  - 10306910-n
   ili: i89744
   members:
   - enchanter
@@ -34235,6 +34263,7 @@
   - a female sorcerer or magician
   hypernym:
   - 10390080-n
+  - 10807146-n
   ili: i89746
   members:
   - enchantress
@@ -34441,6 +34470,7 @@
   - a male enlisted person in the armed forces
   hypernym:
   - 10078585-n
+  - 10306910-n
   ili: i89765
   members:
   - enlisted man
@@ -34459,6 +34489,7 @@
   - a female enlisted person in the armed forces
   hypernym:
   - 10078585-n
+  - 10807146-n
   ili: i89767
   members:
   - enlisted woman
@@ -36159,6 +36190,7 @@
   - a man who is engaged to be married
   hypernym:
   - 09870983-n
+  - 10306910-n
   ili: i89931
   members:
   - fiance
@@ -36169,6 +36201,7 @@
   - a woman who is engaged to be married
   hypernym:
   - 09870983-n
+  - 10807146-n
   ili: i89932
   members:
   - fiancee
@@ -37322,6 +37355,7 @@
   - if you want to leave early you have to ask the foreman
   hypernym:
   - 10696316-n
+  - 10306910-n
   ili: i90042
   members:
   - foreman
@@ -37335,6 +37369,7 @@
   - a man who is foreperson of a jury
   hypernym:
   - 10124361-n
+  - 10306910-n
   ili: i90043
   members:
   - foreman
@@ -37364,6 +37399,7 @@
   - a woman in charge of a group of workers
   hypernym:
   - 10696316-n
+  - 10807146-n
   ili: i90046
   members:
   - forewoman
@@ -37373,6 +37409,7 @@
   - a woman who is foreperson of a jury
   hypernym:
   - 10124361-n
+  - 10807146-n
   ili: i90047
   members:
   - forewoman
@@ -37582,6 +37619,7 @@
   - a woman founder
   hypernym:
   - 10127072-n
+  - 10807146-n
   ili: i90067
   members:
   - foundress
@@ -37737,8 +37775,7 @@
   - 10130792-n
   ili: i90082
   members:
-  - freedman
-  - freedwoman
+  - freedperson
   partOfSpeech: n
 10129862-n:
   definition:
@@ -37800,8 +37837,7 @@
   - 09943131-n
   ili: i90088
   members:
-  - freeman
-  - freewoman
+  - freeperson
   partOfSpeech: n
 10130913-n:
   definition:
@@ -37906,6 +37942,7 @@
   - a man who lives on the frontier
   hypernym:
   - 10454188-n
+  - 10306910-n
   ili: i90099
   members:
   - frontiersman
@@ -37917,6 +37954,7 @@
   - a woman who lives on the frontier
   hypernym:
   - 10454188-n
+  - 10807146-n
   ili: i90100
   members:
   - frontierswoman
@@ -38469,6 +38507,7 @@
   - garmentmaker
   - garment-worker
   - garment worker
+  - dressmaker
   partOfSpeech: n
 10140683-n:
   definition:
@@ -39005,6 +39044,7 @@
   - a female assistant who has a range of duties
   hypernym:
   - 09835195-n
+  - 10807146-n
   ili: i90208
   members:
   - girl Friday
@@ -40261,6 +40301,7 @@
   - a man who has recently been married
   hypernym:
   - 10375765-n
+  - 10306910-n
   ili: i90331
   members:
   - groom
@@ -40271,6 +40312,7 @@
   - a man participant in his own marriage ceremony
   hypernym:
   - 10421528-n
+  - 10306910-n
   ili: i90332
   members:
   - groom
@@ -40281,6 +40323,7 @@
   - a male attendant of the bridegroom at a wedding
   hypernym:
   - 09841233-n
+  - 10306910-n
   ili: i90333
   members:
   - groomsman
@@ -41419,6 +41462,7 @@
   - presiding officer of a school
   hypernym:
   - 10494230-n
+  - 10306910-n
   ili: i90438
   members:
   - headmaster
@@ -41430,6 +41474,7 @@
   - a woman headmaster
   hypernym:
   - 10494230-n
+  - 10807146-n
   ili: i90439
   members:
   - headmistress
@@ -41741,6 +41786,7 @@
   - a female heir
   hypernym:
   - 10188177-n
+  - 10807146-n
   ili: i90470
   members:
   - heiress
@@ -42015,6 +42061,7 @@
   - 07995347-n
   hypernym:
   - 09507794-n
+  - 10306910-n
   ili: i90494
   members:
   - hero
@@ -42024,6 +42071,7 @@
   - the main good female character in a work of fiction
   hypernym:
   - 05937794-n
+  - 10807146-n
   ili: i90495
   members:
   - heroine
@@ -42808,12 +42856,11 @@
   partOfSpeech: n
 10205412-n:
   definition:
-  - a man skilled in equitation
+  - a person skilled in equitation
   hypernym:
   - 10549540-n
   ili: i90570
   members:
-  - horseman
   - equestrian
   - horseback rider
   partOfSpeech: n
@@ -42831,6 +42878,7 @@
   - a woman horseman
   hypernym:
   - 10205412-n
+  - 10807146-n
   ili: i90572
   members:
   - horsewoman
@@ -42901,6 +42949,7 @@
   - a woman innkeeper
   hypernym:
   - 10206393-n
+  - 10807146-n
   ili: i90579
   members:
   - hostess
@@ -42931,6 +42980,7 @@
   - a woman host
   hypernym:
   - 10206749-n
+  - 10807146-n
   ili: i90582
   members:
   - hostess
@@ -43064,6 +43114,7 @@
   - a woman employed as a chaperon in a residence for young people
   hypernym:
   - 09927731-n
+  - 10807146-n
   ili: i90595
   members:
   - housemother
@@ -43372,6 +43423,7 @@
   - a married man; a woman's partner in marriage
   hypernym:
   - 10660018-n
+  - 10306910-n
   ili: i90626
   members:
   - husband
@@ -45496,8 +45548,6 @@
   ili: i90826
   members:
   - juror
-  - juryman
-  - jurywoman
   partOfSpeech: n
 10248138-n:
   definition:
@@ -45718,6 +45768,7 @@
   - a male sovereign; ruler of a kingdom
   hypernym:
   - 10648006-n
+  - 10306910-n
   ili: i90847
   members:
   - king
@@ -45771,8 +45822,6 @@
   - 10552570-n
   ili: i90852
   members:
-  - king
-  - queen
   - world-beater
   partOfSpeech: n
 10254839-n:
@@ -45883,6 +45932,7 @@
   - a male relative
   hypernym:
   - 10255246-n
+  - 10306910-n
   ili: i90862
   members:
   - kinsman
@@ -45892,6 +45942,7 @@
   - a female relative
   hypernym:
   - 10255246-n
+  - 10807146-n
   ili: i90863
   members:
   - kinswoman
@@ -46256,6 +46307,7 @@
   - 08879115-n
   hypernym:
   - 10103592-n
+  - 10807146-n
   ili: i90898
   members:
   - Lady
@@ -46432,6 +46484,7 @@
   - a landlord who is a woman
   hypernym:
   - 10264933-n
+  - 10807146-n
   ili: i90916
   members:
   - landlady
@@ -46835,6 +46888,7 @@
   - actor who plays the leading male role
   hypernym:
   - 09784701-n
+  - 10306910-n
   ili: i90956
   members:
   - leading man
@@ -47059,6 +47113,7 @@
   - 84123305-n
   hypernym:
   - 10202544-n
+  - 10807146-n
   ili: i90976
   members:
   - lesbian
@@ -48065,6 +48120,7 @@
   - 08879115-n
   hypernym:
   - 10000188-n
+  - 10807146-n
   ili: i91076
   members:
   - lollipop lady
@@ -48154,6 +48210,7 @@
   - a titled peer of the realm
   hypernym:
   - 10304832-n
+  - 10306910-n
   ili: i91084
   members:
   - Lord
@@ -48485,7 +48542,6 @@
   ili: i91113
   members:
   - lunatic
-  - madman
   - maniac
   partOfSpeech: n
 10296639-n:
@@ -48732,6 +48788,7 @@
   - 06730109-n
   hypernym:
   - 10296461-n
+  - 10807146-n
   ili: i91137
   members:
   - madwoman
@@ -49290,6 +49347,7 @@
   - a woman manager
   hypernym:
   - 10034684-n
+  - 10807146-n
   ili: i91189
   members:
   - manageress
@@ -49878,6 +49936,7 @@
   - a male massager
   hypernym:
   - 10317650-n
+  - 10306910-n
   ili: i91245
   members:
   - masseur
@@ -49887,6 +49946,7 @@
   - a female massager
   hypernym:
   - 10317650-n
+  - 10807146-n
   ili: i91246
   members:
   - masseuse
@@ -49917,6 +49977,7 @@
   - directs the work of others
   hypernym:
   - 10074465-n
+  - 10306910-n
   ili: i91249
   members:
   - master
@@ -50482,8 +50543,6 @@
   - 10326901-n
   ili: i91304
   members:
-  - clansman
-  - clanswoman
   - clan member
   partOfSpeech: n
 10328061-n:
@@ -50926,6 +50985,7 @@
   - a woman skilled in aiding the delivery of babies
   hypernym:
   - 10386665-n
+  - 10807146-n
   ili: i91349
   members:
   - midwife
@@ -51170,6 +51230,7 @@
   - a woman millionaire
   hypernym:
   - 10548806-n
+  - 10807146-n
   ili: i91372
   members:
   - millionairess
@@ -51494,6 +51555,7 @@
   - a woman master who directs the work of others
   hypernym:
   - 10074465-n
+  - 10807146-n
   ili: i91404
   members:
   - mistress
@@ -51572,6 +51634,7 @@
   - RAF pilots were the heroes of the Battle of Britain
   hypernym:
   - 09646208-n
+  - 10306910-n
   ili: i91411
   members:
   - hero
@@ -52536,6 +52599,7 @@
   - 06730109-n
   hypernym:
   - 10358420-n
+  - 10807146-n
   ili: i91504
   members:
   - murderess
@@ -52647,6 +52711,7 @@
   - a Muslim woman
   hypernym:
   - 09701687-n
+  - 10807146-n
   ili: i91515
   members:
   - Muslimah
@@ -54394,7 +54459,6 @@
   - 09881352-n
   ili: i91685
   members:
-  - oarsman
   - rower
   partOfSpeech: n
   wikidata: Q893169
@@ -54403,6 +54467,7 @@
   - a woman oarsman
   hypernym:
   - 10388619-n
+  - 10807146-n
   ili: i91686
   members:
   - oarswoman
@@ -54452,6 +54517,7 @@
   - a physician specializing in obstetrics
   hypernym:
   - 10651974-n
+  - 10306910-n
   ili: i91691
   members:
   - obstetrician
@@ -55462,13 +55528,14 @@
   - 09786620-n
   ili: i91790
   members:
-  - outdoorsman
+  - outdoorsperson
   partOfSpeech: n
 10406453-n:
   definition:
   - a woman who spends time outdoors (e.g., hunting and fishing)
   hypernym:
   - 10406317-n
+  - 10807146-n
   ili: i91791
   members:
   - outdoorswoman
@@ -58635,6 +58702,7 @@
   - a woman poet
   hypernym:
   - 10463768-n
+  - 10807146-n
   ili: i92097
   members:
   - poetess
@@ -58698,6 +58766,7 @@
   - he is the president's point man on economic issues
   hypernym:
   - 09646208-n
+  - 10306910-n
   ili: i92103
   members:
   - point man
@@ -58718,6 +58787,7 @@
   - a woman who is the forefront of an important enterprise
   hypernym:
   - 09646208-n
+  - 10807146-n
   ili: i92105
   members:
   - point woman
@@ -58760,7 +58830,6 @@
   - 10269156-n
   ili: i92109
   members:
-  - policeman
   - police officer
   - officer
   partOfSpeech: n
@@ -58769,6 +58838,7 @@
   - a woman policeman
   hypernym:
   - 10468557-n
+  - 10807146-n
   ili: i92110
   members:
   - police matron
@@ -59123,6 +59193,7 @@
   - 06730109-n
   hypernym:
   - 10475481-n
+  - 10807146-n
   ili: i92143
   members:
   - poseuse
@@ -59182,6 +59253,7 @@
   - a male poster child
   hypernym:
   - 10476516-n
+  - 10306910-n
   ili: i92149
   members:
   - poster boy
@@ -59203,6 +59275,7 @@
   - a female poster child
   hypernym:
   - 10476516-n
+  - 10807146-n
   ili: i92151
   members:
   - poster girl
@@ -59291,6 +59364,7 @@
   - a woman proprietor
   hypernym:
   - 10408623-n
+  - 10807146-n
   ili: i92160
   members:
   - proprietress
@@ -59372,6 +59446,7 @@
   - a woman postmaster
   hypernym:
   - 10479141-n
+  - 10807146-n
   ili: i92168
   members:
   - postmistress
@@ -59910,8 +59985,6 @@
   ili: i92219
   members:
   - president
-  - chairman
-  - chairwoman
   - chair
   - chairperson
   partOfSpeech: n
@@ -60026,6 +60099,7 @@
   - a person who performs religious duties and ceremonies in a non-Christian religion
   hypernym:
   - 09528285-n
+  - 10306910-n
   ili: i92230
   members:
   - priest
@@ -60036,6 +60110,7 @@
   - a woman priest
   hypernym:
   - 10490364-n
+  - 10807146-n
   ili: i92231
   members:
   - priestess
@@ -60133,6 +60208,7 @@
     a sovereign)
   hypernym:
   - 09827177-n
+  - 10306910-n
   ili: i92240
   members:
   - prince
@@ -60199,6 +60275,7 @@
     of a sovereign)
   hypernym:
   - 09827177-n
+  - 10807146-n
   ili: i92247
   members:
   - princess
@@ -60760,6 +60837,7 @@
   - a woman prophet
   hypernym:
   - 10503115-n
+  - 10807146-n
   ili: i92300
   members:
   - prophetess
@@ -61734,6 +61812,7 @@
   - a female sovereign ruler
   hypernym:
   - 10103592-n
+  - 10807146-n
   ili: i92393
   members:
   - queen
@@ -61767,6 +61846,7 @@
   - the queen of ocean liners
   hypernym:
   - 10437846-n
+  - 10807146-n
   ili: i92396
   members:
   - queen
@@ -63159,7 +63239,6 @@
   ili: i92531
   members:
   - reporter
-  - newsman
   - newsperson
   partOfSpeech: n
 10541446-n:
@@ -63167,6 +63246,7 @@
   - a female newsperson
   hypernym:
   - 10541255-n
+  - 10807146-n
   ili: i92532
   members:
   - newswoman
@@ -63585,6 +63665,7 @@
   - a person whose material wealth is valued at more than a million dollars
   hypernym:
   - 10548806-n
+  - 10306910-n
   ili: i92572
   members:
   - millionaire
@@ -64810,6 +64891,7 @@
   - a woman salesperson
   hypernym:
   - 10568238-n
+  - 10807146-n
   ili: i92690
   members:
   - salesgirl
@@ -64821,6 +64903,7 @@
   - a man salesperson
   hypernym:
   - 10568238-n
+  - 10306910-n
   ili: i92691
   members:
   - salesman
@@ -65515,6 +65598,7 @@
   hypernym:
   - 10305010-n
   - 10578716-n
+  - 10306910-n
   ili: i92756
   members:
   - schoolboy
@@ -65544,6 +65628,7 @@
   - a girl attending school
   hypernym:
   - 10104064-n
+  - 10807146-n
   ili: i92759
   members:
   - schoolgirl
@@ -65563,6 +65648,7 @@
   - a woman schoolteacher (especially one regarded as strict)
   hypernym:
   - 10579780-n
+  - 10807146-n
   ili: i92761
   members:
   - schoolmarm
@@ -65575,6 +65661,7 @@
   - any person (or institution) who acts as an educator
   hypernym:
   - 10065521-n
+  - 10306910-n
   ili: i92762
   members:
   - schoolmaster
@@ -65987,6 +66074,7 @@
   - a woman sculptor
   hypernym:
   - 10585500-n
+  - 10807146-n
   ili: i92802
   members:
   - sculptress
@@ -66495,6 +66583,7 @@
   - 06730109-n
   hypernym:
   - 10594685-n
+  - 10807146-n
   ili: i92849
   members:
   - seductress
@@ -66588,6 +66677,7 @@
   - a male elected member of a board of officials who run New England towns
   hypernym:
   - 10068644-n
+  - 10306910-n
   ili: i92858
   members:
   - selectman
@@ -66597,6 +66687,7 @@
   - a female elected member of a board of officials who run New England towns
   hypernym:
   - 10068644-n
+  - 10807146-n
   ili: i92859
   members:
   - selectwoman
@@ -67338,6 +67429,7 @@
   - the leader of an Arab village or family
   hypernym:
   - 10560786-n
+  - 10306910-n
   ili: i92929
   members:
   - sheik
@@ -69584,6 +69676,7 @@
   - a woman songster (especially of popular songs)
   hypernym:
   - 10643672-n
+  - 10807146-n
   ili: i93145
   members:
   - songstress
@@ -69695,6 +69788,7 @@
   - a woman sorcerer
   hypernym:
   - 10645222-n
+  - 10807146-n
   ili: i93156
   members:
   - sorceress
@@ -70341,6 +70435,7 @@
   - a male spokesperson
   hypernym:
   - 10657783-n
+  - 10306910-n
   ili: i93217
   members:
   - spokesman
@@ -70365,6 +70460,7 @@
   - a female spokesperson
   hypernym:
   - 10657783-n
+  - 10807146-n
   ili: i93219
   members:
   - spokeswoman
@@ -70386,8 +70482,6 @@
   ili: i93221
   members:
   - sport
-  - sportsman
-  - sportswoman
   partOfSpeech: n
 10658445-n:
   definition:
@@ -71142,12 +71236,11 @@
   partOfSpeech: n
 10669601-n:
   definition:
-  - a man who is a respected leader in national or international affairs
+  - a person who is a respected leader in national or international affairs
   hypernym:
   - 10469877-n
   ili: i93293
   members:
-  - statesman
   - solon
   - national leader
   partOfSpeech: n
@@ -71156,6 +71249,7 @@
   - a woman statesman
   hypernym:
   - 10669601-n
+  - 10807146-n
   ili: i93294
   members:
   - stateswoman
@@ -71398,6 +71492,7 @@
   - a woman steward on an airplane
   hypernym:
   - 10675033-n
+  - 10807146-n
   ili: i93318
   members:
   - stewardess
@@ -72142,8 +72237,6 @@
   ili: i93388
   members:
   - double
-  - stunt man
-  - stunt woman
   partOfSpeech: n
 10686480-n:
   definition:
@@ -73570,6 +73663,7 @@
   - a person whose occupation is making and altering garments
   hypernym:
   - 10140473-n
+  - 10306910-n
   ili: i93526
   members:
   - tailor
@@ -73774,6 +73868,7 @@
   - a woman taskmaster
   hypernym:
   - 10711765-n
+  - 10807146-n
   ili: i93546
   members:
   - taskmistress
@@ -74260,6 +74355,7 @@
   - Satan is the great tempter of mankind
   hypernym:
   - 09786620-n
+  - 10306910-n
   ili: i93590
   members:
   - tempter
@@ -77504,6 +77600,7 @@
   - a man who is a member of a church vestry
   hypernym:
   - 09942257-n
+  - 10306910-n
   ili: i93906
   members:
   - vestryman
@@ -77513,6 +77610,7 @@
   - a woman who is a member of a church vestry
   hypernym:
   - 09942257-n
+  - 10807146-n
   ili: i93907
   members:
   - vestrywoman
@@ -77971,6 +78069,7 @@
   - a British peer who ranks below an earl and above a baron
   hypernym:
   - 10432655-n
+  - 10306910-n
   ili: i93951
   members:
   - viscount
@@ -78898,6 +78997,7 @@
   - operates industrial washing machine
   hypernym:
   - 10788571-n
+  - 10306910-n
   ili: i94043
   members:
   - washerman
@@ -78908,6 +79008,7 @@
   - a working woman who takes in washing
   hypernym:
   - 10788571-n
+  - 10807146-n
   ili: i94044
   members:
   - washwoman
@@ -80585,8 +80686,7 @@
   - 10566190-n
   ili: i94206
   members:
-  - yachtsman
-  - yachtswoman
+  - yachtsperson
   partOfSpeech: n
 10821751-n:
   definition:
@@ -119501,6 +119601,15 @@
   mero_member:
   - 09660255-n
   partOfSpeech: n
+80035492-n:
+  definition:
+  - a male person who is not a serf or a slave
+  hypernym:
+  - 10807146-n
+  - 10130792-n
+  members:
+  - freeman
+  partOfSpeech: n
 80147706-n:
   definition:
   - a servile black character in a novel by Harriet Beecher Stowe
@@ -119508,6 +119617,35 @@
   - 09610740-n
   members:
   - Uncle Tom
+  partOfSpeech: n
+80186365-n:
+  definition:
+  - a male person who has received a degree from a school (high school or college
+    or university)
+  hypernym:
+  - 10807146-n
+  - 09805779-n
+  members:
+  - alumnus
+  partOfSpeech: n
+80220778-n:
+  definition:
+  - a female human being whose body has been taken over in whole or in part by electromechanical
+    devices
+  hypernym:
+  - 10807146-n
+  - 10005508-n
+  members:
+  - bionic woman
+  partOfSpeech: n
+80278004-n:
+  definition:
+  - a female member of the United States House of Representatives
+  hypernym:
+  - 10807146-n
+  - 09975260-n
+  members:
+  - congresswoman
   partOfSpeech: n
 80570446-n:
   definition:
@@ -119519,6 +119657,69 @@
   - 84278296-n
   members:
   - yellow woman
+  partOfSpeech: n
+80600405-n:
+  definition:
+  - a male member of a police force
+  hypernym:
+  - 10306910-n
+  - 10468557-n
+  members:
+  - policeman
+  partOfSpeech: n
+80620228-n:
+  definition:
+  - a husband who is an attractive young man; seldom the first husband of an affluent
+    older woman
+  hypernym:
+  - 10800308-n
+  members:
+  - trophy husband
+  partOfSpeech: n
+80679038-n:
+  definition:
+  - a female member of a clan
+  hypernym:
+  - 10807146-n
+  - 10327942-n
+  members:
+  - clanswoman
+  partOfSpeech: n
+81007314-n:
+  definition:
+  - a female who attends a counter (as in a diner)
+  hypernym:
+  - 10807146-n
+  - 09989248-n
+  members:
+  - counterwoman
+  partOfSpeech: n
+81117668-n:
+  definition:
+  - a female person who has been freed from slavery
+  hypernym:
+  - 10807146-n
+  - 10129754-n
+  members:
+  - freedwoman
+  partOfSpeech: n
+81269373-n:
+  definition:
+  - a man hired to help children cross a road safely near a school
+  hypernym:
+  - 10306910-n
+  - 10000188-n
+  members:
+  - lollipop man
+  partOfSpeech: n
+81448123-n:
+  definition:
+  - a human female employed to do housework
+  hypernym:
+  - 10306910-n
+  - 09946547-n
+  members:
+  - cleaning man
   partOfSpeech: n
 81621166-n:
   definition:
@@ -119533,6 +119734,24 @@
   - 09660255-n
   members:
   - paleface
+  partOfSpeech: n
+81650724-n:
+  definition:
+  - a male member of a clan
+  hypernym:
+  - 10807146-n
+  - 10327942-n
+  members:
+  - clansman
+  partOfSpeech: n
+81797116-n:
+  definition:
+  - the female officer who presides at the meetings of an organization
+  hypernym:
+  - 10807146-n
+  - 10488547-n
+  members:
+  - chairwoman
   partOfSpeech: n
 81875840-n:
   definition:
@@ -119590,6 +119809,58 @@
   - Uncle Tom
   - Tom
   partOfSpeech: n
+82609402-n:
+  definition:
+  - a man skilled in equitation
+  hypernym:
+  - 10306910-n
+  - 10205412-n
+  members:
+  - horseman
+  partOfSpeech: n
+82640040-n:
+  definition:
+  - a male person who investigates and reports or edits news stories
+  hypernym:
+  - 10306910-n
+  - 10541255-n
+  members:
+  - newsman
+  partOfSpeech: n
+82846014-n:
+  definition:
+  - a seductive man who uses his sex appeal to exploit women
+  hypernym:
+  - 10807146-n
+  members:
+  - coquet
+  partOfSpeech: n
+82904005-n:
+  definition:
+  - an adulterous man; a man who has an ongoing extramarital sexual relationship with
+    a woman
+  hypernym:
+  - 10807146-n
+  members:
+  - kept man
+  partOfSpeech: n
+83000076-n:
+  definition:
+  - a man who can be a succesful husband and care for his children
+  hypernym:
+  - 10807146-n
+  members:
+  - wonder man
+  partOfSpeech: n
+83017536-n:
+  definition:
+  - a female person who is not a serf or a slave
+  hypernym:
+  - 10807146-n
+  - 10130792-n
+  members:
+  - freewoman
+  partOfSpeech: n
 83027659-n:
   definition:
   - a person who has a large following on one or more social media platform that works
@@ -119599,6 +119870,33 @@
   members:
   - influencer
   partOfSpeech: n
+83067869-n:
+  definition:
+  - a female person who owns or sails a yacht
+  hypernym:
+  - 10807146-n
+  - 10821647-n
+  members:
+  - yachtswoman
+  partOfSpeech: n
+83115757-n:
+  definition:
+  - a male member of the United States House of Representatives
+  hypernym:
+  - 10807146-n
+  - 09975260-n
+  members:
+  - congressman
+  partOfSpeech: n
+83179919-n:
+  definition:
+  - the male officer who presides at the meetings of an organization
+  hypernym:
+  - 10807146-n
+  - 10488547-n
+  members:
+  - chairman
+  partOfSpeech: n
 83192005-n:
   definition:
   - someone who tunes a musical instrument
@@ -119607,14 +119905,59 @@
   members:
   - tuner
   partOfSpeech: n
+83222719-n:
+  definition:
+  - a man who dances in a chorus line
+  hypernym:
+  - 10306910-n
+  - 10009040-n
+  members:
+  - showboy
+  partOfSpeech: n
+83226323-n:
+  definition:
+  - a husband who is left alone much of the time because his wife is playing golf
+  hypernym:
+  - 10800308-n
+  members:
+  - golf widower
+  partOfSpeech: n
+83347365-n:
+  definition:
+  - a male who serves (or waits to be called to serve) on a jury
+  hypernym:
+  - 10807146-n
+  - 10247948-n
+  members:
+  - juryman
+  partOfSpeech: n
+83734211-n:
+  definition:
+  - a male stand-in for movie stars to perform dangerous stunts
+  hypernym:
+  - 10807146-n
+  - 10686285-n
+  members:
+  - stunt man
+  partOfSpeech: n
 83837368-n:
   definition:
   - a homosexual man
   hypernym:
   - 10202544-n
+  - 10306910-n
   members:
   - gay man
   - shirtlifter
+  partOfSpeech: n
+83935783-n:
+  definition:
+  - a male assistant who has a range of duties
+  hypernym:
+  - 10306910-n
+  - 09835195-n
+  members:
+  - boy Friday
   partOfSpeech: n
 84046311-n:
   definition:
@@ -119625,6 +119968,25 @@
   - African American
   - Black American
   - Afro-American
+  partOfSpeech: n
+84232664-n:
+  definition:
+  - a male human being whose body has been taken over in whole or in part by electromechanical
+    devices
+  hypernym:
+  - 10807146-n
+  - 10005508-n
+  members:
+  - bionic man
+  partOfSpeech: n
+84238586-n:
+  definition:
+  - a female who engages in sports
+  hypernym:
+  - 10807146-n
+  - 10658320-n
+  members:
+  - sportswoman
   partOfSpeech: n
 84278296-n:
   definition:
@@ -119658,6 +120020,15 @@
   members:
   - Black woman
   partOfSpeech: n
+84393389-n:
+  definition:
+  - a female stand-in for movie stars to perform dangerous stunts
+  hypernym:
+  - 10807146-n
+  - 10686285-n
+  members:
+  - stunt woman
+  partOfSpeech: n
 84496658-n:
   definition:
   - (ethnic slur) offensive and disparaging term for Black man
@@ -119670,6 +120041,43 @@
   - 84362169-n
   members:
   - boy
+  partOfSpeech: n
+84605489-n:
+  definition:
+  - a male insane person
+  hypernym:
+  - 10306910-n
+  - 10296461-n
+  members:
+  - madman
+  partOfSpeech: n
+84863880-n:
+  definition:
+  - a female journalist employed to provide news stories for newspapers or broadcast
+    media
+  hypernym:
+  - 10807146-n
+  - 09986240-n
+  members:
+  - newspaperwoman
+  partOfSpeech: n
+85242186-n:
+  definition:
+  - a male who operates an aircraft
+  hypernym:
+  - 10306910-n
+  - 09845606-n
+  members:
+  - airman
+  partOfSpeech: n
+85259651-n:
+  definition:
+  - a male who signs a bond as surety for someone else
+  hypernym:
+  - 10807146-n
+  - 09884685-n
+  members:
+  - bondsman
   partOfSpeech: n
 85394298-n:
   definition:
@@ -119684,6 +120092,68 @@
   - 86294295-n
   - 09659490-n
   partOfSpeech: n
+85556310-n:
+  definition:
+  - a human male employed to do housework
+  hypernym:
+  - 10306910-n
+  - 09946547-n
+  members:
+  - charman
+  partOfSpeech: n
+85582747-n:
+  definition:
+  - a young boy who carries flowers in a (wedding) procession
+  hypernym:
+  - 10104064-n
+  members:
+  - flower boy
+  partOfSpeech: n
+85626490-n:
+  definition:
+  - the father of at least one of your children
+  hypernym:
+  - 10807146-n
+  members:
+  - baby papa
+  partOfSpeech: n
+85758093-n:
+  definition:
+  - a female person with fair skin and hair
+  hypernym:
+  - 10807146-n
+  - 09879912-n
+  members:
+  - blonde
+  partOfSpeech: n
+85801071-n:
+  definition:
+  - a female competitor who holds a preeminent position
+  hypernym:
+  - 10807146-n
+  - 10254721-n
+  members:
+  - queen
+  partOfSpeech: n
+85900704-n:
+  definition:
+  - a man who is a respected leader in national or international affairs
+  hypernym:
+  - 10306910-n
+  - 10669601-n
+  members:
+  - statesman
+  partOfSpeech: n
+86032704-n:
+  definition:
+  - a female person who has received a degree from a school (high school or college
+    or university)
+  hypernym:
+  - 10807146-n
+  - 09805779-n
+  members:
+  - alumna
+  partOfSpeech: n
 86191087-n:
   definition:
   - an Asian race
@@ -119695,6 +120165,26 @@
   - Yellow race
   mero_member:
   - 84278296-n
+  partOfSpeech: n
+86250495-n:
+  definition:
+  - a male person of French nationality
+  hypernym:
+  - 10807146-n
+  - 09727801-n
+  members:
+  - Frenchman
+  partOfSpeech: n
+86290056-n:
+  definition:
+  - a male hired hand who tends cattle and performs other duties on horseback
+  hypernym:
+  - 10306910-n
+  - 09992191-n
+  members:
+  - cowboy
+  - cowman
+  - cattleman
   partOfSpeech: n
 86294295-n:
   definition:
@@ -119716,6 +120206,33 @@
   members:
   - Abo
   partOfSpeech: n
+86419394-n:
+  definition:
+  - a male person who has been freed from slavery
+  hypernym:
+  - 10807146-n
+  - 10129754-n
+  members:
+  - freedman
+  partOfSpeech: n
+86461832-n:
+  definition:
+  - A male fan who is obsessive about a particular subject (especially, someone or
+    something in popular entertainment media
+  hypernym:
+  - 10306910-n
+  - 10097373-n
+  members:
+  - fanboy
+  partOfSpeech: n
+86495725-n:
+  definition:
+  - an informal term for a father who can combine childcare and full-time employment
+  hypernym:
+  - 10352098-n
+  members:
+  - superdad
+  partOfSpeech: n
 86740061-n:
   definition:
   - offensive term for an Asian man
@@ -119727,6 +120244,62 @@
   members:
   - yellow man
   partOfSpeech: n
+86947054-n:
+  definition:
+  - a male person with fair skin and hair
+  hypernym:
+  - 10807146-n
+  - 09879912-n
+  members:
+  - blond
+  partOfSpeech: n
+86950860-n:
+  definition:
+  - a female who serves (or waits to be called to serve) on a jury
+  hypernym:
+  - 10807146-n
+  - 10247948-n
+  members:
+  - jurywoman
+  partOfSpeech: n
+86986461-n:
+  definition:
+  - a male employee who mixes and serves alcoholic drinks at a bar
+  hypernym:
+  - 10306910-n
+  - 09860576-n
+  members:
+  - barman
+  partOfSpeech: n
+87143696-n:
+  definition:
+  - a male newspaper columnist who answers questions and offers advice on personal
+    problems to people who write in
+  hypernym:
+  - 10306910-n
+  - 10376291-n
+  members:
+  - agony uncle
+  partOfSpeech: n
+87306750-n:
+  definition:
+  - a male journalist employed to provide news stories for newspapers or broadcast
+    media
+  hypernym:
+  - 10807146-n
+  - 09986240-n
+  members:
+  - newspaperman
+  partOfSpeech: n
+87519584-n:
+  definition:
+  - a very pretty boy who works as a photographer's model
+  hypernym:
+  - 10306910-n
+  - 10446867-n
+  members:
+  - cover boy
+  partOfSpeech: n
 87584402-n:
   definition:
   - archer who uses an arbalest
@@ -119734,6 +120307,24 @@
   - 09824747-n
   members:
   - arbalist
+  partOfSpeech: n
+87595983-n:
+  definition:
+  - a male steward on an airplane
+  hypernym:
+  - 10306910-n
+  - 10675033-n
+  members:
+  - air host
+  partOfSpeech: n
+87657220-n:
+  definition:
+  - a male person who owns or sails a yacht
+  hypernym:
+  - 10807146-n
+  - 10821647-n
+  members:
+  - yachtsman
   partOfSpeech: n
 87736171-n:
   definition:
@@ -119756,6 +120347,24 @@
   - mentee
   - mentoree
   partOfSpeech: n
+87970505-n:
+  definition:
+  - a working woman who takes in washing
+  hypernym:
+  - 10306910-n
+  - 10788571-n
+  members:
+  - washman
+  partOfSpeech: n
+88005275-n:
+  definition:
+  - a male competitor who holds a preeminent position
+  hypernym:
+  - 10807146-n
+  - 10254721-n
+  members:
+  - king
+  partOfSpeech: n
 88020193-n:
   definition:
   - a graduate at an Ivy League school
@@ -119772,6 +120381,24 @@
   members:
   - Red Indian
   partOfSpeech: n
+88429598-n:
+  definition:
+  - a female person of French nationality
+  hypernym:
+  - 10807146-n
+  - 09727801-n
+  members:
+  - Frenchwoman
+  partOfSpeech: n
+88456890-n:
+  definition:
+  - a male adulterer
+  hypernym:
+  - 10306910-n
+  - 09792169-n
+  members:
+  - loose man
+  partOfSpeech: n
 88458300-n:
   definition:
   - (ethnic slur) offensive term for Black people
@@ -119786,6 +120413,34 @@
   - darkie
   - darkey
   partOfSpeech: n
+88561238-n:
+  definition:
+  - a female who signs a bond as surety for someone else
+  hypernym:
+  - 10807146-n
+  - 09884685-n
+  members:
+  - bondswoman
+  partOfSpeech: n
+88651493-n:
+  definition:
+  - a male who engages in sports
+  hypernym:
+  - 10807146-n
+  - 10658320-n
+  members:
+  - sportsman
+  partOfSpeech: n
+88770907-n:
+  definition:
+  - a male native or inhabitant of Scotland
+  hypernym:
+  - 10306910-n
+  - 09749875-n
+  members:
+  - Scotchman
+  - Scotsman
+  partOfSpeech: n
 89085804-n:
   definition:
   - a United States term for Blacks that is now considered offensive
@@ -119799,6 +120454,49 @@
   - colored
   - coloured person
   - coloured
+  partOfSpeech: n
+89388690-n:
+  definition:
+  - the husband or widower of a queen
+  hypernym:
+  - 10103592-n
+  members:
+  - king
+  partOfSpeech: n
+89433552-n:
+  definition:
+  - a male who attends a counter (as in a diner)
+  hypernym:
+  - 10807146-n
+  - 09989248-n
+  members:
+  - counterman
+  partOfSpeech: n
+89782767-n:
+  definition:
+  - the husband of a chief executive
+  hypernym:
+  - 10800308-n
+  members:
+  - first gentleman
+  partOfSpeech: n
+89928249-n:
+  definition:
+  - a male who rows a boat
+  hypernym:
+  - 10306910-n
+  - 10388619-n
+  members:
+  - oarsman
+  partOfSpeech: n
+89964369-n:
+  definition:
+  - a male person who spends time outdoors (e.g., hunting or fishing)
+  hypernym:
+  - 10306910-n
+  - 10406317-n
+  members:
+  - outdoorsman
   partOfSpeech: n
 90000141-n:
   definition:


### PR DESCRIPTION
This pull request fixes #883 

I decided not to introduce an explicit relationship for masculine/feminine as there was not a clear way to proceed with this. This is due to there being several cases:
1. A masculine term and a feminine term with a clear gender-neutral term ('policeman'/'policewoman'/'policeperson')
2. A feminine term and a gender-neutral term ('actress'/'actor')
3. Some terms where a gender-neutral synset does not exist or would be artificial (e.g. 'viscountess')

Instead, this change aims to ensure that no synset contains both a masculine and a feminine form, and wherever the forms are specifically gendered the synset is a hyponym of man `10306910-n` or woman `10807146-n`