### PR TITLE
Emdash instead of hyphens

### DIFF
--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -39868,7 +39868,7 @@
   - no longer connected or joined
   example:
   - a detached part
-  - on one side of the island was a hugh rock, almost detached
+  - on one side of the island was a huge rock, almost detached
   - the separated spacecraft will return to their home bases
   ili: i3168
   members:
@@ -53500,7 +53500,8 @@
   example:
   - had a preference for circumlocutious (or circumlocutory) rather than forthright
     expression
-  - source: T.S.Eliot; (`ambagious' is archaic)
+  - (`ambagious' is archaic)
+  - source: T.S.Eliot
     text: A periphrastic study in a worn-out poetical fashion,/ Leaving one still
       with the intolerable wrestle/ With words and meanings.
   ili: i4235
@@ -60844,7 +60845,7 @@
   - deprived of the rights of citizenship especially the right to vote
   example:
   - labor was voiceless
-  - disenfrenchised masses took to the streets
+  - disenfranchised masses took to the streets
   ili: i4808
   members:
   - disenfranchised
@@ -95455,7 +95456,7 @@
   definition:
   - lacking in sympathy and kindness
   example:
-  - unkindly ancts
+  - unkindly acts
   ili: i7487
   members:
   - unkindly
@@ -98786,7 +98787,7 @@
     special for the general or the general for the special; or the material for the
     thing made of it
   example:
-  - to use `hand' for `worker' or `ten sail' for `ten ships' or `steel' for `sword'
+  - to use `hand' for `worker' or `ten sails' for `ten ships' or `steel' for `sword'
     is to use a synecdochic figure of speech
   ili: i7751
   members:
@@ -134457,7 +134458,7 @@
   - characterized by unrest or disorder
   example:
   - unquiet days of riots
-  - following the assassination of Martin Luter King ours was an unquiet nation
+  - following the assassination of Martin Luther King ours was an unquiet nation
   - spent an unquiet night tossing and turning
   ili: i10549
   members:
@@ -135177,7 +135178,7 @@
     being legendary
   example:
   - the historical Jesus
-  - doubt that a historical Camelot every existed
+  - doubt that a historical Camelot ever existed
   - actual historical events
   ili: i10602
   members:
@@ -152245,7 +152246,7 @@
   definition:
   - having only one part or element
   example:
-  - a simplex word has no affixes and is not part of a compound--like `boy' compared
+  - a simplex word has no affixes and is not part of a compound -- like `boy' compared
     with `boyish' or `house' compared with `houseboat'
   ili: i11963
   members:
@@ -170637,7 +170638,7 @@
   definition:
   - filled or scattered with a disorderly accumulation of objects or rubbish
   example:
-  - the storm left the drivewaylittered with sticks nd debris
+  - the storm left the driveway littered with sticks and debris
   - his library was a cluttered room with piles of books on every chair
   ili: i13420
   members:
@@ -175299,7 +175300,7 @@
   definition:
   - getting higher or more vigorous
   example:
-  - its an up market
+  - it's an up market
   - an improving economy
   ili: i13790
   members:
@@ -176979,7 +176980,7 @@
   domain_topic:
   - 06092831-n
   example:
-  - fishes and amphibians and reptiles and birds and mammals are verbetrate animals
+  - fishes and amphibians and reptiles and birds and mammals are vertebrate animals
   ili: i13921
   members:
   - vertebrate
@@ -179888,7 +179889,7 @@
   definition:
   - moist, damp, wet (especially of air)
   example:
-  - the raw and theumy damp of night air
+  - the raw and rheumy damp of night air
   ili: i14146
   members:
   - rheumy

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -53500,7 +53500,6 @@
   example:
   - had a preference for circumlocutious (or circumlocutory) rather than forthright
     expression
-  - (`ambagious' is archaic)
   - source: T.S.Eliot
     text: A periphrastic study in a worn-out poetical fashion,/ Leaving one still
       with the intolerable wrestle/ With words and meanings.

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -1945,7 +1945,7 @@
     text: a predatory, insensate society in which innocence and decency can prove
       fatal
   - source: W.E.Swinton
-    text: a predacious kind of animal--the early geological gangster
+    text: a predacious kind of animal — the early geological gangster
   ili: i150
   members:
   - predaceous
@@ -7500,8 +7500,8 @@
   - 00112667-a
 00113042-a:
   definition:
-  - using or skilled in using analysis (i.e., separating a whole--intellectual or
-    substantial--into its elemental parts or basic principles)
+  - using or skilled in using analysis (i.e., separating a whole — intellectual or
+    substantial — into its elemental parts or basic principles)
   example:
   - an analytic experiment
   - an analytic approach
@@ -10321,7 +10321,7 @@
   definition:
   - capable of or involving speech or speaking
   example:
-  - human beings--the speaking animals
+  - human beings — the speaking animals
   - a speaking part in the play
   ili: i827
   members:
@@ -16271,7 +16271,7 @@
   - 00236464-a
 00237163-s:
   definition:
-  - having two faces--one looking to the future and one to the past
+  - having two faces — one looking to the future and one to the past
   example:
   - Janus the two-faced god
   ili: i1296
@@ -16840,7 +16840,7 @@
   - of or belonging to a racial group especially of sub-Saharan African origin
   example:
   - source: Martin Luther King Jr.
-    text: a great people--a black people--...injected new meaning and dignity into
+    text: a great people — a black people — ...injected new meaning and dignity into
       the veins of civilization
   ili: i1349
   members:
@@ -18709,7 +18709,7 @@
   - the choking June dust
   - the smothering soft voices
   - smothering heat
-  - the room was suffocating--hot and airless
+  - the room was suffocating — hot and airless
   ili: i1501
   members:
   - smothering
@@ -23974,7 +23974,7 @@
   definition:
   - capable of having the meaning altered or twisted
   example:
-  - our words are distortable things--as in a crooked mirror held up to nature
+  - our words are distortable things — as in a crooked mirror held up to nature
   ili: i1913
   members:
   - distortable
@@ -42542,7 +42542,7 @@
   definition:
   - conspicuously or grossly unconventional or unusual
   example:
-  - restaurants of bizarre design--one like a hat, another like a rabbit
+  - restaurants of bizarre design — one like a hat, another like a rabbit
   - famed for his eccentric spelling
   - a freakish combination of styles
   - his off-the-wall antics
@@ -43925,7 +43925,7 @@
   definition:
   - lacking substance or reality; incapable of being touched or seen
   example:
-  - that intangible thing--the soul
+  - that intangible thing — the soul
   ili: i3489
   members:
   - intangible
@@ -45609,7 +45609,7 @@
   - 06094057-n
   - 06100457-n
   example:
-  - a critical temperature of water is 100 degrees C--its boiling point at standard
+  - a critical temperature of water is 100 degrees C — its boiling point at standard
     atmospheric pressure
   - critical mass
   - go critical
@@ -46200,7 +46200,7 @@
   - 00664333-s
 00663500-s:
   definition:
-  - having dimension--the quality or character or stature proper to a person
+  - having dimension — the quality or character or stature proper to a person
   example:
   - source: Norman Cousins
     text: never matures as a dimensional character; he is pasty, bland, faceless
@@ -49347,7 +49347,7 @@
   definition:
   - made joyful
   example:
-  - the sun and the wind on his back made him feel exhilarated--happy to be alive
+  - the sun and the wind on his back made him feel exhilarated — happy to be alive
   ili: i3917
   members:
   - gladdened
@@ -52026,7 +52026,7 @@
   - having experienced or undergone dedifferentiation or the loss of specialization
     in form or function
   example:
-  - the hebephrenic--the most severely dedifferentiated of all schizophrenic patients
+  - the hebephrenic — the most severely dedifferentiated of all schizophrenic patients
   ili: i4127
   members:
   - dedifferentiated
@@ -53294,7 +53294,7 @@
   - I gave them my candid opinion
   - forthright criticism
   - a forthright approach to the problem
-  - tell me what you think--and you may just as well be frank
+  - tell me what you think — and you may just as well be frank
   - it is possible to be outspoken without being rude
   - plainspoken and to the point
   - a point-blank accusation
@@ -53594,7 +53594,7 @@
   - 00773049-a
 00773485-a:
   definition:
-  - moving from west to east on the celestial sphere; or--for planets--around the
+  - moving from west to east on the celestial sphere; or — for planets — around the
     sun in the same direction as the Earth
   domain_topic:
   - 06104629-n
@@ -53604,7 +53604,7 @@
   partOfSpeech: a
 00773673-a:
   definition:
-  - moving from east to west on the celestial sphere; or--for planets--around the
+  - moving from east to west on the celestial sphere; or — for planets — around the
     sun in a direction opposite to that of the Earth
   domain_topic:
   - 06104629-n
@@ -59007,7 +59007,7 @@
   - an elegant dark suit
   - she was elegant to her fingertips
   - small churches with elegant white spires
-  - an elegant mathematical solution--simple and precise and lucid
+  - an elegant mathematical solution — simple and precise and lucid
   ili: i4666
   members:
   - elegant
@@ -59545,7 +59545,7 @@
   - not characterized by emotion
   example:
   - source: C.W.Cunningham
-    text: a female form in marble--a chilly but ideal medium for depicting abstract
+    text: a female form in marble — a chilly but ideal medium for depicting abstract
       virtues
   ili: i4706
   members:
@@ -75902,7 +75902,7 @@
   definition:
   - drained physically
   example:
-  - the day's events left her completely exhausted--her strength drained
+  - the day's events left her completely exhausted — her strength drained
   ili: i5981
   members:
   - exhausted
@@ -77581,7 +77581,7 @@
   - excessively unwilling to spend
   example:
   - parsimonious thrift relieved by few generous impulses
-  - lived in a most penurious manner--denying himself every indulgence
+  - lived in a most penurious manner — denying himself every indulgence
   ili: i6114
   members:
   - parsimonious
@@ -78869,7 +78869,7 @@
   definition:
   - extremely evil or cruel; expressive of cruelty or befitting hell
   example:
-  - something demonic in him--something that could be cruel
+  - something demonic in him — something that could be cruel
   - fires lit up a diabolic scene
   - diabolical sorcerers under the influence of devils
   - a fiendish despot
@@ -79319,7 +79319,7 @@
   - displaying effortless beauty and simplicity in movement or execution
   example:
   - an elegant dancer
-  - an elegant mathematical solution -- simple and precise
+  - an elegant mathematical solution — simple and precise
   ili: i6234
   members:
   - elegant
@@ -82598,7 +82598,7 @@
   - of comparatively little physical weight or density
   example:
   - a light load
-  - magnesium is a light metal--having a specific gravity of 1.74 at 20 degrees C
+  - magnesium is a light metal — having a specific gravity of 1.74 at 20 degrees C
   ili: i6491
   members:
   - light
@@ -85509,7 +85509,7 @@
   - a despairing view of the world situation
   - the last despairing plea of the condemned criminal
   - a desperate cry for help
-  - helpless and desperate--as if at the end of his tether
+  - helpless and desperate — as if at the end of his tether
   - her desperate screams
   ili: i6726
   members:
@@ -87182,7 +87182,7 @@
   definition:
   - very cold
   example:
-  - whatever the evenings be--frosty and frore or warm and wet
+  - whatever the evenings be — frosty and frore or warm and wet
   exemplifies:
   - 07087487-n
   ili: i6854
@@ -89157,7 +89157,7 @@
   - commanding attention
   example:
   - an arresting drawing of people turning into animals
-  - a sensational concert--one never to be forgotten
+  - a sensational concert — one never to be forgotten
   - a stunning performance
   ili: i6997
   members:
@@ -92800,7 +92800,7 @@
   - having a keen intellect
   example:
   - source: A.T.Quiller-Couch
-    text: poets--those gifted strangely prehensile men
+    text: poets — those gifted strangely prehensile men
   ili: i7285
   members:
   - prehensile
@@ -93017,7 +93017,7 @@
   - having no cause or apparent cause
   example:
   - a causeless miracle
-  - fortuitous encounters--strange accidents of fortune
+  - fortuitous encounters — strange accidents of fortune
   - we cannot regard artistic invention as...uncaused and unrelated to the times
   ili: i7300
   members:
@@ -96778,7 +96778,7 @@
   definition:
   - small and delicate
   example:
-  - she was an elfin creature--graceful and delicate
+  - she was an elfin creature — graceful and delicate
   - obsessed by things elfin and small
   ili: i7586
   members:
@@ -110640,7 +110640,7 @@
   definition:
   - not neurotic
   example:
-  - successful mothers--mothers with unneurotic children
+  - successful mothers — mothers with unneurotic children
   - he's the most unneurotic person I know
   ili: i8693
   members:
@@ -116475,7 +116475,7 @@
   definition:
   - snarled or stalled in complete confusion
   example:
-  - situation normal--all fucked-up
+  - situation normal — all fucked-up
   ili: i9154
   members:
   - fucked-up
@@ -119914,7 +119914,7 @@
   example:
   - a barely palpable dust
   - felt sudden anger in a palpable wave
-  - the air was warm and close--palpable as cotton
+  - the air was warm and close — palpable as cotton
   - a palpable lie
   ili: i9420
   members:
@@ -120007,7 +120007,7 @@
   - 00615275-a
   - 01237040-a
   definition:
-  - slanting or inclined in direction or course or position--neither parallel nor
+  - slanting or inclined in direction or course or position — neither parallel nor
     perpendicular nor right-angled
   example:
   - the oblique rays of the winter sun
@@ -125343,7 +125343,7 @@
   - unornamented
   example:
   - a simple country schoolhouse
-  - her black dress--simple to austerity
+  - her black dress — simple to austerity
   ili: i9855
   members:
   - simple
@@ -126955,7 +126955,7 @@
   - capable of being weighed or considered
   example:
   - source: James Jeans
-    text: something ponderable from the outer world--something of which we can say
+    text: something ponderable from the outer world — something of which we can say
       that its weight is so and so
   ili: i9974
   members:
@@ -132089,7 +132089,7 @@
   example:
   - source: Laurent Le Sage
     text: a snotty little scion of a degenerate family
-  - they're snobs--stuck-up and uppity and persnickety
+  - they're snobs — stuck-up and uppity and persnickety
   ili: i10369
   members:
   - bigheaded
@@ -135367,9 +135367,9 @@
   - real war
   - a real friend
   - a real woman
-  - meat and potatoes--I call that a real meal
+  - meat and potatoes — I call that a real meal
   - it's time he had a real job
-  - it's no penny-ante job--he's making real money
+  - it's no penny-ante job — he's making real money
   ili: i10616
   members:
   - real
@@ -136179,7 +136179,7 @@
   - he had coarse manners but a first-rate mind
   - behavior that branded him as common
   - an untutored and uncouth human being
-  - an uncouth soldier--a real tough guy
+  - an uncouth soldier — a real tough guy
   - appealing to the vulgar taste for violence
   - the vulgar display of the newly rich
   ili: i10673
@@ -142040,7 +142040,7 @@
   example:
   - horned viper
   - great horned owl
-  - the unicorn--a mythical horned beast
+  - the unicorn — a mythical horned beast
   - long-horned cattle
   ili: i11146
   members:
@@ -146921,7 +146921,7 @@
   definition:
   - characterized by insensibility
   example:
-  - the young girls are in a state of possession--blind and deaf and anesthetic
+  - the young girls are in a state of possession — blind and deaf and anesthetic
   - an anesthetic state
   ili: i11526
   members:
@@ -152221,7 +152221,7 @@
   definition:
   - having only one part or element
   example:
-  - a simplex word has no affixes and is not part of a compound -- like `boy' compared
+  - a simplex word has no affixes and is not part of a compound — like `boy' compared
     with `boyish' or `house' compared with `houseboat'
   ili: i11963
   members:
@@ -167096,7 +167096,7 @@
   definition:
   - having a radial form
   example:
-  - starfish are actinoid--that is, they are radially symmetrical
+  - starfish are actinoid — that is, they are radially symmetrical
   ili: i13155
   members:
   - actinoid
@@ -182453,7 +182453,7 @@
   definition:
   - worthy of often limited commendation
   example:
-  - the student's effort on the essay--though not outstanding--was creditable
+  - the student's effort on the essay — though not outstanding — was creditable
   ili: i14348
   members:
   - creditable

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -1945,7 +1945,7 @@
     text: a predatory, insensate society in which innocence and decency can prove
       fatal
   - source: W.E.Swinton
-    text: a predacious kind of animal — the early geological gangster
+    text: a predacious kind of animal--the early geological gangster
   ili: i150
   members:
   - predaceous
@@ -7500,8 +7500,8 @@
   - 00112667-a
 00113042-a:
   definition:
-  - using or skilled in using analysis (i.e., separating a whole — intellectual or
-    substantial — into its elemental parts or basic principles)
+  - using or skilled in using analysis (i.e., separating a whole--intellectual or
+    substantial--into its elemental parts or basic principles)
   example:
   - an analytic experiment
   - an analytic approach
@@ -10321,7 +10321,7 @@
   definition:
   - capable of or involving speech or speaking
   example:
-  - human beings — the speaking animals
+  - human beings--the speaking animals
   - a speaking part in the play
   ili: i827
   members:
@@ -16271,7 +16271,7 @@
   - 00236464-a
 00237163-s:
   definition:
-  - having two faces — one looking to the future and one to the past
+  - having two faces--one looking to the future and one to the past
   example:
   - Janus the two-faced god
   ili: i1296
@@ -16840,7 +16840,7 @@
   - of or belonging to a racial group especially of sub-Saharan African origin
   example:
   - source: Martin Luther King Jr.
-    text: a great people — a black people — ...injected new meaning and dignity into
+    text: a great people--a black people--...injected new meaning and dignity into
       the veins of civilization
   ili: i1349
   members:
@@ -18709,7 +18709,7 @@
   - the choking June dust
   - the smothering soft voices
   - smothering heat
-  - the room was suffocating — hot and airless
+  - the room was suffocating--hot and airless
   ili: i1501
   members:
   - smothering
@@ -23974,7 +23974,7 @@
   definition:
   - capable of having the meaning altered or twisted
   example:
-  - our words are distortable things — as in a crooked mirror held up to nature
+  - our words are distortable things--as in a crooked mirror held up to nature
   ili: i1913
   members:
   - distortable
@@ -42542,7 +42542,7 @@
   definition:
   - conspicuously or grossly unconventional or unusual
   example:
-  - restaurants of bizarre design — one like a hat, another like a rabbit
+  - restaurants of bizarre design--one like a hat, another like a rabbit
   - famed for his eccentric spelling
   - a freakish combination of styles
   - his off-the-wall antics
@@ -43925,7 +43925,7 @@
   definition:
   - lacking substance or reality; incapable of being touched or seen
   example:
-  - that intangible thing — the soul
+  - that intangible thing--the soul
   ili: i3489
   members:
   - intangible
@@ -45609,7 +45609,7 @@
   - 06094057-n
   - 06100457-n
   example:
-  - a critical temperature of water is 100 degrees C — its boiling point at standard
+  - a critical temperature of water is 100 degrees C--its boiling point at standard
     atmospheric pressure
   - critical mass
   - go critical
@@ -46200,7 +46200,7 @@
   - 00664333-s
 00663500-s:
   definition:
-  - having dimension — the quality or character or stature proper to a person
+  - having dimension--the quality or character or stature proper to a person
   example:
   - source: Norman Cousins
     text: never matures as a dimensional character; he is pasty, bland, faceless
@@ -49347,7 +49347,7 @@
   definition:
   - made joyful
   example:
-  - the sun and the wind on his back made him feel exhilarated — happy to be alive
+  - the sun and the wind on his back made him feel exhilarated--happy to be alive
   ili: i3917
   members:
   - gladdened
@@ -52026,7 +52026,7 @@
   - having experienced or undergone dedifferentiation or the loss of specialization
     in form or function
   example:
-  - the hebephrenic — the most severely dedifferentiated of all schizophrenic patients
+  - the hebephrenic--the most severely dedifferentiated of all schizophrenic patients
   ili: i4127
   members:
   - dedifferentiated
@@ -53294,7 +53294,7 @@
   - I gave them my candid opinion
   - forthright criticism
   - a forthright approach to the problem
-  - tell me what you think — and you may just as well be frank
+  - tell me what you think--and you may just as well be frank
   - it is possible to be outspoken without being rude
   - plainspoken and to the point
   - a point-blank accusation
@@ -53594,7 +53594,7 @@
   - 00773049-a
 00773485-a:
   definition:
-  - moving from west to east on the celestial sphere; or — for planets — around the
+  - moving from west to east on the celestial sphere; or--for planets--around the
     sun in the same direction as the Earth
   domain_topic:
   - 06104629-n
@@ -53604,7 +53604,7 @@
   partOfSpeech: a
 00773673-a:
   definition:
-  - moving from east to west on the celestial sphere; or — for planets — around the
+  - moving from east to west on the celestial sphere; or--for planets--around the
     sun in a direction opposite to that of the Earth
   domain_topic:
   - 06104629-n
@@ -59007,7 +59007,7 @@
   - an elegant dark suit
   - she was elegant to her fingertips
   - small churches with elegant white spires
-  - an elegant mathematical solution — simple and precise and lucid
+  - an elegant mathematical solution--simple and precise and lucid
   ili: i4666
   members:
   - elegant
@@ -59545,7 +59545,7 @@
   - not characterized by emotion
   example:
   - source: C.W.Cunningham
-    text: a female form in marble — a chilly but ideal medium for depicting abstract
+    text: a female form in marble--a chilly but ideal medium for depicting abstract
       virtues
   ili: i4706
   members:
@@ -75902,7 +75902,7 @@
   definition:
   - drained physically
   example:
-  - the day's events left her completely exhausted — her strength drained
+  - the day's events left her completely exhausted--her strength drained
   ili: i5981
   members:
   - exhausted
@@ -77581,7 +77581,7 @@
   - excessively unwilling to spend
   example:
   - parsimonious thrift relieved by few generous impulses
-  - lived in a most penurious manner — denying himself every indulgence
+  - lived in a most penurious manner--denying himself every indulgence
   ili: i6114
   members:
   - parsimonious
@@ -78869,7 +78869,7 @@
   definition:
   - extremely evil or cruel; expressive of cruelty or befitting hell
   example:
-  - something demonic in him — something that could be cruel
+  - something demonic in him--something that could be cruel
   - fires lit up a diabolic scene
   - diabolical sorcerers under the influence of devils
   - a fiendish despot
@@ -79319,7 +79319,7 @@
   - displaying effortless beauty and simplicity in movement or execution
   example:
   - an elegant dancer
-  - an elegant mathematical solution — simple and precise
+  - an elegant mathematical solution -- simple and precise
   ili: i6234
   members:
   - elegant
@@ -82598,7 +82598,7 @@
   - of comparatively little physical weight or density
   example:
   - a light load
-  - magnesium is a light metal — having a specific gravity of 1.74 at 20 degrees C
+  - magnesium is a light metal--having a specific gravity of 1.74 at 20 degrees C
   ili: i6491
   members:
   - light
@@ -85509,7 +85509,7 @@
   - a despairing view of the world situation
   - the last despairing plea of the condemned criminal
   - a desperate cry for help
-  - helpless and desperate — as if at the end of his tether
+  - helpless and desperate--as if at the end of his tether
   - her desperate screams
   ili: i6726
   members:
@@ -87182,7 +87182,7 @@
   definition:
   - very cold
   example:
-  - whatever the evenings be — frosty and frore or warm and wet
+  - whatever the evenings be--frosty and frore or warm and wet
   exemplifies:
   - 07087487-n
   ili: i6854
@@ -89157,7 +89157,7 @@
   - commanding attention
   example:
   - an arresting drawing of people turning into animals
-  - a sensational concert — one never to be forgotten
+  - a sensational concert--one never to be forgotten
   - a stunning performance
   ili: i6997
   members:
@@ -92800,7 +92800,7 @@
   - having a keen intellect
   example:
   - source: A.T.Quiller-Couch
-    text: poets — those gifted strangely prehensile men
+    text: poets--those gifted strangely prehensile men
   ili: i7285
   members:
   - prehensile
@@ -93017,7 +93017,7 @@
   - having no cause or apparent cause
   example:
   - a causeless miracle
-  - fortuitous encounters — strange accidents of fortune
+  - fortuitous encounters--strange accidents of fortune
   - we cannot regard artistic invention as...uncaused and unrelated to the times
   ili: i7300
   members:
@@ -96778,7 +96778,7 @@
   definition:
   - small and delicate
   example:
-  - she was an elfin creature — graceful and delicate
+  - she was an elfin creature--graceful and delicate
   - obsessed by things elfin and small
   ili: i7586
   members:
@@ -110640,7 +110640,7 @@
   definition:
   - not neurotic
   example:
-  - successful mothers — mothers with unneurotic children
+  - successful mothers--mothers with unneurotic children
   - he's the most unneurotic person I know
   ili: i8693
   members:
@@ -116475,7 +116475,7 @@
   definition:
   - snarled or stalled in complete confusion
   example:
-  - situation normal — all fucked-up
+  - situation normal--all fucked-up
   ili: i9154
   members:
   - fucked-up
@@ -119914,7 +119914,7 @@
   example:
   - a barely palpable dust
   - felt sudden anger in a palpable wave
-  - the air was warm and close — palpable as cotton
+  - the air was warm and close--palpable as cotton
   - a palpable lie
   ili: i9420
   members:
@@ -120007,7 +120007,7 @@
   - 00615275-a
   - 01237040-a
   definition:
-  - slanting or inclined in direction or course or position — neither parallel nor
+  - slanting or inclined in direction or course or position--neither parallel nor
     perpendicular nor right-angled
   example:
   - the oblique rays of the winter sun
@@ -125343,7 +125343,7 @@
   - unornamented
   example:
   - a simple country schoolhouse
-  - her black dress — simple to austerity
+  - her black dress--simple to austerity
   ili: i9855
   members:
   - simple
@@ -126955,7 +126955,7 @@
   - capable of being weighed or considered
   example:
   - source: James Jeans
-    text: something ponderable from the outer world — something of which we can say
+    text: something ponderable from the outer world--something of which we can say
       that its weight is so and so
   ili: i9974
   members:
@@ -132089,7 +132089,7 @@
   example:
   - source: Laurent Le Sage
     text: a snotty little scion of a degenerate family
-  - they're snobs — stuck-up and uppity and persnickety
+  - they're snobs--stuck-up and uppity and persnickety
   ili: i10369
   members:
   - bigheaded
@@ -135367,9 +135367,9 @@
   - real war
   - a real friend
   - a real woman
-  - meat and potatoes — I call that a real meal
+  - meat and potatoes--I call that a real meal
   - it's time he had a real job
-  - it's no penny-ante job — he's making real money
+  - it's no penny-ante job--he's making real money
   ili: i10616
   members:
   - real
@@ -136179,7 +136179,7 @@
   - he had coarse manners but a first-rate mind
   - behavior that branded him as common
   - an untutored and uncouth human being
-  - an uncouth soldier — a real tough guy
+  - an uncouth soldier--a real tough guy
   - appealing to the vulgar taste for violence
   - the vulgar display of the newly rich
   ili: i10673
@@ -142040,7 +142040,7 @@
   example:
   - horned viper
   - great horned owl
-  - the unicorn — a mythical horned beast
+  - the unicorn--a mythical horned beast
   - long-horned cattle
   ili: i11146
   members:
@@ -146921,7 +146921,7 @@
   definition:
   - characterized by insensibility
   example:
-  - the young girls are in a state of possession — blind and deaf and anesthetic
+  - the young girls are in a state of possession--blind and deaf and anesthetic
   - an anesthetic state
   ili: i11526
   members:
@@ -152221,7 +152221,7 @@
   definition:
   - having only one part or element
   example:
-  - a simplex word has no affixes and is not part of a compound — like `boy' compared
+  - a simplex word has no affixes and is not part of a compound -- like `boy' compared
     with `boyish' or `house' compared with `houseboat'
   ili: i11963
   members:
@@ -167096,7 +167096,7 @@
   definition:
   - having a radial form
   example:
-  - starfish are actinoid — that is, they are radially symmetrical
+  - starfish are actinoid--that is, they are radially symmetrical
   ili: i13155
   members:
   - actinoid
@@ -182453,7 +182453,7 @@
   definition:
   - worthy of often limited commendation
   example:
-  - the student's effort on the essay — though not outstanding — was creditable
+  - the student's effort on the essay--though not outstanding--was creditable
   ili: i14348
   members:
   - creditable

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -131392,8 +131392,8 @@
   definition:
   - in harmony with the spirit of particular persons or occasion
   example:
-  - a decent burial"; "We have come to dedicate a portion of that field...It is altogether
-    fitting and proper that we should do this
+  - a decent burial
+  - we have come to dedicate a portion of that field...It is altogether fitting and proper that we should do this
   ili: i10315
   members:
   - fitting
@@ -140669,8 +140669,8 @@
   - restored to new life and vigor
   example:
   - a revitalized economy
-  - a revitalized inner-city neighborhood"; "Berlin has been reborn after probably
-    the most intense period of construction since the post-war period.
+  - a revitalized inner-city neighborhood
+  - Berlin has been reborn after probably the most intense period of construction since the post-war period.
   ili: i11032
   members:
   - revitalized

--- a/src/yaml/adj.pert.yaml
+++ b/src/yaml/adj.pert.yaml
@@ -11262,7 +11262,7 @@
   partOfSpeech: a
 02805493-a:
   definition:
-  - (used as a combining form) relating to--of or by or to or from or for--the self
+  - (used as a combining form) relating to — of or by or to or from or for — the self
   example:
   - self-knowledge
   - self-proclaimed

--- a/src/yaml/adj.pert.yaml
+++ b/src/yaml/adj.pert.yaml
@@ -11262,7 +11262,7 @@
   partOfSpeech: a
 02805493-a:
   definition:
-  - (used as a combining form) relating to — of or by or to or from or for — the self
+  - (used as a combining form) relating to--of or by or to or from or for--the self
   example:
   - self-knowledge
   - self-proclaimed

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -6858,8 +6858,8 @@
   - if nothing else (`leastwise' is informal and `leastways' is colloquial)
   example:
   - at least he survived
-  - they felt — at any rate Jim felt — relieved though still wary
-  - the influence of economists — or at any rate of economics — is far-reaching
+  - they felt--at any rate Jim felt--relieved though still wary
+  - the influence of economists--or at any rate of economics--is far-reaching
   exemplifies:
   - 07089193-n
   ili: i18798
@@ -10596,7 +10596,7 @@
   - by a great deal
   example:
   - he is the best by a long shot
-  - his labors haven't ended there — not by a long shot
+  - his labors haven't ended there--not by a long shot
   ili: i19189
   members:
   - by a long shot
@@ -10823,7 +10823,7 @@
   - indicating exactness or preciseness
   example:
   - he was doing precisely (or exactly) what she had told him to do
-  - it was just as he said — the jewel was gone
+  - it was just as he said--the jewel was gone
   - it has just enough salt
   - source: Thomas Carlyle
     text: Properly speaking, all true work is religion.
@@ -11065,7 +11065,7 @@
   - without speed (`slow' is sometimes used informally for `slowly')
   example:
   - he spoke slowly
-  - go easy here — the road is slippery
+  - go easy here--the road is slippery
   - glaciers move tardily
   - please go slow so I can see the sights
   exemplifies:
@@ -20481,7 +20481,7 @@
   definition:
   - in a damnable manner
   example:
-  - kindly Arthur — so damnably, politely, endlessly persistent!
+  - kindly Arthur--so damnably, politely, endlessly persistent!
   ili: i20214
   members:
   - damned
@@ -23185,7 +23185,7 @@
   definition:
   - in an inflexible manner
   example:
-  - '`You will — because you must!,'' Madam told her inflexibly'
+  - '`You will--because you must!,'' Madam told her inflexibly'
   ili: i20491
   members:
   - inflexibly
@@ -24679,7 +24679,7 @@
   definition:
   - in an immaculate manner
   example:
-  - gone was the casually dressed Canadian she had thought a backwoodsman — this man
+  - gone was the casually dressed Canadian she had thought a backwoodsman--this man
     was immaculately tailored
   ili: i20649
   members:
@@ -28981,7 +28981,7 @@
   definition:
   - in a priggish manner
   example:
-  - this professor acts so priggishly — like a moderator with a gavel!
+  - this professor acts so priggishly--like a moderator with a gavel!
   ili: i21108
   members:
   - priggishly
@@ -30244,7 +30244,7 @@
   definition:
   - in a peacefully serene manner
   example:
-  - I had the feeling that he was waiting, too — serenely patient
+  - I had the feeling that he was waiting, too--serenely patient
   ili: i21246
   members:
   - serenely
@@ -30308,7 +30308,7 @@
   definition:
   - in a manner characterized by trembling or shaking
   example:
-  - '`I — I''m going to make you a cup of tea'', she explained shakily'
+  - '`I--I''m going to make you a cup of tea'', she explained shakily'
   ili: i21253
   members:
   - shakily

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -9885,7 +9885,8 @@
   definition:
   - as much as necessary
   example:
-  - Have I eaten enough?"; (`plenty' is nonstandard) "I've had plenty, thanks
+  - have I eaten enough?
+  - (`plenty' is nonstandard) I've had plenty, thanks
   ili: i19117
   members:
   - enough

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -6858,8 +6858,8 @@
   - if nothing else (`leastwise' is informal and `leastways' is colloquial)
   example:
   - at least he survived
-  - they felt--at any rate Jim felt--relieved though still wary
-  - the influence of economists--or at any rate of economics--is far-reaching
+  - they felt — at any rate Jim felt — relieved though still wary
+  - the influence of economists — or at any rate of economics — is far-reaching
   exemplifies:
   - 07089193-n
   ili: i18798
@@ -10596,7 +10596,7 @@
   - by a great deal
   example:
   - he is the best by a long shot
-  - his labors haven't ended there--not by a long shot
+  - his labors haven't ended there — not by a long shot
   ili: i19189
   members:
   - by a long shot
@@ -10823,7 +10823,7 @@
   - indicating exactness or preciseness
   example:
   - he was doing precisely (or exactly) what she had told him to do
-  - it was just as he said--the jewel was gone
+  - it was just as he said — the jewel was gone
   - it has just enough salt
   - source: Thomas Carlyle
     text: Properly speaking, all true work is religion.
@@ -11065,7 +11065,7 @@
   - without speed (`slow' is sometimes used informally for `slowly')
   example:
   - he spoke slowly
-  - go easy here--the road is slippery
+  - go easy here — the road is slippery
   - glaciers move tardily
   - please go slow so I can see the sights
   exemplifies:
@@ -20481,7 +20481,7 @@
   definition:
   - in a damnable manner
   example:
-  - kindly Arthur--so damnably, politely, endlessly persistent!
+  - kindly Arthur — so damnably, politely, endlessly persistent!
   ili: i20214
   members:
   - damned
@@ -23185,7 +23185,7 @@
   definition:
   - in an inflexible manner
   example:
-  - '`You will--because you must!,'' Madam told her inflexibly'
+  - '`You will — because you must!,'' Madam told her inflexibly'
   ili: i20491
   members:
   - inflexibly
@@ -24679,7 +24679,7 @@
   definition:
   - in an immaculate manner
   example:
-  - gone was the casually dressed Canadian she had thought a backwoodsman--this man
+  - gone was the casually dressed Canadian she had thought a backwoodsman — this man
     was immaculately tailored
   ili: i20649
   members:
@@ -28981,7 +28981,7 @@
   definition:
   - in a priggish manner
   example:
-  - this professor acts so priggishly--like a moderator with a gavel!
+  - this professor acts so priggishly — like a moderator with a gavel!
   ili: i21108
   members:
   - priggishly
@@ -30244,7 +30244,7 @@
   definition:
   - in a peacefully serene manner
   example:
-  - I had the feeling that he was waiting, too--serenely patient
+  - I had the feeling that he was waiting, too — serenely patient
   ili: i21246
   members:
   - serenely
@@ -30308,7 +30308,7 @@
   definition:
   - in a manner characterized by trembling or shaking
   example:
-  - '`I--I''m going to make you a cup of tea'', she explained shakily'
+  - '`I — I''m going to make you a cup of tea'', she explained shakily'
   ili: i21253
   members:
   - shakily

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -1545,7 +1545,7 @@
   example:
   - they managed somehow
   - he expected somehow to discover a woman who would love him
-  - he tried to make is someway acceptable
+  - he tried to make it someway acceptable
   ili: i18293
   members:
   - somehow
@@ -21503,7 +21503,7 @@
   definition:
   - in an honest manner
   example:
-  - in he can't get it honestly, he is willing to steal it
+  - if he can't get it honestly, he is willing to steal it
   - was known for dealing aboveboard in everything
   ili: i20318
   members:

--- a/src/yaml/entries-a.yaml
+++ b/src/yaml/entries-a.yaml
@@ -48752,6 +48752,8 @@ ambagious:
     sense:
     - derivation:
       - 'ambage%1:10:00::'
+      exemplifies:
+      - 'archaism%1:10:00::'  
       id: ambagious%5:00:00:indirect:02
       synset: 00771186-s
 ambassador:

--- a/src/yaml/entries-b.yaml
+++ b/src/yaml/entries-b.yaml
@@ -6235,7 +6235,7 @@ Bletilla striata:
 Bleu Végétal Pour Les Veines:
   n:
     sense:
-    - id: 'bleu_vegetal_pour_les_veines%1:27:01::'
+    - id: 'bleu_végétal_pour_les_veines%1:27:01::'
       synset: 92427729-n
 Blida:
   n:

--- a/src/yaml/entries-b.yaml
+++ b/src/yaml/entries-b.yaml
@@ -6232,10 +6232,10 @@ Bletilla striata:
     sense:
     - id: 'bletilla_striata%1:20:00::'
       synset: 12067284-n
-Bleu Végétal Pour Les Veines:
+Bleu Vegetal Pour Les Veines:
   n:
     sense:
-    - id: 'bleu_végétal_pour_les_veines%1:27:01::'
+    - id: 'bleu_vegetal_pour_les_veines%1:27:01::'
       synset: 92427729-n
 Blida:
   n:

--- a/src/yaml/entries-b.yaml
+++ b/src/yaml/entries-b.yaml
@@ -6232,7 +6232,7 @@ Bletilla striata:
     sense:
     - id: 'bletilla_striata%1:20:00::'
       synset: 12067284-n
-Bleu Vegetal Pour Les Veines:
+Bleu Végétal Pour Les Veines:
   n:
     sense:
     - id: 'bleu_vegetal_pour_les_veines%1:27:01::'

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -47891,7 +47891,7 @@
   - the act of hearing attentively
   example:
   - you can learn a lot by just listening
-  - they make good music — you should give them a hearing
+  - they make good music--you should give them a hearing
   hypernym:
   - 00878552-n
   ili: i40034

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -4710,7 +4710,7 @@
   - the act of raising something
   example:
   - he responded with a lift of his eyebrow
-  - fireman learn several different raises for getting ladders up
+  - firemen learn several different raises for getting ladders up
   hypernym:
   - 00045991-n
   ili: i36018
@@ -60329,7 +60329,7 @@
   - the act of transacting within or between groups (as carrying on commercial activities)
   example:
   - no transactions are possible without him
-  - he has always been honest is his dealings with me
+  - he has always been honest in his dealings with me
   hypernym:
   - 01082290-n
   ili: i41201

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -47891,7 +47891,7 @@
   - the act of hearing attentively
   example:
   - you can learn a lot by just listening
-  - they make good music--you should give them a hearing
+  - they make good music — you should give them a hearing
   hypernym:
   - 00878552-n
   ili: i40034

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -3735,7 +3735,7 @@
 02732289-n:
   definition:
   - (classical mythology) a golden apple thrown into a banquet of the gods by Eris
-    (goddess of discord — who had not been invited); the apple had `for the fairest'
+    (goddess of discord--who had not been invited); the apple had `for the fairest'
     written on it and Hera and Athena and Aphrodite all claimed it; when Paris (prince
     of Troy) awarded it to Aphrodite it began a chain of events that led to the Trojan
     War
@@ -30573,7 +30573,7 @@
   partOfSpeech: n
 03154617-n:
   definition:
-  - something unusual — perhaps worthy of collecting
+  - something unusual -- perhaps worthy of collecting
   hypernym:
   - 00002684-n
   ili: i52628
@@ -101646,7 +101646,7 @@
   partOfSpeech: n
 04295922-n:
   definition:
-  - the lowest stone in an arch — from which it springs
+  - the lowest stone in an arch -- from which it springs
   hypernym:
   - 04333222-n
   ili: i59392

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -3735,7 +3735,7 @@
 02732289-n:
   definition:
   - (classical mythology) a golden apple thrown into a banquet of the gods by Eris
-    (goddess of discord--who had not been invited); the apple had `for the fairest'
+    (goddess of discord — who had not been invited); the apple had `for the fairest'
     written on it and Hera and Athena and Aphrodite all claimed it; when Paris (prince
     of Troy) awarded it to Aphrodite it began a chain of events that led to the Trojan
     War
@@ -30573,7 +30573,7 @@
   partOfSpeech: n
 03154617-n:
   definition:
-  - something unusual -- perhaps worthy of collecting
+  - something unusual — perhaps worthy of collecting
   hypernym:
   - 00002684-n
   ili: i52628
@@ -101646,7 +101646,7 @@
   partOfSpeech: n
 04295922-n:
   definition:
-  - the lowest stone in an arch -- from which it springs
+  - the lowest stone in an arch — from which it springs
   hypernym:
   - 04333222-n
   ili: i59392

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -45320,7 +45320,7 @@
   - a framework that supports and protects a picture or a mirror
   example:
   - the frame enhances but is not itself the subject of attention
-  - the frame was much more valuable than the miror it held
+  - the frame was much more valuable than the mirror it held
   hypernym:
   - 03396616-n
   ili: i54028
@@ -57200,7 +57200,7 @@
   definition:
   - a device that prevents an automotive engine from starting
   example:
-  - car theives know how to bypass the ignition interlock
+  - car thieves know how to bypass the ignition interlock
   hypernym:
   - 03187746-n
   ili: i55152
@@ -123901,7 +123901,7 @@
   - A cheek-rouging cosmetic made by baking colored liquid on terra cotta tiles.
   example:
   - Baked blush is considered to give a more long-lasting and vibrant effect than
-    a tradiional pressed powder formula.
+    a traditional pressed powder formula.
   hypernym:
   - 04119846-n
   members:

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -65,7 +65,7 @@
   partOfSpeech: n
 04624919-n:
   definition:
-  - the complex of all the attributes — behavioral, temperamental, emotional and mental — that
+  - the complex of all the attributes--behavioral, temperamental, emotional and mental--that
     characterize a unique individual
   example:
   - their different reactions reflected their very different personalities
@@ -2091,7 +2091,7 @@
   - 02260390-a
   - 02260821-a
   definition:
-  - the quality of being gregarious — having a dislike of being alone
+  - the quality of being gregarious--having a dislike of being alone
   hypernym:
   - 04660287-n
   ili: i61523
@@ -8280,7 +8280,7 @@
   partOfSpeech: n
 04777307-n:
   definition:
-  - the quality of being steady — regular and unvarying
+  - the quality of being steady--regular and unvarying
   hypernym:
   - 04774586-n
   ili: i62079
@@ -8451,7 +8451,7 @@
   partOfSpeech: n
 04780421-n:
   definition:
-  - the quality of being unsteady — varying and unpredictable
+  - the quality of being unsteady--varying and unpredictable
   hypernym:
   - 04777450-n
   ili: i62096
@@ -12294,7 +12294,7 @@
   partOfSpeech: n
 04851574-n:
   definition:
-  - the quality of being crass — devoid of refinement
+  - the quality of being crass--devoid of refinement
   hypernym:
   - 04851255-n
   ili: i62446
@@ -20183,7 +20183,7 @@
   example:
   - source: Joe Hing Lowe
     text: I establish the colors and principal values by organizing the painting into
-      three values — dark, medium...and light
+      three values--dark, medium...and light
   hypernym:
   - 04982235-n
   ili: i63169
@@ -32913,7 +32913,7 @@
   - 00307112-a
   - 00308272-a
   definition:
-  - the quality of being capable — physically or intellectually or legally
+  - the quality of being capable -- physically or intellectually or legally
   example:
   - he worked to the limits of his capability
   hypernym:
@@ -33172,7 +33172,7 @@
   partOfSpeech: n
 05214838-n:
   definition:
-  - the quality of not being capable — physically or intellectually or legally
+  - the quality of not being capable -- physically or intellectually or legally
   hypernym:
   - 05214398-n
   ili: i64332
@@ -36922,7 +36922,7 @@
     system.
   example:
   - Galileo's discovery was that the period of swing of a pendulum is independent
-    of its amplitude — the arc of the swing — the isochronism of the pendulum.
+    of its amplitude--the arc of the swing--the isochronism of the pendulum.
   hypernym:
   - 04923519-n
   members:

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -33353,7 +33353,7 @@
   definition:
   - unspecified qualities required to do or be something
   example:
-  - the stuff of heros
+  - the stuff of heroes
   - you don't have the stuff to be a United States Marine
   hypernym:
   - 04731092-n
@@ -34730,7 +34730,7 @@
     with someone other than their spouse.
   example:
   - He consequently interprets his own behaviour in sociobiological terms so that,
-    having slept with his ex-wif Charlotte in her current marital bed, he is unnerved
+    having slept with his ex-wife Charlotte in her current marital bed, he is unnerved
     not by the adulterousness of the act, which is routine for him, but by the infringement
     of male territorial boundaries.
   hypernym:

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -65,7 +65,7 @@
   partOfSpeech: n
 04624919-n:
   definition:
-  - the complex of all the attributes--behavioral, temperamental, emotional and mental--that
+  - the complex of all the attributes — behavioral, temperamental, emotional and mental — that
     characterize a unique individual
   example:
   - their different reactions reflected their very different personalities
@@ -2091,7 +2091,7 @@
   - 02260390-a
   - 02260821-a
   definition:
-  - the quality of being gregarious--having a dislike of being alone
+  - the quality of being gregarious — having a dislike of being alone
   hypernym:
   - 04660287-n
   ili: i61523
@@ -8280,7 +8280,7 @@
   partOfSpeech: n
 04777307-n:
   definition:
-  - the quality of being steady--regular and unvarying
+  - the quality of being steady — regular and unvarying
   hypernym:
   - 04774586-n
   ili: i62079
@@ -8451,7 +8451,7 @@
   partOfSpeech: n
 04780421-n:
   definition:
-  - the quality of being unsteady--varying and unpredictable
+  - the quality of being unsteady — varying and unpredictable
   hypernym:
   - 04777450-n
   ili: i62096
@@ -12294,7 +12294,7 @@
   partOfSpeech: n
 04851574-n:
   definition:
-  - the quality of being crass--devoid of refinement
+  - the quality of being crass — devoid of refinement
   hypernym:
   - 04851255-n
   ili: i62446
@@ -20183,7 +20183,7 @@
   example:
   - source: Joe Hing Lowe
     text: I establish the colors and principal values by organizing the painting into
-      three values--dark, medium...and light
+      three values — dark, medium...and light
   hypernym:
   - 04982235-n
   ili: i63169
@@ -32913,7 +32913,7 @@
   - 00307112-a
   - 00308272-a
   definition:
-  - the quality of being capable -- physically or intellectually or legally
+  - the quality of being capable — physically or intellectually or legally
   example:
   - he worked to the limits of his capability
   hypernym:
@@ -33172,7 +33172,7 @@
   partOfSpeech: n
 05214838-n:
   definition:
-  - the quality of not being capable -- physically or intellectually or legally
+  - the quality of not being capable — physically or intellectually or legally
   hypernym:
   - 05214398-n
   ili: i64332
@@ -36922,7 +36922,7 @@
     system.
   example:
   - Galileo's discovery was that the period of swing of a pendulum is independent
-    of its amplitude--the arc of the swing--the isochronism of the pendulum.
+    of its amplitude — the arc of the swing — the isochronism of the pendulum.
   hypernym:
   - 04923519-n
   members:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -13813,7 +13813,7 @@
   definition:
   - a concept or idea not associated with any specific instance
   example:
-  - he loved her only in the abstract — not in person
+  - he loved her only in the abstract--not in person
   hypernym:
   - 05844071-n
   ili: i67636
@@ -16032,7 +16032,7 @@
   example:
   - he wasn't going to admit his mistake
   - make no mistake about his intentions
-  - there must be some misunderstanding — I don't have a sister
+  - there must be some misunderstanding--I don't have a sister
   hypernym:
   - 05902260-n
   ili: i67829
@@ -33387,8 +33387,8 @@
   - a philosophy or media theory dedicated to studying what lies beyond the realm
     of metaphysics.
   example:
-  - Of all the French cultural exports over the last 150 years or so, 'pataphysics — the
-    science of imaginary solutions and the laws governing exceptions — has proven to
+  - Of all the French cultural exports over the last 150 years or so, 'pataphysics--the
+    science of imaginary solutions and the laws governing exceptions--has proven to
     be one of the most durable.
   hypernym:
   - 05786951-n
@@ -35077,7 +35077,7 @@
   definition:
   - A point (proposition in a debate etc.) that forms part of a larger point.
   example:
-  - The subpoint is that slogans aren't going to help — as I have written here, and
+  - The subpoint is that slogans aren't going to help -- as I have written here, and
     in all three of my books for parents, education from schools, faith based communities,
     and parents will.
   hypernym:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -13813,7 +13813,7 @@
   definition:
   - a concept or idea not associated with any specific instance
   example:
-  - he loved her only in the abstract--not in person
+  - he loved her only in the abstract — not in person
   hypernym:
   - 05844071-n
   ili: i67636
@@ -16032,7 +16032,7 @@
   example:
   - he wasn't going to admit his mistake
   - make no mistake about his intentions
-  - there must be some misunderstanding--I don't have a sister
+  - there must be some misunderstanding — I don't have a sister
   hypernym:
   - 05902260-n
   ili: i67829
@@ -33387,8 +33387,8 @@
   - a philosophy or media theory dedicated to studying what lies beyond the realm
     of metaphysics.
   example:
-  - Of all the French cultural exports over the last 150 years or so, 'pataphysics--the
-    science of imaginary solutions and the laws governing exceptions--has proven to
+  - Of all the French cultural exports over the last 150 years or so, 'pataphysics — the
+    science of imaginary solutions and the laws governing exceptions — has proven to
     be one of the most durable.
   hypernym:
   - 05786951-n
@@ -35077,7 +35077,7 @@
   definition:
   - A point (proposition in a debate etc.) that forms part of a larger point.
   example:
-  - The subpoint is that slogans aren't going to help -- as I have written here, and
+  - The subpoint is that slogans aren't going to help — as I have written here, and
     in all three of my books for parents, education from schools, faith based communities,
     and parents will.
   hypernym:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -34215,7 +34215,7 @@
   definition:
   - the scientific study of smells or of the sense of smell.
   example:
-  - Suitably equipped, man and rodent traded sniff for sniff in what must haye been
+  - Suitably equipped, man and rodent traded sniff for sniff in what must have been
     one of the most exciting contests in the history of olfactology.
   hypernym:
   - 06005806-n

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -11088,7 +11088,7 @@
   partOfSpeech: n
 06464033-n:
   definition:
-  - the Jewish scriptures which consist of three divisions — the Torah and the Prophets
+  - the Jewish scriptures which consist of three divisions--the Torah and the Prophets
     and the Writings
   ili: i70375
   instance_hypernym:
@@ -29375,7 +29375,7 @@
   definition:
   - something intended to misrepresent the true nature of an activity
   example:
-  - he wasn't sick — it was just a subterfuge
+  - he wasn't sick--it was just a subterfuge
   - the holding company was just a blind
   hypernym:
   - 06770936-n
@@ -40753,7 +40753,7 @@
 06956140-n:
   definition:
   - a Thraco-Phrygian language spoken by the ancient inhabitants of Phrygia and now
-    extinct — preserved only in a few inscriptions
+    extinct--preserved only in a few inscriptions
   hypernym:
   - 06955789-n
   ili: i73083
@@ -63590,7 +63590,7 @@
   - a dispatch sent via radio transmission.
   example:
   - A radio dispatch gets its veracity from the authentic sound of the reporter being
-    in the scene — even interacting with others in the scene.
+    in the scene--even interacting with others in the scene.
   hypernym:
   - 06695539-n
   members:
@@ -64128,7 +64128,7 @@
     is important to the text's interpretation.
   example:
   - What caught my eye about this is that it bears interesting relation to Bakhtin's
-    concept of the dialogism of the "living word" — in fact, capitalize that "w"
+    concept of the dialogism of the "living word" -- in fact, capitalize that "w"
     and it would be downright eerie.
   hypernym:
   - 07112859-n

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -34222,7 +34222,7 @@
   - a single written symbol that represents an entire word or phrase without indicating
     its pronunciation
   example:
-  - `7' is a logogram that is pronounced `seven' in English and `nanatsu' in Japanese
+  - "`7' is a logogram that is pronounced `seven' in English and `nanatsu' in Japanese"
   hypernym:
   - 06853698-n
   ili: i72469

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -34222,7 +34222,7 @@
   - a single written symbol that represents an entire word or phrase without indicating
     its pronunciation
   example:
-  - 7 is a logogram that is pronounced `seven' in English and `nanatsu' in Japanese
+  - `7' is a logogram that is pronounced `seven' in English and `nanatsu' in Japanese
   hypernym:
   - 06853698-n
   ili: i72469
@@ -53331,7 +53331,7 @@
   definition:
   - a commonly repeated word or phrase
   example:
-  - she repeated `So pleased with how its going' at intervals like a mantra
+  - she repeated `So pleased with how it's going' at intervals like a mantra
   hypernym:
   - 07166967-n
   ili: i74250
@@ -61682,7 +61682,7 @@
   - An accent on the first syllable of a word.
   example:
   - The fronting took place more slowly in American English and so Modern American
-    English has forms like elo'ngate, imprégnate and remonstrate where British English
+    English has forms like eˈlongate, imˈpregnate and reˈmonstrate where British English
     usually has initial stress.
   hypernym:
   - 07100280-n
@@ -63564,7 +63564,7 @@
   definition:
   - a poetic phrase, utterance, etc.
   example:
-  - Just as hath is a poeticism in Keats and an unmarked form for Shakespeare, sogebided
+  - Just as `hath' is a poeticism in Keats and an unmarked form for Shakespeare, `sogebided'
     may have been a poeticism to Alfred and an unmarked form for Qedmon.
   hypernym:
   - 06297048-n
@@ -64192,7 +64192,7 @@
   - small circular, rectangular, or square advertisement appearing usually at the
     bottom of a webpage.
   example:
-  - They are mostly ideal for co-branding excercises, where one website associates
+  - They are mostly ideal for co-branding exercises, where one website associates
     itself intrinsically with another via the use of a button ad instead of normal
     hyperlink.
   hypernym:
@@ -64648,7 +64648,7 @@
     on a remote computer.
   example:
   - Your Web browser is a client program that has requested a service from a server;
-    in fact, the service and resouce the server provided is the delivery of this Web
+    in fact, the service and resource the server provided is the delivery of this Web
     page.
   hypernym:
   - 06581154-n

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -11088,7 +11088,7 @@
   partOfSpeech: n
 06464033-n:
   definition:
-  - the Jewish scriptures which consist of three divisions--the Torah and the Prophets
+  - the Jewish scriptures which consist of three divisions — the Torah and the Prophets
     and the Writings
   ili: i70375
   instance_hypernym:
@@ -29375,7 +29375,7 @@
   definition:
   - something intended to misrepresent the true nature of an activity
   example:
-  - he wasn't sick--it was just a subterfuge
+  - he wasn't sick — it was just a subterfuge
   - the holding company was just a blind
   hypernym:
   - 06770936-n
@@ -40753,7 +40753,7 @@
 06956140-n:
   definition:
   - a Thraco-Phrygian language spoken by the ancient inhabitants of Phrygia and now
-    extinct--preserved only in a few inscriptions
+    extinct — preserved only in a few inscriptions
   hypernym:
   - 06955789-n
   ili: i73083
@@ -63590,7 +63590,7 @@
   - a dispatch sent via radio transmission.
   example:
   - A radio dispatch gets its veracity from the authentic sound of the reporter being
-    in the scene--even interacting with others in the scene.
+    in the scene — even interacting with others in the scene.
   hypernym:
   - 06695539-n
   members:
@@ -64128,7 +64128,7 @@
     is important to the text's interpretation.
   example:
   - What caught my eye about this is that it bears interesting relation to Bakhtin's
-    concept of the dialogism of the "living word" -- in fact, capitalize that "w"
+    concept of the dialogism of the "living word" — in fact, capitalize that "w"
     and it would be downright eerie.
   hypernym:
   - 07112859-n

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -61681,9 +61681,10 @@
   definition:
   - An accent on the first syllable of a word.
   example:
-  - The fronting took place more slowly in American English and so Modern American
-    English has forms like eˈlongate, imˈpregnate and reˈmonstrate where British English
-    usually has initial stress.
+  - source: English Phonetics and Phonology for Spanish Students - Brian Mott
+    text: The fronting took place more slowly in American English and so Modern American
+      English has forms like elóngate, imprégnate and remónstrate where British English
+      usually has initial stress.
   hypernym:
   - 07100280-n
   members:

--- a/src/yaml/noun.feeling.yaml
+++ b/src/yaml/noun.feeling.yaml
@@ -1084,7 +1084,7 @@
   - deep in her breast lives the silent wound
   - source: Robert Frost
     text: The right reader of a good poem can tell the moment it strikes him that
-      he has taken an immortal wound--that he will never get over it
+      he has taken an immortal wound — that he will never get over it
   hypernym:
   - 07511603-n
   ili: i76142

--- a/src/yaml/noun.feeling.yaml
+++ b/src/yaml/noun.feeling.yaml
@@ -1084,7 +1084,7 @@
   - deep in her breast lives the silent wound
   - source: Robert Frost
     text: The right reader of a good poem can tell the moment it strikes him that
-      he has taken an immortal wound — that he will never get over it
+      he has taken an immortal wound--that he will never get over it
   hypernym:
   - 07511603-n
   ili: i76142

--- a/src/yaml/noun.food.yaml
+++ b/src/yaml/noun.food.yaml
@@ -1134,7 +1134,7 @@
   partOfSpeech: n
 07592534-n:
   definition:
-  - a cookout at the seashore where clams and fish and other foods are cooked — usually
+  - a cookout at the seashore where clams and fish and other foods are cooked--usually
     on heated stones covered with seaweed
   hypernym:
   - 07592142-n
@@ -1256,7 +1256,7 @@
   definition:
   - a small amount eaten or drunk
   example:
-  - take a taste — you'll like it
+  - take a taste--you'll like it
   hypernym:
   - 13782456-n
   ili: i76588
@@ -15963,7 +15963,7 @@
   partOfSpeech: n
 07811293-n:
   definition:
-  - any market fish — edible saltwater fish or shellfish — except herring
+  - any market fish--edible saltwater fish or shellfish--except herring
   domain_region:
   - 08879115-n
   hypernym:

--- a/src/yaml/noun.food.yaml
+++ b/src/yaml/noun.food.yaml
@@ -1134,7 +1134,7 @@
   partOfSpeech: n
 07592534-n:
   definition:
-  - a cookout at the seashore where clams and fish and other foods are cooked--usually
+  - a cookout at the seashore where clams and fish and other foods are cooked — usually
     on heated stones covered with seaweed
   hypernym:
   - 07592142-n
@@ -1256,7 +1256,7 @@
   definition:
   - a small amount eaten or drunk
   example:
-  - take a taste--you'll like it
+  - take a taste — you'll like it
   hypernym:
   - 13782456-n
   ili: i76588
@@ -15963,7 +15963,7 @@
   partOfSpeech: n
 07811293-n:
   definition:
-  - any market fish--edible saltwater fish or shellfish--except herring
+  - any market fish — edible saltwater fish or shellfish — except herring
   domain_region:
   - 08879115-n
   hypernym:

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -12763,7 +12763,7 @@
   - an international organization of European countries formed after World War II
     to reduce trade barriers and increase cooperation among its members
   example:
-  - he tried to take Britain into the Europen Union
+  - he tried to take Britain into the European Union
   hypernym:
   - 08311617-n
   ili: i80101
@@ -31383,7 +31383,7 @@
     the cultural context in which it was created.
   example:
   - In Western capitalist nations, he saw a preponderance of folklorism due to the
-    expansion of undistrial markets, ranging from tourism to commodity goods.
+    expansion of industrial markets, ranging from tourism to commodity goods.
   hypernym:
   - 08483654-n
   members:

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -3815,7 +3815,7 @@
   definition:
   - the area in which something exists or lives
   example:
-  - the country — the flat agricultural surround
+  - the country--the flat agricultural surround
   hypernym:
   - 08591861-n
   ili: i82005

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -3815,7 +3815,7 @@
   definition:
   - the area in which something exists or lives
   example:
-  - the country--the flat agricultural surround
+  - the country — the flat agricultural surround
   hypernym:
   - 08591861-n
   ili: i82005

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -6993,7 +6993,7 @@
   definition:
   - a mythical Greek hero of the Iliad; a foremost Greek warrior at the siege of Troy;
     when he was a baby his mother tried to make him immortal by bathing him in a magical
-    river but the heel by which she held him remained vulnerable--his `Achilles' heel'
+    river but the heel by which she held him remained vulnerable — his `Achilles' heel'
   ili: i87084
   instance_hypernym:
   - 09507794-n
@@ -18581,7 +18581,7 @@
   - someone who tries to bring peace by acceding to demands
   example:
   - source: Winston Churchill
-    text: An appeaser is one who feeds a crocodile--hoping it will eat him last
+    text: An appeaser is one who feeds a crocodile — hoping it will eat him last
   hypernym:
   - 09971642-n
   ili: i88255
@@ -33413,7 +33413,7 @@
   definition:
   - an eater who dips food into a liquid before eating it
   example:
-  - he was a dunker--he couldn't eat a doughnut without a cup of coffee to dunk it
+  - he was a dunker — he couldn't eat a doughnut without a cup of coffee to dunk it
     in
   hypernym:
   - 10062108-n
@@ -51533,7 +51533,7 @@
   partOfSpeech: n
 10342840-n:
   definition:
-  - someone sent on a mission--especially a religious or charitable mission to a foreign
+  - someone sent on a mission — especially a religious or charitable mission to a foreign
     country
   hypernym:
   - 09651570-n
@@ -60712,7 +60712,7 @@
   definition:
   - a member of the working class (not necessarily employed)
   example:
-  - workers of the world--unite!
+  - workers of the world — unite!
   hypernym:
   - 09633435-n
   ili: i92288
@@ -68826,7 +68826,7 @@
   definition:
   - an unexpected achiever of success
   example:
-  - the winner was a true sleeper--no one expected him to get it
+  - the winner was a true sleeper — no one expected him to get it
   hypernym:
   - 09782244-n
   ili: i93062
@@ -89408,7 +89408,7 @@
 10959622-n:
   definition:
   - English engineer who developed a method of preserving food by sterilizing it with
-    heat and sealing it inside a steel container--the first tin can (1768-1855)
+    heat and sealing it inside a steel container — the first tin can (1768-1855)
   ili: i94945
   instance_hypernym:
   - 09638837-n

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -22949,7 +22949,7 @@
   - a man who is the lover of a man or woman
   example:
   - if I'd known he was her boyfriend I wouldn't have asked
-  - When the law changed, Pet could finally married his long-time boyfriend Jim
+  - When the law changed, Pet could finally marry his long-time boyfriend Jim
   hypernym:
   - 10306910-n
   - 09645472-n

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -6993,7 +6993,7 @@
   definition:
   - a mythical Greek hero of the Iliad; a foremost Greek warrior at the siege of Troy;
     when he was a baby his mother tried to make him immortal by bathing him in a magical
-    river but the heel by which she held him remained vulnerable — his `Achilles' heel'
+    river but the heel by which she held him remained vulnerable--his `Achilles' heel'
   ili: i87084
   instance_hypernym:
   - 09507794-n
@@ -18581,7 +18581,7 @@
   - someone who tries to bring peace by acceding to demands
   example:
   - source: Winston Churchill
-    text: An appeaser is one who feeds a crocodile — hoping it will eat him last
+    text: An appeaser is one who feeds a crocodile--hoping it will eat him last
   hypernym:
   - 09971642-n
   ili: i88255
@@ -33413,7 +33413,7 @@
   definition:
   - an eater who dips food into a liquid before eating it
   example:
-  - he was a dunker — he couldn't eat a doughnut without a cup of coffee to dunk it
+  - he was a dunker--he couldn't eat a doughnut without a cup of coffee to dunk it
     in
   hypernym:
   - 10062108-n
@@ -51533,7 +51533,7 @@
   partOfSpeech: n
 10342840-n:
   definition:
-  - someone sent on a mission — especially a religious or charitable mission to a foreign
+  - someone sent on a mission--especially a religious or charitable mission to a foreign
     country
   hypernym:
   - 09651570-n
@@ -60712,7 +60712,7 @@
   definition:
   - a member of the working class (not necessarily employed)
   example:
-  - workers of the world — unite!
+  - workers of the world--unite!
   hypernym:
   - 09633435-n
   ili: i92288
@@ -68826,7 +68826,7 @@
   definition:
   - an unexpected achiever of success
   example:
-  - the winner was a true sleeper — no one expected him to get it
+  - the winner was a true sleeper--no one expected him to get it
   hypernym:
   - 09782244-n
   ili: i93062
@@ -89408,7 +89408,7 @@
 10959622-n:
   definition:
   - English engineer who developed a method of preserving food by sterilizing it with
-    heat and sealing it inside a steel container — the first tin can (1768-1855)
+    heat and sealing it inside a steel container--the first tin can (1768-1855)
   ili: i94945
   instance_hypernym:
   - 09638837-n

--- a/src/yaml/noun.phenomenon.yaml
+++ b/src/yaml/noun.phenomenon.yaml
@@ -2331,7 +2331,7 @@
   - energy made available by the flow of electric charge through a conductor
   example:
   - they built a car that runs on electricity
-  - The power went oout around midnight
+  - The power went out around midnight
   hypernym:
   - 11472635-n
   ili: i97765

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -33593,7 +33593,7 @@
 12164634-n:
   definition:
   - (Great Britain) any of various cereal plants (especially the dominant crop of
-    the region — wheat in Great Britain or oats in Scotland and Ireland)
+    the region--wheat in Great Britain or oats in Scotland and Ireland)
   hypernym:
   - 12162012-n
   ili: i100968
@@ -55506,7 +55506,7 @@
   partOfSpeech: n
 12542693-n:
   definition:
-  - any of those hardwood trees of the genus Dalbergia that yield rosewood — valuable
+  - any of those hardwood trees of the genus Dalbergia that yield rosewood--valuable
     cabinet woods of a dark red or purplish color streaked and variegated with black
   hypernym:
   - 13124818-n
@@ -59651,7 +59651,7 @@
   partOfSpeech: n
 12612463-n:
   definition:
-  - Malaysian palm whose pithy trunk yields sago — a starch used as a food thickener
+  - Malaysian palm whose pithy trunk yields sago--a starch used as a food thickener
     and fabric stiffener; Malaya to Fiji
   hypernym:
   - 12603413-n
@@ -92781,7 +92781,7 @@
   partOfSpeech: n
 13180456-n:
   definition:
-  - a leaf with the base united around — and apparently pierced by — the stem
+  - a leaf with the base united around--and apparently pierced by--the stem
   hypernym:
   - 13176981-n
   ili: i105813

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -33593,7 +33593,7 @@
 12164634-n:
   definition:
   - (Great Britain) any of various cereal plants (especially the dominant crop of
-    the region--wheat in Great Britain or oats in Scotland and Ireland)
+    the region — wheat in Great Britain or oats in Scotland and Ireland)
   hypernym:
   - 12162012-n
   ili: i100968
@@ -55506,7 +55506,7 @@
   partOfSpeech: n
 12542693-n:
   definition:
-  - any of those hardwood trees of the genus Dalbergia that yield rosewood--valuable
+  - any of those hardwood trees of the genus Dalbergia that yield rosewood — valuable
     cabinet woods of a dark red or purplish color streaked and variegated with black
   hypernym:
   - 13124818-n
@@ -59651,7 +59651,7 @@
   partOfSpeech: n
 12612463-n:
   definition:
-  - Malaysian palm whose pithy trunk yields sago--a starch used as a food thickener
+  - Malaysian palm whose pithy trunk yields sago — a starch used as a food thickener
     and fabric stiffener; Malaya to Fiji
   hypernym:
   - 12603413-n
@@ -92781,7 +92781,7 @@
   partOfSpeech: n
 13180456-n:
   definition:
-  - a leaf with the base united around--and apparently pierced by--the stem
+  - a leaf with the base united around — and apparently pierced by — the stem
   hypernym:
   - 13176981-n
   ili: i105813

--- a/src/yaml/noun.possession.yaml
+++ b/src/yaml/noun.possession.yaml
@@ -6900,7 +6900,7 @@
   - great wealth
   example:
   - source: Ben Jonson
-    text: Whilst that for which all virtue now is sold, and almost every vice--almighty
+    text: Whilst that for which all virtue now is sold, and almost every vice — almighty
       gold
   hypernym:
   - 13374295-n

--- a/src/yaml/noun.possession.yaml
+++ b/src/yaml/noun.possession.yaml
@@ -6900,7 +6900,7 @@
   - great wealth
   example:
   - source: Ben Jonson
-    text: Whilst that for which all virtue now is sold, and almost every vice — almighty
+    text: Whilst that for which all virtue now is sold, and almost every vice--almighty
       gold
   hypernym:
   - 13374295-n

--- a/src/yaml/noun.process.yaml
+++ b/src/yaml/noun.process.yaml
@@ -3940,7 +3940,7 @@
 13516839-n:
   definition:
   - (psychiatry) a defense mechanism that splits something you are ambivalent about
-    into two representations--one good and one bad
+    into two representations — one good and one bad
   domain_topic:
   - 06065477-n
   hypernym:

--- a/src/yaml/noun.process.yaml
+++ b/src/yaml/noun.process.yaml
@@ -3940,7 +3940,7 @@
 13516839-n:
   definition:
   - (psychiatry) a defense mechanism that splits something you are ambivalent about
-    into two representations — one good and one bad
+    into two representations--one good and one bad
   domain_topic:
   - 06065477-n
   hypernym:

--- a/src/yaml/noun.relation.yaml
+++ b/src/yaml/noun.relation.yaml
@@ -3556,7 +3556,7 @@
   definition:
   - the way two individuals relate to each other
   example:
-  - their chemistry was wrong from the beginning -- they hated each other
+  - their chemistry was wrong from the beginning — they hated each other
   - a mysterious alchemy brought them together
   hypernym:
   - 00033122-n

--- a/src/yaml/noun.relation.yaml
+++ b/src/yaml/noun.relation.yaml
@@ -3556,7 +3556,7 @@
   definition:
   - the way two individuals relate to each other
   example:
-  - their chemistry was wrong from the beginning — they hated each other
+  - their chemistry was wrong from the beginning -- they hated each other
   - a mysterious alchemy brought them together
   hypernym:
   - 00033122-n

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -2115,7 +2115,7 @@
   partOfSpeech: n
 13982086-n:
   definition:
-  - the state of being there--not here--in position
+  - the state of being there — not here — in position
   hypernym:
   - 13980887-n
   ili: i110289
@@ -4196,7 +4196,7 @@
   example:
   - liberty of opinion
   - liberty of worship
-  - liberty--perfect liberty--to think or feel or do just as one pleases
+  - liberty — perfect liberty — to think or feel or do just as one pleases
   - at liberty to choose whatever occupation one wishes
   hypernym:
   - 14015308-n
@@ -12742,7 +12742,7 @@
   partOfSpeech: n
 14170694-n:
   definition:
-  - a fungal infection characterized by nodular lesions--first in the lungs and spreading
+  - a fungal infection characterized by nodular lesions — first in the lungs and spreading
     to the nervous system
   hypernym:
   - 14200377-n
@@ -29024,7 +29024,7 @@
   definition:
   - the state of being banished or ostracized (excluded from society by general consent)
   example:
-  - the association should get rid of its elderly members--not by euthanasia, of course,
+  - the association should get rid of its elderly members — not by euthanasia, of course,
     but by Coventry
   hypernym:
   - 13958260-n

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -2115,7 +2115,7 @@
   partOfSpeech: n
 13982086-n:
   definition:
-  - the state of being there — not here — in position
+  - the state of being there--not here--in position
   hypernym:
   - 13980887-n
   ili: i110289
@@ -4196,7 +4196,7 @@
   example:
   - liberty of opinion
   - liberty of worship
-  - liberty — perfect liberty — to think or feel or do just as one pleases
+  - liberty--perfect liberty--to think or feel or do just as one pleases
   - at liberty to choose whatever occupation one wishes
   hypernym:
   - 14015308-n
@@ -12742,7 +12742,7 @@
   partOfSpeech: n
 14170694-n:
   definition:
-  - a fungal infection characterized by nodular lesions — first in the lungs and spreading
+  - a fungal infection characterized by nodular lesions--first in the lungs and spreading
     to the nervous system
   hypernym:
   - 14200377-n
@@ -29024,7 +29024,7 @@
   definition:
   - the state of being banished or ostracized (excluded from society by general consent)
   example:
-  - the association should get rid of its elderly members — not by euthanasia, of course,
+  - the association should get rid of its elderly members--not by euthanasia, of course,
     but by Coventry
   hypernym:
   - 13958260-n

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -2274,7 +2274,8 @@
   example:
   - he hoped for a new life in Australia
   - he wanted to live his own life without interference from others
-  - get a life!" "he is trying to rebuild his life
+  - get a life!
+  - he is trying to rebuild his life
   hypernym:
   - 13977471-n
   ili: i110304

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -38183,7 +38183,7 @@
   - The characteristic of being exhilarating, tending to upset the mind or senses.
   example:
   - How a mere convention gathering could generate such a shift in regard to an issue
-    like abortion reveals something of the headiness in which many of the garthered
+    like abortion reveals something of the headiness in which many of the gathered
     were luxuriating.
   hypernym:
   - 14548451-n
@@ -38209,7 +38209,7 @@
   - The state or quality of being in the nature of an expression of praise, congratulation,
     encouragement, or respect.
   example:
-  - M. Bourget is highly complimentary to these magots of literature ; but be is ingeniously
+  - M. Bourget is highly complimentary to these maggots of literature; but he is ingeniously
     vague in his complimentariness.
   hypernym:
   - 14435778-n

--- a/src/yaml/noun.substance.yaml
+++ b/src/yaml/noun.substance.yaml
@@ -31970,12 +31970,12 @@
     lines on the skin on the temples and below neck, meant to imitate blue veins and
     thus emphasize pale complexion.
   example:
-  - Bleu Végétal Pour Les Veines came in a form of sticks or pencils prepared from
+  - Bleu Vegetal Pour Les Veines came in a form of sticks or pencils prepared from
     chalk, gum and blue pigment.
   hypernym:
   - 15009532-n
   members:
-  - Bleu Végétal Pour Les Veines
+  - Bleu Vegetal Pour Les Veines
   partOfSpeech: n
   source: plWordNet 4.0
 92428084-n:

--- a/src/yaml/noun.substance.yaml
+++ b/src/yaml/noun.substance.yaml
@@ -31970,12 +31970,12 @@
     lines on the skin on the temples and below neck, meant to imitate blue veins and
     thus emphasize pale complexion.
   example:
-  - Bleu Végetal Pour Les Veines came in a form of sticks or pencils prepared from
+  - Bleu Végétal Pour Les Veines came in a form of sticks or pencils prepared from
     chalk, gum and blue pigment.
   hypernym:
   - 15009532-n
   members:
-  - Bleu Vegetal Pour Les Veines
+  - Bleu Végétal Pour Les Veines
   partOfSpeech: n
   source: plWordNet 4.0
 92428084-n:

--- a/src/yaml/verb.body.yaml
+++ b/src/yaml/verb.body.yaml
@@ -724,7 +724,7 @@
   definition:
   - shake, as from cold
   example:
-  - The children are shivering--turn on the heat!
+  - The children are shivering — turn on the heat!
   hypernym:
   - 00010047-v
   ili: i21837
@@ -1089,7 +1089,7 @@
   definition:
   - not go to bed
   example:
-  - Don't stay up so late--you have to go to work tomorrow
+  - Don't stay up so late — you have to go to work tomorrow
   - We sat up all night to watch the election
   hypernym:
   - 00020126-v
@@ -2841,7 +2841,7 @@
   definition:
   - dress too warmly
   example:
-  - You should not overclothe the child--she will be too hot
+  - You should not overclothe the child — she will be too hot
   hypernym:
   - 00047662-v
   ili: i22017
@@ -2916,7 +2916,7 @@
   definition:
   - remove clothes or shoes
   example:
-  - take off your shirt--it's very hot in here
+  - take off your shirt — it's very hot in here
   hypernym:
   - 00049617-v
   ili: i22023
@@ -3989,7 +3989,7 @@
   definition:
   - cry or whine with snuffling
   example:
-  - Stop snivelling--you got yourself into this mess!
+  - Stop snivelling — you got yourself into this mess!
   hypernym:
   - 00065962-v
   ili: i22112
@@ -6052,7 +6052,7 @@
   definition:
   - extend one's body or limbs
   example:
-  - Let's stretch for a minute--we've been sitting here for over 3 hours
+  - Let's stretch for a minute — we've been sitting here for over 3 hours
   hypernym:
   - 01835473-v
   ili: i22280
@@ -6304,7 +6304,7 @@
   definition:
   - be conscious of a physical, mental, or emotional state
   example:
-  - My cold is gone--I feel fine today
+  - My cold is gone — I feel fine today
   - She felt tired after the long hike
   - She felt sad after her loss
   hypernym:

--- a/src/yaml/verb.body.yaml
+++ b/src/yaml/verb.body.yaml
@@ -724,7 +724,7 @@
   definition:
   - shake, as from cold
   example:
-  - The children are shivering — turn on the heat!
+  - The children are shivering--turn on the heat!
   hypernym:
   - 00010047-v
   ili: i21837
@@ -1089,7 +1089,7 @@
   definition:
   - not go to bed
   example:
-  - Don't stay up so late — you have to go to work tomorrow
+  - Don't stay up so late--you have to go to work tomorrow
   - We sat up all night to watch the election
   hypernym:
   - 00020126-v
@@ -2841,7 +2841,7 @@
   definition:
   - dress too warmly
   example:
-  - You should not overclothe the child — she will be too hot
+  - You should not overclothe the child--she will be too hot
   hypernym:
   - 00047662-v
   ili: i22017
@@ -2916,7 +2916,7 @@
   definition:
   - remove clothes or shoes
   example:
-  - take off your shirt — it's very hot in here
+  - take off your shirt--it's very hot in here
   hypernym:
   - 00049617-v
   ili: i22023
@@ -3989,7 +3989,7 @@
   definition:
   - cry or whine with snuffling
   example:
-  - Stop snivelling — you got yourself into this mess!
+  - Stop snivelling--you got yourself into this mess!
   hypernym:
   - 00065962-v
   ili: i22112
@@ -6052,7 +6052,7 @@
   definition:
   - extend one's body or limbs
   example:
-  - Let's stretch for a minute — we've been sitting here for over 3 hours
+  - Let's stretch for a minute--we've been sitting here for over 3 hours
   hypernym:
   - 01835473-v
   ili: i22280
@@ -6304,7 +6304,7 @@
   definition:
   - be conscious of a physical, mental, or emotional state
   example:
-  - My cold is gone — I feel fine today
+  - My cold is gone--I feel fine today
   - She felt tired after the long hike
   - She felt sad after her loss
   hypernym:

--- a/src/yaml/verb.body.yaml
+++ b/src/yaml/verb.body.yaml
@@ -3659,7 +3659,7 @@
   definition:
   - make infertile
   example:
-  - in some countries, people with genetically transmissible disabilites are sterilized
+  - in some countries, people with genetically transmissible disabilities are sterilized
   hypernym:
   - 00083562-v
   ili: i22085

--- a/src/yaml/verb.change.yaml
+++ b/src/yaml/verb.change.yaml
@@ -4787,7 +4787,7 @@
   definition:
   - cut out, as for political reasons
   example:
-  - several line in the report were blanked out
+  - several lines in the report were blanked out
   hypernym:
   - 00200761-v
   ili: i22733
@@ -14433,7 +14433,7 @@
   definition:
   - grow and flourish
   example:
-  - a militant party bourgeons in India
+  - a militant party burgeons in India
   hypernym:
   - 00231172-v
   ili: i23525
@@ -22609,7 +22609,7 @@
   definition:
   - withdraw, as from reality
   example:
-  - he lost himslef in his music
+  - he lost himself in his music
   hypernym:
   - 00496934-v
   members:
@@ -27960,7 +27960,7 @@
   definition:
   - make opaque
   example:
-  - The glass was opacified more greater privacy
+  - The glass was opacified for greater privacy
   hypernym:
   - 00126072-v
   ili: i24641

--- a/src/yaml/verb.change.yaml
+++ b/src/yaml/verb.change.yaml
@@ -341,7 +341,7 @@
   definition:
   - maintain the same position; wait it out
   example:
-  - Let's not make a decision — let's sit tight
+  - Let's not make a decision--let's sit tight
   hypernym:
   - 00117793-v
   ili: i22353
@@ -7524,7 +7524,7 @@
   - grow old or older
   example:
   - She aged gracefully
-  - we age every day — what a depressing thought!
+  - we age every day--what a depressing thought!
   - Young men senesce
   hypernym:
   - 00252905-v
@@ -8153,7 +8153,7 @@
   definition:
   - crack; of the male voice in puberty
   example:
-  - his voice is breaking — he should no longer sing in the choir
+  - his voice is breaking--he should no longer sing in the choir
   hypernym:
   - 00145958-v
   ili: i23009
@@ -8303,7 +8303,7 @@
   definition:
   - try to fix or mend
   example:
-  - Can you tinker with the T.V. set — it's not working right
+  - Can you tinker with the T.V. set--it's not working right
   - She always fiddles with her van on the weekend
   hypernym:
   - 00261534-v
@@ -10962,7 +10962,7 @@
   definition:
   - make (clothes) larger
   example:
-  - Let out that dress — I gained a lot of weight
+  - Let out that dress--I gained a lot of weight
   hypernym:
   - 00122978-v
   ili: i23244
@@ -10974,7 +10974,7 @@
   definition:
   - make (clothes) smaller
   example:
-  - Please take in this skirt — I've lost weight
+  - Please take in this skirt--I've lost weight
   hypernym:
   - 00122978-v
   ili: i23245
@@ -16454,7 +16454,7 @@
   definition:
   - become stultified, suppressed, or stifled
   example:
-  - He is suffocating — living at home with his aged parents in the small village
+  - He is suffocating--living at home with his aged parents in the small village
   hypernym:
   - 02632685-v
   ili: i23687
@@ -20445,7 +20445,7 @@
   example:
   - The milk has soured
   - The wine worked
-  - The cream has turned — we have to throw it out
+  - The cream has turned--we have to throw it out
   hypernym:
   - 00145958-v
   ili: i24013
@@ -20506,7 +20506,7 @@
   - act at high speed
   example:
   - We have to rush!
-  - hurry — it's late!
+  - hurry--it's late!
   hypernym:
   - 02372362-v
   ili: i24017
@@ -22442,7 +22442,7 @@
   definition:
   - make radioactive by adding radioactive material
   example:
-  - Don't drink the water — it's contaminated
+  - Don't drink the water--it's contaminated
   hypernym:
   - 00126072-v
   ili: i24175
@@ -23947,7 +23947,7 @@
   definition:
   - cause to perform again
   example:
-  - We have to rerun the subjects — they misunderstood the instructions
+  - We have to rerun the subjects--they misunderstood the instructions
   hypernym:
   - 00518609-v
   ili: i24304
@@ -27625,7 +27625,7 @@
   definition:
   - cease to use
   example:
-  - leave off your jacket — no need to wear it here
+  - leave off your jacket--no need to wear it here
   hypernym:
   - 02686624-v
   ili: i24613

--- a/src/yaml/verb.change.yaml
+++ b/src/yaml/verb.change.yaml
@@ -341,7 +341,7 @@
   definition:
   - maintain the same position; wait it out
   example:
-  - Let's not make a decision--let's sit tight
+  - Let's not make a decision — let's sit tight
   hypernym:
   - 00117793-v
   ili: i22353
@@ -7524,7 +7524,7 @@
   - grow old or older
   example:
   - She aged gracefully
-  - we age every day--what a depressing thought!
+  - we age every day — what a depressing thought!
   - Young men senesce
   hypernym:
   - 00252905-v
@@ -8153,7 +8153,7 @@
   definition:
   - crack; of the male voice in puberty
   example:
-  - his voice is breaking--he should no longer sing in the choir
+  - his voice is breaking — he should no longer sing in the choir
   hypernym:
   - 00145958-v
   ili: i23009
@@ -8303,7 +8303,7 @@
   definition:
   - try to fix or mend
   example:
-  - Can you tinker with the T.V. set--it's not working right
+  - Can you tinker with the T.V. set — it's not working right
   - She always fiddles with her van on the weekend
   hypernym:
   - 00261534-v
@@ -10962,7 +10962,7 @@
   definition:
   - make (clothes) larger
   example:
-  - Let out that dress--I gained a lot of weight
+  - Let out that dress — I gained a lot of weight
   hypernym:
   - 00122978-v
   ili: i23244
@@ -10974,7 +10974,7 @@
   definition:
   - make (clothes) smaller
   example:
-  - Please take in this skirt--I've lost weight
+  - Please take in this skirt — I've lost weight
   hypernym:
   - 00122978-v
   ili: i23245
@@ -16454,7 +16454,7 @@
   definition:
   - become stultified, suppressed, or stifled
   example:
-  - He is suffocating--living at home with his aged parents in the small village
+  - He is suffocating — living at home with his aged parents in the small village
   hypernym:
   - 02632685-v
   ili: i23687
@@ -20445,7 +20445,7 @@
   example:
   - The milk has soured
   - The wine worked
-  - The cream has turned--we have to throw it out
+  - The cream has turned — we have to throw it out
   hypernym:
   - 00145958-v
   ili: i24013
@@ -20506,7 +20506,7 @@
   - act at high speed
   example:
   - We have to rush!
-  - hurry--it's late!
+  - hurry — it's late!
   hypernym:
   - 02372362-v
   ili: i24017
@@ -22442,7 +22442,7 @@
   definition:
   - make radioactive by adding radioactive material
   example:
-  - Don't drink the water--it's contaminated
+  - Don't drink the water — it's contaminated
   hypernym:
   - 00126072-v
   ili: i24175
@@ -23947,7 +23947,7 @@
   definition:
   - cause to perform again
   example:
-  - We have to rerun the subjects--they misunderstood the instructions
+  - We have to rerun the subjects — they misunderstood the instructions
   hypernym:
   - 00518609-v
   ili: i24304
@@ -27625,7 +27625,7 @@
   definition:
   - cease to use
   example:
-  - leave off your jacket--no need to wear it here
+  - leave off your jacket — no need to wear it here
   hypernym:
   - 02686624-v
   ili: i24613

--- a/src/yaml/verb.cognition.yaml
+++ b/src/yaml/verb.cognition.yaml
@@ -341,7 +341,7 @@
   definition:
   - be understanding of
   example:
-  - You don't need to explain — I understand!
+  - You don't need to explain--I understand!
   ili: i24734
   members:
   - sympathize
@@ -1939,7 +1939,7 @@
   - be a mystery or bewildering to
   example:
   - This beats me!
-  - Got me — I don't know the answer!
+  - Got me--I don't know the answer!
   - a vexing problem
   - This question really stuck me
   hypernym:
@@ -2321,7 +2321,7 @@
   definition:
   - substitute a natural for a supernatural explanation of
   example:
-  - you can rationalize away all the strange noises you hear — there is no poltergeist
+  - you can rationalize away all the strange noises you hear--there is no poltergeist
     in the house!
   hypernym:
   - 00634289-v
@@ -3646,7 +3646,7 @@
   entails:
   - 00654571-v
   example:
-  - How would you classify these pottery shards — are they prehistoric?
+  - How would you classify these pottery shards--are they prehistoric?
   hypernym:
   - 00658931-v
   ili: i25002
@@ -4562,7 +4562,7 @@
   definition:
   - underestimate the real value or ability of
   example:
-  - Don't sell your students short — they are just shy and don't show off their knowledge
+  - Don't sell your students short--they are just shy and don't show off their knowledge
   hypernym:
   - 00673254-v
   ili: i25078
@@ -6264,7 +6264,7 @@
   - deliberate or decide
   example:
   - See whether you can come tomorrow
-  - let's see — which movie should we see tonight?
+  - let's see--which movie should we see tonight?
   hypernym:
   - 00814706-v
   ili: i25225
@@ -7077,7 +7077,7 @@
   definition:
   - show an exaggerated response to something
   example:
-  - Don't overreact to the bad news — take it easy
+  - Don't overreact to the bad news--take it easy
   hypernym:
   - 00719282-v
   ili: i25291

--- a/src/yaml/verb.cognition.yaml
+++ b/src/yaml/verb.cognition.yaml
@@ -341,7 +341,7 @@
   definition:
   - be understanding of
   example:
-  - You don't need to explain--I understand!
+  - You don't need to explain — I understand!
   ili: i24734
   members:
   - sympathize
@@ -1939,7 +1939,7 @@
   - be a mystery or bewildering to
   example:
   - This beats me!
-  - Got me--I don't know the answer!
+  - Got me — I don't know the answer!
   - a vexing problem
   - This question really stuck me
   hypernym:
@@ -2321,7 +2321,7 @@
   definition:
   - substitute a natural for a supernatural explanation of
   example:
-  - you can rationalize away all the strange noises you hear--there is no poltergeist
+  - you can rationalize away all the strange noises you hear — there is no poltergeist
     in the house!
   hypernym:
   - 00634289-v
@@ -3646,7 +3646,7 @@
   entails:
   - 00654571-v
   example:
-  - How would you classify these pottery shards--are they prehistoric?
+  - How would you classify these pottery shards — are they prehistoric?
   hypernym:
   - 00658931-v
   ili: i25002
@@ -4562,7 +4562,7 @@
   definition:
   - underestimate the real value or ability of
   example:
-  - Don't sell your students short--they are just shy and don't show off their knowledge
+  - Don't sell your students short — they are just shy and don't show off their knowledge
   hypernym:
   - 00673254-v
   ili: i25078
@@ -6264,7 +6264,7 @@
   - deliberate or decide
   example:
   - See whether you can come tomorrow
-  - let's see--which movie should we see tonight?
+  - let's see — which movie should we see tonight?
   hypernym:
   - 00814706-v
   ili: i25225
@@ -7077,7 +7077,7 @@
   definition:
   - show an exaggerated response to something
   example:
-  - Don't overreact to the bad news--take it easy
+  - Don't overreact to the bad news — take it easy
   hypernym:
   - 00719282-v
   ili: i25291

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -146,7 +146,7 @@
   definition:
   - contact, usually in order to remind of something
   example:
-  - I'll ping my accountant--April 15 is nearing
+  - I'll ping my accountant — April 15 is nearing
   hypernym:
   - 00745330-v
   ili: i25415
@@ -205,7 +205,7 @@
   definition:
   - cause to speak
   example:
-  - Can you draw her out--she is always so quiet
+  - Can you draw her out — she is always so quiet
   hypernym:
   - 00746558-v
   ili: i25420
@@ -2207,7 +2207,7 @@
   - continue talking
   example:
   - '`I know it''s hard'', he continued, `but there is no choice'''
-  - carry on--pretend we are not in the room
+  - carry on — pretend we are not in the room
   hypernym:
   - 00964479-v
   ili: i25591
@@ -2764,7 +2764,7 @@
   definition:
   - return or repeat a telephone call
   example:
-  - I am busy right now--can you call back in an hour?
+  - I am busy right now — can you call back in an hour?
   - She left a message but the contractor never called back
   hypernym:
   - 00817348-v
@@ -4641,7 +4641,7 @@
   - 00672179-v
   example:
   - The paper criticized the new movie
-  - Don't knock the food--it's free
+  - Don't knock the food — it's free
   hypernym:
   - 01060446-v
   ili: i25788
@@ -5235,7 +5235,7 @@
   definition:
   - pretend to do something by acting as if one was really doing it
   example:
-  - She isn't really working--she's just going through the motions
+  - She isn't really working — she's just going through the motions
   hypernym:
   - 00840203-v
   ili: i25838
@@ -6033,7 +6033,7 @@
   definition:
   - indulge in horseplay
   example:
-  - Enough horsing around--let's get back to work!
+  - Enough horsing around — let's get back to work!
   - The bored children were fooling about
   hypernym:
   - 02423786-v
@@ -9319,7 +9319,7 @@
   - utter in a loud voice; talk in a loud voice (usually denoting characteristic manner
     of speaking)
   example:
-  - My grandmother is hard of hearing--you'll have to shout
+  - My grandmother is hard of hearing — you'll have to shout
   hypernym:
   - 00944022-v
   ili: i26176
@@ -9330,7 +9330,7 @@
   definition:
   - utter or declare in a very loud voice
   example:
-  - You don't have to yell--I can hear you just fine
+  - You don't have to yell — I can hear you just fine
   hypernym:
   - 00914426-v
   ili: i26177
@@ -9586,7 +9586,7 @@
   - express a supposition
   example:
   - Let us say that he did not tell the truth
-  - Let's say you had a lot of money--what would you do?
+  - Let's say you had a lot of money — what would you do?
   hypernym:
   - 00929020-v
   ili: i26199
@@ -10697,7 +10697,7 @@
   definition:
   - divulge confidential information or secrets
   example:
-  - Be careful--his secretary talks
+  - Be careful — his secretary talks
   hypernym:
   - 00935783-v
   ili: i26293
@@ -10719,7 +10719,7 @@
   definition:
   - refrain from divulging sensitive information; keep quiet about confidential information
   example:
-  - Don't tell him any secrets--he cannot keep his mouth shut!
+  - Don't tell him any secrets — he cannot keep his mouth shut!
   ili: i26294
   members:
   - keep quiet
@@ -13588,7 +13588,7 @@
   definition:
   - make understand
   example:
-  - Can you enlighten me--I don't understand this proposal
+  - Can you enlighten me — I don't understand this proposal
   hypernym:
   - 00830768-v
   ili: i26541
@@ -17939,7 +17939,7 @@
   definition:
   - utter meaningless sounds, like a baby, or utter in an incoherent way
   example:
-  - The old man is only babbling--don't pay attention
+  - The old man is only babbling — don't pay attention
   hypernym:
   - 00944022-v
   ili: i26916

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -146,7 +146,7 @@
   definition:
   - contact, usually in order to remind of something
   example:
-  - I'll ping my accountant — April 15 is nearing
+  - I'll ping my accountant--April 15 is nearing
   hypernym:
   - 00745330-v
   ili: i25415
@@ -205,7 +205,7 @@
   definition:
   - cause to speak
   example:
-  - Can you draw her out — she is always so quiet
+  - Can you draw her out--she is always so quiet
   hypernym:
   - 00746558-v
   ili: i25420
@@ -2207,7 +2207,7 @@
   - continue talking
   example:
   - '`I know it''s hard'', he continued, `but there is no choice'''
-  - carry on — pretend we are not in the room
+  - carry on--pretend we are not in the room
   hypernym:
   - 00964479-v
   ili: i25591
@@ -2764,7 +2764,7 @@
   definition:
   - return or repeat a telephone call
   example:
-  - I am busy right now — can you call back in an hour?
+  - I am busy right now--can you call back in an hour?
   - She left a message but the contractor never called back
   hypernym:
   - 00817348-v
@@ -4641,7 +4641,7 @@
   - 00672179-v
   example:
   - The paper criticized the new movie
-  - Don't knock the food — it's free
+  - Don't knock the food--it's free
   hypernym:
   - 01060446-v
   ili: i25788
@@ -5235,7 +5235,7 @@
   definition:
   - pretend to do something by acting as if one was really doing it
   example:
-  - She isn't really working — she's just going through the motions
+  - She isn't really working--she's just going through the motions
   hypernym:
   - 00840203-v
   ili: i25838
@@ -6033,7 +6033,7 @@
   definition:
   - indulge in horseplay
   example:
-  - Enough horsing around — let's get back to work!
+  - Enough horsing around--let's get back to work!
   - The bored children were fooling about
   hypernym:
   - 02423786-v
@@ -9319,7 +9319,7 @@
   - utter in a loud voice; talk in a loud voice (usually denoting characteristic manner
     of speaking)
   example:
-  - My grandmother is hard of hearing — you'll have to shout
+  - My grandmother is hard of hearing--you'll have to shout
   hypernym:
   - 00944022-v
   ili: i26176
@@ -9330,7 +9330,7 @@
   definition:
   - utter or declare in a very loud voice
   example:
-  - You don't have to yell — I can hear you just fine
+  - You don't have to yell--I can hear you just fine
   hypernym:
   - 00914426-v
   ili: i26177
@@ -9586,7 +9586,7 @@
   - express a supposition
   example:
   - Let us say that he did not tell the truth
-  - Let's say you had a lot of money — what would you do?
+  - Let's say you had a lot of money--what would you do?
   hypernym:
   - 00929020-v
   ili: i26199
@@ -10697,7 +10697,7 @@
   definition:
   - divulge confidential information or secrets
   example:
-  - Be careful — his secretary talks
+  - Be careful--his secretary talks
   hypernym:
   - 00935783-v
   ili: i26293
@@ -10719,7 +10719,7 @@
   definition:
   - refrain from divulging sensitive information; keep quiet about confidential information
   example:
-  - Don't tell him any secrets — he cannot keep his mouth shut!
+  - Don't tell him any secrets--he cannot keep his mouth shut!
   ili: i26294
   members:
   - keep quiet
@@ -13588,7 +13588,7 @@
   definition:
   - make understand
   example:
-  - Can you enlighten me — I don't understand this proposal
+  - Can you enlighten me--I don't understand this proposal
   hypernym:
   - 00830768-v
   ili: i26541
@@ -17939,7 +17939,7 @@
   definition:
   - utter meaningless sounds, like a baby, or utter in an incoherent way
   example:
-  - The old man is only babbling — don't pay attention
+  - The old man is only babbling--don't pay attention
   hypernym:
   - 00944022-v
   ili: i26916

--- a/src/yaml/verb.competition.yaml
+++ b/src/yaml/verb.competition.yaml
@@ -3385,7 +3385,7 @@
   definition:
   - protect excessively
   example:
-  - Don't overprotect your son — he is an adult now!
+  - Don't overprotect your son--he is an adult now!
   hypernym:
   - 01130619-v
   ili: i27246
@@ -4987,7 +4987,7 @@
   definition:
   - take revenge or even out a score
   example:
-  - I cannot accept the defeat — I want to get even
+  - I cannot accept the defeat--I want to get even
   hypernym:
   - 01155952-v
   ili: i27392

--- a/src/yaml/verb.competition.yaml
+++ b/src/yaml/verb.competition.yaml
@@ -3385,7 +3385,7 @@
   definition:
   - protect excessively
   example:
-  - Don't overprotect your son--he is an adult now!
+  - Don't overprotect your son — he is an adult now!
   hypernym:
   - 01130619-v
   ili: i27246
@@ -4987,7 +4987,7 @@
   definition:
   - take revenge or even out a score
   example:
-  - I cannot accept the defeat--I want to get even
+  - I cannot accept the defeat — I want to get even
   hypernym:
   - 01155952-v
   ili: i27392

--- a/src/yaml/verb.consumption.yaml
+++ b/src/yaml/verb.consumption.yaml
@@ -943,7 +943,7 @@
   - eat intermittently; take small bites of
   example:
   - He pieced at the sandwich all morning
-  - She never eats a full meal — she just nibbles
+  - She never eats a full meal--she just nibbles
   hypernym:
   - 01170802-v
   ili: i27489
@@ -1043,7 +1043,7 @@
   definition:
   - drink to the last drop
   example:
-  - drink up — there's more wine coming
+  - drink up--there's more wine coming
   hypernym:
   - 01172332-v
   ili: i27497
@@ -1066,7 +1066,7 @@
   definition:
   - provide with choice or abundant food or drink
   example:
-  - Don't worry about the expensive wine — I'm treating
+  - Don't worry about the expensive wine--I'm treating
   - She treated her houseguests with good food every night
   hypernym:
   - 01185006-v
@@ -1773,7 +1773,7 @@
   definition:
   - be hungry; go without food
   example:
-  - Let's eat — I'm starving!
+  - Let's eat--I'm starving!
   hypernym:
   - 00064841-v
   ili: i27558
@@ -1786,7 +1786,7 @@
   definition:
   - be sated, have enough to eat
   example:
-  - I'm full — don't give me any more beans, please
+  - I'm full--don't give me any more beans, please
   ili: i27559
   members:
   - be full
@@ -2674,7 +2674,7 @@
   definition:
   - pass through the esophagus as part of eating or drinking
   example:
-  - Swallow the raw fish — it won't kill you!
+  - Swallow the raw fish--it won't kill you!
   ili: i27632
   members:
   - swallow

--- a/src/yaml/verb.consumption.yaml
+++ b/src/yaml/verb.consumption.yaml
@@ -943,7 +943,7 @@
   - eat intermittently; take small bites of
   example:
   - He pieced at the sandwich all morning
-  - She never eats a full meal--she just nibbles
+  - She never eats a full meal — she just nibbles
   hypernym:
   - 01170802-v
   ili: i27489
@@ -1043,7 +1043,7 @@
   definition:
   - drink to the last drop
   example:
-  - drink up--there's more wine coming
+  - drink up — there's more wine coming
   hypernym:
   - 01172332-v
   ili: i27497
@@ -1066,7 +1066,7 @@
   definition:
   - provide with choice or abundant food or drink
   example:
-  - Don't worry about the expensive wine--I'm treating
+  - Don't worry about the expensive wine — I'm treating
   - She treated her houseguests with good food every night
   hypernym:
   - 01185006-v
@@ -1773,7 +1773,7 @@
   definition:
   - be hungry; go without food
   example:
-  - Let's eat--I'm starving!
+  - Let's eat — I'm starving!
   hypernym:
   - 00064841-v
   ili: i27558
@@ -1786,7 +1786,7 @@
   definition:
   - be sated, have enough to eat
   example:
-  - I'm full--don't give me any more beans, please
+  - I'm full — don't give me any more beans, please
   ili: i27559
   members:
   - be full
@@ -2674,7 +2674,7 @@
   definition:
   - pass through the esophagus as part of eating or drinking
   example:
-  - Swallow the raw fish--it won't kill you!
+  - Swallow the raw fish — it won't kill you!
   ili: i27632
   members:
   - swallow

--- a/src/yaml/verb.contact.yaml
+++ b/src/yaml/verb.contact.yaml
@@ -17375,7 +17375,7 @@
   definition:
   - remove from the crate
   example:
-  - uncrate the glassed carefully!
+  - uncrate the glasses carefully!
   hypernym:
   - 01488139-v
   ili: i29153

--- a/src/yaml/verb.contact.yaml
+++ b/src/yaml/verb.contact.yaml
@@ -484,7 +484,7 @@
   definition:
   - take out of a container or enclosed space
   example:
-  - Get out your best dress — we are going to a party!
+  - Get out your best dress--we are going to a party!
   hypernym:
   - 01488139-v
   ili: i27694
@@ -9227,7 +9227,7 @@
   definition:
   - close with a zipper
   example:
-  - Zip up your jacket — it's cold
+  - Zip up your jacket--it's cold
   hypernym:
   - 01343121-v
   ili: i28462
@@ -16626,7 +16626,7 @@
   - release, as from one's grip
   example:
   - Let go of the door handle, please!
-  - relinquish your grip on the rope — you won't fall
+  - relinquish your grip on the rope--you won't fall
   ili: i29090
   members:
   - let go of
@@ -19839,7 +19839,7 @@
   definition:
   - be operating, running or functioning
   example:
-  - The car is still running — turn it off!
+  - The car is still running--turn it off!
   hypernym:
   - 01528454-v
   ili: i29360
@@ -21249,7 +21249,7 @@
   entails:
   - 01252288-v
   example:
-  - Please erase the formula on the blackboard — it is wrong!
+  - Please erase the formula on the blackboard--it is wrong!
   hypernym:
   - 01551969-v
   ili: i29476
@@ -21337,7 +21337,7 @@
   definition:
   - cut (a body) open while still alive
   example:
-  - people no longer vivisect animals — it's considered unethical
+  - people no longer vivisect animals--it's considered unethical
   hypernym:
   - 01553002-v
   ili: i29483

--- a/src/yaml/verb.contact.yaml
+++ b/src/yaml/verb.contact.yaml
@@ -484,7 +484,7 @@
   definition:
   - take out of a container or enclosed space
   example:
-  - Get out your best dress--we are going to a party!
+  - Get out your best dress — we are going to a party!
   hypernym:
   - 01488139-v
   ili: i27694
@@ -9227,7 +9227,7 @@
   definition:
   - close with a zipper
   example:
-  - Zip up your jacket--it's cold
+  - Zip up your jacket — it's cold
   hypernym:
   - 01343121-v
   ili: i28462
@@ -16626,7 +16626,7 @@
   - release, as from one's grip
   example:
   - Let go of the door handle, please!
-  - relinquish your grip on the rope--you won't fall
+  - relinquish your grip on the rope — you won't fall
   ili: i29090
   members:
   - let go of
@@ -19839,7 +19839,7 @@
   definition:
   - be operating, running or functioning
   example:
-  - The car is still running--turn it off!
+  - The car is still running — turn it off!
   hypernym:
   - 01528454-v
   ili: i29360
@@ -21249,7 +21249,7 @@
   entails:
   - 01252288-v
   example:
-  - Please erase the formula on the blackboard--it is wrong!
+  - Please erase the formula on the blackboard — it is wrong!
   hypernym:
   - 01551969-v
   ili: i29476
@@ -21337,7 +21337,7 @@
   definition:
   - cut (a body) open while still alive
   example:
-  - people no longer vivisect animals--it's considered unethical
+  - people no longer vivisect animals — it's considered unethical
   hypernym:
   - 01553002-v
   ili: i29483

--- a/src/yaml/verb.creation.yaml
+++ b/src/yaml/verb.creation.yaml
@@ -1018,7 +1018,7 @@
   definition:
   - imagine or visualize
   example:
-  - Just think--you could be rich one day!
+  - Just think — you could be rich one day!
   - Think what a scene it must have been!
   hypernym:
   - 01639939-v
@@ -3954,7 +3954,7 @@
   definition:
   - pursue a creative activity; be engaged in a creative activity
   example:
-  - Don't disturb him--he is creating
+  - Don't disturb him — he is creating
   hypernym:
   - 02372362-v
   ili: i30173
@@ -4940,7 +4940,7 @@
   definition:
   - make a play on words
   example:
-  - Japanese like to pun--their language is well suited to punning
+  - Japanese like to pun — their language is well suited to punning
   hypernym:
   - 00855315-v
   ili: i30256

--- a/src/yaml/verb.creation.yaml
+++ b/src/yaml/verb.creation.yaml
@@ -1018,7 +1018,7 @@
   definition:
   - imagine or visualize
   example:
-  - Just think — you could be rich one day!
+  - Just think--you could be rich one day!
   - Think what a scene it must have been!
   hypernym:
   - 01639939-v
@@ -3954,7 +3954,7 @@
   definition:
   - pursue a creative activity; be engaged in a creative activity
   example:
-  - Don't disturb him — he is creating
+  - Don't disturb him--he is creating
   hypernym:
   - 02372362-v
   ili: i30173
@@ -4940,7 +4940,7 @@
   definition:
   - make a play on words
   example:
-  - Japanese like to pun — their language is well suited to punning
+  - Japanese like to pun--their language is well suited to punning
   hypernym:
   - 00855315-v
   ili: i30256

--- a/src/yaml/verb.emotion.yaml
+++ b/src/yaml/verb.emotion.yaml
@@ -349,7 +349,7 @@
   definition:
   - disturb the peace of mind of; afflict with mental agitation or distress
   example:
-  - I cannot sleep — my daughter's health is worrying me
+  - I cannot sleep--my daughter's health is worrying me
   hypernym:
   - 01768023-v
   ili: i30567
@@ -1325,7 +1325,7 @@
     obsessively
   example:
   - His work preoccupies him
-  - The matter preoccupies her completely — she cannot think of anything else
+  - The matter preoccupies her completely--she cannot think of anything else
   hypernym:
   - 02445887-v
   ili: i30650
@@ -1960,7 +1960,7 @@
   definition:
   - worry unnecessarily or excessively
   example:
-  - don't fuss too much over the grandchildren — they are quite big now
+  - don't fuss too much over the grandchildren--they are quite big now
   hypernym:
   - 01771015-v
   ili: i30700
@@ -2951,7 +2951,7 @@
   definition:
   - abandon hope; give up hope; lose heart
   example:
-  - Don't despair — help is on the way!
+  - Don't despair--help is on the way!
   ili: i30782
   members:
   - despair

--- a/src/yaml/verb.emotion.yaml
+++ b/src/yaml/verb.emotion.yaml
@@ -349,7 +349,7 @@
   definition:
   - disturb the peace of mind of; afflict with mental agitation or distress
   example:
-  - I cannot sleep--my daughter's health is worrying me
+  - I cannot sleep — my daughter's health is worrying me
   hypernym:
   - 01768023-v
   ili: i30567
@@ -1325,7 +1325,7 @@
     obsessively
   example:
   - His work preoccupies him
-  - The matter preoccupies her completely--she cannot think of anything else
+  - The matter preoccupies her completely — she cannot think of anything else
   hypernym:
   - 02445887-v
   ili: i30650
@@ -1960,7 +1960,7 @@
   definition:
   - worry unnecessarily or excessively
   example:
-  - don't fuss too much over the grandchildren--they are quite big now
+  - don't fuss too much over the grandchildren — they are quite big now
   hypernym:
   - 01771015-v
   ili: i30700
@@ -2951,7 +2951,7 @@
   definition:
   - abandon hope; give up hope; lose heart
   example:
-  - Don't despair--help is on the way!
+  - Don't despair — help is on the way!
   ili: i30782
   members:
   - despair

--- a/src/yaml/verb.emotion.yaml
+++ b/src/yaml/verb.emotion.yaml
@@ -654,7 +654,7 @@
   definition:
   - irritate
   example:
-  - Her childish behavior really get to me
+  - Her childish behavior really gets to me
   - His lying really gets me
   hypernym:
   - 01791774-v

--- a/src/yaml/verb.motion.yaml
+++ b/src/yaml/verb.motion.yaml
@@ -860,7 +860,7 @@
   definition:
   - grow late or (of time) elapse
   example:
-  - It is getting on midnight--let's all go to bed!
+  - It is getting on midnight — let's all go to bed!
   hypernym:
   - 01853713-v
   ili: i30958
@@ -1407,7 +1407,7 @@
   definition:
   - signal to stop
   example:
-  - Let's flag down a cab--it's starting to rain
+  - Let's flag down a cab — it's starting to rain
   - The policeman flagged down our car
   hypernym:
   - 01863207-v
@@ -3395,7 +3395,7 @@
   definition:
   - lightly throw to see which side comes up
   example:
-  - I don't know what to do--I may as well flip a coin!
+  - I don't know what to do — I may as well flip a coin!
   hypernym:
   - 01911251-v
   ili: i31170
@@ -5202,7 +5202,7 @@
   partOfSpeech: v
 01926747-v:
   definition:
-  - creep up -- used especially of plants
+  - creep up — used especially of plants
   example:
   - The roses ramped over the wall
   hypernym:
@@ -5230,7 +5230,7 @@
   entails:
   - 01926888-v
   example:
-  - The ascent was easy--roping down the mountain would be much more difficult and
+  - The ascent was easy — roping down the mountain would be much more difficult and
     dangerous
   - You have to learn how to abseil when you want to do technical climbing
   hypernym:
@@ -5447,7 +5447,7 @@
   definition:
   - move fast by using one's feet, with one foot off the ground at any given time
   example:
-  - Don't run--you'll be out of breath
+  - Don't run — you'll be out of breath
   - The children ran to the store
   hypernym:
   - 02059573-v
@@ -10773,7 +10773,7 @@
   definition:
   - waste time
   example:
-  - Get busy--don't dally!
+  - Get busy — don't dally!
   hypernym:
   - 00010428-v
   ili: i31796
@@ -11728,7 +11728,7 @@
   definition:
   - crowd or draw together
   example:
-  - let's huddle together--it's cold!
+  - let's huddle together — it's cold!
   hypernym:
   - 02028855-v
   ili: i31877
@@ -14564,7 +14564,7 @@
   example:
   - The horses broke from the stable
   - Three inmates broke jail
-  - Nobody can break out--this prison is high security
+  - Nobody can break out — this prison is high security
   hypernym:
   - 02078906-v
   ili: i32114

--- a/src/yaml/verb.motion.yaml
+++ b/src/yaml/verb.motion.yaml
@@ -860,7 +860,7 @@
   definition:
   - grow late or (of time) elapse
   example:
-  - It is getting on midnight — let's all go to bed!
+  - It is getting on midnight--let's all go to bed!
   hypernym:
   - 01853713-v
   ili: i30958
@@ -1407,7 +1407,7 @@
   definition:
   - signal to stop
   example:
-  - Let's flag down a cab — it's starting to rain
+  - Let's flag down a cab--it's starting to rain
   - The policeman flagged down our car
   hypernym:
   - 01863207-v
@@ -3395,7 +3395,7 @@
   definition:
   - lightly throw to see which side comes up
   example:
-  - I don't know what to do — I may as well flip a coin!
+  - I don't know what to do--I may as well flip a coin!
   hypernym:
   - 01911251-v
   ili: i31170
@@ -5202,7 +5202,7 @@
   partOfSpeech: v
 01926747-v:
   definition:
-  - creep up — used especially of plants
+  - creep up -- used especially of plants
   example:
   - The roses ramped over the wall
   hypernym:
@@ -5230,7 +5230,7 @@
   entails:
   - 01926888-v
   example:
-  - The ascent was easy — roping down the mountain would be much more difficult and
+  - The ascent was easy--roping down the mountain would be much more difficult and
     dangerous
   - You have to learn how to abseil when you want to do technical climbing
   hypernym:
@@ -5447,7 +5447,7 @@
   definition:
   - move fast by using one's feet, with one foot off the ground at any given time
   example:
-  - Don't run — you'll be out of breath
+  - Don't run--you'll be out of breath
   - The children ran to the store
   hypernym:
   - 02059573-v
@@ -10773,7 +10773,7 @@
   definition:
   - waste time
   example:
-  - Get busy — don't dally!
+  - Get busy--don't dally!
   hypernym:
   - 00010428-v
   ili: i31796
@@ -11728,7 +11728,7 @@
   definition:
   - crowd or draw together
   example:
-  - let's huddle together — it's cold!
+  - let's huddle together--it's cold!
   hypernym:
   - 02028855-v
   ili: i31877
@@ -14564,7 +14564,7 @@
   example:
   - The horses broke from the stable
   - Three inmates broke jail
-  - Nobody can break out — this prison is high security
+  - Nobody can break out--this prison is high security
   hypernym:
   - 02078906-v
   ili: i32114

--- a/src/yaml/verb.perception.yaml
+++ b/src/yaml/verb.perception.yaml
@@ -877,7 +877,7 @@
   definition:
   - have or perceive an itch
   example:
-  - I'm itching — the air is so dry!
+  - I'm itching--the air is so dry!
   hypernym:
   - 02126629-v
   ili: i32362
@@ -1329,7 +1329,7 @@
   example:
   - You have to be a good observer to see all the details
   - Can you see the bird in that tree?
-  - He is blind — he cannot see
+  - He is blind--he cannot see
   hypernym:
   - 02110960-v
   ili: i32402
@@ -1405,7 +1405,7 @@
   example:
   - She looked over the expanse of land
   - Look at your child!
-  - Look — a deer in the backyard!
+  - Look--a deer in the backyard!
   hypernym:
   - 02372362-v
   ili: i32408
@@ -3420,7 +3420,7 @@
   - throw a glance at; take a brief look at
   example:
   - She only glanced at the paper
-  - I only peeked — I didn't see anything interesting
+  - I only peeked--I didn't see anything interesting
   hypernym:
   - 02134989-v
   ili: i32579

--- a/src/yaml/verb.perception.yaml
+++ b/src/yaml/verb.perception.yaml
@@ -877,7 +877,7 @@
   definition:
   - have or perceive an itch
   example:
-  - I'm itching--the air is so dry!
+  - I'm itching — the air is so dry!
   hypernym:
   - 02126629-v
   ili: i32362
@@ -1329,7 +1329,7 @@
   example:
   - You have to be a good observer to see all the details
   - Can you see the bird in that tree?
-  - He is blind--he cannot see
+  - He is blind — he cannot see
   hypernym:
   - 02110960-v
   ili: i32402
@@ -1405,7 +1405,7 @@
   example:
   - She looked over the expanse of land
   - Look at your child!
-  - Look--a deer in the backyard!
+  - Look — a deer in the backyard!
   hypernym:
   - 02372362-v
   ili: i32408
@@ -3420,7 +3420,7 @@
   - throw a glance at; take a brief look at
   example:
   - She only glanced at the paper
-  - I only peeked--I didn't see anything interesting
+  - I only peeked — I didn't see anything interesting
   hypernym:
   - 02134989-v
   ili: i32579

--- a/src/yaml/verb.possession.yaml
+++ b/src/yaml/verb.possession.yaml
@@ -3279,7 +3279,7 @@
   - be a substitute
   example:
   - The young teacher had to substitute for the sick colleague
-  - The skim milk substitutes for cream — we are on a strict diet
+  - The skim milk substitutes for cream--we are on a strict diet
   hypernym:
   - 02262178-v
   ili: i33028
@@ -9419,7 +9419,7 @@
   definition:
   - get or extort (money or other possessions) from someone
   example:
-  - They bled me dry — I have nothing left!
+  - They bled me dry--I have nothing left!
   hypernym:
   - 02245889-v
   ili: i33552

--- a/src/yaml/verb.possession.yaml
+++ b/src/yaml/verb.possession.yaml
@@ -9924,7 +9924,7 @@
   definition:
   - officially distribute a new product or service to the public
   example:
-  - '"Israel has been the fastest to roll out inoculations."'
+  - Israel has been the fastest to roll out inoculations.
   hypernym:
   - 02299397-v
   members:

--- a/src/yaml/verb.possession.yaml
+++ b/src/yaml/verb.possession.yaml
@@ -3279,7 +3279,7 @@
   - be a substitute
   example:
   - The young teacher had to substitute for the sick colleague
-  - The skim milk substitutes for cream--we are on a strict diet
+  - The skim milk substitutes for cream — we are on a strict diet
   hypernym:
   - 02262178-v
   ili: i33028
@@ -9419,7 +9419,7 @@
   definition:
   - get or extort (money or other possessions) from someone
   example:
-  - They bled me dry--I have nothing left!
+  - They bled me dry — I have nothing left!
   hypernym:
   - 02245889-v
   ili: i33552

--- a/src/yaml/verb.possession.yaml
+++ b/src/yaml/verb.possession.yaml
@@ -1601,7 +1601,7 @@
   definition:
   - allot again
   example:
-  - They were realloted additional farm land
+  - They were reallotted additional farm land
   hypernym:
   - 02299397-v
   ili: i32889

--- a/src/yaml/verb.social.yaml
+++ b/src/yaml/verb.social.yaml
@@ -843,7 +843,7 @@
   - withdraw from established society, especially because of disillusion with conventional
     values
   example:
-  - She hasn't heard from her brother in years — he dropped out after moving to California
+  - She hasn't heard from her brother in years--he dropped out after moving to California
   hypernym:
   - 02385151-v
   ili: i33671
@@ -5988,7 +5988,7 @@
   - Call off the engagement
   - cancel the dinner party
   - we had to scrub our vacation plans
-  - scratch that meeting — the chair is ill
+  - scratch that meeting--the chair is ill
   ili: i34109
   members:
   - cancel
@@ -6825,7 +6825,7 @@
   - celebrate noisily, often indulging in drinking; engage in uproarious festivities
   example:
   - The members of the wedding party made merry all night
-  - Let's whoop it up — the boss is gone!
+  - Let's whoop it up--the boss is gone!
   hypernym:
   - 02496526-v
   ili: i34179
@@ -8325,7 +8325,7 @@
   definition:
   - behave affectedly or unnaturally in order to impress others
   example:
-  - Don't pay any attention to him — he is always posing to impress his peers!
+  - Don't pay any attention to him--he is always posing to impress his peers!
   - She postured and made a total fool of herself
   hypernym:
   - 00010428-v

--- a/src/yaml/verb.social.yaml
+++ b/src/yaml/verb.social.yaml
@@ -6528,7 +6528,8 @@
   definition:
   - make a date
   example:
-  - Has he asked you out yet?" "He asekd me to a dance
+  - has he asked you out yet?
+  - he asked me to a dance
   hypernym:
   - 00754770-v
   ili: i34154

--- a/src/yaml/verb.social.yaml
+++ b/src/yaml/verb.social.yaml
@@ -843,7 +843,7 @@
   - withdraw from established society, especially because of disillusion with conventional
     values
   example:
-  - She hasn't heard from her brother in years--he dropped out after moving to California
+  - She hasn't heard from her brother in years — he dropped out after moving to California
   hypernym:
   - 02385151-v
   ili: i33671
@@ -5988,7 +5988,7 @@
   - Call off the engagement
   - cancel the dinner party
   - we had to scrub our vacation plans
-  - scratch that meeting--the chair is ill
+  - scratch that meeting — the chair is ill
   ili: i34109
   members:
   - cancel
@@ -6825,7 +6825,7 @@
   - celebrate noisily, often indulging in drinking; engage in uproarious festivities
   example:
   - The members of the wedding party made merry all night
-  - Let's whoop it up--the boss is gone!
+  - Let's whoop it up — the boss is gone!
   hypernym:
   - 02496526-v
   ili: i34179
@@ -8325,7 +8325,7 @@
   definition:
   - behave affectedly or unnaturally in order to impress others
   example:
-  - Don't pay any attention to him--he is always posing to impress his peers!
+  - Don't pay any attention to him — he is always posing to impress his peers!
   - She postured and made a total fool of herself
   hypernym:
   - 00010428-v

--- a/src/yaml/verb.stative.yaml
+++ b/src/yaml/verb.stative.yaml
@@ -685,8 +685,8 @@
   - We went without water and food for 3 days
   - These superstitions survive in the backwaters of America
   - The race car driver lived through several very serious accidents
-  - how long can a person last without food and water?" "One crash victim died, the
-    other lived
+  - how long can a person last without food and water?
+  - one crash victim died, the other lived
   ili: i34765
   members:
   - survive

--- a/src/yaml/verb.stative.yaml
+++ b/src/yaml/verb.stative.yaml
@@ -1808,7 +1808,7 @@
   - dwell
   example:
   - You can stay with me while you are in town
-  - stay a bit longer--the day is still young
+  - stay a bit longer — the day is still young
   exemplifies:
   - 07087487-n
   hypernym:
@@ -2852,7 +2852,7 @@
   - stay clear of, avoid
   example:
   - Keep your hands off my wife!
-  - Keep your distance from this man--he is dangerous
+  - Keep your distance from this man — he is dangerous
   hypernym:
   - 02661230-v
   ili: i34944
@@ -4417,7 +4417,7 @@
   definition:
   - end weakly
   example:
-  - The music just petered out--there was no proper ending
+  - The music just petered out — there was no proper ending
   hypernym:
   - 02689663-v
   ili: i35074
@@ -7097,7 +7097,7 @@
   definition:
   - abstain from doing; always used with a negative
   example:
-  - I can't help myself--I have to smoke
+  - I can't help myself — I have to smoke
   - She could not help watching the sad spectacle
   hypernym:
   - 02731589-v
@@ -7373,7 +7373,7 @@
   definition:
   - feel as if crawling with insects
   example:
-  - My skin crawled--I was terrified
+  - My skin crawled — I was terrified
   hypernym:
   - 02736346-v
   ili: i35318
@@ -7766,7 +7766,7 @@
   definition:
   - be relaxed
   example:
-  - Don't be so worried all the time--just let go!
+  - Don't be so worried all the time — just let go!
   hypernym:
   - 02610777-v
   ili: i35353
@@ -7815,7 +7815,7 @@
   - be in the right place or situation
   example:
   - Where do these books belong?
-  - Let's put health care where it belongs--under the control of the government
+  - Let's put health care where it belongs — under the control of the government
   - Where do these books go?
   hypernym:
   - 02661230-v
@@ -8273,7 +8273,7 @@
   partOfSpeech: v
 02750695-v:
   definition:
-  - to remain unmolested, undisturbed, or uninterrupted -- used only in infinitive
+  - to remain unmolested, undisturbed, or uninterrupted — used only in infinitive
     form
   example:
   - let her be
@@ -8875,7 +8875,7 @@
   definition:
   - be or become fixed
   example:
-  - The door sticks--we will have to plane it
+  - The door sticks — we will have to plane it
   hypernym:
   - 02610777-v
   ili: i35448

--- a/src/yaml/verb.stative.yaml
+++ b/src/yaml/verb.stative.yaml
@@ -1808,7 +1808,7 @@
   - dwell
   example:
   - You can stay with me while you are in town
-  - stay a bit longer — the day is still young
+  - stay a bit longer--the day is still young
   exemplifies:
   - 07087487-n
   hypernym:
@@ -2852,7 +2852,7 @@
   - stay clear of, avoid
   example:
   - Keep your hands off my wife!
-  - Keep your distance from this man — he is dangerous
+  - Keep your distance from this man--he is dangerous
   hypernym:
   - 02661230-v
   ili: i34944
@@ -4417,7 +4417,7 @@
   definition:
   - end weakly
   example:
-  - The music just petered out — there was no proper ending
+  - The music just petered out--there was no proper ending
   hypernym:
   - 02689663-v
   ili: i35074
@@ -7097,7 +7097,7 @@
   definition:
   - abstain from doing; always used with a negative
   example:
-  - I can't help myself — I have to smoke
+  - I can't help myself--I have to smoke
   - She could not help watching the sad spectacle
   hypernym:
   - 02731589-v
@@ -7373,7 +7373,7 @@
   definition:
   - feel as if crawling with insects
   example:
-  - My skin crawled — I was terrified
+  - My skin crawled--I was terrified
   hypernym:
   - 02736346-v
   ili: i35318
@@ -7766,7 +7766,7 @@
   definition:
   - be relaxed
   example:
-  - Don't be so worried all the time — just let go!
+  - Don't be so worried all the time--just let go!
   hypernym:
   - 02610777-v
   ili: i35353
@@ -7815,7 +7815,7 @@
   - be in the right place or situation
   example:
   - Where do these books belong?
-  - Let's put health care where it belongs — under the control of the government
+  - Let's put health care where it belongs--under the control of the government
   - Where do these books go?
   hypernym:
   - 02661230-v
@@ -8273,7 +8273,7 @@
   partOfSpeech: v
 02750695-v:
   definition:
-  - to remain unmolested, undisturbed, or uninterrupted — used only in infinitive
+  - to remain unmolested, undisturbed, or uninterrupted -- used only in infinitive
     form
   example:
   - let her be
@@ -8875,7 +8875,7 @@
   definition:
   - be or become fixed
   example:
-  - The door sticks — we will have to plane it
+  - The door sticks--we will have to plane it
   hypernym:
   - 02610777-v
   ili: i35448

--- a/src/yaml/verb.weather.yaml
+++ b/src/yaml/verb.weather.yaml
@@ -91,7 +91,7 @@
   definition:
   - rain heavily
   example:
-  - Put on your rain coat-- it's pouring outside!
+  - Put on your rain coat — it's pouring outside!
   hypernym:
   - 02762516-v
   ili: i35471
@@ -555,7 +555,7 @@
   definition:
   - be bright by reflecting or casting light
   example:
-  - Drive carefully--the wet road reflects
+  - Drive carefully — the wet road reflects
   hypernym:
   - 02773266-v
   ili: i35510

--- a/src/yaml/verb.weather.yaml
+++ b/src/yaml/verb.weather.yaml
@@ -91,7 +91,7 @@
   definition:
   - rain heavily
   example:
-  - Put on your rain coat — it's pouring outside!
+  - Put on your rain coat-- it's pouring outside!
   hypernym:
   - 02762516-v
   ili: i35471
@@ -555,7 +555,7 @@
   definition:
   - be bright by reflecting or casting light
   example:
-  - Drive carefully — the wet road reflects
+  - Drive carefully--the wet road reflects
   hypernym:
   - 02773266-v
   ili: i35510


### PR DESCRIPTION
**Use EM dash** (—, unicode x2014) instead of obsoleted and illegible double hyphen to offset parenthetical text.
The scope is definitions + examples.
The contexts have been reviewed but no undue use of parenthetical text was noted — the semantics seems good and I'll stick with Princeton's work.
So the substitution is 'automatic', but for the spaces around '--' which have been normalized (in most cases, but not all, there was no space).
This follows [Merriam Webster's guidelines](https://www.merriam-webster.com/grammar/em-dash-en-dash-how-to-use).
This change is easily reversible for legacy work that uses '--'.