### PR TITLE
WordNet Quoting

### DIFF
--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -183415,7 +183415,7 @@
   partOfSpeech: a
 87988931-s:
   definition:
-  - denoting or characteristic of countries of Asia; 'oriental civilization'
+  - denoting or characteristic of countries of Asia; `oriental civilization'
   members:
   - oriental
   partOfSpeech: s

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -100508,7 +100508,7 @@
   domain_topic:
   - 06186749-n
   example:
-  - the English vowel sounds in `pat', `pet', `pit', `pot', putt' are short
+  - the English vowel sounds in `pat', `pet', `pit', `pot', `putt' are short
   ili: i7894
   members:
   - short

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -15355,7 +15355,7 @@
   partOfSpeech: n
 01580459-n:
   definition:
-  - a genus containing the 'typical' mynas (Acridotheres)
+  - a genus containing the `typical' mynas (Acridotheres)
   hypernym:
   - 01509816-n
   ili: i43575
@@ -24069,8 +24069,8 @@
   partOfSpeech: n
 01717327-n:
   definition:
-  - primitive theropod found in Argentina; primitive theropod found in Argentina;
-    early Triassic; its name means 'Herrera's lizard' after the rancher who discovered
+  - primitive theropod found in Argentina;
+    early Triassic; its name means `Herrera's lizard' after the rancher who discovered
     the first specimen (Herrerasaurus)
   hypernym:
   - 01660364-n
@@ -24092,8 +24092,8 @@
   partOfSpeech: n
 01717623-n:
   definition:
-  - primitive theropod found in Argentina; primitive theropod found in Argentina;
-    early Triassic; its name is derived from the Greek word Eos, meaning 'dawn' (Eoraptor)
+  - primitive theropod found in Argentina;
+    early Triassic; its name is derived from the Greek word Eos, meaning `dawn' (Eoraptor)
   hypernym:
   - 01660364-n
   ili: i44323

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -126744,7 +126744,7 @@
 92461496-n:
   definition:
   - a sensitive photographic paper with pure silver bromide emulsions that produce
-    neutral black or 'cold' blue-black image tones.
+    neutral black or `cold' blue-black image tones.
   hypernym:
   - 03932650-n
   members:

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -125776,7 +125776,7 @@
   - An axial flow turbine operates in the exactly reverse of an axial flow compressor,
   example:
   - source: https://en.wikipedia.org
-    text: Whereas for an axial turbine the rotor is 'impacted' by the air flow, for
+    text: Whereas for an axial turbine the rotor is `impacted' by the air flow, for
       a radial turbine, the flow is smoothly orientated at 90 degrees by the compressor
       towards the combustion chamber and driving the turbine in the same way water
       drives a watermill.

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -35247,7 +35247,7 @@
   - The state or quality of being Serbian.
   example:
   - The linking thread between the groups is the rejection of the EU, Nato and other
-    western influences which could endanger 'Serbianness'.
+    western influences which could endanger `Serbianness'.
   hypernym:
   - 04923519-n
   members:
@@ -36256,7 +36256,7 @@
   - A moderate reddish purple that is bluer, stronger, and slightly lighter than heliotrope
     see heliotrope and bluer and duller than eupatorium purple.
   example:
-  - He wrote that it turned 'the colour of bishop's violet' and that he would bear
+  - He wrote that it turned `the colour of bishop's violet' and that he would bear
     the signs of it for weeks.
   hypernym:
   - 04978025-n
@@ -36346,7 +36346,7 @@
   - The quality or state of being a distinguishing feature of a person or thing.
   example:
   - The behaviours generated in this study were rated for characteristicness of an
-    'ideally intelligent person' by a group of lay people (not students) and a group
+    `ideally intelligent person' by a group of lay people (not students) and a group
     of experts (PhD psychologists studying intelligence).
   hypernym:
   - 04770548-n

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -33387,7 +33387,7 @@
   - a philosophy or media theory dedicated to studying what lies beyond the realm
     of metaphysics.
   example:
-  - Of all the French cultural exports over the last 150 years or so, 'pataphysics'--the
+  - Of all the French cultural exports over the last 150 years or so, `pataphysics'--the
     science of imaginary solutions and the laws governing exceptions--has proven to
     be one of the most durable.
   hypernym:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -33387,7 +33387,7 @@
   - a philosophy or media theory dedicated to studying what lies beyond the realm
     of metaphysics.
   example:
-  - Of all the French cultural exports over the last 150 years or so, 'pataphysics--the
+  - Of all the French cultural exports over the last 150 years or so, 'pataphysics'--the
     science of imaginary solutions and the laws governing exceptions--has proven to
     be one of the most durable.
   hypernym:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -33051,8 +33051,8 @@
     toleration along with Jews and Christians and usually identified with the Mandaeans
     or the Elkesaites.
   example:
-  - 'The ''olah, or burnt offering, suppresses the wrong view: Sabianism in the broad
-    sense of belief in astrology, magic, and superstition.'
+  - "The `olah', or burnt offering, suppresses the wrong view: Sabianism in the broad
+    sense of belief in astrology, magic, and superstition."
   hypernym:
   - 05957131-n
   members:
