### PR TITLE
Align quoting, fix def/example, punctuation

### DIFF
--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -6615,7 +6615,7 @@
   - 00096133-a
 00099000-s:
   definition:
-  - killed; `slain' is formal or literary as in "slain warriors"
+  - killed; `slain' is formal or literary as in `slain warriors'
   example:
   - a picture of St. George and the slain dragon
   ili: i517
@@ -24170,7 +24170,7 @@
   - 00348093-a
 00348809-s:
   definition:
-  - incapable of being changed or moved or undone; e.g. "frozen prices"
+  - incapable of being changed or moved or undone; e.g. `frozen prices'
   example:
   - living on fixed incomes
   ili: i1928
@@ -50856,7 +50856,7 @@
   - 00731008-a
 00732270-s:
   definition:
-  - (of a binary operation) independent of order; as in e.g. "a x b = b x a"
+  - "(of a binary operation) independent of order; as in e.g.: `a x b' = `b x a'"
   domain_topic:
   - 06009822-n
   ili: i4031
@@ -133392,9 +133392,8 @@
   - 01914420-a
 01915458-s:
   definition:
-  - (of color) discolored by impurities; not bright and clear
+  - (of color) discolored by impurities; not bright and clear; `dirty' is often used in combination
   example:
-  - '"dirty" is often used in combination'
   - a dirty (or dingy) white
   - the muddied grey of the sea
   - muddy colors
@@ -161549,8 +161548,8 @@
   domain_topic:
   - 06182505-n
   example:
-  - the following use of `access' was judged unacceptable by a panel of linguists;
-    `You can access your cash at any of 300 automatic tellers'
+  - "the following use of `access' was judged unacceptable by a panel of linguists:
+    `You can access your cash at any of 300 automatic tellers'"
   ili: i12724
   members:
   - unacceptable

--- a/src/yaml/adj.pert.yaml
+++ b/src/yaml/adj.pert.yaml
@@ -23068,7 +23068,9 @@
 03013361-a:
   definition:
   - pertaining to or characteristic of a body of rules and principles accepted as
-    axiomatic; e.g. "canonist communism"
+    axiomatic; e.g. `canonist communism'
+  example:
+  - canonist communism
   ili: i17154
   members:
   - canonist

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -1295,7 +1295,7 @@
   - left for work long ago
   - he has long since given up mountain climbing
   - This name has long since been forgotten
-  - '"lang syne" is Scottish'
+  - "`lang syne' is Scottish"
   ili: i18268
   members:
   - long ago

--- a/src/yaml/entries-s.yaml
+++ b/src/yaml/entries-s.yaml
@@ -34364,6 +34364,8 @@ scribbling block:
     sense:
     - id: 'scribbling_block%1:27:00::'
       synset: 15045756-n
+    - exemplifies:
+      - 'british_english%1:10:01::'
 scribe:
   n:
     pronunciation:

--- a/src/yaml/entries-s.yaml
+++ b/src/yaml/entries-s.yaml
@@ -34364,7 +34364,7 @@ scribbling block:
     sense:
     - id: 'scribbling_block%1:27:00::'
       synset: 15045756-n
-    - exemplifies:
+      exemplifies:
       - 'british_english%1:10:01::'
 scribe:
   n:

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -66754,7 +66754,7 @@
   partOfSpeech: n
 01222212-n:
   definition:
-  - promise of reward as in "carrot and stick"
+  - promise of reward as in `carrot and stick'
   example:
   - used the carrot of subsidized housing for the workers to get their vote
   hypernym:
@@ -73509,7 +73509,7 @@
     and rapidly increasing difficulty.
   example:
   - source: https://en.wikipedia.org
-    text: The term "arcade game" is also used to refer to an action video game that
+    text: The term `arcade game' is also used to refer to an action video game that
       was designed to play similarly to an arcade game with frantic, addictive gameplay.
   hypernym:
   - 00459914-n

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -121501,7 +121501,8 @@
 04612521-n:
   definition:
   - a woolen fabric with a hard textured surface and no nap; woven of worsted yarns
-    "he wore a worsted suit"
+  example:
+  - he wore a worsted suit
   hypernym:
   - 03314753-n
   ili: i61274
@@ -122646,8 +122647,9 @@
 92299310-n:
   definition:
   - a defensive missile designed to shoot down incoming intercontinental ballistic
-    missiles; "the Strategic Arms Limitation Talks placed limits on the deployment
-    of ABMs"
+    missiles
+  example:
+  - the Strategic Arms Limitation Talks placed limits on the deployment of ABMs
   hypernym:
   - 03471094-n
   members:
@@ -122808,7 +122810,7 @@
     sounds.
   example:
   - source: https://en.wikipedia.org
-    text: Guitarists derive their signature sound or "tone" from their choice of instrument,
+    text: Guitarists derive their signature sound or `tone' from their choice of instrument,
       pickups, effects units, and guitar amp.
   hypernym:
   - 03282682-n
@@ -124837,7 +124839,7 @@
   example:
   - The introduction of the tilt barrier seems to have originated in the south, as
     it only became a standard feature of jousting in Germany in the 16th century,
-    and was there called the Italian or "welsch" mode.
+    and was there called the Italian or `welsch' mode.
   hypernym:
   - 02799782-n
   members:
@@ -125457,7 +125459,7 @@
   example:
   - source: https://en.wikipedia.org
     text: Prince William's royal yards are the highest and smallest yards on the ship,
-      are made of wood, and are "lifting yards" that can be raised along a section
+      are made of wood, and are `lifting yards' that can be raised along a section
       of the mast.
   hypernym:
   - 04618033-n
@@ -125558,7 +125560,7 @@
     out, or dug into a hillside.
   example:
   - Dugouts are one of the most ancient types of human housing known to archeologists,
-    and the same methods have evolved into modern "earth shelter" technology.
+    and the same methods have evolved into modern `earth shelter' technology.
   hypernym:
   - 04198638-n
   - 03264208-n
@@ -126072,7 +126074,7 @@
   example:
   - source: https://en.wikipedia.org
     text: Vibratory hammers can either drive in or extract a pile; extraction is commonly
