### PR TITLE
Fix meanings of 'wight'

### DIFF
--- a/src/yaml/entries-w.yaml
+++ b/src/yaml/entries-w.yaml
@@ -21655,6 +21655,8 @@ wight:
     sense:
     - id: 'wight%1:18:00::'
       synset: 09995959-n
+    - id: 'wight%1:18:01::'
+      synset: 87269273-n
 wigless:
   a:
     sense:
@@ -30998,6 +31000,8 @@ wraith:
     sense:
     - id: 'wraith%1:09:00::'
       synset: 05906778-n
+    - id: 'wraith%1:18:01::'
+      synset: 87269273-n
 wraithlike:
   a:
     sense:

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -29553,8 +29553,10 @@
 09995959-n:
   definition:
   - a living being
+  exemplifies:
+  - 07087487-n
   hypernym:
-  - 00007846-n
+  - 00004475-n
   ili: i89301
   members:
   - creature
@@ -120281,6 +120283,15 @@
   - 10376291-n
   members:
   - agony uncle
+  partOfSpeech: n
+87269273-n:
+  definition:
+  - a malevolent or haunting spirit
+  hypernym:
+  - 09569105-n
+  members:
+  - wight
+  - wraith
   partOfSpeech: n
 87306750-n:
   definition:


### PR DESCRIPTION
* Move the old meaning of 'wight' or 'creature' to refer to organisms, which better fits the definition
* Added a new synset for 'wight'/'wraith' as a ghost (as this is the most frequent sense)