@@ -33346,8 +33346,8 @@
   - (Stoic philosophy) a matter having no moral merit or demerit.
   example:
   - Esteem (or reputation, fame, glory) was for Stoics an adiaphoron, and though it
-    could be classed as proe'gmenon with a certain 'value', it was only after Diogenes'
-    time that they conceded that its 'value' was more than instrumental.
+    could be classed as proe'gmenon with a certain `value', it was only after Diogenes'
+    time that they conceded that its `value' was more than instrumental.
   hypernym:
   - 05844071-n
   members:
@@ -34020,7 +34020,7 @@
   definition:
   - in physics, the theory that describes the weak force.
   example:
-  - Fermi's 'theory of β rays' or, as it came to be called, the theory of weak interaction,
+  - Fermi's `theory of β rays' or, as it came to be called, the theory of weak interaction,
     was decisively advanced by two experimental discoveries.
   hypernym:
   - 92437059-n
@@ -34438,8 +34438,8 @@
   - in logic, the formal analysis of logical terms and operators and the structures
     that make it possible to infer true conclusions from given premises.
   example:
-  - Aristotelian syllogistic became known as 'categorical syllogistic' and the Peripatetic
-    adaptation of Stoic syllogistic as 'hypothetical syllogistic'.
+  - Aristotelian syllogistic became known as `categorical syllogistic' and the Peripatetic
+    adaptation of Stoic syllogistic as `hypothetical syllogistic'.
   hypernym:
   - 06173467-n
   members:
@@ -34621,7 +34621,7 @@
   definition:
   - A form of collectivism proposed by François-Noël Babeuf.
   example:
-  - But Herzen's attack on its advocacy of terror that frees by 'despotism', on its
+  - But Herzen's attack on its advocacy of terror that frees by `despotism', on its
     Babeufism, was quite explicit.
   hypernym:
   - 06230561-n
@@ -34973,7 +34973,7 @@
   - a conflict of the soul (as with the body or between good and evil).
   example:
   - Later echoes of medieval psychomachy can be found in Shakespeare's 144th sonnet
-    and in Tennyson's poem 'The Two Voices' (1842).
+    and in Tennyson's poem `The Two Voices' (1842).
   hypernym:
   - 05929076-n
   members:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -49750,7 +49750,7 @@
   definition:
   - using more words than necessary
   example:
-  - plenoasms such as 'a tiny little child'
+  - plenoasms such as `a tiny little child'
   hypernym:
   - 07103943-n
   ili: i73916
@@ -50474,7 +50474,7 @@
   definition:
   - an exclamatory rhetorical device
   example:
-  - exclamation such as 'O tempore! O mores'
+  - exclamation such as `O tempore! O mores'
   hypernym:
   - 07112859-n
   ili: i73986
@@ -50505,7 +50505,7 @@
   definition:
   - immediate rephrasing for intensification or justification
   example:
-  - epanorthosis such as 'Seems, madam! Nay, it is'
+  - epanorthosis such as `Seems, madam! Nay, it is'
   hypernym:
   - 07112859-n
   ili: i73989
@@ -56301,7 +56301,7 @@
   definition:
   - a grammatically substandard but emphatic negative
   example:
-  - double negative such as 'I don't never go'
+  - double negative such as `I don't never go'
   hypernym:
   - 07219571-n
   ili: i74521
@@ -56312,7 +56312,7 @@
   definition:
   - an affirmative constructed from two negatives
   example:
-  - double negative such as 'A not unwelcome outcome'
+  - double negative such as `A not unwelcome outcome'
   hypernym:
   - 07218356-n
   ili: i74522
@@ -64088,7 +64088,7 @@
   definition:
   - a clitic that is associated with a following word.
   example:
-  - The indefinite article 'a' is a proclitic, a word that wants to merge phonologically
+  - The indefinite article `a' is a proclitic, a word that wants to merge phonologically
     with the word that follows it.
   hypernym:
   - 92460927-n

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -61633,7 +61633,7 @@
   - The characteristic quality of poetry that is marked by departure from the subject,
     course, or idea at hand; or by an exploration of a different or unrelated concern.
   example:
