### PR TITLE
Etc requires trailing dot

### DIFF
--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -13305,14 +13305,14 @@
   partOfSpeech: a
 00198256-a:
   definition:
-  - of flowering plants (especially grasses etc) that are pollinated by the wind
+  - of flowering plants (especially grasses etc.) that are pollinated by the wind
   ili: i1052
   members:
   - anemophilous
   partOfSpeech: a
 00198391-a:
   definition:
-  - of flowering plants (especially orchids etc) that are pollinated by insects
+  - of flowering plants (especially orchids etc.) that are pollinated by insects
   ili: i1053
   members:
   - entomophilous
@@ -35398,7 +35398,7 @@
   - 00502614-a
 00503732-s:
   definition:
-  - failing to speak or communicate etc when expected to
+  - failing to speak or communicate etc. when expected to
   example:
   - the witness remained silent
   ili: i2824
@@ -76215,7 +76215,7 @@
   partOfSpeech: a
 01097016-a:
   definition:
-  - fitted or equipped with necessary rigging (sails and shrouds and stays etc)
+  - fitted or equipped with necessary rigging (sails and shrouds and stays etc.)
   domain_topic:
   - 00315295-n
   ili: i6006
@@ -116069,7 +116069,7 @@
   partOfSpeech: a
 01667666-a:
   definition:
-  - of leaves etc; growing in pairs on either side of a stem
+  - of leaves etc.; growing in pairs on either side of a stem
   domain_topic:
   - 06076105-n
   example:
@@ -116081,7 +116081,7 @@
   partOfSpeech: a
 01667824-a:
   definition:
-  - of leaves and branches etc; first on one side and then on the other in two ranks
+  - of leaves and branches etc.; first on one side and then on the other in two ranks
     along an axis; not paired
   domain_topic:
   - 06076105-n
@@ -135788,7 +135788,7 @@
   - 01951277-a
 01951627-s:
   definition:
-  - (of theories etc) incapable of being defended or justified
+  - (of theories etc.) incapable of being defended or justified
   ili: i10645
   members:
   - indefensible

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -1415,7 +1415,7 @@
   partOfSpeech: r
 00024715-r:
   definition:
-  - used to express refusal or denial or disagreement etc or especially to emphasize
+  - used to express refusal or denial or disagreement etc. or especially to emphasize
     a negative statement
   example:
   - no, you are wrong

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -1560,7 +1560,7 @@
   partOfSpeech: n
 00063271-n:
   definition:
-  - the act of consummating something (a desire or promise etc)
+  - the act of consummating something (a desire or promise etc.)
   hypernym:
   - 00062418-n
   ili: i35736
@@ -2842,7 +2842,7 @@
   partOfSpeech: n
 00085191-n:
   definition:
-  - the appropriation (of ideas or words etc) from another source
+  - the appropriation (of ideas or words etc.) from another source
   example:
   - the borrowing of ancient motifs was very apparent
   hypernym:
@@ -10097,7 +10097,7 @@
   partOfSpeech: n
 00209981-n:
   definition:
-  - a temporary debarment (from a privilege or position etc)
+  - a temporary debarment (from a privilege or position etc.)
   hypernym:
   - 01079805-n
   ili: i36504
@@ -12611,7 +12611,7 @@
   partOfSpeech: n
 00256989-n:
   definition:
-  - the washing of dishes etc after a meal
+  - the washing of dishes etc. after a meal
   hypernym:
   - 00256577-n
   ili: i36737
@@ -27394,7 +27394,7 @@
   partOfSpeech: n
 00521936-n:
   definition:
-  - a brief show (music or dance etc) inserted between the sections of a longer performance
+  - a brief show (music or dance etc.) inserted between the sections of a longer performance
   domain_topic:
   - 07034009-n
   hypernym:
@@ -43454,7 +43454,7 @@
   partOfSpeech: n
 00806369-n:
   definition:
-  - (engineering) the art or technique of trying to control rivers with dams etc in
+  - (engineering) the art or technique of trying to control rivers with dams etc. in
     order to minimize the occurrence of floods
   domain_topic:
   - 06134474-n