-      used to recover steel "H" piles used in temporary foundation shoring.
+      used to recover steel `H' piles used in temporary foundation shoring.
   hypernym:
   - 92460211-n
   members:
@@ -126180,7 +126182,7 @@
       electronic drum kit, consisting of a set of drum pads mounted on a stand or
       rack in a configuration similar to that of an acoustic drum kit layout, with
       rubberized (Roland, Yamaha, Alesis, for example) or specialized acoustic/electronic
-      cymbals (e.g. Zildjian's "Gen 16").
+      cymbals (e.g. Zildjian's `Gen 16').
   hypernym:
   - 03921556-n
   - 03284064-n
@@ -126938,7 +126940,7 @@
 92461769-n:
   definition:
   - a printing press used for offset printing, in which the inked image is transferred
-    (or "offset") from a plate to a rubber blanket, then to the printing surface.
+    (or `offset') from a plate to a rubber blanket, then to the printing surface.
   example:
   - source: https://en.wikipedia.org
     text: Many modern offset presses use computer-to-plate systems as opposed to the
@@ -127349,7 +127351,7 @@
 92462427-n:
   definition:
   - a sewing machine that binds fabric together using two threads, upper and lower,
-    and "locking" (entwining) them together in the hole in the fabric through which
+    and `locking' (entwining) them together in the hole in the fabric through which
     they pass.
   example:
   - source: https://en.wikipedia.org
@@ -127456,7 +127458,7 @@
   example:
   - source: https://en.wikipedia.org
     text: Rotary encoders are used in many applications that require precise shaft
-      unlimited rotation—including industrial controls, robotics, special purpose
+      unlimited rotation — including industrial controls, robotics, special purpose
       photographic lenses, computer input devices (such as optomechanical mice and
       trackballs), controlled stress rheometers, and rotating radar platforms.
   hypernym:

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -26793,8 +26793,7 @@
   partOfSpeech: n
 05102125-n:
   definition:
-  - intellectual depth, penetrating knowledge, keen insight, etc.; "the depth of my
-    feeling"; "the profoundness of the silence"
+  - intellectual depth, penetrating knowledge, keen insight, etc.
   example:
   - the depth of my feeling
   - the profoundness of the silence
@@ -35400,8 +35399,8 @@
   - The state or quality of being contemporary, modern, of the present age.
   example:
   - Most obvious, perhaps, is the contemporariness of her language, for example, when
-    wishing to instil organisational members with "a feel for the modern 1990s arm
-    of brewing."
+    wishing to instil organisational members with `a feel for the modern 1990s arm
+    of brewing.'
   hypernym:
   - 05057819-n
   members:
@@ -35464,9 +35463,9 @@
   definition:
   - The behaviour of a stickler; inflexible adherence to rules.
   example:
-  - '"We, the intellectually curious, may soon find ourselves trapped in a pen, fenced
+  - "`We, the intellectually curious, may soon find ourselves trapped in a pen, fenced
     in by rule-bound sticklerism and overzealous concern for our personal safety,
-    unless we exercise our civil liberties and our curiosity," he declaims.'
+    unless we exercise our civil liberties and our curiosity,' he declaims."
   hypernym:
   - 04679712-n
   - 04667618-n
@@ -35480,7 +35479,7 @@
     prints to be compared.
   example:
   - The major minutia features of fingerprint ridges are ridge ending, bifurcation,
-    and short ridge (or dot.
+    and short ridge (or dot).
   hypernym:
   - 04731092-n
   members:
@@ -35762,7 +35761,7 @@
   - The quality of having a beard.
   example:
   - In this scene, the penetrated partner's head is stretched awkwardly out on the
-    floor—placing further emphasis on his beardedness.
+    floor — placing further emphasis on his beardedness.
   hypernym:
   - 04690810-n
   members:
@@ -36538,8 +36537,8 @@
   - the state or quality of being Scottish.
   example:
   - Indeed the formation of these regiments helped to unite the Highlanders and Lowlanders,
-    and give them a shared sense of "Scottishness", by changing the image of Highlanders
-    from being backward and savage, to being "the very embodiment of Scotland" (which
+    and give them a shared sense of `Scottishness', by changing the image of Highlanders
+    from being backward and savage, to being `the very embodiment of Scotland' (which
     became clearly evident during the Romanticist period in Scotland).
   hypernym:
   - 04923519-n
@@ -36856,7 +36855,7 @@
   - The state or quality of behaving like a troublemaker, often violent; like a rude
     violent person; like a yob.
   example:
-  - True, this is hardly the drink to inspire "Girls Gone Wild" loutishness.
+  - True, this is hardly the drink to inspire `Girls Gone Wild' loutishness.
   hypernym:
   - 04921753-n
   members:
@@ -37068,7 +37067,7 @@
   definition:
   - The state of being able to be dismissed from office.
   example:
-  - The "democratic revolution" emphasized the delegation of authority and the removability
+  - The `democratic revolution' emphasized the delegation of authority and the removability
     of officials, precisely because, as we shall see, neither delegation nor removability
     were much recognized in actual institutions.
   hypernym:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -33471,7 +33471,7 @@
   source: plWordNet 4.0
 92439250-n:
   definition:
-  - the scientific philosophy where laws are "induced" from sets of data.
+  - the scientific philosophy where laws are `induced' from sets of data.
   hypernym:
   - 06177044-n
   members:
@@ -33519,8 +33519,8 @@
     have visited Earth and made contact with humans in antiquity and prehistory.
   example:
   - Sagan argued that while many legends, artifacts and purported out-of-place artifacts
-    were cited in support of ancient astronaut theories, "very few require more than
-    passing mention" and could be easily explained with more conventional theories.
+    were cited in support of ancient astronaut theories, `very few require more than
+    passing mention' and could be easily explained with more conventional theories.
   hypernym:
   - 05786951-n
   members:
@@ -33569,7 +33569,7 @@
   definition:
   - the study of Etruscan civilization, especially its artifacts and language.
   example:
-  - Half a century ago, however, Massimo Pallottino, the father figure of modern "Etruscology",
+  - Half a century ago, however, Massimo Pallottino, the father figure of modern `Etruscology',
     demolished this thesis once and for all, and today it is accepted that the origins
     of the Etruscan city states must be found in the internal social transformations
     that took place among the indigenous late prehistoric societies of Etruria in
@@ -33585,7 +33585,7 @@
   - the philology of Classical Sanskrit, Greek and Classical Latin.
   example:
   - Classical philology was a major preoccupation of the 19th-century German education
-    system, which became "the paradigm for higher education" throughout Western culture.
+    system, which became `the paradigm for higher education' throughout Western culture.
   hypernym:
   - 06180756-n
   members:
@@ -33597,7 +33597,7 @@
   - an interdisciplinary field of research and scholarship pertaining to a particular
     geographical, national/federal, or cultural region.
   example:
-  - Other large and important programs followed Ford's—most notably, the National
+  - Other large and important programs followed Ford's — most notably, the National
     Defense Education Act of 1957, renamed the Higher Education Act in 1965, which
     allocated funding for some 125 university-based area studies units known as National
     Resource Center programs at U.S. universities, as well as for Foreign Language
@@ -34411,7 +34411,7 @@
     religious attitude, opposition to intolerance, and castigation of bigotry.
   example:
   - Declarations of pan-Voltairianism will prove no panacea, but rather simply capture
-    an aspirational bonhomie reflected in "unity" marches that, however impressive,
+    an aspirational bonhomie reflected in `unity' marches that, however impressive,
     conceal seeds of future violent explosions given a still elusive and unfinished
     accounting of the broader equities at play.
   hypernym:
@@ -34482,7 +34482,7 @@
   - An obsolete term for ritualistic act or sequence of acts performed by a person
     with obsessive-compulsive neurosis.
   example:
-  - The conceptual history of "anancasm" in psychiatry remains almost unexplored and
+  - The conceptual history of `anancasm' in psychiatry remains almost unexplored and
     this article will help to remove this deficit.
   hypernym:
   - 05708366-n

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -12072,7 +12072,9 @@
   partOfSpeech: n
 06481268-n:
   definition:
-  - a summary list; as in e.g. "a news roundup"
+  - a summary list; as in e.g. `a news roundup'
+  example:
+  - a news roundup
   hypernym:
   - 06478678-n
   ili: i70457
@@ -34261,7 +34263,7 @@
   partOfSpeech: n
 06854923-n:
   definition:
-  - a punctuation mark (&) used to represent conjunction (and)
+  - a punctuation mark (`&') used to represent conjunction (and)
   hypernym:
   - 06854415-n
   ili: i72473
@@ -34270,7 +34272,7 @@
   partOfSpeech: n
 06855037-n:
   definition:
-  - the mark (') used to indicate the omission of one or more letters from a printed
+  - the mark (`'') used to indicate the omission of one or more letters from a printed
     word
   hypernym:
   - 06854415-n
@@ -34280,7 +34282,7 @@
   partOfSpeech: n
 06855215-n:
   definition:
-  - either of two punctuation marks ({ or }) used to enclose textual material
+  - either of two punctuation marks (`{' or `}') used to enclose textual material
   hypernym:
   - 06854415-n
   ili: i72475
@@ -34289,7 +34291,7 @@
   partOfSpeech: n
 06855340-n:
   definition:
-  - either of two punctuation marks ([ or ]) used to enclose textual material
+  - either of two punctuation marks (`[' or `]') used to enclose textual material
   hypernym:
   - 06854415-n
   ili: i72476
@@ -34310,7 +34312,7 @@
   partOfSpeech: n
 06855710-n:
   definition:
-  - a punctuation mark (:) used after a word introducing a series or an example or
+  - a punctuation mark (`:') used after a word introducing a series or an example or
     an explanation (or after the salutation of a business letter)
   hypernym:
   - 06854415-n
@@ -34320,7 +34322,7 @@
   partOfSpeech: n
 06855902-n:
   definition:
-  - a punctuation mark (,) used to indicate the separation of elements within the
+  - a punctuation mark (`,') used to indicate the separation of elements within the
     grammatical structure of a sentence
   hypernym:
   - 06854415-n
@@ -34330,7 +34332,7 @@
   partOfSpeech: n
 06856067-n:
   definition:
-  - a punctuation mark (!) used after an exclamation
+  - a punctuation mark (`!') used after an exclamation
   hypernym:
   - 06854415-n
   ili: i72480
@@ -34340,7 +34342,7 @@
   partOfSpeech: n
 06856198-n:
   definition:
-  - a punctuation mark (-) used between parts of a compound word or between the syllables
+  - a punctuation mark (`-') used between parts of a compound word or between the syllables
     of a word when the word is divided at the end of a line of text
   hypernym:
   - 06854415-n
@@ -34351,7 +34353,7 @@
   partOfSpeech: n
 06856443-n:
   definition:
-  - either of two punctuation marks (or) used to enclose textual material
+  - either of two punctuation marks `(' or `)' used to enclose textual material
   hypernym:
   - 06854415-n
   ili: i72482
@@ -34360,7 +34362,7 @@
   partOfSpeech: n
 06856570-n:
   definition:
-  - a punctuation mark (.) placed at the end of a declarative sentence to indicate
+  - a punctuation mark (`.') placed at the end of a declarative sentence to indicate
     a full stop or after abbreviations
   example:
   - in England they call a period a stop
@@ -34376,7 +34378,7 @@
   partOfSpeech: n
 06856888-n:
   definition:
-  - (usually plural) one of a series of points indicating that something has been
+  - (usually plural) one of a series of points (`…') indicating that something has been
     omitted or that the sentence is incomplete
   exemplifies:
   - 06306016-n
@@ -34388,7 +34390,7 @@
   partOfSpeech: n
 06857090-n:
   definition:
-  - a punctuation mark (?) placed at the end of a sentence to indicate a question
+  - a punctuation mark (`?') placed at the end of a sentence to indicate a question
   hypernym:
   - 06854415-n
   ili: i72485
@@ -34436,7 +34438,7 @@
   partOfSpeech: n
 06857789-n:
   definition:
-  - a punctuation mark (;) used to connect independent clauses; indicates a closer
+  - a punctuation mark (`;') used to connect independent clauses; indicates a closer
     relation than does a period
   hypernym:
   - 06854415-n
@@ -34446,7 +34448,7 @@
   partOfSpeech: n
 06857953-n:
   definition:
-  - a punctuation mark (/) used to separate related items of information
+  - a punctuation mark (`/') used to separate related items of information
   hypernym:
   - 06854415-n
   ili: i72491
@@ -34460,7 +34462,7 @@
   partOfSpeech: n
 06858126-n:
   definition:
-  - a punctuation mark used in text to indicate the omission of a word
+  - a punctuation mark (`⁓') used in text to indicate the omission of a word
   hypernym:
   - 06854415-n
   ili: i72492
@@ -34519,7 +34521,7 @@
   partOfSpeech: n
 06864792-n:
   definition:
-  - a formally registered symbol identifying the manufacturer or distributor of a
+  - a formally registered symbol (`™') identifying the manufacturer or distributor of a
     product
   exemplifies:
   - 92433720-n
@@ -52548,7 +52550,7 @@
 07153212-n:
   definition:
   - a report of a discourse in which deictic terms are modified appropriately (e.g.,
-    "he said `I am a fool'" would be modified to "he said he is a fool")
+    `he said "I am a fool"' would be modified to `he said he is a fool')
   hypernym:
   - 07232584-n
   ili: i74177
@@ -61483,7 +61485,7 @@
   definition:
   - A subgenre of alternative rock typified by significant use of guitar distortion,
     feedback, obscured vocals and the blurring of component musical parts into indistinguishable
-    "walls of sound"
+    `walls of sound'
   hypernym:
   - 07073295-n
   members:
@@ -61536,7 +61538,7 @@
   - a meter of poetry consisting of three iambic units per line.
   example:
   - In the dramatic forms of tragedy and comedy, iambic trimeter was used mainly for
-    the verses "spoken" by a character, that is, the dialogue rather than the choral
+    the verses `spoken' by a character, that is, the dialogue rather than the choral
     passages.
   hypernym:
   - 07109509-n
@@ -62055,8 +62057,8 @@
   source: plWordNet 4.0
 92444678-n:
   definition:
-  - A direct mate with the stipulation "White to move and checkmate Black in no more
-    than n moves against any defence" where n is greater than 3.
+  - A direct mate with the stipulation `White to move and checkmate Black in no more
+    than n moves against any defence' where n is greater than 3.
   example:
   - This week's problem is a more-mover by a composer better known for his endgame
     study and theory work.
@@ -62068,8 +62070,8 @@
   source: plWordNet 4.0
 92444679-n:
   definition:
-  - A problem with the stipulation "White to move and checkmate Black in two moves
-    against any defence".
+  - A problem with the stipulation `White to move and checkmate Black in two moves
+    against any defence'.
   example:
   - Although, if he was consistent, perhaps he should have said that a three-mover
     would be three times as difficult as a two-mover.
@@ -62081,8 +62083,8 @@
   source: plWordNet 4.0
 92444680-n:
   definition:
-  - A problem with the stipulation "White to move and checkmate Black in no more than
-    three moves against any defence".
+  - A problem with the stipulation `White to move and checkmate Black in no more than
+    three moves against any defence'.
   example:
   - Accordingly, the solver usually takes it for granted that a three-mover has a
     threat, unless the setting definitely suggests a block position.
@@ -62167,8 +62169,8 @@
     features (it can modify verbs used with the noun, affect the noun's declension
     etc.).
   example:
-  - In other words, the inanimacy of a head noun like "evidence" appeared not to penetrate
-    the syntactic analysis of the verb "examined."
+  - In other words, the inanimacy of a head noun like `evidence' appeared not to penetrate
+    the syntactic analysis of the verb `examined'.
   hypernym:
   - 06320373-n
   members:
@@ -62206,7 +62208,7 @@
   definition:
   - (linguistics, poetry) the use of isosyllabic verse.
   example:
-  - But it is likewise true that—especially in the context of the eighteenth century—anapestic
+  - But it is likewise true that — especially in the context of the eighteenth century — anapestic
     meter seemed somewhat flippant and irreverent in comparison with the staid isosyllabism
     of iambic pentameter.
   hypernym:
@@ -62236,7 +62238,7 @@
   example:
   - source: https://en.wikipedia.org
     text: As an information management tool, a PIM tool's purpose is to facilitate
-      the recording, tracking, and management of certain types of "personal information".
+      the recording, tracking, and management of certain types of `personal information'.
   hypernym:
   - 06581154-n
   members:
@@ -62571,7 +62573,7 @@
   definition:
   - a symbol that represents peace, in the form of three lines within a circle.
   example:
-  - In the 1950s the "peace sign", as it is known today, was designed as the logo
+  - In the 1950s the `peace sign' as it is known today, was designed as the logo
     for the British Campaign for Nuclear Disarmament and adopted by anti-war and counterculture
     activists in the United States and elsewhere.
   hypernym:
@@ -62634,7 +62636,7 @@
   example:
   - The sotadic metre or sotadic verse, which has been classified by ancient and modern
     scholars as a form of ionic metre, is one that reads backwards and forwards the
-    same, as "llewd did I live, and evil I did dwell."
+    same, as `llewd did I live, and evil I did dwell'.
   hypernym:
   - 06389065-n
   members:
@@ -62669,12 +62671,12 @@
 92460868-n:
   definition:
   - a large subgenre of trance music, named for the feeling which listeners claim
-    to get (often described as a "rush").
+    to get (often described as a `rush').
   example:
   - Instead of the darker tone of Goa, uplifting trance uses similar chord progressions
     as progressive trance, but tracks' chord progressions usually rest on a major
     chord, and the balance between major and minor chords in a progression will determine
-    how "happy" or "sad" the progression sounds.
+    how `happy' or `sad' the progression sounds.
   hypernym:
   - 92460865-n
   members:
@@ -62686,9 +62688,9 @@
   definition:
   - a dash that is one-half the length of an em dash.
   example:
-  - The en dash is commonly used to indicate a closed range of values—a range with
-    clearly defined and finite upper and lower boundaries—roughly signifying what
-    might otherwise be communicated by the word "through".
+  - The en dash is commonly used to indicate a closed range of values — a range with
+    clearly defined and finite upper and lower boundaries — roughly signifying what
+    might otherwise be communicated by the word `through'.
   hypernym:
   - 06856198-n
   members:
@@ -62727,8 +62729,8 @@
   - a poem whose meaning is conveyed through its graphic shape or pattern on the printed
     page.
   example:
-  - '"The Mouse''s Tale" is a concrete poem by Lewis Carroll which appears in his
-    novel Alice''s Adventures in Wonderland.'
+  - "`The Mouse's Tale' is a concrete poem by Lewis Carroll which appears in his
+    novel Alice's Adventures in Wonderland."
   hypernym:
   - 06389065-n
   members:
@@ -62764,7 +62766,7 @@
 92460923-n:
   definition:
   - a type of operatic soprano voice that has the limpidity and easy high notes of
-    a lyric soprano, yet can be "pushed" on to achieve dramatic climaxes without strain.
+    a lyric soprano, yet can be `pushed' on to achieve dramatic climaxes without strain.
   example:
   - The more dramatic sister of the lyric soprano is the spinto soprano, not quite
     a full-on dramatic soprano, but possessing a combination of qualities of both
@@ -62809,8 +62811,8 @@
   definition:
   - a piece of music composed for the Hungarian Csárdás dance.
   example:
-  - 'The Csárdás is characterized by a variation in tempo: it starts out slowly
-    (lassú) and ends in a very fast tempo (friss, literally "fresh").'
+  - "The Csárdás is characterized by a variation in tempo: it starts out slowly
+    (lassú) and ends in a very fast tempo (friss, literally `fresh')."
   hypernym:
   - 07068473-n
   members:
@@ -62907,8 +62909,8 @@
   - In their present form in the Roman Rite, the Improperia are a series of three
     couplets, sung antiphonally by cantors and followed by alternate Greek and Latin
     responses from the two halves of the choir; and nine other lines sung by the cantors,
-    with the full choir responding after each with the refrain "Popule meus, quid
-    feci tibi? . . . ."
+    with the full choir responding after each with the refrain `Popule meus, quid
+    feci tibi? …'
   hypernym:
   - 07046732-n
   members:
@@ -62945,12 +62947,12 @@
   definition:
   - a meaningless chant or expression used in conjuring or incantation.
   example:
-  - This claim is substantiated by the fact that in the Netherlands, the words Hocus
-    pocus are usually accompanied by the additional words pilatus pas, and this is
+  - This claim is substantiated by the fact that in the Netherlands, the words `Hocus
+    pocus' are usually accompanied by the additional words `pilatus pas', and this is
     said to be based on a post-Reformation parody of the traditional Catholic ritual
     of transubstantiation during mass, being a Dutch corruption of the Latin words
-    "Hoc est corpus", meaning this is (my) body, and the credo "sub Pontio Pilato
-    passus et sepultus est", meaning under Pontius Pilate he suffered and was buried.
+    `Hoc est corpus', meaning `this is (my) body', and the credo `sub Pontio Pilato
+    passus et sepultus est', meaning `under Pontius Pilate he suffered and was buried'.
   hypernym:
   - 07174442-n
   members:
@@ -63149,8 +63151,8 @@
     the alveolar ridge.
   example:
   - The sibilant postalveolars (i.e. fricatives and affricates) are sometimes called
-    "hush consonants" because they include the sound of English Shhh! (as distinguished
-    from the "hiss consonant" [s], as in Ssss!).
+    `hush consonants' because they include the sound of English `Shhh!' (as distinguished
+    from the `hiss' consonant [s], as in `Ssss!').
   hypernym:
   - 07129729-n
   members:
@@ -63178,8 +63180,8 @@
   - the tense that is used to refer to events, actions, and conditions that are happening
     all the time, or exist now.
   example:
-  - The sentences "I live in Madrid", "She doesn't like cheese", and "I think you're
-    wrong" are all in the present simple.
+  - The sentences `I live in Madrid', `She doesn't like cheese', and `I think you're
+    wrong' are all in the present simple.
   hypernym:
   - 06340727-n
   members:
@@ -63213,8 +63215,8 @@
   source: plWordNet 4.0
 92462179-n:
   definition:
-  - the ​form of a ​verb used to ​describe an ​action that ​happened before
-    the ​present ​time and is no ​longer ​happening.
+  - the form of a verb used to describe an action that happened before
+    the present time and is no longer happening.
   example:
   - Regular verbs form the simple past in -ed; however there are a few hundred irregular
     verbs with different forms.
@@ -63230,7 +63232,7 @@
   - a verb form expressing action as single in its occurrence without repetition or
     continuation.
   example:
-  - Semelfactive verbs include "blink", "sneeze", and "knock".
+  - Semelfactive verbs include `blink', `sneeze', and `knock'.
   hypernym:
   - 92462256-n
   members:
@@ -63268,9 +63270,9 @@
   definition:
   - the name of an object which may be perceived by one or more of the five senses.
   example:
-  - '"Kitten" is an example of a concrete noun. A kitten registers with the five senses:
+  - "`Kitten' is an example of a concrete noun. A kitten registers with the five senses:
     you can see a kitten, pet its fur, smell its breath, hear it purr and taste its
-    kisses.'
+    kisses."
   hypernym:
   - 06330286-n
   members:
@@ -63318,7 +63320,7 @@
     to increase or diminution.
   example:
   - An example using a positive-degree adverb that doesn't end in -ly would be the
-    adverb "fast" in the sentence, "She drove fast."
+    adverb `fast' in the sentence, `She drove fast'.
   hypernym:
   - 06333461-n
   members:
@@ -63330,7 +63332,7 @@
   definition:
   - An adverb that describes how the action of a verb is carried out.
   example:
-  - Adverbs of manner (like "desperately") can modify verbs directly.
+  - Adverbs of manner (like `desperately') can modify verbs directly.
   hypernym:
   - 06334605-n
   members:
@@ -63577,7 +63579,7 @@
   definition:
   - an extreme form of tragicomedy.
   example:
-  - The Suicide of Solitude, a "tragifarce" production, is currently being performed
+  - The Suicide of Solitude, a `tragifarce' production, is currently being performed
     by the local theatre troupe at Rochford Winery in Healesville.
   hypernym:
   - 07029911-n
@@ -63710,7 +63712,7 @@
   source: plWordNet 4.0
 92463196-n:
   definition:
-  - a name of a "minor" or small natural feature (e.g., a field, path, bridge, ditch,
+  - a name of a `minor' or small natural feature (e.g., a field, path, bridge, ditch,
     etc.).
   example:
   - Larrain is the name of a farmhouse in Astigarraga (Gipuzkoa) and a microtoponym
@@ -63873,7 +63875,7 @@
   definition:
   - (phonetics) Any vowel sound produced in the front of the mouth.
   example:
-  - Examples of front vowels include "a" in "man" and "e" in "gel".
+  - Examples of front vowels include `a' in `man' and `e' in `gel'.
   hypernym:
   - 07127258-n
   members:
@@ -63884,7 +63886,7 @@
   definition:
   - (phonetics) Any vowel sound produced in the back of the mouth.
   example:
-  - Examples of back vowels include "u" in "rule" and "o" in "pole".
+  - Examples of back vowels include `u' in `rule' and `o' in `pole'.
   hypernym:
   - 07127258-n
   members:
@@ -64128,7 +64130,7 @@
     is important to the text's interpretation.
   example:
   - What caught my eye about this is that it bears interesting relation to Bakhtin's
-    concept of the dialogism of the "living word" — in fact, capitalize that "w"
+    concept of the dialogism of the `living word' — in fact, capitalize that `w'
     and it would be downright eerie.
   hypernym:
   - 07112859-n
@@ -64219,7 +64221,7 @@
   definition:
   - an adverbial that describes when the action of a verb is carried out.
   example:
-  - An adverb phrase that answers the question "when?" is called a temporal adverbial.
+  - An adverb phrase that answers the question `when?' is called a temporal adverbial.
   hypernym:
   - 06335348-n
   members:
@@ -64281,8 +64283,8 @@
   - (grammar) a pronoun having no specific referent, such as someone, anybody, or
     nothing.
   example:
-  - In "many disagree with his views" the word "many" functions as an indefinite pronoun,
-    while in "many people disagree with his views" it functions as a quantifier.
+  - In `many disagree with his views' the word `many' functions as an indefinite pronoun,
+    while in `many people disagree with his views' it functions as a quantifier.
   hypernym:
   - 06336363-n
   members:
@@ -64320,7 +64322,7 @@
     or on coins or medals.
   example:
   - One practice was rendering an over-used, formulaic phrase only as a siglum, e.g.
-    RIP for requiescat in pace ("Rest in Peace"), because the long-form written usage
+    RIP for `requiescat in pace' (`Rest in Peace'), because the long-form written usage
     of the abbreviated phrase, itself, was rare.
   hypernym:
   - 06831828-n
@@ -64332,7 +64334,7 @@
   definition:
   - an act of describing oneself.
   example:
-  - His self-description as an "experimenter" puts him shoulder-to-shoulder with William
+  - His self-description as an `experimenter' puts him shoulder-to-shoulder with William
     James and John Dewey.
   hypernym:
   - 07216025-n
@@ -64431,9 +64433,9 @@
 92464557-n:
   definition:
   - The subject of a sentence that expresses the actual agent of an expressed or implied
-    action (as father in "it is your father speaking") or that is the thing about
-    which something is otherwise predicated (as to do right in "it is sometimes hard
-    to do right").
+    action (as father in `it is your father speaking') or that is the thing about
+    which something is otherwise predicated (as to do right in `it is sometimes hard
+    to do right').
   example:
   - The notion of a logical subject can be made more precise in terms of a definition
     of reference, for something is a logical subject only if it is a referent of a
@@ -64450,9 +64452,9 @@
     subject in normal English word order and anticipates a subsequent word or phrase
     that specifies the actual substantive content.
   example:
-  - In the sentence "the bear was killed by the hunter," The topicalized goal of the
-    action ("the bear") is the grammatical subject of the passive sentence and is
-    acted upon by the agent ("the hunter"), which is the logical, but not the grammatical,
+  - In the sentence `the bear was killed by the hunter', the topicalized goal of the
+    action (`the bear') is the grammatical subject of the passive sentence and is
+    acted upon by the agent (`the hunter'), which is the logical, but not the grammatical,
     subject of the passive sentence.
   hypernym:
   - 06320921-n
@@ -64511,7 +64513,7 @@
   - a word or line of verse of seven syllables.
   example:
   - On the other hand, this heptasyllable is not merely common in the Saturnian but
-    obviously the "regular" or "normal" form of the longer cola.
+    obviously the `regular' or `normal' form of the longer cola.
   hypernym:
   - 06396351-n
   members:
@@ -64562,7 +64564,7 @@
   - a constructed language designed for aesthetic pleasure.
   example:
   - By far the largest group of artistic languages are fictional languages (sometimes
-    also referred to as "professional artlangs"), intended to be the languages of
+    also referred to as `professional artlangs'), intended to be the languages of
     a fictional world, and often designed with the intent of giving more depth and
     an appearance of plausibility to the fictional worlds with which they are associated,
     and to have their characters communicate in a fashion which is both alien and
@@ -64588,15 +64590,15 @@
   source: plWordNet 4.0
 92465794-n:
   definition:
-  - 'A rhetorical figure resulting from a reverted arrangement in the last clause
+  - "A rhetorical figure resulting from a reverted arrangement in the last clause
     of a sentence of the two principal words of the clause preceding; inversion of
-    the members of an antithesis: as, "A poem is a speaking picture; a picture a mute
-    poem".'
+    the members of an antithesis: as, `A poem is a speaking picture; a picture a mute
+    poem'."
   example:
   - I am not of Paracelsus's mind, that boldly delivers a receipt to make a man without
     conjunction; yet cannot but wonder at the multitude of heads that do deny traduction,
     having no other arguments to confirm their belief than that rhetorical sentence
-    and antimetathesis of Augustine, "creando infunditur, infundendo creatur."
+    and antimetathesis of Augustine, `creando infunditur, infundendo creatur'.
   hypernym:
   - 07112859-n
   members:
@@ -64723,7 +64725,7 @@
   source: plWordNet 4.0
 92470531-n:
   definition:
-  - a song associated with the dance "The Twist" and the associated cultural craze.
+  - a song associated with the dance `The Twist' and the associated cultural craze.
   example:
   - There was Twist merchandise and memorabilia sold in those times, and many other
     music artists recorded twist songs.
@@ -64786,7 +64788,7 @@
   definition:
   - an indication of satisfaction or approval.
   example:
-  - The phrase "two thumbs up" has come to be used as an indication of very high quality
+  - The phrase `two thumbs up' has come to be used as an indication of very high quality
     or unanimity of praise.
   hypernym:
   - 06699481-n

--- a/src/yaml/noun.event.yaml
+++ b/src/yaml/noun.event.yaml
@@ -11856,7 +11856,7 @@
     individual conscience because it is neither forbidden nor enjoined by the scriptures.
   example:
   - For all of the wild-eyed (and completely sectarian) assertions floating around
-    the LCMS that ordination is a mere adiaphoron, that "laying on of hands" does
+    the LCMS that ordination is a mere adiaphoron, that `laying on of hands' does
     not mean ritual ordination but rather a democratic election, that ordination confers
     nothing - I have yet to ever read about anyone actually graduating seminary and
     taking a call to a congregation and choosing to forgo the rite of ordination.

--- a/src/yaml/noun.food.yaml
+++ b/src/yaml/noun.food.yaml
@@ -25904,8 +25904,9 @@
   wikidata: Q396184
 92326409-n:
   definition:
-  - a circular helping of food (especially a boneless cut of meat) "medallions of
-    veal"
+  - a circular helping of food (especially a boneless cut of meat)
+  example:
+  - medallions of veal
   hypernym:
   - 07593928-n
   - 07673512-n
@@ -26337,7 +26338,7 @@
   - a simple type of soup where a basic roux is thinned with cream or milk and then
     mushrooms and/or mushroom broth are added.
   example:
-  - Canned cream of mushroom soup has been described as "America's béchamel".
+  - Canned cream of mushroom soup has been described as `America's béchamel'.
   hypernym:
   - 07598762-n
   members:

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -30426,7 +30426,7 @@
   - a boundless succession of elements arranged in a given order.
   example:
   - Normally, the term infinite sequence refers to a sequence which is infinite in
-    one direction, and finite in the other—the sequence has a first element, but
+    one direction, and finite in the other — the sequence has a first element, but
     no final element (a singly infinite sequence).
   hypernym:
   - 08476263-n
@@ -30982,8 +30982,8 @@
     by a tendency to use free verse, complicated metrical innovations, and daring
     imagery and symbolism instead of traditional form and content.
   example:
-  - Jorge Luis Borges declared that the "newest aesthetic," Ultraism, is the poetic
-    alternative to "the prevailing Rubenism and Anecdotalism."
+  - Jorge Luis Borges declared that the `newest aesthetic,' Ultraism, is the poetic
+    alternative to `the prevailing Rubenism and Anecdotalism.'
   hypernym:
   - 08483654-n
   members:
@@ -31010,7 +31010,7 @@
     nearby Slavic states in the Balkans as well as Russia.
   example:
   - The Neo-Slavism of 1908-1910 and its effects up to the First World. War were to
-    a large extent a creation of Czech "foreign policy".
+    a large extent a creation of Czech `foreign policy'.
   hypernym:
   - 08481612-n
   members:
@@ -31025,7 +31025,7 @@
   example:
   - This ephemeral appearance of Karaism on Spanish soil was fruitful for Jewish historical
     literature, for it induced the philosophically trained Abraham ibn Daud of Toledo
-    to write his "Sefer ha-Ḳabbalah" (1161), which is invaluable for the history
+    to write his `Sefer ha-Ḳabbalah' (1161), which is invaluable for the history
     of the Jews in Spain.
   hypernym:
   - 08110979-n
@@ -31105,8 +31105,8 @@
   definition:
   - The quality of being Japanese.
   example:
-  - Japan's continuous obsession with the idea of the "Japaneseness" in craft products
-    was complicated by its effort to redeﬁne itself in terms of its "Orientalness."
+  - Japan's continuous obsession with the idea of the `Japaneseness' in craft products
+    was complicated by its effort to redeﬁne itself in terms of its `Orientalness'.
   hypernym:
   - 08304765-n
   members:
@@ -31341,7 +31341,7 @@
   definition:
   - Advocacy of rural life instead of urbanism or city living.
   example:
-  - By "ruralism" I mean the glorification of country life, and a dissatisfaction
+  - By `ruralism' I mean the glorification of country life, and a dissatisfaction
     with urbanism.
   hypernym:
   - 08481612-n

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -1232,7 +1232,7 @@
   domain_topic:
   - 00315295-n
   example:
-  - '"on her beam-ends" means heeled over on the side so that the deck is almost vertical'
+  - "`on her beam-ends' means heeled over on the side so that the deck is almost vertical"
   hypernym:
   - 08527687-n
   ili: i81775
@@ -38317,8 +38317,8 @@
   - A predesignated portion of a chess board that a starting piece must reach in order
     to receive a promotion.
   example:
-  - In traditional Western chess the pawns promote/enrobe on the 8th rank [the `promotion
-    zone'].
+  - In traditional Western chess the pawns promote/enrobe on the 8th rank (the `promotion
+    zone').
   hypernym:
   - 08526463-n
   members:

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -8855,7 +8855,7 @@
   wikidata: Q2072081
 09659490-n:
   definition:
-  - a person with African ancestry, "Negro" and "Negroid" are archaic and pejorative
+  - a person with African ancestry, `Negro' and `Negroid' are archaic and pejorative
     today
   hypernym:
   - 09786620-n
@@ -120221,7 +120221,7 @@
 86461832-n:
   definition:
   - A male fan who is obsessive about a particular subject (especially, someone or
-    something in popular entertainment media
+    something in popular entertainment media)
   hypernym:
   - 10306910-n
   - 10097373-n

--- a/src/yaml/noun.possession.yaml
+++ b/src/yaml/noun.possession.yaml
@@ -11479,7 +11479,7 @@
   - an option where the buyer has the right to exercise at a set (always discretely
     spaced) number of times.
   example:
-  - The Bermudan option is somewhat American and somewhat European—in terms of both
+  - The Bermudan option is somewhat American and somewhat European — in terms of both
     option style and physical location.
   hypernym:
   - 13262498-n
@@ -11583,7 +11583,7 @@
   - a fixed rate paid according to the quantity produced.
   example:
   - source: https://en.wikipedia.org
-    text: Factories today may receive the label "sweatshop" more because they have
+    text: Factories today may receive the label `sweatshop' more because they have
       the long hours and poor working conditions, even if they pay an hourly or daily
       wage instead of a piece rate.
   hypernym:

--- a/src/yaml/noun.process.yaml
+++ b/src/yaml/noun.process.yaml
@@ -8557,8 +8557,8 @@
   wikidata: Q208388
 92440974-n:
   definition:
-  - the spread of cultural items—such as ideas, styles, religions, technologies,
-    languages etc.—between individuals, whether within a single culture or from
+  - the spread of cultural items — such as ideas, styles, religions, technologies,
+    languages etc. — between individuals, whether within a single culture or from
     one culture to another.
   example:
   - The case of cultural diffusion, in contrast, makes it tempting to suggest that

--- a/src/yaml/noun.quantity.yaml
+++ b/src/yaml/noun.quantity.yaml
@@ -14084,7 +14084,7 @@
   definition:
   - a type of measure of a country's money supply.
   example:
-  - There is no single "correct" measure of the money supply; instead, there are several
+  - There is no single `correct' measure of the money supply; instead, there are several
     measures, classified along a spectrum or continuum between narrow and broad monetary
     aggregates.
   hypernym:

--- a/src/yaml/noun.relation.yaml
+++ b/src/yaml/noun.relation.yaml
@@ -4923,8 +4923,8 @@
   - the inflection of nouns, pronouns, adjectives, and articles to indicate masculine
     grammatical gender.
   example:
-  - Feminine declension treats k, g, ch as softenable, whereas masculine and neuter
-    declension does not (hence they take the "other" ending, -u).
+  - Feminine declension treats `k', `g', `ch' as softenable, whereas masculine and neuter
+    declension does not (hence they take the `other' ending, `-u').
   hypernym:
   - 13826415-n
   members:
@@ -4935,7 +4935,7 @@
   definition:
   - a conjunction that expresses something inferred from another statement or fact.
   example:
-  - One could argue grammatically in favour of "accordingly" being an illative conjunction.
+  - One could argue grammatically in favour of `accordingly' being an illative conjunction.
   hypernym:
   - 13821604-n
   members:

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -30874,7 +30874,7 @@
   definition:
   - not wearing a jacket
   example:
-  - '"in your shirtsleeves" means you are not wearing anything over your shirt'
+  - "`in your shirtsleeves' means you are not wearing anything over your shirt"
   - in hot weather they dined in their shirtsleeves
   hypernym:
   - 14481286-n
@@ -38196,8 +38196,8 @@
   - The property of being of dubious veracity; of questionable accuracy or truthfulness.
   example:
   - Not sure of the relative apocryphalness of this story, but I've always heard that
-    the Chevrolet Nova didn't sell too well in Latin America because "no va" in Spanish
-    means "it does not go".
+    the Chevrolet Nova didn't sell too well in Latin America because `no va' in Spanish
+    means `it does not go'.
   hypernym:
   - 13983750-n
   members:
@@ -38359,7 +38359,7 @@
   definition:
   - The state or condition of being fundamental; essential importance.
   example:
-  - At a similar level of fundamentalness or "broadness" is the question of whether
+  - At a similar level of fundamentalness or `broadness' is the question of whether
     to adopt strategies that are overt versus covert.
   hypernym:
   - 14458819-n
@@ -38465,7 +38465,7 @@
   source: plWordNet 4.0
 92432634-n:
   definition:
-  - that which is required in a particular situation —usually used in plural.
+  - that which is required in a particular situation — usually used in plural.
   example:
   - The trench maps used in the Great War resulted from the exigencies of war.
   hypernym:
@@ -38614,7 +38614,7 @@
   example:
   - In Treatise on Money (1930, chapter 29), economist John Maynard Keynes argued
     that in commodity markets, backwardation is not an abnormal market situation,
-    but rather arises naturally as "normal backwardation" from the fact that producers
+    but rather arises naturally as `normal backwardation' from the fact that producers
     of commodities are more prone to hedge their price risk than consumers.
   hypernym:
   - 14512178-n

--- a/src/yaml/noun.substance.yaml
+++ b/src/yaml/noun.substance.yaml
@@ -25842,9 +25842,7 @@
   partOfSpeech: n
 15045756-n:
   definition:
-  - pad for preliminary or hasty writing or notes or sketches etc.
-  example:
-  - '"scribbling block" is a British term'
+  - pad for preliminary or hasty writing or notes or sketches etc; `scribbling block' is a British term
   hypernym:
   - 15045652-n
   ili: i116098
@@ -32085,9 +32083,9 @@
   - an aqueous suspension of calcium hydroxide, used in tanning as a basic agent.
   example:
   - source: https://en.wikipedia.org
-    text: 'After soaking, the hides and skins are taken for liming: treatment with
-      milk of lime (a basic agent) that may involve the addition of "sharpening agents"
-      (disulfide reducing agents) like sodium sulfide, cyanides, amines etc.'
+    text: "After soaking, the hides and skins are taken for liming: treatment with
+      milk of lime (a basic agent) that may involve the addition of `sharpening agents'
+      (disulfide reducing agents) like sodium sulfide, cyanides, amines etc."
   - source: https://en.wikipedia.org
     text: When excess calcium hydroxide is added to limewater, a suspension of calcium
       hydroxide particles results, giving it a milky aspect, in which case it has

--- a/src/yaml/noun.time.yaml
+++ b/src/yaml/noun.time.yaml
@@ -11725,7 +11725,7 @@
   - a reckoning of the passage of time based on the Sun's position in the sky.
   example:
   - In September the Sun takes less time (as measured by an accurate clock) to make
-    an apparent revolution than it does in December; 24 "hours" of solar time can
+    an apparent revolution than it does in December; 24 `hours' of solar time can
     be 21 seconds less or 29 seconds more than 24 hours of clock time.
   hypernym:
   - 00028468-n
@@ -11806,7 +11806,7 @@
     for the child's welfare.
   example:
   - source: https://en.wikipedia.org
-    text: The terms "parental leave" and "family leave" include maternity, paternity,
+    text: The terms `parental leave' and `family leave' include maternity, paternity,
       and adoption leave.
   hypernym:
   - 15164090-n

--- a/src/yaml/verb.competition.yaml
+++ b/src/yaml/verb.competition.yaml
@@ -3266,7 +3266,7 @@
   partOfSpeech: v
 01129126-v:
   definition:
-  - 'assail or attack on all sides:'
+  - assail or attack on all sides
   hypernym:
   - 01122487-v
   ili: i27235

--- a/src/yaml/verb.contact.yaml
+++ b/src/yaml/verb.contact.yaml
@@ -10808,7 +10808,7 @@
   partOfSpeech: v
 01380788-v:
   definition:
-  - spread by scattering ("straw" is archaic)
+  - spread by scattering (`straw' is archaic)
   example:
   - strew toys all over the carpet
   hypernym:


### PR DESCRIPTION
Align quoting to `quoted' scheme (less than 100 cases)
Fix erroneous definition/example separation
Fix examples that are actually part of definition (usage)
Fix emdash-surrounding spaces
Quote punctuation when defined
Fix erratic punctuation (unclosed parenthesis, odd square brackets)
Quote where necessary (reference to expression).
Remove ZWSP (Zero-Width Space)