-  - Eighteenth-century writers, says Stabler, were never 'lost' in their digressiveness
+  - Eighteenth-century writers, says Stabler, were never `lost' in their digressiveness
     and used it as a method of supporting their concepts.
   hypernym:
   - 07080699-n
@@ -62741,7 +62741,7 @@
     and using electronic instruments such as guitars and synthesizers.
   example:
   - Jazz Fusion incorporates elements of different genres while maintaining an element
-    that is distinctly 'jazz'.
+    that is distinctly `jazz'.
   hypernym:
   - 07076737-n
   members:
@@ -62986,7 +62986,7 @@
   definition:
   - Etiquette practiced or advocated in electronic communication over a computer network.
   example:
-  - I know there is a UK political blog war going on at the moment about 'netiquette'
+  - I know there is a UK political blog war going on at the moment about `netiquette'
     and lies and spin and deceit, and I have not wanted to join in.
   hypernym:
   - 06677590-n

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -61096,7 +61096,7 @@
   partOfSpeech: n
 80475027-n:
   definition:
-  - English orthography used in Canada (characterized by 'analyze', 'centre', 'useable')
+  - English orthography used in Canada (characterized by `analyze', `centre', `useable')
   hypernym:
   - 06364852-n
   members:
@@ -61155,7 +61155,7 @@
   partOfSpeech: n
 84746436-n:
   definition:
-  - English orthography used in Australia (characterized by 'analyse', 'centre', 'usable')
+  - English orthography used in Australia (characterized by `analyse', `centre', `usable')
   hypernym:
   - 06364852-n
   members:
@@ -61175,7 +61175,7 @@
 86712636-n:
   definition:
   - English orthography used in the UK, Ireland and most of the Commonwealth (characterized
-    by 'analyse', 'centre' and 'useable')
+    by `analyse', `centre' and `useable')
   hypernym:
   - 06364852-n
   members:
@@ -61194,8 +61194,8 @@
   partOfSpeech: n
 87027384-n:
   definition:
-  - English orthography used in the United States (characterized by 'analyze', 'center',
-    'usable')
+  - English orthography used in the United States (characterized by `analyze', `center',
+    `usable')
   hypernym:
   - 06364852-n
   members:
@@ -61398,7 +61398,7 @@
   source: Colloquial WordNet
 90011161-n:
   definition:
-  - An expression meaning 'praise God' in Arabic
+  - An expression meaning `praise God' in Arabic
   hypernym:
   - 06642524-n
   members:

--- a/src/yaml/noun.food.yaml
+++ b/src/yaml/noun.food.yaml
@@ -26765,7 +26765,7 @@
   - The practice of eating mainly vegetarian food, but making occasional exceptions
     for social, pragmatic, cultural, or nutritional reasons.
   example:
-  - Flexitarianism will be the next 'mega trend' leading to sales of vegetarian foods
+  - Flexitarianism will be the next `mega trend' leading to sales of vegetarian foods
     in the UK to grow by 10% by 2016, according to food trends agency The Food People.
   hypernym:
   - 07576677-n

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -30907,7 +30907,7 @@
   source: plWordNet 4.0
 92428451-n:
   definition:
-  - fictional people in the 'Fortess', a series of fantasy novels by science fiction
+  - fictional people in the `Fortess', a series of fantasy novels by science fiction
     and fantasy author C. J. Cherryh.
   domain_topic:
   - 06380048-n
@@ -31312,7 +31312,7 @@
   source: plWordNet 4.0
 92447043-n:
   definition:
-  - any form of drama which is not naturalistic, traditional, conventional or 'legit';
+  - any form of drama which is not naturalistic, traditional, conventional or `legit';
     thus, theatre which disobeys or actively goes against accepted laws and rules
     of dramaturgy.
   example:

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -38317,7 +38317,7 @@
   - A predesignated portion of a chess board that a starting piece must reach in order
     to receive a promotion.
   example:
-  - In traditional Western chess the pawns promote/enrobe on the 8th rank [the 'promotion
+  - In traditional Western chess the pawns promote/enrobe on the 8th rank [the `promotion
     zone'].
   hypernym:
   - 08526463-n

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -2130,7 +2130,7 @@
   partOfSpeech: n
 09542327-n:
   definition:
-  - a name under which Ninkhursag was worshipped, meaning 'Mother'
+  - a name under which Ninkhursag was worshipped, meaning `Mother'
   ili: i86651
   instance_hypernym:
   - 09537037-n
@@ -2269,7 +2269,7 @@
   wikidata: Q836170
 09544186-n:
   definition:
-  - a name under which Ninkhursag was worshipped, meaning 'Lady of Birth'
+  - a name under which Ninkhursag was worshipped, meaning `Lady of Birth'
   ili: i86664
   instance_hypernym:
   - 09537037-n

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -15363,7 +15363,7 @@
 11854046-n:
   definition:
   - a caryophyllaceous genus of the family Chenopodiaceae, its name is derived from