@@ -43662,7 +43662,7 @@
   partOfSpeech: n
 00810428-n:
   definition:
-  - fixing (of prices or wages etc) at a particular level
+  - fixing (of prices or wages etc.) at a particular level
   example:
   - a freeze on hiring
   hypernym:
@@ -48935,7 +48935,7 @@
   partOfSpeech: n
 00901459-n:
   definition:
-  - an elaborate representation of scenes from history etc; usually involves a parade
+  - an elaborate representation of scenes from history etc.; usually involves a parade
     with rich costumes
   hypernym:
   - 00900216-n
@@ -50193,7 +50193,7 @@
   partOfSpeech: n
 00924141-n:
   definition:
-  - the act of extracting ores or coal etc from the earth
+  - the act of extracting ores or coal etc. from the earth
   hypernym:
   - 00915536-n
   ili: i40257
@@ -68046,7 +68046,7 @@
   partOfSpeech: n
 01243544-n:
   definition:
-  - (law) a formal termination (of a relationship or a judicial proceeding etc)
+  - (law) a formal termination (of a relationship or a judicial proceeding etc.)
   domain_topic:
   - 08458195-n
   hypernym:

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -11130,7 +11130,7 @@
   partOfSpeech: n
 01517719-n:
   definition:
-  - 'any bird associated with night: owl, nightingale, nighthawk, etc'
+  - 'any bird associated with night: owl, nightingale, nighthawk, etc.'
   hypernym:
   - 01505702-n
   ili: i43215

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -16668,7 +16668,7 @@
   wikidata: Q5002767
 02931992-n:
   definition:
-  - a round fastener sewn to shirts and coats etc to fit through buttonholes
+  - a round fastener sewn to shirts and coats etc. to fit through buttonholes
   hypernym:
   - 03328648-n
   ili: i51314
@@ -31962,7 +31962,7 @@
   partOfSpeech: n
 03176704-n:
   definition:
-  - a device intended to turn aside the flow of something (water or air or smoke etc)
+  - a device intended to turn aside the flow of something (water or air or smoke etc.)
   hypernym:
   - 03187746-n
   ili: i52765
@@ -42030,7 +42030,7 @@
 03346242-n:
   definition:
   - a narrow strip of wood on the neck of some stringed instruments (violin or cello
-    or guitar etc) where the strings are held against the wood with the fingers
+    or guitar etc.) where the strings are held against the wood with the fingers
   hypernym:
   - 04346716-n
   ili: i53713
@@ -42087,7 +42087,7 @@
   partOfSpeech: n
 03347207-n:
   definition:
-  - a flat protective covering (on a door or wall etc) to prevent soiling by dirty
+  - a flat protective covering (on a door or wall etc.) to prevent soiling by dirty
     fingers
   hypernym:
   - 04020673-n
@@ -44074,7 +44074,7 @@
   partOfSpeech: n
 03377201-n:
   definition:
-  - a groove or furrow in cloth etc (particularly a shallow concave groove on the
+  - a groove or furrow in cloth etc. (particularly a shallow concave groove on the
     shaft of a column)
   hypernym:
   - 13916479-n
@@ -55309,7 +55309,7 @@
   partOfSpeech: n
 03552838-n:
   definition:
-  - the central part of a car wheel (or fan or propeller etc) through which the shaft
+  - the central part of a car wheel (or fan or propeller etc.) through which the shaft
     or axle passes
   hypernym:
   - 03898588-n
@@ -57627,7 +57627,7 @@
   partOfSpeech: n
 03591929-n:
   definition:
-  - work made of iron (gratings or rails or railings etc)
+  - work made of iron (gratings or rails or railings etc.)
   example:
   - the houses had much ornamental ironwork
   hypernym:
@@ -77622,7 +77622,7 @@
   partOfSpeech: n
 03911327-n:
   definition:
-  - a hole (in a door or an oven etc) through which you can peep
+  - a hole (in a door or an oven etc.) through which you can peep
   hypernym:
   - 03531378-n
   ili: i57091
@@ -90822,7 +90822,7 @@
   partOfSpeech: n
 04126572-n:
   definition:
-  - a recreation room for noisy activities (parties or children's play etc)
+  - a recreation room for noisy activities (parties or children's play etc.)
   hypernym:
   - 04072576-n
   ili: i58344
@@ -122953,7 +122953,7 @@
   source: plWordNet 4.0
 92435345-n:
   definition:
-  - (mountaineering) a tool for extracting a nut, chock, etc, from a crack after use.
+  - (mountaineering) a tool for extracting a nut, chock, etc., from a crack after use.
   hypernym:
   - 04459089-n
   - 92435347-n

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -26793,7 +26793,7 @@
   partOfSpeech: n
 05102125-n:
   definition:
-  - intellectual depth, penetrating knowledge, keen insight, etc; "the depth of my
+  - intellectual depth, penetrating knowledge, keen insight, etc.; "the depth of my
     feeling"; "the profoundness of the silence"
   example:
   - the depth of my feeling

--- a/src/yaml/noun.body.yaml
+++ b/src/yaml/noun.body.yaml
@@ -13864,7 +13864,7 @@
 05468925-n:
   definition:
   - a widely distributed system consisting of all the cells able to ingest bacteria
-    or colloidal particles etc, except for certain white blood cells
+    or colloidal particles etc., except for certain white blood cells
   hypernym:
   - 05244557-n
   ili: i65658

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -13000,7 +13000,7 @@
   partOfSpeech: n
 06499232-n:
   definition:
-  - a list or register of events (appointments or social events or court cases etc)
+  - a list or register of events (appointments or social events or court cases etc.)
   example:
   - I have you on my calendar for next Monday
   hypernym:
@@ -13567,7 +13567,7 @@
   partOfSpeech: n
 06507815-n:
   definition:
-  - a list of those who are ill (e.g. on a warship or in a regiment etc)
+  - a list of those who are ill (e.g. on a warship or in a regiment etc.)
   hypernym:
   - 06492991-n
   ili: i70594
@@ -62165,7 +62165,7 @@
   - (linguistics) The characteristic of a noun, in some languages, that is dependent
     on its unliving or non-sentient nature; this characteristic affects grammatical
     features (it can modify verbs used with the noun, affect the noun's declension
-    etc).
+    etc.).
   example:
   - In other words, the inanimacy of a head noun like "evidence" appeared not to penetrate
     the syntactic analysis of the verb "examined."
@@ -62524,7 +62524,7 @@
   source: plWordNet 4.0
 92460709-n:
   definition:
-  - the variant readings, footnotes, etc found in a scholarly work or a critical edition
+  - the variant readings, footnotes, etc. found in a scholarly work or a critical edition
     of a text.
   example:
   - The first printed edition of the New Testament with critical apparatus, noting

--- a/src/yaml/noun.event.yaml
+++ b/src/yaml/noun.event.yaml
@@ -2061,7 +2061,7 @@
   partOfSpeech: n
 07334374-n:
   definition:
-  - a failure to hit (or meet or find etc)
+  - a failure to hit (or meet or find etc.)
   hypernym:
   - 07332364-n
   ili: i75155
@@ -4680,7 +4680,7 @@
   partOfSpeech: n
 07378268-n:
   definition:
-  - a sudden downpour (as of tears or sparks etc) likened to a rain shower
+  - a sudden downpour (as of tears or sparks etc.) likened to a rain shower
   example:
   - a little shower of rose petals
   - a sudden cascade of sparks

--- a/src/yaml/noun.food.yaml
+++ b/src/yaml/noun.food.yaml
@@ -2278,7 +2278,7 @@
   partOfSpeech: n
 07608770-n:
   definition:
-  - an assortment of foods starting with herring or smoked eel or salmon etc with
+  - an assortment of foods starting with herring or smoked eel or salmon etc. with
     bread and butter; then cheeses and eggs and pickled vegetables and aspics; finally
     hot foods; served as a buffet meal
   domain_region:

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -19218,7 +19218,7 @@
   partOfSpeech: n
 08301768-n:
   definition:
-  - a school where secretarial skills (typing and shorthand and filing etc) are taught
+  - a school where secretarial skills (typing and shorthand and filing etc.) are taught
   hypernym:
   - 08293641-n
   ili: i80681
@@ -20734,8 +20734,8 @@
 08328863-n:
   definition:
   - '(chiefly Brit) a council representing employer and employees of a plant or business
-    to discuss working conditions etc; also: a committee representing the workers
-    elected to negotiate with management about grievances and wages etc'
+    to discuss working conditions etc.; also: a committee representing the workers
+    elected to negotiate with management about grievances and wages etc.'
   domain_region:
   - 08879115-n
   hypernym:

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -56472,7 +56472,7 @@
   partOfSpeech: n
 10423621-n:
   definition:
-  - a traveler riding in a vehicle (a boat or bus or car or plane or train etc) who
+  - a traveler riding in a vehicle (a boat or bus or car or plane or train etc.) who
     is not operating it
   domain_topic:
   - 02861626-n
@@ -120877,7 +120877,7 @@
   source: Colloquial WordNet
 92465797-n:
   definition:
-  - a person, group, etc, making a suggestion or plea that is ignored.
+  - a person, group, etc., making a suggestion or plea that is ignored.
   example:
   - Churchill's early warning of the danger of Nazism was a voice in the wilderness.
   hypernym:

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -90549,7 +90549,7 @@
 13143123-n:
   definition:
   - 'a semiaquatic plant that grows in soft wet land; most are monocots: sedge, sphagnum,
-    grasses, cattails, etc; possibly heath'
+    grasses, cattails, etc.; possibly heath'
   hypernym:
   - 13142303-n
   ili: i105605

--- a/src/yaml/noun.possession.yaml
+++ b/src/yaml/noun.possession.yaml
@@ -297,7 +297,7 @@
 13266745-n:
   definition:
   - personal as opposed to real property; any tangible movable property (furniture
-    or domestic animals or a car etc)
+    or domestic animals or a car etc.)
   domain_topic:
   - 03410635-n
   - 02961779-n
@@ -3811,7 +3811,7 @@
 13323315-n:
   definition:
   - any cost incurred by a producer or wholesaler or retailer or distributor (as for
-    advertising and shipping etc)
+    advertising and shipping etc.)
   hypernym:
   - 13296870-n
   ili: i106584

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -5224,7 +5224,7 @@
   partOfSpeech: n
 14036138-n:
   definition:
-  - a state of inactivity (in business or art etc)
+  - a state of inactivity (in business or art etc.)
   domain_topic:
   - 01096649-n
   - 00935235-n
@@ -20256,7 +20256,7 @@
   partOfSpeech: n
 14302737-n:
   definition:
-  - disease of tomatoes and potatoes and tobacco etc caused by the bacterium Pseudomonas
+  - disease of tomatoes and potatoes and tobacco etc. caused by the bacterium Pseudomonas
     solanacearum
   hypernym:
   - 14302275-n
@@ -26307,7 +26307,7 @@
 14404122-n:
   definition:
   - an anxiety disorder characterized by chronic free-floating anxiety and such symptoms
-    as tension or sweating or trembling or lightheadedness or irritability etc that
+    as tension or sweating or trembling or lightheadedness or irritability etc. that
     has lasted for more than six months
   hypernym:
   - 14403878-n
@@ -26660,7 +26660,7 @@
   definition:
   - any phobia (other than agoraphobia) associated with situations in which you are
     subject to criticism by others (as fear of eating in public or public speaking
-    etc)
+    etc.)
   hypernym:
   - 14404821-n
   ili: i112610

--- a/src/yaml/noun.substance.yaml
+++ b/src/yaml/noun.substance.yaml
@@ -15831,7 +15831,7 @@
   partOfSpeech: n
 14880285-n:
   definition:
-  - loose material (stone fragments and silt etc) that is worn away from rocks
+  - loose material (stone fragments and silt etc.) that is worn away from rocks
   hypernym:
   - 14604877-n
   ili: i115127


### PR DESCRIPTION
The proper 'et cetera' abbreviation requires a trailing dot.