### PR TITLE
Update definitions of a.m./p.m.

### DIFF
--- a/src/deprecations.csv
+++ b/src/deprecations.csv
@@ -106,3 +106,5 @@
 "ewn-01746607-v","i30448","ewn-02560130-v","i34465","Duplicate (#950)"
 "ewn-01729245-s","i9466","ewn-02090537-s","i11414","Duplicate (#987)"
 "ewn-00507570-r","i21674","ewn-00028715-r","i18302","Not lexical, tag 'only' as an adverb by itself (#977)"
+"ewn-00131590-s","i695","ewn-00252773-r","i19878","Incorrect part of speech (#976)"
+"ewn-00131773-s","i697","ewn-00252877-r","i19879","Incorrect part of speech (#976)"

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -8733,18 +8733,6 @@
   members:
   - antemeridian
   partOfSpeech: a
-  similar:
-  - 00131590-s
-00131590-s:
-  definition:
-  - before twelve noon
-  ili: i695
-  members:
-  - ante meridiem
-  - a.m.
-  partOfSpeech: s
-  similar:
-  - 00131484-a
 00131668-a:
   attribute:
   - 15154879-n
@@ -8754,18 +8742,6 @@
   members:
   - postmeridian
   partOfSpeech: a
-  similar:
-  - 00131773-s
-00131773-s:
-  definition:
-  - after noon
-  ili: i697
-  members:
-  - post meridiem
-  - p.m.
-  partOfSpeech: s
-  similar:
-  - 00131668-a
 00131850-a:
   also:
   - 00199739-a

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -17278,6 +17278,9 @@
   members:
   - ante meridiem
   - A.M.
+  - a.m.
+  - am
+  - AM
   partOfSpeech: r
 00252877-r:
   definition:
@@ -17290,6 +17293,9 @@
   members:
   - post meridiem
   - P.M.
+  - p.m.
+  - pm
+  - PM
   partOfSpeech: r
 00252994-r:
   definition:

--- a/src/yaml/entries-a.yaml
+++ b/src/yaml/entries-a.yaml
@@ -128,6 +128,10 @@ A.E.:
     - id: 'a.e.%1:18:00::'
       synset: 11295025-n
 A.M.:
+  n:
+    sense:
+    - id: 'a.m.%1:28:01::'
+      synset: 84502472-n
   r:
     sense:
     - id: 'a.m.%4:02:00::'
@@ -480,6 +484,12 @@ AM:
       synset: 06713764-n
     - id: 'am%1:10:00::'
       synset: 06292247-n
+    - id: 'am%1:28:02::'
+      synset: 84502472-n
+  r:
+    sense:
+    - id: 'am%4:02:05::'
+      synset: 00252773-r
 AMD:
   n:
     sense:
@@ -18863,10 +18873,14 @@ a.k.a.:
     - id: 'a.k.a.%4:02:00::'
       synset: 00271877-r
 a.m.:
-  a:
+  n:
     sense:
-    - id: a.m.%5:00:00:antemeridian:00
-      synset: 00131590-s
+    - id: 'a.m.%1:28:02::'
+      synset: 84502472-n
+  r:
+    sense:
+    - id: 'a.m.%4:02:03::'
+      synset: 00252773-r
 aa:
   n:
     pronunciation:
@@ -48377,6 +48391,15 @@ alyssum:
     sense:
     - id: 'alyssum%1:20:01::'
       synset: 11891216-n
+am:
+  n:
+    sense:
+    - id: 'am%1:28:03::'
+      synset: 84502472-n
+  r:
+    sense:
+    - id: 'am%4:02:04::'
+      synset: 00252773-r
 amabilis fir:
   n:
     sense:
@@ -58421,10 +58444,6 @@ ante:
       undergoer:
       - 'ante%1:21:00::'
 ante meridiem:
-  a:
-    sense:
-    - id: ante_meridiem%5:00:00:antemeridian:00
-      synset: 00131590-s
   r:
     sense:
     - id: 'ante_meridiem%4:02:00::'

--- a/src/yaml/entries-p.yaml
+++ b/src/yaml/entries-p.yaml
@@ -38,6 +38,10 @@ P.E.:
     - id: 'p.e.%1:19:00::'
       synset: 11514872-n
 P.M.:
+  n:
+    sense:
+    - id: 'p.m.%1:28:01::'
+      synset: 89528311-n
   r:
     sense:
     - id: 'p.m.%4:02:00::'
@@ -249,6 +253,12 @@ PM:
       synset: 09926654-n
     - id: 'pm%1:10:00::'
       synset: 06292501-n
+    - id: 'pm%1:28:01::'
+      synset: 89528311-n
+  r:
+    sense:
+    - id: 'pm%4:02:03::'
+      synset: 00252877-r
 PMS:
   n:
     sense:
@@ -15189,10 +15199,14 @@ p.a.:
     - id: 'p.a.%4:02:00::'
       synset: 00252039-r
 p.m.:
-  a:
+  n:
     sense:
-    - id: p.m.%5:00:00:postmeridian:00
-      synset: 00131773-s
+    - id: 'p.m.%1:28:02::'
+      synset: 89528311-n
+  r:
+    sense:
+    - id: 'p.m.%4:02:03::'
+      synset: 00252877-r
 pH:
   n:
     sense:
@@ -59489,6 +59503,11 @@ plywood:
     sense:
     - id: 'plywood%1:06:00::'
       synset: 03977576-n
+pm:
+  r:
+    sense:
+    - id: 'pm%4:02:02::'
+      synset: 00252877-r
 pneumatic:
   a:
     pronunciation:
@@ -68606,10 +68625,6 @@ post house:
     - id: 'post_house%1:06:00::'
       synset: 03996256-n
 post meridiem:
-  a:
-    sense:
-    - id: post_meridiem%5:00:00:postmeridian:00
-      synset: 00131773-s
   r:
     sense:
     - id: 'post_meridiem%4:02:00::'

--- a/src/yaml/noun.time.yaml
+++ b/src/yaml/noun.time.yaml
@@ -11648,6 +11648,33 @@
   - Sept. 11
   - Sep 11
   partOfSpeech: n
+84502472-n:
+  definition:
+  - the period between midnight and noon
+  example:
+  - source: Title of album by One Direction
+    text: Made in the A.M.
+  hypernym:
+  - 15137796-n
+  members:
+  - A.M.
+  - a.m.
+  - AM
+  - am
+  partOfSpeech: n
+89528311-n:
+  definition:
+  - the period between noon and midnight
+  example:
+  - source: Title of album by Christina Milan
+    text: AM to PM
+  hypernym:
+  - 15137796-n
+  members:
+  - P.M.
+  - p.m.
+  - PM
+  partOfSpeech: n
 90001211-n:
   definition:
   - The day before Valentine's Day, e.g., February 1


### PR DESCRIPTION
a.m./p.m. are now an adverb (the most frequent sense) or a noun (with some attestations). The adjective senses are removed and replaced with the adverb sense (not some adjective-like usages, e.g., "the a.m. shift" should be nouns now).

Fixes #976 