-    the Greek words 'salt' and 'neighbour' (Halogeton)
+    the Greek words `salt' and `neighbour' (Halogeton)
   hypernym:
   - 11594111-n
   ili: i99470

--- a/src/yaml/noun.possession.yaml
+++ b/src/yaml/noun.possession.yaml
@@ -11253,7 +11253,7 @@
     banks against an approved collateral.
   example:
   - source: https://en.wikipedia.org
-    text: Lending is via central banks, in particular the securities 'eligible for
+    text: Lending is via central banks, in particular the securities `eligible for
       collateral' which are registered on lists; as a general rule, the Lombard rate
       (interest rate) is more or less one per cent above discount rate.
   hypernym:

--- a/src/yaml/noun.quantity.yaml
+++ b/src/yaml/noun.quantity.yaml
@@ -1124,7 +1124,7 @@
   definition:
   - a quantity expressed in two different units
   example:
-  - compound number such as 'one hour and ten minutes'
+  - compound number such as `one hour and ten minutes'
   hypernym:
   - 13603216-n
   ili: i108152

--- a/src/yaml/noun.shape.yaml
+++ b/src/yaml/noun.shape.yaml
@@ -3849,7 +3849,7 @@
   - a curve whose equation in Cartesian coordinates is of the form y = a cos x.
   example:
   - The shape of the cosine curve is the same for each full rotation of the angle
-    and so the function is called 'periodic'.
+    and so the function is called `periodic'.
   hypernym:
   - 13890262-n
   members:
@@ -3872,7 +3872,7 @@
   - a plane curve that is the graph of the equation y = tan x, where x is an angle.
   example:
   - The shape of the tangent curve is the same for each full rotation of the angle
-    and so the function is called 'periodic'.
+    and so the function is called `periodic'.
   hypernym:
   - 13890262-n
   members:

--- a/src/yaml/noun.substance.yaml
+++ b/src/yaml/noun.substance.yaml
@@ -31848,8 +31848,8 @@
   source: plWordNet 4.0
 92424810-n:
   definition:
-  - '#DD: The name ''ecdysteroid'' refers to the insect moulting and sex hormones
-    which include ecdysone and its homologues such as 20-hydroxyecdysone.'
+  - "#DD: The name `ecdysteroid' refers to the insect moulting and sex hormones
+    which include ecdysone and its homologues such as 20-hydroxyecdysone."
   example:
   - source: https://en.wikipedia.org
     text: Ecdysteroids also occur in other invertebrates where they can play a different
@@ -31863,7 +31863,7 @@
   wikidata: Q138983
 92424812-n:
   definition:
-  - The term 'zooecdysone' refers to the molting hormones of insects.
+  - The term `zooecdysone' refers to the molting hormones of insects.
   hypernym:
   - 92424810-n
   members:

--- a/src/yaml/verb.change.yaml
+++ b/src/yaml/verb.change.yaml
@@ -23371,7 +23371,7 @@
   definition:
   - mark with a dot
   example:
-  - dot your `i's
+  - dot your i's
   hypernym:
   - 00509113-v
   ili: i24253

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -9363,7 +9363,7 @@
   - 00914001-v
 00915748-v:
   definition:
-  - cry hollo
+  - cry `hollo'
   hypernym:
   - 00915018-v
   ili: i26179
@@ -9372,7 +9372,7 @@
   partOfSpeech: v
 00915838-v:
   definition:
-  - encourage somebody by crying hollo
+  - encourage somebody by crying `hollo'
   hypernym:
   - 01822202-v
   ili: i26180

--- a/src/yaml/verb.creation.yaml
+++ b/src/yaml/verb.creation.yaml
@@ -4296,6 +4296,7 @@
   - trace a line through or across
   example:
   - cross your `t'
+  - dot your i's and cross your t's!
   hypernym:
   - 01694952-v
   ili: i30201


### PR DESCRIPTION
Core WordNet had this convention while quoting **within** definitions or examples:
- open with a backtick (`, aka grave accent)
- close with apostrophe (', aka single quote)

This is not ideal (and I will later propose another scheme leaving the apostrophe to its original function, namely to ellipsize characters).

The number of  quotations departing from this rule is quite limited for now and they're easy to correct.
This PR enforces the consistent, uniform application of the original WN quotation `xxx' scheme, a prerequisite for any change.

Incidentally, this will make any processing easier. 