### PR TITLE
merge.py: Make result independent of filesystem order

### DIFF
--- a/scripts/merge.py
+++ b/scripts/merge.py
@@ -77,7 +77,7 @@ def wn_merge():
     
         ET.register_namespace("dc", "https://globalwordnet.github.io/schemas/dc/")
 
-        for wn_part in glob("src/xml/wn-*.xml"):
+        for wn_part in sorted(glob("src/xml/wn-*.xml")):
             tree = ET.parse(wn_part).getroot()
             for element in tree[0]:
                 if(element.tag == "LexicalEntry"):


### PR DESCRIPTION
As things stands, running the build on different systems or at different times can result in different XML outputs.

This is problematic for software distributions, which may require (or merely prefer) building english-wordnet from source rather than using published build artefacts, but cannot check the result against published releases.

