### PR TITLE
Quoting with single quotes

### DIFF
--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -50856,7 +50856,7 @@
   - 00731008-a
 00732270-s:
   definition:
-  - "(of a binary operation) independent of order; as in e.g.: `a x b' = `b x a'"
+  - '(of a binary operation) independent of order; as in e.g.: `a x b'' = `b x a'''
   domain_topic:
   - 06009822-n
   ili: i4031
@@ -58254,8 +58254,8 @@
   - marked by qualities giving the power to produce an intended effect
   example:
   - source: Aldous Huxley
-    text: written propaganda is less efficacious than the habits and prejudices … of
-      the readers
+    text: written propaganda is less efficacious than the habits and prejudices …
+      of the readers
   - the medicine is efficacious in stopping a cough
   ili: i4604
   members:
@@ -82120,7 +82120,8 @@
   - being or having the nature of a god
   example:
   - source: J.G.Frazier
-    text: the custom of killing the divine king upon any serious failure of his … powers
+    text: the custom of killing the divine king upon any serious failure of his …
+      powers
   - the divine will
   - the divine capacity for love
   - source: J.G.Saxe
@@ -90995,8 +90996,8 @@
   - not straightforward or candid; giving a false appearance of frankness
   example:
   - source: David Cannadine
-    text: an ambitious, disingenuous, philistine, and hypocritical operator, who … exemplified … the
-      most disagreeable traits of his time
+    text: an ambitious, disingenuous, philistine, and hypocritical operator, who …
+      exemplified … the most disagreeable traits of his time
   - a disingenuous excuse
   ili: i7140
   members:
@@ -131369,7 +131370,8 @@
   - in harmony with the spirit of particular persons or occasion
   example:
   - a decent burial
-  - we have come to dedicate a portion of that field … It is altogether fitting and proper that we should do this
+  - we have come to dedicate a portion of that field … It is altogether fitting and
+    proper that we should do this
   ili: i10315
   members:
   - fitting
@@ -133392,7 +133394,8 @@
   - 01914420-a
 01915458-s:
   definition:
-  - (of color) discolored by impurities; not bright and clear; `dirty' is often used in combination
+  - (of color) discolored by impurities; not bright and clear; `dirty' is often used
+    in combination
   example:
   - a dirty (or dingy) white
   - the muddied grey of the sea
@@ -140645,7 +140648,8 @@
   example:
   - a revitalized economy
   - a revitalized inner-city neighborhood
-  - Berlin has been reborn after probably the most intense period of construction since the post-war period.
+  - Berlin has been reborn after probably the most intense period of construction
+    since the post-war period.
   ili: i11032
   members:
   - revitalized
@@ -161548,8 +161552,8 @@
   domain_topic:
   - 06182505-n
   example:
-  - "the following use of `access' was judged unacceptable by a panel of linguists:
-    `You can access your cash at any of 300 automatic tellers'"
+  - 'the following use of `access'' was judged unacceptable by a panel of linguists:
+    `You can access your cash at any of 300 automatic tellers'''
   ili: i12724
   members:
   - unacceptable
@@ -162237,7 +162241,8 @@
   - a dry book
   - a dry lecture filled with trivial details
   - source: John Mason Brown
-    text: dull and juiceless as only book knowledge can be when it is unrelated to … life
+    text: dull and juiceless as only book knowledge can be when it is unrelated to
+      … life
   ili: i12779
   members:
   - dry

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -7431,7 +7431,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '‘all spinsters are unmarried’ is an analytic proposition'
+  - ‘all spinsters are unmarried’ is an analytic proposition
   ili: i589
   members:
   - analytic
@@ -7447,7 +7447,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '‘all men are arrogant’ is a synthetic proposition'
+  - ‘all men are arrogant’ is a synthetic proposition
   ili: i590
   members:
   - synthetic
@@ -11668,7 +11668,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '‘red’ is an attributive adjective in ‘a red apple’'
+  - ‘red’ is an attributive adjective in ‘a red apple’
   ili: i931
   members:
   - attributive
@@ -11695,7 +11695,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '‘red’ is a predicative adjective in ‘the apple is red’'
+  - ‘red’ is a predicative adjective in ‘the apple is red’
   ili: i933
   members:
   - predicative
@@ -12846,7 +12846,7 @@
   - inclined to or marked by drowsiness
   example:
   - slumberous (or slumbrous) eyes
-  - '‘slumbery’ is archaic'
+  - ‘slumbery’ is archaic
   - the sound had a somnolent effect
   ili: i1022
   members:
@@ -13891,7 +13891,7 @@
   example:
   - they considered themselves a tough outfit and weren't bashful about letting anybody
     know it
-  - '‘blate’ is a Scottish term for bashful'
+  - ‘blate’ is a Scottish term for bashful
   ili: i1100
   members:
   - bashful
@@ -17055,7 +17055,7 @@
   - a dark-skinned beauty
   - gold earrings gleamed against her dusky cheeks
   - a smile on his swarthy face
-  - '‘swart’ is archaic'
+  - ‘swart’ is archaic
   exemplifies:
   - 07087487-n
   ili: i1369
@@ -19225,7 +19225,7 @@
   example:
   - the gloomy forest
   - the glooming interior of an old inn
-  - '‘gloomful’ is archaic'
+  - ‘gloomful’ is archaic
   ili: i1541
   members:
   - glooming
@@ -19489,7 +19489,7 @@
   - scintillant mica
   - the scintillating stars
   - a dress with sparkly sequins
-  - '‘glistering’ is an archaic term'
+  - ‘glistering’ is an archaic term
   ili: i1560
   members:
   - aglitter
@@ -28722,7 +28722,7 @@
   example:
   - girls decked out in brave new dresses
   - brave banners flying
-  - '‘braw’ is a Scottish word'
+  - ‘braw’ is a Scottish word
   - a dress a bit too gay for her years
   - birds with gay plumage
   ili: i2307
@@ -30808,7 +30808,7 @@
   definition:
   - stupefied or dizzied by something overpowering
   example:
-  - source: '‘Chanticler’ by Rostand'
+  - source: ‘Chanticler’ by Rostand
     text: I fall back dazzled at beholding myself all rosy red, / At having, I myself,
       caused the sun to rise.
   ili: i2463
@@ -38643,7 +38643,7 @@
   definition:
   - repetition of same and identical sense with different and non-identical words
   example:
-  - '‘a true fact’ and ‘a free gift’ are pleonastic expressions'
+  - ‘a true fact’ and ‘a free gift’ are pleonastic expressions
   - the phrase ‘a beginner who has just started’ is tautological
   - source: J.B.Conant
     text: at the risk of being redundant I return to my original proposition
@@ -38798,8 +38798,8 @@
   domain_topic:
   - 06184139-n
   example:
-  - '‘and’ in ‘John and Mary’ or in ‘John walked and Mary rode’ is a coordinating
-    conjunction; and so is ‘or’ in ‘will you go or stay?’'
+  - ‘and’ in ‘John and Mary’ or in ‘John walked and Mary rode’ is a coordinating conjunction;
+    and so is ‘or’ in ‘will you go or stay?’
   ili: i3083
   members:
   - coordinating
@@ -38811,7 +38811,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '‘when’ in ‘I will come when I can’ is a subordinating conjunction'
+  - ‘when’ in ‘I will come when I can’ is a subordinating conjunction
   ili: i3084
   members:
   - subordinating
@@ -39560,7 +39560,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '‘and’ is a copulative conjunction'
+  - ‘and’ is a copulative conjunction
   ili: i3146
   members:
   - copulative
@@ -41680,7 +41680,7 @@
   definition:
   - having no interruptions
   example:
-  - '‘continual’ is often used interchangeably with ‘continuous’'
+  - ‘continual’ is often used interchangeably with ‘continuous’
   ili: i3306
   members:
   - continual
@@ -44143,7 +44143,7 @@
   - source: Shakespeare
     text: what seemed corporal melted as breath into the wind
   - an incarnate spirit
-  - '‘corporate’ is an archaic term'
+  - ‘corporate’ is an archaic term
   ili: i3508
   members:
   - bodied
@@ -48997,7 +48997,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - '‘boys’ and ‘swam’ are inflected English words'
+  - ‘boys’ and ‘swam’ are inflected English words
   - German is an inflected language
   ili: i3892
   members:
@@ -49009,7 +49009,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - '‘boy’ and ‘swim’ are uninflected English words'
+  - ‘boy’ and ‘swim’ are uninflected English words
   ili: i3893
   members:
   - uninflected
@@ -49570,7 +49570,7 @@
   example:
   - brittle bones
   - glass is brittle
-  - '‘brickle’ and ‘brickly’ are dialectal'
+  - ‘brickle’ and ‘brickly’ are dialectal
   ili: i3933
   members:
   - brittle
@@ -56737,8 +56737,8 @@
   definition:
   - indicating the first or earliest or original
   example:
-  - '‘proto’ is a combining form in a word like ‘protolanguage’ that refers to the
-    hypothetical ancestor of another language or group of languages'
+  - ‘proto’ is a combining form in a word like ‘protolanguage’ that refers to the
+    hypothetical ancestor of another language or group of languages
   exemplifies:
   - 06318142-n
   ili: i4490
@@ -62900,7 +62900,7 @@
   definition:
   - of or the nature of euphemism
   example:
-  - '‘peepee’ is a common euphemistic term'
+  - ‘peepee’ is a common euphemistic term
   ili: i4973
   members:
   - euphemistic
@@ -62909,7 +62909,7 @@
   definition:
   - of or the nature of dysphemism
   example:
-  - '‘kick the bucket’ is a dysphemistic term for ‘die’'
+  - ‘kick the bucket’ is a dysphemistic term for ‘die’
   ili: i4974
   members:
   - dysphemistic
@@ -74521,7 +74521,7 @@
   - touched by rot or decay
   example:
   - tainted bacon
-  - '‘corrupt’ is archaic'
+  - ‘corrupt’ is archaic
   ili: i5871
   members:
   - corrupt
@@ -75651,7 +75651,7 @@
   example:
   - a tray loaded with dishes
   - table laden with food
-  - '‘ladened’ is not current usage'
+  - ‘ladened’ is not current usage
   ili: i5960
   members:
   - laden
@@ -77301,7 +77301,7 @@
   domain_topic:
   - 03252323-n
   example:
-  - '‘Acetaminophen’ is the generic form of the proprietary drug ‘Tylenol’'
+  - ‘Acetaminophen’ is the generic form of the proprietary drug ‘Tylenol’
   ili: i6095
   members:
   - generic
@@ -77324,7 +77324,7 @@
   - protected by trademark or patent or copyright; made or produced or distributed
     by one having exclusive rights
   example:
-  - '‘Tylenol’ is a proprietary drug of which ‘acetaminophen’ is the generic form'
+  - ‘Tylenol’ is a proprietary drug of which ‘acetaminophen’ is the generic form
   ili: i6097
   members:
   - proprietary
@@ -90091,7 +90091,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '‘therefore’ is an illative word'
+  - ‘therefore’ is an illative word
   ili: i7070
   members:
   - illative
@@ -93273,7 +93273,7 @@
   example:
   - a dismissive shrug
   - the firm is dismissive of the competitor's product
-  - '‘chronic fatigue syndrome’ was known by the dismissive term ‘housewife syndrome’'
+  - ‘chronic fatigue syndrome’ was known by the dismissive term ‘housewife syndrome’
   ili: i7322
   members:
   - dismissive
@@ -98713,7 +98713,7 @@
   definition:
   - beyond the literal or primary sense
   example:
-  - '‘hot off the press’ shows an extended sense of ‘hot’'
+  - ‘hot off the press’ shows an extended sense of ‘hot’
   ili: i7747
   members:
   - extended
@@ -103672,7 +103672,7 @@
   definition:
   - neither male nor female (of grammatical gender)
   example:
-  - '‘it’ is the third-person singular neuter pronoun'
+  - ‘it’ is the third-person singular neuter pronoun
   ili: i8150
   members:
   - neuter
@@ -106618,7 +106618,7 @@
   example:
   - takeout pizza
   - the takeout counter
-  - '‘take-away’ is chiefly British'
+  - ‘take-away’ is chiefly British
   ili: i8380
   members:
   - takeout
@@ -107302,7 +107302,7 @@
   definition:
   - (used as a combining form) recent or new
   example:
-  - '‘neo’ is a combining form in words like ‘neocolonialism’'
+  - ‘neo’ is a combining form in words like ‘neocolonialism’
   exemplifies:
   - 06318142-n
   ili: i8433
@@ -118658,7 +118658,7 @@
   domain_topic:
   - 06076105-n
   example:
-  - '‘foliate’ is combined with the prefix ‘tri’ to form the word ‘trifoliate’'
+  - ‘foliate’ is combined with the prefix ‘tri’ to form the word ‘trifoliate’
   ili: i9320
   members:
   - foliate
@@ -118672,7 +118672,7 @@
   domain_topic:
   - 06076105-n
   example:
-  - '‘foliolate’ is combined with the prefix ‘bi’ to form the word ‘bifoliolate’'
+  - ‘foliolate’ is combined with the prefix ‘bi’ to form the word ‘bifoliolate’
   ili: i9321
   members:
   - foliolate
@@ -120697,7 +120697,7 @@
   - gone by; or in the past
   example:
   - two years ago
-  - '‘agone’ is an archaic word for ‘ago’'
+  - ‘agone’ is an archaic word for ‘ago’
   ili: i9484
   members:
   - ago
@@ -123530,7 +123530,7 @@
   - for your own use
   - do your own thing
   - she makes her own clothes
-  - '‘ain’ is Scottish'
+  - ‘ain’ is Scottish
   ili: i9704
   members:
   - own
@@ -133628,7 +133628,7 @@
   - (of pets) trained to urinate and defecate outside or in a special place
   example:
   - housebroken pets
-  - '‘house-trained’ is chiefly British'
+  - ‘house-trained’ is chiefly British
   ili: i10486
   members:
   - housebroken
@@ -137034,7 +137034,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '‘sing’ is a strong verb'
+  - ‘sing’ is a strong verb
   ili: i10742
   members:
   - strong
@@ -140603,7 +140603,7 @@
   - brought back
   example:
   - the Victorian era redux
-  - '‘Rabbit Redux’ by John Updike'
+  - ‘Rabbit Redux’ by John Updike
   ili: i11028
   members:
   - redux
@@ -141303,7 +141303,7 @@
   definition:
   - lacking funds
   example:
-  - '‘skint’ is a British slang term'
+  - ‘skint’ is a British slang term
   ili: i11084
   members:
   - broke
@@ -142337,7 +142337,7 @@
   - had a tall burly frame
   - clothing sizes for husky boys
   - a strapping boy of eighteen
-  - '‘buirdly’ is a Scottish term'
+  - ‘buirdly’ is a Scottish term
   ili: i11165
   members:
   - beefy
@@ -152930,7 +152930,7 @@
   definition:
   - used of a single unit or thing; not two or more
   example:
-  - '‘ane’ is Scottish'
+  - ‘ane’ is Scottish
   ili: i12006
   members:
   - one
@@ -164917,7 +164917,7 @@
   - considered of the highest quality and lasting significance or worth
   example:
   - a classic car
-  - '‘War and Peace’ is a classic novel'
+  - ‘War and Peace’ is a classic novel
   members:
   - classic
   partOfSpeech: s
@@ -167529,7 +167529,7 @@
   definition:
   - of words or propositions so related that each is the negation of the other
   example:
-  - '‘male’ and ‘female’ are complementary terms'
+  - ‘male’ and ‘female’ are complementary terms
   ili: i13190
   members:
   - complementary
@@ -167541,7 +167541,7 @@
   - of words or propositions so related that both cannot be true and both cannot be
     false
   example:
-  - '‘perfect’ and ‘imperfect’ are contradictory terms'
+  - ‘perfect’ and ‘imperfect’ are contradictory terms
   ili: i13191
   members:
   - contradictory
@@ -167552,7 +167552,7 @@
   definition:
   - of words or propositions so related that both cannot be true but both may be false
   example:
-  - '‘hot’ and ‘cold’ are contrary terms'
+  - ‘hot’ and ‘cold’ are contrary terms
   ili: i13192
   members:
   - contrary
@@ -167563,7 +167563,7 @@
   definition:
   - of words so related that one contrasts with the other
   example:
-  - '‘rich’ and ‘hard-up’ are contrastive terms'
+  - ‘rich’ and ‘hard-up’ are contrastive terms
   ili: i13193
   members:
   - contrastive
@@ -167575,7 +167575,7 @@
   definition:
   - of words so related that one reverses the relation denoted by the other
   example:
-  - '‘parental’ and ‘filial’ are converse terms'
+  - ‘parental’ and ‘filial’ are converse terms
   ili: i13194
   members:
   - converse
@@ -170361,7 +170361,7 @@
   - a sparing father and a spending son
   - sparing in their use of heat and light
   - stinting in bestowing gifts
-  - '‘scotch’ is used only informally'
+  - ‘scotch’ is used only informally
   exemplifies:
   - 07089193-n
   ili: i13402
@@ -171175,7 +171175,7 @@
   definition:
   - physically and mentally fatigued
   example:
-  - '‘aweary’ is archaic'
+  - ‘aweary’ is archaic
   ili: i13465
   members:
   - aweary
@@ -178484,7 +178484,7 @@
   definition:
   - providing coolness
   example:
-  - '‘caller’ is a Scottish term as in ‘a caller breeze’'
+  - ‘caller’ is a Scottish term as in ‘a caller breeze’
   ili: i14035
   members:
   - caller
@@ -178835,7 +178835,7 @@
   definition:
   - increasing or having the power to increase especially in size or amount or degree
   example:
-  - '‘up’ is an augmentative word in ‘hurry up’'
+  - ‘up’ is an augmentative word in ‘hurry up’
   ili: i14065
   members:
   - augmentative
@@ -181561,7 +181561,7 @@
   - covered with or consisting of bushes or thickets
   example:
   - brushy undergrowth
-  - '‘bosky’ is a literary term'
+  - ‘bosky’ is a literary term
   - source: Jack Beatty
     text: a bosky park leading to a modest yet majestic plaza
   ili: i14278
@@ -182954,7 +182954,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '‘or’ is a syncategorematic term'
+  - ‘or’ is a syncategorematic term
   ili: i14396
   members:
   - syncategorematic

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -33181,7 +33181,7 @@
   definition:
   - (of a word) referring singly and without exception to the members of a group
   example:
-  - whereas `each,´ `every,´ `either,´ `neither,´ and `none´ are distributive or referring
+  - whereas `each´, `every´, `either´, `neither´, and `none´ are distributive or referring
     to a single member of a group, `which´ in `which of the men´ is separative
   ili: i2643
   members:

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -3,7 +3,7 @@
   - 05207437-n
   - 05624029-n
   definition:
-  - (usually followed by `to') having the necessary means or skill or know-how or
+  - (usually followed by `to´) having the necessary means or skill or know-how or
     authority to do something
   example:
   - able to swim
@@ -18,7 +18,7 @@
   attribute:
   - 05207437-n
   definition:
-  - (usually followed by `to') not having the necessary means or skill or know-how
+  - (usually followed by `to´) not having the necessary means or skill or know-how
   example:
   - unable to get to town without a car
   - unable to obtain funds
@@ -664,7 +664,7 @@
   definition:
   - existing only in the mind; separated from embodiment
   example:
-  - abstract words like `truth' and `justice'
+  - abstract words like `truth´ and `justice´
   ili: i54
   members:
   - abstract
@@ -1550,7 +1550,7 @@
   - 00025245-s
 00025079-s:
   definition:
-  - (often followed by `to') unfamiliar
+  - (often followed by `to´) unfamiliar
   example:
   - new experiences
   - experiences new to him
@@ -2732,8 +2732,8 @@
   - 00041583-a
 00041840-a:
   definition:
-  - (used of verbs (e.g. `to run') and participial adjectives (e.g. `running' in `running
-    water')) expressing action rather than a state of being
+  - (used of verbs (e.g. `to run´) and participial adjectives (e.g. `running´ in `running
+    water´)) expressing action rather than a state of being
   domain_topic:
   - 06184139-n
   ili: i211
@@ -2743,7 +2743,7 @@
   partOfSpeech: a
 00042063-a:
   definition:
-  - (used of verbs (e.g. `be' or `own') and most participial adjectives) expressing
+  - (used of verbs (e.g. `be´ or `own´) and most participial adjectives) expressing
     existence or a state rather than an action
   domain_topic:
   - 06184139-n
@@ -3300,7 +3300,7 @@
   definition:
   - (of mail) marked with a destination
   example:
-  - I throw away all mail addressed to `resident'
+  - I throw away all mail addressed to `resident´
   ili: i261
   members:
   - addressed
@@ -4473,7 +4473,7 @@
   - 00068247-s
 00067988-s:
   definition:
-  - (comparative and superlative of `well') wiser or more advantageous and hence advisable
+  - (comparative and superlative of `well´) wiser or more advantageous and hence advisable
   example:
   - it would be better to speak to him
   - the White House thought it best not to respond
@@ -4808,7 +4808,7 @@
   - 00073398-s
 00072889-s:
   definition:
-  - (usually followed by `to') not affected by a given influence
+  - (usually followed by `to´) not affected by a given influence
   example:
   - immune to persuasion
   ili: i379
@@ -4819,7 +4819,7 @@
   - 00072600-a
 00073044-s:
   definition:
-  - (often followed by `to') above being affected or influenced by
+  - (often followed by `to´) above being affected or influenced by
   example:
   - he is superior to fear
   - an ignited firework proceeds superior to circumstances until its blazing vitality
@@ -6505,7 +6505,7 @@
   - 00096133-a
 00097766-s:
   definition:
-  - abbreviation for `dead on arrival' at the emergency room
+  - abbreviation for `dead on arrival´ at the emergency room
   ili: i507
   members:
   - d.o.a.
@@ -6615,7 +6615,7 @@
   - 00096133-a
 00099000-s:
   definition:
-  - killed; `slain' is formal or literary as in `slain warriors'
+  - killed; `slain´ is formal or literary as in `slain warriors´
   example:
   - a picture of St. George and the slain dragon
   ili: i517
@@ -7431,7 +7431,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '`all spinsters are unmarried'' is an analytic proposition'
+  - '`all spinsters are unmarried´ is an analytic proposition'
   ili: i589
   members:
   - analytic
@@ -7447,7 +7447,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '`all men are arrogant'' is a synthetic proposition'
+  - '`all men are arrogant´ is a synthetic proposition'
   ili: i590
   members:
   - synthetic
@@ -7541,7 +7541,7 @@
   - characterized by inflections indicating a semantic relation between a word and
     its base
   example:
-  - the morphological relation between `sing' and `singer' and `song' is derivational
+  - the morphological relation between `sing´ and `singer´ and `song´ is derivational
   ili: i598
   members:
   - derivational
@@ -8023,7 +8023,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - the word `dog' is animate
+  - the word `dog´ is animate
   ili: i636
   members:
   - animate
@@ -8034,7 +8034,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - the word `car' is inanimate
+  - the word `car´ is inanimate
   ili: i637
   members:
   - inanimate
@@ -11073,7 +11073,7 @@
   attribute:
   - 05089997-n
   definition:
-  - (often followed by `to') giving care or attention
+  - (often followed by `to´) giving care or attention
   example:
   - attentive to details
   - the nurse was attentive to her patient
@@ -11632,7 +11632,7 @@
   - 00172851-a
 00173433-s:
   definition:
-  - (usually followed by `to') given credit for
+  - (usually followed by `to´) given credit for
   example:
   - an invention credited to Edison
   ili: i928
@@ -11643,7 +11643,7 @@
   - 00172851-a
 00173569-s:
   definition:
-  - (usually followed by `to') able to be traced to
+  - (usually followed by `to´) able to be traced to
   example:
   - a failure traceable to lack of energy
   ili: i929
@@ -11668,7 +11668,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`red'' is an attributive adjective in `a red apple'''
+  - '`red´ is an attributive adjective in `a red apple´'
   ili: i931
   members:
   - attributive
@@ -11682,7 +11682,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - an example of the attributive genitive is `John's' in `John's mother'
+  - an example of the attributive genitive is `John's´ in `John's mother´
   ili: i932
   members:
   - attributive genitive
@@ -11695,7 +11695,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`red'' is a predicative adjective in `the apple is red'''
+  - '`red´ is a predicative adjective in `the apple is red´'
   ili: i933
   members:
   - predicative
@@ -11811,7 +11811,7 @@
   definition:
   - uttered without voice
   example:
-  - could hardly hear her breathed plea, `Help me'
+  - could hardly hear her breathed plea, `Help me´
   - voiceless whispers
   ili: i942
   members:
@@ -11844,7 +11844,7 @@
   definition:
   - not made to sound
   example:
-  - the silent `h' at the beginning of `honor'
+  - the silent `h´ at the beginning of `honor´
   - in French certain letters are often unsounded
   ili: i945
   members:
@@ -12846,7 +12846,7 @@
   - inclined to or marked by drowsiness
   example:
   - slumberous (or slumbrous) eyes
-  - '`slumbery'' is archaic'
+  - '`slumbery´ is archaic'
   - the sound had a somnolent effect
   ili: i1022
   members:
@@ -12907,7 +12907,7 @@
   attribute:
   - 05683749-n
   definition:
-  - (sometimes followed by `of') having or showing knowledge or understanding or realization
+  - (sometimes followed by `of´) having or showing knowledge or understanding or realization
     or perception
   example:
   - was aware of his opponent's hostility
@@ -12942,7 +12942,7 @@
   - 00191603-a
 00192448-s:
   definition:
-  - (followed by `of') showing realization or recognition of something
+  - (followed by `of´) showing realization or recognition of something
   example:
   - few voters seem conscious of the issue's importance
   - conscious of having succeeded
@@ -12978,7 +12978,7 @@
   attribute:
   - 05683749-n
   definition:
-  - (often followed by `of') not aware
+  - (often followed by `of´) not aware
   example:
   - seemed unaware of the scrutiny
   - unaware of the danger they were in
@@ -12996,7 +12996,7 @@
   - 00194124-s
 00193532-s:
   definition:
-  - (followed by `to' or `of') lacking conscious awareness of
+  - (followed by `to´ or `of´) lacking conscious awareness of
   example:
   - oblivious of the mounting pressures for political reform
   - oblivious to the risks she ran
@@ -13018,7 +13018,7 @@
   - 00193091-a
 00193933-s:
   definition:
-  - (followed by `of') not knowing or perceiving
+  - (followed by `of´) not knowing or perceiving
   example:
   - source: Charles Dickens
     text: happily unconscious of the new calamity at home
@@ -13030,7 +13030,7 @@
   - 00193091-a
 00194124-s:
   definition:
-  - (often followed by `of') not knowing or expecting; not thinking likely
+  - (often followed by `of´) not knowing or expecting; not thinking likely
   example:
   - an unsuspecting victim
   - unsuspecting (or unaware) of the fact that I would one day be their leader
@@ -13891,7 +13891,7 @@
   example:
   - they considered themselves a tough outfit and weren't bashful about letting anybody
     know it
-  - '`blate'' is a Scottish term for bashful'
+  - '`blate´ is a Scottish term for bashful'
   ili: i1100
   members:
   - bashful
@@ -15701,7 +15701,7 @@
   - 02349336-a
   - 02449153-a
   definition:
-  - (superlative of `good') having the most positive qualities
+  - (superlative of `good´) having the most positive qualities
   example:
   - the best film of the year
   - the best solution
@@ -15863,7 +15863,7 @@
   - 01129296-a
   - 02353767-a
   definition:
-  - (superlative of `bad') most wanting in quality or value or condition
+  - (superlative of `bad´) most wanting in quality or value or condition
   example:
   - the worst player on the team
   - the worst weather of the year
@@ -15914,7 +15914,7 @@
   - 00231222-a
 00231927-a:
   definition:
-  - (comparative of `good') superior to another (of the same class or set or kind)
+  - (comparative of `good´) superior to another (of the same class or set or kind)
     in excellence or quality or desirability or suitability; more highly skilled than
     another
   example:
@@ -15948,7 +15948,7 @@
   - 00231927-a
 00232532-s:
   definition:
-  - (comparative of `fine') greater in quality or excellence
+  - (comparative of `fine´) greater in quality or excellence
   example:
   - a finer wine
   - a finer musician
@@ -15974,7 +15974,7 @@
   - 00231927-a
 00232844-a:
   definition:
-  - (comparative of `bad') inferior to another in quality or condition or desirability
+  - (comparative of `bad´) inferior to another in quality or condition or desirability
   example:
   - this road is worse than the first one we took
   - the road is in worse shape than it was
@@ -16001,7 +16001,7 @@
   - 00232844-a
 00233353-a:
   definition:
-  - (comparative of `good') changed for the better in health or fitness
+  - (comparative of `good´) changed for the better in health or fitness
   example:
   - her health is better now
   - I feel better
@@ -17055,7 +17055,7 @@
   - a dark-skinned beauty
   - gold earrings gleamed against her dusky cheeks
   - a smile on his swarthy face
-  - '`swart'' is archaic'
+  - '`swart´ is archaic'
   exemplifies:
   - 07087487-n
   ili: i1369
@@ -19225,7 +19225,7 @@
   example:
   - the gloomy forest
   - the glooming interior of an old inn
-  - '`gloomful'' is archaic'
+  - '`gloomful´ is archaic'
   ili: i1541
   members:
   - glooming
@@ -19489,7 +19489,7 @@
   - scintillant mica
   - the scintillating stars
   - a dress with sparkly sequins
-  - '`glistering'' is an archaic term'
+  - '`glistering´ is an archaic term'
   ili: i1560
   members:
   - aglitter
@@ -21275,7 +21275,7 @@
   - 05209765-n
   - 05630964-n
   definition:
-  - (usually followed by `of') having capacity or ability
+  - (usually followed by `of´) having capacity or ability
   example:
   - capable of winning
   - capable of hard work
@@ -21338,7 +21338,7 @@
   - 05209765-n
   - 05630964-n
   definition:
-  - (followed by `of') lacking capacity or ability
+  - (followed by `of´) lacking capacity or ability
   example:
   - incapable of carrying a tune
   - he is incapable of understanding the matter
@@ -21351,7 +21351,7 @@
   - 00308592-s
 00308592-s:
   definition:
-  - (usually followed by `to') lacking necessary physical or mental ability
+  - (usually followed by `to´) lacking necessary physical or mental ability
   example:
   - dyslexics are unable to learn to read adequately
   - the sun was unable to melt enough snow
@@ -21363,7 +21363,7 @@
   - 00308272-a
 00308813-a:
   definition:
-  - (followed by `of') having the temperament or inclination for
+  - (followed by `of´) having the temperament or inclination for
   example:
   - no one believed her capable of murder
   ili: i1700
@@ -21372,7 +21372,7 @@
   partOfSpeech: a
 00308986-a:
   definition:
-  - (followed by `of') not having the temperament or inclination for
+  - (followed by `of´) not having the temperament or inclination for
   example:
   - simply incapable of lying
   ili: i1701
@@ -21573,7 +21573,7 @@
   - 00309819-a
 00311985-s:
   definition:
-  - (usually followed by `of') solicitously caring or mindful
+  - (usually followed by `of´) solicitously caring or mindful
   example:
   - protective of his reputation
   ili: i1716
@@ -21995,7 +21995,7 @@
   partOfSpeech: a
 00317905-a:
   definition:
-  - made for or formed by carving (`carven' is archaic or literary)
+  - made for or formed by carving (`carven´ is archaic or literary)
   domain_topic:
   - 06376048-n
   example:
@@ -23662,7 +23662,7 @@
   - 00342190-s
 00341524-s:
   definition:
-  - (usually followed by `to') governed by fate
+  - (usually followed by `to´) governed by fate
   example:
   - bound to happen
   - an old house destined to be demolished
@@ -23676,7 +23676,7 @@
   - 00341137-a
 00341725-s:
   definition:
-  - (usually followed by `to') determined by tragic fate
+  - (usually followed by `to´) determined by tragic fate
   example:
   - doomed to unhappiness
   - fated to be the scene of Kennedy's assassination
@@ -24170,7 +24170,7 @@
   - 00348093-a
 00348809-s:
   definition:
-  - incapable of being changed or moved or undone; e.g. `frozen prices'
+  - incapable of being changed or moved or undone; e.g. `frozen prices´
   example:
   - living on fixed incomes
   ili: i1928
@@ -28722,7 +28722,7 @@
   example:
   - girls decked out in brave new dresses
   - brave banners flying
-  - '`braw'' is a Scottish word'
+  - '`braw´ is a Scottish word'
   - a dress a bit too gay for her years
   - birds with gay plumage
   ili: i2307
@@ -30808,7 +30808,7 @@
   definition:
   - stupefied or dizzied by something overpowering
   example:
-  - source: '`Chanticler'' by Rostand'
+  - source: '`Chanticler´ by Rostand'
     text: I fall back dazzled at beholding myself all rosy red, / At having, I myself,
       caused the sun to rise.
   ili: i2463
@@ -31293,7 +31293,7 @@
   - 00444378-a
 00445635-s:
   definition:
-  - (comparatives of `far') most remote in space or time or order
+  - (comparatives of `far´) most remote in space or time or order
   example:
   - had traveled to the farthest frontier
   - don't go beyond the farthermost (or furthermost) tree
@@ -31519,7 +31519,7 @@
   - 00447582-a
 00448792-s:
   definition:
-  - distant but within sight (`yon' is dialectal)
+  - distant but within sight (`yon´ is dialectal)
   example:
   - yonder valley
   - the hills yonder
@@ -33181,8 +33181,8 @@
   definition:
   - (of a word) referring singly and without exception to the members of a group
   example:
-  - whereas `each,' `every,' `either,' `neither,' and `none' are distributive or referring
-    to a single member of a group, `which' in `which of the men' is separative
+  - whereas `each,´ `every,´ `either,´ `neither,´ and `none´ are distributive or referring
+    to a single member of a group, `which´ in `which of the men´ is separative
   ili: i2643
   members:
   - separative
@@ -33353,7 +33353,7 @@
   - 00473832-s
 00473562-s:
   definition:
-  - (followed by `to') as reported or stated by
+  - (followed by `to´) as reported or stated by
   example:
   - according to historians
   ili: i2659
@@ -33690,7 +33690,7 @@
   - 00477739-a
 00477986-a:
   definition:
-  - large and roomy (`convenient' is archaic in this sense)
+  - large and roomy (`convenient´ is archaic in this sense)
   example:
   - a commodious harbor
   - a commodious building suitable for conventions
@@ -33743,7 +33743,7 @@
   attribute:
   - 14468845-n
   definition:
-  - providing or experiencing physical well-being or relief (`comfy' is informal)
+  - providing or experiencing physical well-being or relief (`comfy´ is informal)
   example:
   - comfortable clothes
   - comfortable suburban houses
@@ -33836,8 +33836,8 @@
   - 00481182-s
 00480301-s:
   definition:
-  - feeling physical discomfort or pain (`tough' is occasionally used colloquially
-    for `bad')
+  - feeling physical discomfort or pain (`tough´ is occasionally used colloquially
+    for `bad´)
   example:
   - my throat feels bad
   - she felt bad all over
@@ -34119,7 +34119,7 @@
 00484662-s:
   definition:
   - properly related in size or degree or other measurable characteristics; usually
-    followed by `to'
+    followed by `to´
   example:
   - the punishment ought to be proportional to the crime
   - earnings relative to production
@@ -34391,8 +34391,8 @@
   definition:
   - frequently encountered
   example:
-  - a frequent (or common) error is using the transitive verb `lay' for the intransitive
-    `lie'
+  - a frequent (or common) error is using the transitive verb `lay´ for the intransitive
+    `lie´
   ili: i2743
   members:
   - frequent
@@ -36571,7 +36571,7 @@
   - 00521748-s
 00521402-s:
   definition:
-  - (followed by `to') dedicated exclusively to a purpose or use
+  - (followed by `to´) dedicated exclusively to a purpose or use
   example:
   - large sums devoted to the care of the poor
   - a life devoted to poetry
@@ -36595,7 +36595,7 @@
   - 00521136-a
 00521748-s:
   definition:
-  - (often followed by `to') devoted exclusively to a single use or purpose or person
+  - (often followed by `to´) devoted exclusively to a single use or purpose or person
   example:
   - a fund sacred to charity
   - a morning hour sacred to study
@@ -37470,7 +37470,7 @@
   - 00533547-a
 00534780-s:
   definition:
-  - thrown into a state of agitated confusion; (`rattled' is an informal term)
+  - thrown into a state of agitated confusion; (`rattled´ is an informal term)
   exemplifies:
   - 07089193-n
   ili: i2979
@@ -38527,7 +38527,7 @@
   example:
   - a crisp retort
   - a response so curt as to be almost rude
-  - the laconic reply; `yes'
+  - the laconic reply; `yes´
   - short and terse and easy to understand
   ili: i3062
   members:
@@ -38643,8 +38643,8 @@
   definition:
   - repetition of same and identical sense with different and non-identical words
   example:
-  - '`a true fact'' and `a free gift'' are pleonastic expressions'
-  - the phrase `a beginner who has just started' is tautological
+  - '`a true fact´ and `a free gift´ are pleonastic expressions'
+  - the phrase `a beginner who has just started´ is tautological
   - source: J.B.Conant
     text: at the risk of being redundant I return to my original proposition
   ili: i3071
@@ -38798,8 +38798,8 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`and'' in `John and Mary'' or in `John walked and Mary rode'' is a coordinating
-    conjunction; and so is `or'' in `will you go or stay?'''
+  - '`and´ in `John and Mary´ or in `John walked and Mary rode´ is a coordinating
+    conjunction; and so is `or´ in `will you go or stay?´'
   ili: i3083
   members:
   - coordinating
@@ -38811,7 +38811,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`when'' in `I will come when I can'' is a subordinating conjunction'
+  - '`when´ in `I will come when I can´ is a subordinating conjunction'
   ili: i3084
   members:
   - subordinating
@@ -38819,7 +38819,7 @@
   partOfSpeech: a
 00555061-a:
   definition:
-  - being in agreement or harmony; often followed by `with'
+  - being in agreement or harmony; often followed by `with´
   example:
   - source: Thomas Hardy
     text: a place perfectly accordant with man's nature
@@ -38835,7 +38835,7 @@
   - 00555952-s
 00555360-s:
   definition:
-  - (followed by `to') in agreement with or accordant with
+  - (followed by `to´) in agreement with or accordant with
   example:
   - according to instructions
   ili: i3086
@@ -39560,7 +39560,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`and'' is a copulative conjunction'
+  - '`and´ is a copulative conjunction'
   ili: i3146
   members:
   - copulative
@@ -39598,7 +39598,7 @@
   definition:
   - expressing antithesis or opposition
   example:
-  - the adversative conjunction `but' in `poor but happy'
+  - the adversative conjunction `but´ in `poor but happy´
   ili: i3149
   members:
   - adversative
@@ -39624,7 +39624,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - disjunctive conjunctions like `but', `or', or `though' serve a contrastive function
+  - disjunctive conjunctions like `but´, `or´, or `though´ serve a contrastive function
   ili: i3151
   members:
   - contrastive
@@ -40430,7 +40430,7 @@
   also:
   - 02515761-a
   definition:
-  - (sometimes followed by `with') in agreement or consistent or reliable
+  - (sometimes followed by `with´) in agreement or consistent or reliable
   example:
   - testimony consistent with the known facts
   - source: FDR
@@ -40465,7 +40465,7 @@
   - 00579031-a
 00579756-s:
   definition:
-  - (followed by `to') in conformance to or agreement with
+  - (followed by `to´) in conformance to or agreement with
   example:
   - pursuant to our agreement
   - pursuant to the dictates of one's conscience
@@ -41680,7 +41680,7 @@
   definition:
   - having no interruptions
   example:
-  - '`continual'' is often used interchangeably with `continuous'''
+  - '`continual´ is often used interchangeably with `continuous´'
   ili: i3306
   members:
   - continual
@@ -44143,7 +44143,7 @@
   - source: Shakespeare
     text: what seemed corporal melted as breath into the wind
   - an incarnate spirit
-  - '`corporate'' is an archaic term'
+  - '`corporate´ is an archaic term'
   ili: i3508
   members:
   - bodied
@@ -44794,7 +44794,7 @@
   - without care or thought for others
   example:
   - the thoughtless saying of a great princess on being informed that the people had
-    no bread; `Let them eat cake'
+    no bread; `Let them eat cake´
   ili: i3558
   members:
   - thoughtless
@@ -45272,7 +45272,7 @@
   - 00650003-s
 00649713-s:
   definition:
-  - (a common but incorrect usage where `credulous' would be appropriate) credulous
+  - (a common but incorrect usage where `credulous´ would be appropriate) credulous
   example:
   - she was not the … credible fool he expected
   ili: i3594
@@ -47665,7 +47665,7 @@
   - 00682414-a
 00683423-s:
   definition:
-  - out of working order (`busted' is an informal substitute for `broken')
+  - out of working order (`busted´ is an informal substitute for `broken´)
   example:
   - a broken washing machine
   - the coke machine is broken
@@ -47716,7 +47716,7 @@
   - 00682414-a
 00684067-s:
   definition:
-  - (often followed by `with') damaged throughout by numerous perforations or holes
+  - (often followed by `with´) damaged throughout by numerous perforations or holes
   example:
   - a sweater riddled with moth holes
   - cliffs riddled with caves
@@ -48997,7 +48997,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - '`boys'' and `swam'' are inflected English words'
+  - '`boys´ and `swam´ are inflected English words'
   - German is an inflected language
   ili: i3892
   members:
@@ -49009,7 +49009,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - '`boy'' and `swim'' are uninflected English words'
+  - '`boy´ and `swim´ are uninflected English words'
   ili: i3893
   members:
   - uninflected
@@ -49570,7 +49570,7 @@
   example:
   - brittle bones
   - glass is brittle
-  - '`brickle'' and `brickly'' are dialectal'
+  - '`brickle´ and `brickly´ are dialectal'
   ili: i3933
   members:
   - brittle
@@ -49908,7 +49908,7 @@
   - compelling immediate action
   example:
   - too pressing to permit of longer delay
-  - the urgent words `Hurry! Hurry!'
+  - the urgent words `Hurry! Hurry!´
   - bridges in urgent need of repair
   ili: i3958
   members:
@@ -50856,7 +50856,7 @@
   - 00731008-a
 00732270-s:
   definition:
-  - '(of a binary operation) independent of order; as in e.g.: `a x b'' = `b x a'''
+  - '(of a binary operation) independent of order; as in e.g.: `a x b´ = `b x a´'
   domain_topic:
   - 06009822-n
   ili: i4031
@@ -51217,7 +51217,7 @@
   - more desirable than another
   example:
   - coffee is preferable to tea
-  - Danny's preferred name is `Dan'
+  - Danny's preferred name is `Dan´
   ili: i4063
   members:
   - preferable
@@ -55097,7 +55097,7 @@
   - 00794782-a
 00796324-s:
   definition:
-  - (sometimes followed by `to') not subject to or influenced by
+  - (sometimes followed by `to´) not subject to or influenced by
   example:
   - overcome by a superior opponent
   - trust magnates who felt themselves superior to law
@@ -55521,7 +55521,7 @@
   - 00800854-a
 00802700-s:
   definition:
-  - British informal for `intoxicated'
+  - British informal for `intoxicated´
   ili: i4397
   members:
   - half-seas-over
@@ -56006,7 +56006,7 @@
   - 90010621-s
 00808685-s:
   definition:
-  - (often followed by `with') full of life and spirit
+  - (often followed by `with´) full of life and spirit
   example:
   - she was wonderfully alive for her age
   - a face alive with mischief
@@ -56447,7 +56447,7 @@
   - 00814485-a
 00815105-s:
   definition:
-  - (usually followed by `to') full of eagerness
+  - (usually followed by `to´) full of eagerness
   example:
   - impatient to begin
   - raring to go
@@ -56669,7 +56669,7 @@
   - 00816521-a
 00818180-s:
   definition:
-  - (comparative and superlative of `early') more early than; most early
+  - (comparative and superlative of `early´) more early than; most early
   example:
   - a fashion popular in earlier times
   - his earlier work reflects the influence of his teacher
@@ -56737,7 +56737,7 @@
   definition:
   - indicating the first or earliest or original
   example:
-  - '`proto'' is a combining form in a word like `protolanguage'' that refers to the
+  - '`proto´ is a combining form in a word like `protolanguage´ that refers to the
     hypothetical ancestor of another language or group of languages'
   exemplifies:
   - 06318142-n
@@ -57879,7 +57879,7 @@
   - being in effect or operation
   example:
   - source: Leslie Marmon Silko
-    text: de facto apartheid is still operational even in the `new' African nations
+    text: de facto apartheid is still operational even in the `new´ African nations
   - bus service is in operation during the emergency
   - the company had several operating divisions
   ili: i4578
@@ -60448,7 +60448,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - when `three blind mice' serves as a noun it is an endocentric construction
+  - when `three blind mice´ serves as a noun it is an endocentric construction
   ili: i4777
   members:
   - endocentric
@@ -60459,7 +60459,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - when `until last Easter' serves as an adverb it is an exocentric construction
+  - when `until last Easter´ serves as an adverb it is an exocentric construction
   ili: i4778
   members:
   - exocentric
@@ -61594,7 +61594,7 @@
   - 00891011-a
 00891492-s:
   definition:
-  - (usually followed by `for') extremely desirous
+  - (usually followed by `for´) extremely desirous
   example:
   - athirst for knowledge
   - hungry for recognition
@@ -61609,7 +61609,7 @@
   - 00891011-a
 00891770-s:
   definition:
-  - (often followed by `for') ardently or excessively desirous
+  - (often followed by `for´) ardently or excessively desirous
   example:
   - avid for adventure
   - an avid ambition to succeed
@@ -62811,7 +62811,7 @@
   definition:
   - expressing disapproval
   example:
-  - dyslogistic terms like `nitwit' and `scalawag'
+  - dyslogistic terms like `nitwit´ and `scalawag´
   ili: i4966
   members:
   - dyslogistic
@@ -62900,7 +62900,7 @@
   definition:
   - of or the nature of euphemism
   example:
-  - '`peepee'' is a common euphemistic term'
+  - '`peepee´ is a common euphemistic term'
   ili: i4973
   members:
   - euphemistic
@@ -62909,7 +62909,7 @@
   definition:
   - of or the nature of dysphemism
   example:
-  - '`kick the bucket'' is a dysphemistic term for `die'''
+  - '`kick the bucket´ is a dysphemistic term for `die´'
   ili: i4974
   members:
   - dysphemistic
@@ -67198,7 +67198,7 @@
   domain_topic:
   - 06376048-n
   example:
-  - gothic novels like `Frankenstein'
+  - gothic novels like `Frankenstein´
   ili: i5305
   members:
   - gothic
@@ -68567,7 +68567,7 @@
   - 00989218-a
 00991265-s:
   definition:
-  - euphemisms for `fat'
+  - euphemisms for `fat´
   example:
   - men are portly and women are stout
   ili: i5409
@@ -70441,7 +70441,7 @@
   - being the last or concluding element of a series
   example:
   - the ultimate sonata of that opus
-  - a distinction between the verb and noun senses of `conflict' is that in the verb
+  - a distinction between the verb and noun senses of `conflict´ is that in the verb
     the stress is on the ultimate (or last) syllable
   ili: i5548
   members:
@@ -73449,7 +73449,7 @@
   - 01058772-a
 01060596-s:
   definition:
-  - (used with `of' or `with') noticeably odorous
+  - (used with `of´ or `with´) noticeably odorous
   example:
   - the hall was redolent of floor wax
   - air redolent with the fumes of beer and whiskey
@@ -74521,7 +74521,7 @@
   - touched by rot or decay
   example:
   - tainted bacon
-  - '`corrupt'' is archaic'
+  - '`corrupt´ is archaic'
   ili: i5871
   members:
   - corrupt
@@ -75569,7 +75569,7 @@
   - 01086845-a
 01088332-s:
   definition:
-  - (usually followed by `with' or used as a combining form) generously supplied with
+  - (usually followed by `with´ or used as a combining form) generously supplied with
   example:
   - theirs was a house filled with laughter
   - a large hall filled with rows of desks
@@ -75632,7 +75632,7 @@
   - 01086845-a
 01089130-s:
   definition:
-  - (followed by `with') deeply filled or permeated
+  - (followed by `with´) deeply filled or permeated
   example:
   - imbued with the spirit of the Reformation
   - words instinct with love
@@ -75651,7 +75651,7 @@
   example:
   - a tray loaded with dishes
   - table laden with food
-  - '`ladened'' is not current usage'
+  - '`ladened´ is not current usage'
   ili: i5960
   members:
   - laden
@@ -76937,7 +76937,7 @@
   attribute:
   - 04771667-n
   definition:
-  - (sometimes followed by `to') applying to or characterized by or distinguishing
+  - (sometimes followed by `to´) applying to or characterized by or distinguishing
     something particular or special or unique
   example:
   - rules with specific application
@@ -77047,7 +77047,7 @@
   - 01106714-a
 01108735-s:
   definition:
-  - (followed by `to') applying exclusively to a given category or condition or locality
+  - (followed by `to´) applying exclusively to a given category or condition or locality
   example:
   - a species unique to Australia
   ili: i6075
@@ -77301,7 +77301,7 @@
   domain_topic:
   - 03252323-n
   example:
-  - '`Acetaminophen'' is the generic form of the proprietary drug `Tylenol'''
+  - '`Acetaminophen´ is the generic form of the proprietary drug `Tylenol´'
   ili: i6095
   members:
   - generic
@@ -77324,7 +77324,7 @@
   - protected by trademark or patent or copyright; made or produced or distributed
     by one having exclusive rights
   example:
-  - '`Tylenol'' is a proprietary drug of which `acetaminophen'' is the generic form'
+  - '`Tylenol´ is a proprietary drug of which `acetaminophen´ is the generic form'
   ili: i6097
   members:
   - proprietary
@@ -80544,8 +80544,8 @@
   - 01160257-s
 01160257-s:
   definition:
-  - produced with the back of the tongue touching or near the soft palate (as `k'
-    in `cat' and `g' in `gun' and `ng' in `sing')
+  - produced with the back of the tongue touching or near the soft palate (as `k´
+    in `cat´ and `g´ in `gun´ and `ng´ in `sing´)
   ili: i6329
   members:
   - velar
@@ -80555,7 +80555,7 @@
 01160432-a:
   definition:
   - (of speech sounds); produced with the back of the tongue raised toward the hard
-    palate; characterized by a hissing or hushing sound (as `s' and `sh')
+    palate; characterized by a hissing or hushing sound (as `s´ and `sh´)
   ili: i6330
   members:
   - soft
@@ -80565,8 +80565,8 @@
   - 01161001-s
 01160686-s:
   definition:
-  - of speech sounds produced by forcing air through a constricted passage (as `f',
-    `s', `z', or `th' in both `thin' and `then')
+  - of speech sounds produced by forcing air through a constricted passage (as `f´,
+    `s´, `z´, or `th´ in both `thin´ and `then´)
   ili: i6331
   members:
   - fricative
@@ -80579,9 +80579,9 @@
   - 01160432-a
 01161001-s:
   definition:
-  - produced with the front of the tongue near or touching the hard palate (as `y')
-    or with the blade of the tongue near the hard palate (as `ch' in `chin' or `j'
-    in `gin')
+  - produced with the front of the tongue near or touching the hard palate (as `y´)
+    or with the blade of the tongue near the hard palate (as `ch´ in `chin´ or `j´
+    in `gin´)
   ili: i6332
   members:
   - palatal
@@ -80882,7 +80882,7 @@
   - 01163575-a
 01165528-s:
   definition:
-  - (sometimes followed by `to') causing harm or injury
+  - (sometimes followed by `to´) causing harm or injury
   example:
   - damaging to career and reputation
   - the reporter's coverage resulted in prejudicial publicity for the defendant
@@ -83097,7 +83097,7 @@
   - 01197871-s
 01197642-s:
   definition:
-  - (usually followed by `of') without due thought or consideration
+  - (usually followed by `of´) without due thought or consideration
   example:
   - careless of the consequences
   - crushing the blooms with regardless tread
@@ -83110,7 +83110,7 @@
   - 01197257-a
 01197871-s:
   definition:
-  - (usually followed by `to') unwilling or refusing to pay heed
+  - (usually followed by `to´) unwilling or refusing to pay heed
   example:
   - deaf to her warnings
   ili: i6530
@@ -83735,7 +83735,7 @@
   - 05144430-n
   definition:
   - (literal meaning) being at or having a relatively great or specific elevation
-    or upward extension (sometimes used in combinations like `knee-high')
+    or upward extension (sometimes used in combinations like `knee-high´)
   example:
   - a high mountain
   - high ceilings
@@ -86899,7 +86899,7 @@
   - 01250274-a
 01252393-s:
   definition:
-  - made warm or hot (`het' is a dialectal variant of `heated')
+  - made warm or hot (`het´ is a dialectal variant of `heated´)
   example:
   - a heated swimming pool
   - wiped his heated-up face with a large bandana
@@ -89025,7 +89025,7 @@
   - 01283088-a
 01283686-s:
   definition:
-  - (often followed by `to') lacking importance; not mattering one way or the other
+  - (often followed by `to´) lacking importance; not mattering one way or the other
   example:
   - whether you choose to do it or not is a matter that is quite immaterial (or indifferent)
   - what others think is altogether indifferent to him
@@ -89737,7 +89737,7 @@
   also:
   - 02575716-a
   definition:
-  - (often followed by `to') having a preference, disposition, or tendency
+  - (often followed by `to´) having a preference, disposition, or tendency
   example:
   - wasn't inclined to believe the excuse
   - inclined to be moody
@@ -89752,7 +89752,7 @@
   - 01296172-s
 01295534-s:
   definition:
-  - (usually followed by `to') naturally disposed toward
+  - (usually followed by `to´) naturally disposed toward
   example:
   - he is apt to ignore matters he considers unimportant
   - I am not minded to answer any questions
@@ -89768,7 +89768,7 @@
   - 01295251-a
 01295806-s:
   definition:
-  - (followed by `of' or `to') having a strong preference or liking for
+  - (followed by `of´ or `to´) having a strong preference or liking for
   example:
   - fond of chocolate
   - partial to horror movies
@@ -89830,7 +89830,7 @@
   - 01296281-a
 01296665-s:
   definition:
-  - (usually followed by `to') strongly opposed
+  - (usually followed by `to´) strongly opposed
   example:
   - antipathetic to new ideas
   - averse to taking risks
@@ -90091,7 +90091,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`therefore'' is an illative word'
+  - '`therefore´ is an illative word'
   ili: i7070
   members:
   - illative
@@ -90757,7 +90757,7 @@
   - 01309228-a
 01310022-s:
   definition:
-  - (usually followed by `with') well informed about or knowing thoroughly
+  - (usually followed by `with´) well informed about or knowing thoroughly
   example:
   - conversant with business trends
   - familiar with the complex machinery
@@ -90821,7 +90821,7 @@
   - 01309228-a
 01311044-s:
   definition:
-  - (followed by `to') informed about something secret or not generally known
+  - (followed by `to´) informed about something secret or not generally known
   example:
   - privy to the details of the conspiracy
   ili: i7127
@@ -91321,7 +91321,7 @@
   - 01316883-a
 01318293-s:
   definition:
-  - (meaning literally `born') used to indicate the maiden or family name of a married
+  - (meaning literally `born´) used to indicate the maiden or family name of a married
     woman
   example:
   - Hillary Clinton nee Rodham
@@ -93273,7 +93273,7 @@
   example:
   - a dismissive shrug
   - the firm is dismissive of the competitor's product
-  - '`chronic fatigue syndrome'' was known by the dismissive term `housewife syndrome'''
+  - '`chronic fatigue syndrome´ was known by the dismissive term `housewife syndrome´'
   ili: i7322
   members:
   - dismissive
@@ -95500,7 +95500,7 @@
   definition:
   - most familiar or renowned
   example:
-  - Stevenson's best-known work is probably `Treasure Island'
+  - Stevenson's best-known work is probably `Treasure Island´
   ili: i7492
   members:
   - best-known
@@ -95638,7 +95638,7 @@
   - 01379820-a
 01380414-s:
   definition:
-  - (usually used with `to') occurring or existing without the knowledge of
+  - (usually used with `to´) occurring or existing without the knowledge of
   example:
   - a crisis unbeknown to me
   - she had been ill for months, unbeknownst to the family
@@ -98713,7 +98713,7 @@
   definition:
   - beyond the literal or primary sense
   example:
-  - '`hot off the press'' shows an extended sense of `hot'''
+  - '`hot off the press´ shows an extended sense of `hot´'
   ili: i7747
   members:
   - extended
@@ -98737,7 +98737,7 @@
   definition:
   - using the name of one thing for that of another with which it is closely associated
   example:
-  - to say `he spent the evening reading Shakespeare' is metonymic because it substitutes
+  - to say `he spent the evening reading Shakespeare´ is metonymic because it substitutes
     the author himself for the author's works
   ili: i7749
   members:
@@ -98763,7 +98763,7 @@
     special for the general or the general for the special; or the material for the
     thing made of it
   example:
-  - to use `hand' for `worker' or `ten sails' for `ten ships' or `steel' for `sword'
+  - to use `hand´ for `worker´ or `ten sails´ for `ten ships´ or `steel´ for `sword´
     is to use a synecdochic figure of speech
   ili: i7751
   members:
@@ -100498,7 +100498,7 @@
   domain_topic:
   - 06186749-n
   example:
-  - the English vowel sounds in `bate', `beat', `bite', `boat', `boot' are long
+  - the English vowel sounds in `bate´, `beat´, `bite´, `boat´, `boot´ are long
   ili: i7893
   members:
   - long
@@ -100509,7 +100509,7 @@
   domain_topic:
   - 06186749-n
   example:
-  - the English vowel sounds in `pat', `pet', `pit', `pot', `putt' are short
+  - the English vowel sounds in `pat´, `pet´, `pit´, `pot´, `putt´ are short
   ili: i7894
   members:
   - short
@@ -103672,7 +103672,7 @@
   definition:
   - neither male nor female (of grammatical gender)
   example:
-  - '`it'' is the third-person singular neuter pronoun'
+  - '`it´ is the third-person singular neuter pronoun'
   ili: i8150
   members:
   - neuter
@@ -104169,7 +104169,7 @@
   - 01496955-s
 01496571-s:
   definition:
-  - of wines, fruit, cheeses; having reached a desired or final condition; (`aged'
+  - of wines, fruit, cheeses; having reached a desired or final condition; (`aged´
     pronounced as one syllable)
   example:
   - mature well-aged cheeses
@@ -104406,7 +104406,7 @@
   - 01499316-a
 01499887-s:
   definition:
-  - insignificantly small; a matter of form only (`tokenish' is informal)
+  - insignificantly small; a matter of form only (`tokenish´ is informal)
   example:
   - the fee was nominal
   - a token gesture of resistance
@@ -104666,7 +104666,7 @@
   definition:
   - resembling the unthinking functioning of a machine
   example:
-  - an automatic `thank you'
+  - an automatic `thank you´
   - machinelike efficiency
   ili: i8228
   members:
@@ -106618,7 +106618,7 @@
   example:
   - takeout pizza
   - the takeout counter
-  - '`take-away'' is chiefly British'
+  - '`take-away´ is chiefly British'
   ili: i8380
   members:
   - takeout
@@ -107302,7 +107302,7 @@
   definition:
   - (used as a combining form) recent or new
   example:
-  - '`neo'' is a combining form in words like `neocolonialism'''
+  - '`neo´ is a combining form in words like `neocolonialism´'
   exemplifies:
   - 06318142-n
   ili: i8433
@@ -107611,7 +107611,7 @@
   - 01544533-a
 01545039-s:
   definition:
-  - restricted in meaning; (as e.g. `man' in `a tall man')
+  - restricted in meaning; (as e.g. `man´ in `a tall man´)
   domain_topic:
   - 06184139-n
   ili: i8457
@@ -108357,8 +108357,8 @@
   attribute:
   - 05129173-n
   definition:
-  - a quantifier that can be used with count nouns and is often preceded by `as' or
-    `too' or `so' or `that'; amounting to a large but indefinite number; quantifier,
+  - a quantifier that can be used with count nouns and is often preceded by `as´ or
+    `too´ or `so´ or `that´; amounting to a large but indefinite number; quantifier,
     plural pronoun; quantifier, plural
   example:
   - many temptations
@@ -108447,7 +108447,7 @@
   attribute:
   - 05129173-n
   definition:
-  - a quantifier that can be used with count nouns and is often preceded by `a'; a
+  - a quantifier that can be used with count nouns and is often preceded by `a´; a
     small but indefinite number
   example:
   - a few weeks ago
@@ -108548,7 +108548,7 @@
   - 01559809-a
   definition:
   - (quantifier used with mass nouns) small in quantity or degree; not much or almost
-    none or (with `a') at least some
+    none or (with `a´) at least some
   example:
   - little rain fell in May
   - gave it little thought
@@ -108581,7 +108581,7 @@
   also:
   - 01557986-a
   definition:
-  - (comparative of `much' used with mass nouns) a quantifier meaning greater in size
+  - (comparative of `much´ used with mass nouns) a quantifier meaning greater in size
     or amount or extent or degree; above; more than
   example:
   - more land
@@ -108599,7 +108599,7 @@
   also:
   - 01558903-a
   definition:
-  - (comparative of `little' usually used with mass nouns) a quantifier meaning not
+  - (comparative of `little´ usually used with mass nouns) a quantifier meaning not
     as great in amount or degree
   example:
   - of less importance
@@ -108614,8 +108614,8 @@
   partOfSpeech: a
 01560125-a:
   definition:
-  - the superlative of `much' that can be used with mass nouns and is usually preceded
-    by `the'; a quantifier meaning the greatest in amount or extent or degree
+  - the superlative of `much´ that can be used with mass nouns and is usually preceded
+    by `the´; a quantifier meaning the greatest in amount or extent or degree
   example:
   - made the most money he could
   - what attracts the most attention?
@@ -108628,8 +108628,8 @@
   partOfSpeech: a
 01560454-a:
   definition:
-  - the superlative of `little' that can be used with mass nouns and is usually preceded
-    by `the'; a quantifier meaning smallest in amount or extent or degree
+  - the superlative of `little´ that can be used with mass nouns and is usually preceded
+    by `the´; a quantifier meaning smallest in amount or extent or degree
   example:
   - didn't care the least bit
   - he has the least talent of anyone
@@ -108644,7 +108644,7 @@
   - 01555990-a
   - 01559526-a
   definition:
-  - (comparative of `many' used with count nouns) quantifier meaning greater in number
+  - (comparative of `many´ used with count nouns) quantifier meaning greater in number
   example:
   - a hall with more seats
   - we have no more bananas
@@ -108660,7 +108660,7 @@
   - 01557242-a
   - 01559809-a
   definition:
-  - (comparative of `few' used with count nouns) quantifier meaning a smaller number
+  - (comparative of `few´ used with count nouns) quantifier meaning a smaller number
     of
   example:
   - fewer birds came this year
@@ -108689,7 +108689,7 @@
   - 01561009-a
 01561513-a:
   definition:
-  - (superlative of `many' used with count nouns and often preceded by `the') quantifier
+  - (superlative of `many´ used with count nouns and often preceded by `the´) quantifier
     meaning the greatest in number
   example:
   - who has the most apples?
@@ -108703,7 +108703,7 @@
   partOfSpeech: a
 01561779-a:
   definition:
-  - (superlative of `few' used with count nouns and usually preceded by `the') quantifier
+  - (superlative of `few´ used with count nouns and usually preceded by `the´) quantifier
     meaning the smallest in number
   example:
   - the fewest birds in recent memory
@@ -109324,7 +109324,7 @@
   definition:
   - used of a series of photographs presented so as to create the illusion of motion
   example:
-  - Her ambition was to be in moving pictures or `the movies'
+  - Her ambition was to be in moving pictures or `the movies´
   ili: i8593
   members:
   - moving
@@ -111081,7 +111081,7 @@
   - 01598062-s
 01597282-s:
   definition:
-  - of low birth or station (`base' is archaic in this sense)
+  - of low birth or station (`base´ is archaic in this sense)
   example:
   - baseborn wretches with dirty faces
   - of humble (or lowly) birth
@@ -112153,7 +112153,7 @@
   - disregarded
   example:
   - his cries were unheeded
-  - Shaw's neglected one-act comedy, `A Village Wooing'
+  - Shaw's neglected one-act comedy, `A Village Wooing´
   - her ignored advice
   ili: i8805
   members:
@@ -113124,7 +113124,7 @@
 01627541-s:
   definition:
   - (of facilities such as telephones or lavatories) unavailable for use by anyone
-    else or indicating unavailability; (`engaged' is a British term for a busy telephone
+    else or indicating unavailability; (`engaged´ is a British term for a busy telephone
     line)
   example:
   - her line is busy
@@ -114618,7 +114618,7 @@
   - 01651236-s
 01648667-s:
   definition:
-  - advanced in years; (`aged' is pronounced as two syllables)
+  - advanced in years; (`aged´ is pronounced as two syllables)
   example:
   - aged members of the society
   - elderly residents could remember the construction of the first skyscraper
@@ -114634,7 +114634,7 @@
   - 01648062-a
 01648983-s:
   definition:
-  - having attained a specific age; (`aged' is pronounced as one syllable)
+  - having attained a specific age; (`aged´ is pronounced as one syllable)
   example:
   - aged ten
   - ten years of age
@@ -114713,7 +114713,7 @@
 01649932-s:
   definition:
   - honorably retired from assigned duties and retaining your title along with the
-    additional title `emeritus' as in `professor emeritus'
+    additional title `emeritus´ as in `professor emeritus´
   ili: i9008
   members:
   - emeritus
@@ -117340,7 +117340,7 @@
 01687482-s:
   definition:
   - headed or intending to head in a certain direction; often used as a combining
-    form as in `college-bound students'
+    form as in `college-bound students´
   example:
   - children bound for school
   - a flight destined for New York
@@ -117706,7 +117706,7 @@
   - a stock answer
   - repeating threadbare jokes
   - parroting some timeworn axiom
-  - the trite metaphor `hard as nails'
+  - the trite metaphor `hard as nails´
   ili: i9245
   members:
   - banal
@@ -118658,7 +118658,7 @@
   domain_topic:
   - 06076105-n
   example:
-  - '`foliate'' is combined with the prefix `tri'' to form the word `trifoliate'''
+  - '`foliate´ is combined with the prefix `tri´ to form the word `trifoliate´'
   ili: i9320
   members:
   - foliate
@@ -118672,7 +118672,7 @@
   domain_topic:
   - 06076105-n
   example:
-  - '`foliolate'' is combined with the prefix `bi'' to form the word `bifoliolate'''
+  - '`foliolate´ is combined with the prefix `bi´ to form the word `bifoliolate´'
   ili: i9321
   members:
   - foliolate
@@ -119844,7 +119844,7 @@
   definition:
   - not paintable especially not suitable for artistic representation on canvas
   example:
-  - the inexpressible, unpaintable `tick' in the unconscious
+  - the inexpressible, unpaintable `tick´ in the unconscious
   ili: i9415
   members:
   - unpaintable
@@ -120697,7 +120697,7 @@
   - gone by; or in the past
   example:
   - two years ago
-  - '`agone'' is an archaic word for `ago'''
+  - '`agone´ is an archaic word for `ago´'
   ili: i9484
   members:
   - ago
@@ -123530,7 +123530,7 @@
   - for your own use
   - do your own thing
   - she makes her own clothes
-  - '`ain'' is Scottish'
+  - '`ain´ is Scottish'
   ili: i9704
   members:
   - own
@@ -128695,7 +128695,7 @@
   definition:
   - farther along in physical or mental development
   example:
-  - the child's skeletal age was classified as `advanced'
+  - the child's skeletal age was classified as `advanced´
   - children in the advanced classes in elementary school read far above grade average
   ili: i10109
   members:
@@ -129055,7 +129055,7 @@
   - 01849304-a
 01850926-s:
   definition:
-  - (usually followed by `on' or `for') in readiness
+  - (usually followed by `on´ or `for´) in readiness
   example:
   - he was up on his homework
   - had to be up for the game
@@ -129861,7 +129861,7 @@
   - 01861659-a
 01862869-a:
   definition:
-  - (sometimes followed by `to') minor or casual or subordinate in significance or
+  - (sometimes followed by `to´) minor or casual or subordinate in significance or
     nature or occurring as a chance concomitant or consequence
   example:
   - incidental expenses
@@ -133394,7 +133394,7 @@
   - 01914420-a
 01915458-s:
   definition:
-  - (of color) discolored by impurities; not bright and clear; `dirty' is often used
+  - (of color) discolored by impurities; not bright and clear; `dirty´ is often used
     in combination
   example:
   - a dirty (or dingy) white
@@ -133628,7 +133628,7 @@
   - (of pets) trained to urinate and defecate outside or in a special place
   example:
   - housebroken pets
-  - '`house-trained'' is chiefly British'
+  - '`house-trained´ is chiefly British'
   ili: i10486
   members:
   - housebroken
@@ -134047,7 +134047,7 @@
   definition:
   - as claimed by and for yourself often without justification
   example:
-  - the self-styled `doctor' has no degree of any kind
+  - the self-styled `doctor´ has no degree of any kind
   ili: i10518
   members:
   - self-styled
@@ -134319,7 +134319,7 @@
   - 01926330-a
 01928267-s:
   definition:
-  - resembling a sustained `sh' or soft whistle
+  - resembling a sustained `sh´ or soft whistle
   example:
   - swishing windshield wipers
   - a swishy skirt
@@ -134952,7 +134952,7 @@
   - 01936911-a
 01937602-s:
   definition:
-  - (usually followed by `to' or `for') on the point of or strongly disposed
+  - (usually followed by `to´ or `for´) on the point of or strongly disposed
   example:
   - in no fit state to continue
   - fit to drop
@@ -136757,7 +136757,7 @@
   definition:
   - listed or recorded officially
   example:
-  - record is made of `registered mail' at each point on its route to assure safe
+  - record is made of `registered mail´ at each point on its route to assure safe
     delivery
   - registered bonds
   ili: i10721
@@ -137034,7 +137034,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`sing'' is a strong verb'
+  - '`sing´ is a strong verb'
   ili: i10742
   members:
   - strong
@@ -139348,7 +139348,7 @@
   - derisive laughter
   - a jeering crowd
   - her mocking smile
-  - taunting shouts of `coward' and `sissy'
+  - taunting shouts of `coward´ and `sissy´
   ili: i10928
   members:
   - derisive
@@ -139957,7 +139957,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - the restrictive clause in `Each made a list of the books that had influenced him'
+  - the restrictive clause in `Each made a list of the books that had influenced him´
     limits the books on the list to only those particular ones defined by the clause
   ili: i10974
   members:
@@ -140026,7 +140026,7 @@
   - 06184139-n
   example:
   - the nonrestrictive clause in `I always buy his books, which have influenced me
-    greatly,' refers to his books generally and adds an additional fact about them
+    greatly,´ refers to his books generally and adds an additional fact about them
   ili: i10980
   members:
   - nonrestrictive
@@ -140603,7 +140603,7 @@
   - brought back
   example:
   - the Victorian era redux
-  - '`Rabbit Redux'' by John Updike'
+  - '`Rabbit Redux´ by John Updike'
   ili: i11028
   members:
   - redux
@@ -141303,7 +141303,7 @@
   definition:
   - lacking funds
   example:
-  - '`skint'' is a British slang term'
+  - '`skint´ is a British slang term'
   ili: i11084
   members:
   - broke
@@ -142337,7 +142337,7 @@
   - had a tall burly frame
   - clothing sizes for husky boys
   - a strapping boy of eighteen
-  - '`buirdly'' is a Scottish term'
+  - '`buirdly´ is a Scottish term'
   ili: i11165
   members:
   - beefy
@@ -144222,7 +144222,7 @@
   domain_topic:
   - 07111327-n
   example:
-  - note the assonant words and syllables in `tilting at windmills'
+  - note the assonant words and syllables in `tilting at windmills´
   ili: i11317
   members:
   - assonant
@@ -144440,10 +144440,10 @@
   - 02072149-a
 02074467-s:
   definition:
-  - (often followed by `from') not alike; different in nature or quality
+  - (often followed by `from´) not alike; different in nature or quality
   example:
   - plants of several distinct types
-  - the word `nationalism' is used in at least two distinct senses
+  - the word `nationalism´ is used in at least two distinct senses
   - gold is distinct from iron
   - a tree related to but quite distinct from the European beech
   - management had interests quite distinct from those of their employees
@@ -146085,7 +146085,7 @@
   - 02098722-s
 02098448-s:
   definition:
-  - (usually followed by `of') pointing out or revealing clearly
+  - (usually followed by `of´) pointing out or revealing clearly
   example:
   - actions indicative of fear
   ili: i11461
@@ -147123,7 +147123,7 @@
   - 02113931-s
 02113646-s:
   definition:
-  - (followed by `to' or `of') aware of
+  - (followed by `to´ or `of´) aware of
   example:
   - is alive to the moods of others
   ili: i11542
@@ -147192,7 +147192,7 @@
   - 02114041-a
 02114666-s:
   definition:
-  - (followed by `to') not showing human feeling or sensitivity; unresponsive
+  - (followed by `to´) not showing human feeling or sensitivity; unresponsive
   example:
   - passersby were dead to our plea for help
   - numb to the cries for mercy
@@ -152223,8 +152223,8 @@
   definition:
   - having only one part or element
   example:
-  - a simplex word has no affixes and is not part of a compound — like `boy' compared
-    with `boyish' or `house' compared with `houseboat'
+  - a simplex word has no affixes and is not part of a compound — like `boy´ compared
+    with `boyish´ or `house´ compared with `houseboat´
   ili: i11963
   members:
   - simplex
@@ -152403,7 +152403,7 @@
   - 02183738-a
 02185861-s:
   definition:
-  - extremely intricate; usually in phrase `Gordian knot'
+  - extremely intricate; usually in phrase `Gordian knot´
   ili: i11975
   members:
   - Gordian
@@ -152930,7 +152930,7 @@
   definition:
   - used of a single unit or thing; not two or more
   example:
-  - '`ane'' is Scottish'
+  - '`ane´ is Scottish'
   ili: i12006
   members:
   - one
@@ -159454,8 +159454,8 @@
   - 02276900-s
 02276640-s:
   definition:
-  - (used with singular count nouns) colloquial for `not a' or `not one' or `never
-    a'
+  - (used with singular count nouns) colloquial for `not a´ or `not one´ or `never
+    a´
   example:
   - heard nary a sound
   ili: i12558
@@ -159585,7 +159585,7 @@
   definition:
   - very sophisticated especially because of surfeit; versed in the ways of the world
   example:
-  - the blase traveler refers to the ocean he has crossed as `the pond'
+  - the blase traveler refers to the ocean he has crossed as `the pond´
   - the benefits of his worldly wisdom
   ili: i12567
   members:
@@ -160692,7 +160692,7 @@
   definition:
   - produced with vibration of the vocal cords
   example:
-  - voiced consonants such as `b' and `g' and `z'
+  - voiced consonants such as `b´ and `g´ and `z´
   ili: i12653
   members:
   - voiced
@@ -160703,7 +160703,7 @@
   definition:
   - produced without vibration of the vocal cords
   example:
-  - unvoiced consonants such as `p' and `k' and `s'
+  - unvoiced consonants such as `p´ and `k´ and `s´
   ili: i12654
   members:
   - unvoiced
@@ -160790,7 +160790,7 @@
   definition:
   - having characteristics of a vowel sound
   example:
-  - the vowellike nature of `r'
+  - the vowellike nature of `r´
   ili: i12661
   members:
   - vowellike
@@ -160855,7 +160855,7 @@
   definition:
   - (of speech sounds) forming the nucleus of a syllable
   example:
-  - the syllabic `nl' in `riddle'
+  - the syllabic `nl´ in `riddle´
   ili: i12667
   members:
   - syllabic
@@ -160864,7 +160864,7 @@
   definition:
   - (of speech sounds) not forming or capable of forming the nucleus of a syllable
   example:
-  - initial `l' in `little' is nonsyllabic
+  - initial `l´ in `little´ is nonsyllabic
   ili: i12668
   members:
   - nonsyllabic
@@ -160954,8 +160954,8 @@
     sound dominated by other vowel sounds in a syllable (as the second vowel in a
     falling diphthong)
   example:
-  - the nonsyllabic `n' in `botany' when it is pronounced `botny'
-  - the nonsyllabic `i' in `oi'
+  - the nonsyllabic `n´ in `botany´ when it is pronounced `botny´
+  - the nonsyllabic `i´ in `oi´
   ili: i12677
   members:
   - nonsyllabic
@@ -161551,8 +161551,8 @@
   domain_topic:
   - 06182505-n
   example:
-  - 'the following use of `access'' was judged unacceptable by a panel of linguists:
-    `You can access your cash at any of 300 automatic tellers'''
+  - 'the following use of `access´ was judged unacceptable by a panel of linguists:
+    `You can access your cash at any of 300 automatic tellers´'
   ili: i12724
   members:
   - unacceptable
@@ -163116,7 +163116,7 @@
   - bearing a stress or accent
   example:
   - an iambic foot consists of an unstressed syllable followed by a stressed syllable
-    as in `delay'
+    as in `delay´
   ili: i12848
   members:
   - stressed
@@ -163145,7 +163145,7 @@
   - 07034009-n
   example:
   - a masculine cadence
-  - the masculine rhyme of `annoy, enjoy'
+  - the masculine rhyme of `annoy, enjoy´
   ili: i12850
   members:
   - masculine
@@ -164917,7 +164917,7 @@
   - considered of the highest quality and lasting significance or worth
   example:
   - a classic car
-  - '`War and Peace'' is a classic novel'
+  - '`War and Peace´ is a classic novel'
   members:
   - classic
   partOfSpeech: s
@@ -165192,7 +165192,7 @@
   - 02353767-a
 02355910-s:
   definition:
-  - (usually preceded by `no') lower in quality
+  - (usually preceded by `no´) lower in quality
   example:
   - no less than perfect
   ili: i13000
@@ -166101,7 +166101,7 @@
   attribute:
   - 14553663-n
   definition:
-  - (often followed by `of' or `to') yielding readily to or capable of
+  - (often followed by `of´ or `to´) yielding readily to or capable of
   example:
   - susceptible to colds
   - susceptible of proof
@@ -166197,7 +166197,7 @@
   - 02369003-a
 02370732-s:
   definition:
-  - (often followed by `to') likely to be affected with
+  - (often followed by `to´) likely to be affected with
   example:
   - liable to diabetes
   ili: i13079
@@ -166325,7 +166325,7 @@
   - 02371926-a
 02372634-s:
   definition:
-  - not being susceptible to or admitting of something (usually followed by `of')
+  - not being susceptible to or admitting of something (usually followed by `of´)
   example:
   - incapable of solution
   ili: i13090
@@ -166980,7 +166980,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - the arguments of the symmetric relation, `is a sister of,' are interchangeable
+  - the arguments of the symmetric relation, `is a sister of,´ are interchangeable
   ili: i13145
   members:
   - interchangeable
@@ -167065,7 +167065,7 @@
   - 06009822-n
   - 06173467-n
   example:
-  - the arguments of the symmetric relation, `is the father of', are noninterchangeable
+  - the arguments of the symmetric relation, `is the father of´, are noninterchangeable
   ili: i13152
   members:
   - noninterchangeable
@@ -167529,7 +167529,7 @@
   definition:
   - of words or propositions so related that each is the negation of the other
   example:
-  - '`male'' and `female'' are complementary terms'
+  - '`male´ and `female´ are complementary terms'
   ili: i13190
   members:
   - complementary
@@ -167541,7 +167541,7 @@
   - of words or propositions so related that both cannot be true and both cannot be
     false
   example:
-  - '`perfect'' and `imperfect'' are contradictory terms'
+  - '`perfect´ and `imperfect´ are contradictory terms'
   ili: i13191
   members:
   - contradictory
@@ -167552,7 +167552,7 @@
   definition:
   - of words or propositions so related that both cannot be true but both may be false
   example:
-  - '`hot'' and `cold'' are contrary terms'
+  - '`hot´ and `cold´ are contrary terms'
   ili: i13192
   members:
   - contrary
@@ -167563,7 +167563,7 @@
   definition:
   - of words so related that one contrasts with the other
   example:
-  - '`rich'' and `hard-up'' are contrastive terms'
+  - '`rich´ and `hard-up´ are contrastive terms'
   ili: i13193
   members:
   - contrastive
@@ -167575,7 +167575,7 @@
   definition:
   - of words so related that one reverses the relation denoted by the other
   example:
-  - '`parental'' and `filial'' are converse terms'
+  - '`parental´ and `filial´ are converse terms'
   ili: i13194
   members:
   - converse
@@ -169194,7 +169194,7 @@
   - 02412395-a
 02413664-a:
   definition:
-  - pronounced with relatively tense tongue muscles (e.g., the vowel sound in `beat')
+  - pronounced with relatively tense tongue muscles (e.g., the vowel sound in `beat´)
   domain_topic:
   - 06186749-n
   ili: i13313
@@ -169217,7 +169217,7 @@
 02413956-a:
   definition:
   - pronounced with muscles of the tongue and jaw relatively relaxed (e.g., the vowel
-    sound in `bet')
+    sound in `bet´)
   domain_topic:
   - 06186749-n
   ili: i13315
@@ -170239,7 +170239,7 @@
   - deeply or seriously thoughtful
   example:
   - Byron lives on not only in his poetry, but also in his creation of the `Byronic
-    hero' - the persona of a brooding melancholy young man
+    hero´ - the persona of a brooding melancholy young man
   ili: i13393
   members:
   - brooding
@@ -170361,7 +170361,7 @@
   - a sparing father and a spending son
   - sparing in their use of heat and light
   - stinting in bestowing gifts
-  - '`scotch'' is used only informally'
+  - '`scotch´ is used only informally'
   exemplifies:
   - 07089193-n
   ili: i13402
@@ -171175,7 +171175,7 @@
   definition:
   - physically and mentally fatigued
   example:
-  - '`aweary'' is archaic'
+  - '`aweary´ is archaic'
   ili: i13465
   members:
   - aweary
@@ -174546,7 +174546,7 @@
   - 02485330-a
 02487166-s:
   definition:
-  - (usually followed by `with') united in effort as if in a league
+  - (usually followed by `with´) united in effort as if in a league
   example:
   - they found out that some policemen were in league with the criminals
   ili: i13733
@@ -177247,7 +177247,7 @@
   definition:
   - (of an actor or role) being or playing the villain
   example:
-  - Iago is the heavy role in `Othello'
+  - Iago is the heavy role in `Othello´
   ili: i13943
   members:
   - heavy
@@ -177529,7 +177529,7 @@
   definition:
   - giving no light
   example:
-  - lightless stars `visible' only to radio antennae
+  - lightless stars `visible´ only to radio antennae
   ili: i13964
   members:
   - lightless
@@ -178484,7 +178484,7 @@
   definition:
   - providing coolness
   example:
-  - '`caller'' is a Scottish term as in `a caller breeze'''
+  - '`caller´ is a Scottish term as in `a caller breeze´'
   ili: i14035
   members:
   - caller
@@ -178835,7 +178835,7 @@
   definition:
   - increasing or having the power to increase especially in size or amount or degree
   example:
-  - '`up'' is an augmentative word in `hurry up'''
+  - '`up´ is an augmentative word in `hurry up´'
   ili: i14065
   members:
   - augmentative
@@ -181561,7 +181561,7 @@
   - covered with or consisting of bushes or thickets
   example:
   - brushy undergrowth
-  - '`bosky'' is a literary term'
+  - '`bosky´ is a literary term'
   - source: Jack Beatty
     text: a bosky park leading to a modest yet majestic plaza
   ili: i14278
@@ -182954,7 +182954,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '`or'' is a syncategorematic term'
+  - '`or´ is a syncategorematic term'
   ili: i14396
   members:
   - syncategorematic
@@ -183418,7 +183418,7 @@
   partOfSpeech: a
 87988931-s:
   definition:
-  - denoting or characteristic of countries of Asia; `oriental civilization'
+  - denoting or characteristic of countries of Asia; `oriental civilization´
   members:
   - oriental
   partOfSpeech: s

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -3,7 +3,7 @@
   - 05207437-n
   - 05624029-n
   definition:
-  - (usually followed by `to´) having the necessary means or skill or know-how or
+  - (usually followed by ‘to’) having the necessary means or skill or know-how or
     authority to do something
   example:
   - able to swim
@@ -18,7 +18,7 @@
   attribute:
   - 05207437-n
   definition:
-  - (usually followed by `to´) not having the necessary means or skill or know-how
+  - (usually followed by ‘to’) not having the necessary means or skill or know-how
   example:
   - unable to get to town without a car
   - unable to obtain funds
@@ -664,7 +664,7 @@
   definition:
   - existing only in the mind; separated from embodiment
   example:
-  - abstract words like `truth´ and `justice´
+  - abstract words like ‘truth’ and ‘justice’
   ili: i54
   members:
   - abstract
@@ -1550,7 +1550,7 @@
   - 00025245-s
 00025079-s:
   definition:
-  - (often followed by `to´) unfamiliar
+  - (often followed by ‘to’) unfamiliar
   example:
   - new experiences
   - experiences new to him
@@ -2732,8 +2732,8 @@
   - 00041583-a
 00041840-a:
   definition:
-  - (used of verbs (e.g. `to run´) and participial adjectives (e.g. `running´ in `running
-    water´)) expressing action rather than a state of being
+  - (used of verbs (e.g. ‘to run’) and participial adjectives (e.g. ‘running’ in ‘running
+    water’)) expressing action rather than a state of being
   domain_topic:
   - 06184139-n
   ili: i211
@@ -2743,7 +2743,7 @@
   partOfSpeech: a
 00042063-a:
   definition:
-  - (used of verbs (e.g. `be´ or `own´) and most participial adjectives) expressing
+  - (used of verbs (e.g. ‘be’ or ‘own’) and most participial adjectives) expressing
     existence or a state rather than an action
   domain_topic:
   - 06184139-n
@@ -3300,7 +3300,7 @@
   definition:
   - (of mail) marked with a destination
   example:
-  - I throw away all mail addressed to `resident´
+  - I throw away all mail addressed to ‘resident’
   ili: i261
   members:
   - addressed
@@ -4473,7 +4473,7 @@
   - 00068247-s
 00067988-s:
   definition:
-  - (comparative and superlative of `well´) wiser or more advantageous and hence advisable
+  - (comparative and superlative of ‘well’) wiser or more advantageous and hence advisable
   example:
   - it would be better to speak to him
   - the White House thought it best not to respond
@@ -4808,7 +4808,7 @@
   - 00073398-s
 00072889-s:
   definition:
-  - (usually followed by `to´) not affected by a given influence
+  - (usually followed by ‘to’) not affected by a given influence
   example:
   - immune to persuasion
   ili: i379
@@ -4819,7 +4819,7 @@
   - 00072600-a
 00073044-s:
   definition:
-  - (often followed by `to´) above being affected or influenced by
+  - (often followed by ‘to’) above being affected or influenced by
   example:
   - he is superior to fear
   - an ignited firework proceeds superior to circumstances until its blazing vitality
@@ -6505,7 +6505,7 @@
   - 00096133-a
 00097766-s:
   definition:
-  - abbreviation for `dead on arrival´ at the emergency room
+  - abbreviation for ‘dead on arrival’ at the emergency room
   ili: i507
   members:
   - d.o.a.
@@ -6615,7 +6615,7 @@
   - 00096133-a
 00099000-s:
   definition:
-  - killed; `slain´ is formal or literary as in `slain warriors´
+  - killed; ‘slain’ is formal or literary as in ‘slain warriors’
   example:
   - a picture of St. George and the slain dragon
   ili: i517
@@ -7431,7 +7431,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '`all spinsters are unmarried´ is an analytic proposition'
+  - '‘all spinsters are unmarried’ is an analytic proposition'
   ili: i589
   members:
   - analytic
@@ -7447,7 +7447,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '`all men are arrogant´ is a synthetic proposition'
+  - '‘all men are arrogant’ is a synthetic proposition'
   ili: i590
   members:
   - synthetic
@@ -7541,7 +7541,7 @@
   - characterized by inflections indicating a semantic relation between a word and
     its base
   example:
-  - the morphological relation between `sing´ and `singer´ and `song´ is derivational
+  - the morphological relation between ‘sing’ and ‘singer’ and ‘song’ is derivational
   ili: i598
   members:
   - derivational
@@ -8023,7 +8023,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - the word `dog´ is animate
+  - the word ‘dog’ is animate
   ili: i636
   members:
   - animate
@@ -8034,7 +8034,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - the word `car´ is inanimate
+  - the word ‘car’ is inanimate
   ili: i637
   members:
   - inanimate
@@ -11073,7 +11073,7 @@
   attribute:
   - 05089997-n
   definition:
-  - (often followed by `to´) giving care or attention
+  - (often followed by ‘to’) giving care or attention
   example:
   - attentive to details
   - the nurse was attentive to her patient
@@ -11632,7 +11632,7 @@
   - 00172851-a
 00173433-s:
   definition:
-  - (usually followed by `to´) given credit for
+  - (usually followed by ‘to’) given credit for
   example:
   - an invention credited to Edison
   ili: i928
@@ -11643,7 +11643,7 @@
   - 00172851-a
 00173569-s:
   definition:
-  - (usually followed by `to´) able to be traced to
+  - (usually followed by ‘to’) able to be traced to
   example:
   - a failure traceable to lack of energy
   ili: i929
@@ -11668,7 +11668,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`red´ is an attributive adjective in `a red apple´'
+  - '‘red’ is an attributive adjective in ‘a red apple’'
   ili: i931
   members:
   - attributive
@@ -11682,7 +11682,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - an example of the attributive genitive is `John's´ in `John's mother´
+  - an example of the attributive genitive is ‘John's’ in ‘John's mother’
   ili: i932
   members:
   - attributive genitive
@@ -11695,7 +11695,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`red´ is a predicative adjective in `the apple is red´'
+  - '‘red’ is a predicative adjective in ‘the apple is red’'
   ili: i933
   members:
   - predicative
@@ -11811,7 +11811,7 @@
   definition:
   - uttered without voice
   example:
-  - could hardly hear her breathed plea, `Help me´
+  - could hardly hear her breathed plea, ‘Help me’
   - voiceless whispers
   ili: i942
   members:
@@ -11844,7 +11844,7 @@
   definition:
   - not made to sound
   example:
-  - the silent `h´ at the beginning of `honor´
+  - the silent ‘h’ at the beginning of ‘honor’
   - in French certain letters are often unsounded
   ili: i945
   members:
@@ -12846,7 +12846,7 @@
   - inclined to or marked by drowsiness
   example:
   - slumberous (or slumbrous) eyes
-  - '`slumbery´ is archaic'
+  - '‘slumbery’ is archaic'
   - the sound had a somnolent effect
   ili: i1022
   members:
@@ -12907,7 +12907,7 @@
   attribute:
   - 05683749-n
   definition:
-  - (sometimes followed by `of´) having or showing knowledge or understanding or realization
+  - (sometimes followed by ‘of’) having or showing knowledge or understanding or realization
     or perception
   example:
   - was aware of his opponent's hostility
@@ -12942,7 +12942,7 @@
   - 00191603-a
 00192448-s:
   definition:
-  - (followed by `of´) showing realization or recognition of something
+  - (followed by ‘of’) showing realization or recognition of something
   example:
   - few voters seem conscious of the issue's importance
   - conscious of having succeeded
@@ -12978,7 +12978,7 @@
   attribute:
   - 05683749-n
   definition:
-  - (often followed by `of´) not aware
+  - (often followed by ‘of’) not aware
   example:
   - seemed unaware of the scrutiny
   - unaware of the danger they were in
@@ -12996,7 +12996,7 @@
   - 00194124-s
 00193532-s:
   definition:
-  - (followed by `to´ or `of´) lacking conscious awareness of
+  - (followed by ‘to’ or ‘of’) lacking conscious awareness of
   example:
   - oblivious of the mounting pressures for political reform
   - oblivious to the risks she ran
@@ -13018,7 +13018,7 @@
   - 00193091-a
 00193933-s:
   definition:
-  - (followed by `of´) not knowing or perceiving
+  - (followed by ‘of’) not knowing or perceiving
   example:
   - source: Charles Dickens
     text: happily unconscious of the new calamity at home
@@ -13030,7 +13030,7 @@
   - 00193091-a
 00194124-s:
   definition:
-  - (often followed by `of´) not knowing or expecting; not thinking likely
+  - (often followed by ‘of’) not knowing or expecting; not thinking likely
   example:
   - an unsuspecting victim
   - unsuspecting (or unaware) of the fact that I would one day be their leader
@@ -13891,7 +13891,7 @@
   example:
   - they considered themselves a tough outfit and weren't bashful about letting anybody
     know it
-  - '`blate´ is a Scottish term for bashful'
+  - '‘blate’ is a Scottish term for bashful'
   ili: i1100
   members:
   - bashful
@@ -15701,7 +15701,7 @@
   - 02349336-a
   - 02449153-a
   definition:
-  - (superlative of `good´) having the most positive qualities
+  - (superlative of ‘good’) having the most positive qualities
   example:
   - the best film of the year
   - the best solution
@@ -15863,7 +15863,7 @@
   - 01129296-a
   - 02353767-a
   definition:
-  - (superlative of `bad´) most wanting in quality or value or condition
+  - (superlative of ‘bad’) most wanting in quality or value or condition
   example:
   - the worst player on the team
   - the worst weather of the year
@@ -15914,7 +15914,7 @@
   - 00231222-a
 00231927-a:
   definition:
-  - (comparative of `good´) superior to another (of the same class or set or kind)
+  - (comparative of ‘good’) superior to another (of the same class or set or kind)
     in excellence or quality or desirability or suitability; more highly skilled than
     another
   example:
@@ -15948,7 +15948,7 @@
   - 00231927-a
 00232532-s:
   definition:
-  - (comparative of `fine´) greater in quality or excellence
+  - (comparative of ‘fine’) greater in quality or excellence
   example:
   - a finer wine
   - a finer musician
@@ -15974,7 +15974,7 @@
   - 00231927-a
 00232844-a:
   definition:
-  - (comparative of `bad´) inferior to another in quality or condition or desirability
+  - (comparative of ‘bad’) inferior to another in quality or condition or desirability
   example:
   - this road is worse than the first one we took
   - the road is in worse shape than it was
@@ -16001,7 +16001,7 @@
   - 00232844-a
 00233353-a:
   definition:
-  - (comparative of `good´) changed for the better in health or fitness
+  - (comparative of ‘good’) changed for the better in health or fitness
   example:
   - her health is better now
   - I feel better
@@ -17055,7 +17055,7 @@
   - a dark-skinned beauty
   - gold earrings gleamed against her dusky cheeks
   - a smile on his swarthy face
-  - '`swart´ is archaic'
+  - '‘swart’ is archaic'
   exemplifies:
   - 07087487-n
   ili: i1369
@@ -19225,7 +19225,7 @@
   example:
   - the gloomy forest
   - the glooming interior of an old inn
-  - '`gloomful´ is archaic'
+  - '‘gloomful’ is archaic'
   ili: i1541
   members:
   - glooming
@@ -19489,7 +19489,7 @@
   - scintillant mica
   - the scintillating stars
   - a dress with sparkly sequins
-  - '`glistering´ is an archaic term'
+  - '‘glistering’ is an archaic term'
   ili: i1560
   members:
   - aglitter
@@ -21275,7 +21275,7 @@
   - 05209765-n
   - 05630964-n
   definition:
-  - (usually followed by `of´) having capacity or ability
+  - (usually followed by ‘of’) having capacity or ability
   example:
   - capable of winning
   - capable of hard work
@@ -21338,7 +21338,7 @@
   - 05209765-n
   - 05630964-n
   definition:
-  - (followed by `of´) lacking capacity or ability
+  - (followed by ‘of’) lacking capacity or ability
   example:
   - incapable of carrying a tune
   - he is incapable of understanding the matter
@@ -21351,7 +21351,7 @@
   - 00308592-s
 00308592-s:
   definition:
-  - (usually followed by `to´) lacking necessary physical or mental ability
+  - (usually followed by ‘to’) lacking necessary physical or mental ability
   example:
   - dyslexics are unable to learn to read adequately
   - the sun was unable to melt enough snow
@@ -21363,7 +21363,7 @@
   - 00308272-a
 00308813-a:
   definition:
-  - (followed by `of´) having the temperament or inclination for
+  - (followed by ‘of’) having the temperament or inclination for
   example:
   - no one believed her capable of murder
   ili: i1700
@@ -21372,7 +21372,7 @@
   partOfSpeech: a
 00308986-a:
   definition:
-  - (followed by `of´) not having the temperament or inclination for
+  - (followed by ‘of’) not having the temperament or inclination for
   example:
   - simply incapable of lying
   ili: i1701
@@ -21573,7 +21573,7 @@
   - 00309819-a
 00311985-s:
   definition:
-  - (usually followed by `of´) solicitously caring or mindful
+  - (usually followed by ‘of’) solicitously caring or mindful
   example:
   - protective of his reputation
   ili: i1716
@@ -21995,7 +21995,7 @@
   partOfSpeech: a
 00317905-a:
   definition:
-  - made for or formed by carving (`carven´ is archaic or literary)
+  - made for or formed by carving (‘carven’ is archaic or literary)
   domain_topic:
   - 06376048-n
   example:
@@ -23662,7 +23662,7 @@
   - 00342190-s
 00341524-s:
   definition:
-  - (usually followed by `to´) governed by fate
+  - (usually followed by ‘to’) governed by fate
   example:
   - bound to happen
   - an old house destined to be demolished
@@ -23676,7 +23676,7 @@
   - 00341137-a
 00341725-s:
   definition:
-  - (usually followed by `to´) determined by tragic fate
+  - (usually followed by ‘to’) determined by tragic fate
   example:
   - doomed to unhappiness
   - fated to be the scene of Kennedy's assassination
@@ -24170,7 +24170,7 @@
   - 00348093-a
 00348809-s:
   definition:
-  - incapable of being changed or moved or undone; e.g. `frozen prices´
+  - incapable of being changed or moved or undone; e.g. ‘frozen prices’
   example:
   - living on fixed incomes
   ili: i1928
@@ -28722,7 +28722,7 @@
   example:
   - girls decked out in brave new dresses
   - brave banners flying
-  - '`braw´ is a Scottish word'
+  - '‘braw’ is a Scottish word'
   - a dress a bit too gay for her years
   - birds with gay plumage
   ili: i2307
@@ -30808,7 +30808,7 @@
   definition:
   - stupefied or dizzied by something overpowering
   example:
-  - source: '`Chanticler´ by Rostand'
+  - source: '‘Chanticler’ by Rostand'
     text: I fall back dazzled at beholding myself all rosy red, / At having, I myself,
       caused the sun to rise.
   ili: i2463
@@ -31293,7 +31293,7 @@
   - 00444378-a
 00445635-s:
   definition:
-  - (comparatives of `far´) most remote in space or time or order
+  - (comparatives of ‘far’) most remote in space or time or order
   example:
   - had traveled to the farthest frontier
   - don't go beyond the farthermost (or furthermost) tree
@@ -31519,7 +31519,7 @@
   - 00447582-a
 00448792-s:
   definition:
-  - distant but within sight (`yon´ is dialectal)
+  - distant but within sight (‘yon’ is dialectal)
   example:
   - yonder valley
   - the hills yonder
@@ -33181,8 +33181,8 @@
   definition:
   - (of a word) referring singly and without exception to the members of a group
   example:
-  - whereas `each´, `every´, `either´, `neither´, and `none´ are distributive or referring
-    to a single member of a group, `which´ in `which of the men´ is separative
+  - whereas ‘each’, ‘every’, ‘either’, ‘neither’, and ‘none’ are distributive or referring
+    to a single member of a group, ‘which’ in ‘which of the men’ is separative
   ili: i2643
   members:
   - separative
@@ -33353,7 +33353,7 @@
   - 00473832-s
 00473562-s:
   definition:
-  - (followed by `to´) as reported or stated by
+  - (followed by ‘to’) as reported or stated by
   example:
   - according to historians
   ili: i2659
@@ -33690,7 +33690,7 @@
   - 00477739-a
 00477986-a:
   definition:
-  - large and roomy (`convenient´ is archaic in this sense)
+  - large and roomy (‘convenient’ is archaic in this sense)
   example:
   - a commodious harbor
   - a commodious building suitable for conventions
@@ -33743,7 +33743,7 @@
   attribute:
   - 14468845-n
   definition:
-  - providing or experiencing physical well-being or relief (`comfy´ is informal)
+  - providing or experiencing physical well-being or relief (‘comfy’ is informal)
   example:
   - comfortable clothes
   - comfortable suburban houses
@@ -33836,8 +33836,8 @@
   - 00481182-s
 00480301-s:
   definition:
-  - feeling physical discomfort or pain (`tough´ is occasionally used colloquially
-    for `bad´)
+  - feeling physical discomfort or pain (‘tough’ is occasionally used colloquially
+    for ‘bad’)
   example:
   - my throat feels bad
   - she felt bad all over
@@ -34119,7 +34119,7 @@
 00484662-s:
   definition:
   - properly related in size or degree or other measurable characteristics; usually
-    followed by `to´
+    followed by ‘to’
   example:
   - the punishment ought to be proportional to the crime
   - earnings relative to production
@@ -34391,8 +34391,8 @@
   definition:
   - frequently encountered
   example:
-  - a frequent (or common) error is using the transitive verb `lay´ for the intransitive
-    `lie´
+  - a frequent (or common) error is using the transitive verb ‘lay’ for the intransitive
+    ‘lie’
   ili: i2743
   members:
   - frequent
@@ -36571,7 +36571,7 @@
   - 00521748-s
 00521402-s:
   definition:
-  - (followed by `to´) dedicated exclusively to a purpose or use
+  - (followed by ‘to’) dedicated exclusively to a purpose or use
   example:
   - large sums devoted to the care of the poor
   - a life devoted to poetry
@@ -36595,7 +36595,7 @@
   - 00521136-a
 00521748-s:
   definition:
-  - (often followed by `to´) devoted exclusively to a single use or purpose or person
+  - (often followed by ‘to’) devoted exclusively to a single use or purpose or person
   example:
   - a fund sacred to charity
   - a morning hour sacred to study
@@ -37470,7 +37470,7 @@
   - 00533547-a
 00534780-s:
   definition:
-  - thrown into a state of agitated confusion; (`rattled´ is an informal term)
+  - thrown into a state of agitated confusion; (‘rattled’ is an informal term)
   exemplifies:
   - 07089193-n
   ili: i2979
@@ -38527,7 +38527,7 @@
   example:
   - a crisp retort
   - a response so curt as to be almost rude
-  - the laconic reply; `yes´
+  - the laconic reply; ‘yes’
   - short and terse and easy to understand
   ili: i3062
   members:
@@ -38643,8 +38643,8 @@
   definition:
   - repetition of same and identical sense with different and non-identical words
   example:
-  - '`a true fact´ and `a free gift´ are pleonastic expressions'
-  - the phrase `a beginner who has just started´ is tautological
+  - '‘a true fact’ and ‘a free gift’ are pleonastic expressions'
+  - the phrase ‘a beginner who has just started’ is tautological
   - source: J.B.Conant
     text: at the risk of being redundant I return to my original proposition
   ili: i3071
@@ -38798,8 +38798,8 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`and´ in `John and Mary´ or in `John walked and Mary rode´ is a coordinating
-    conjunction; and so is `or´ in `will you go or stay?´'
+  - '‘and’ in ‘John and Mary’ or in ‘John walked and Mary rode’ is a coordinating
+    conjunction; and so is ‘or’ in ‘will you go or stay?’'
   ili: i3083
   members:
   - coordinating
@@ -38811,7 +38811,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`when´ in `I will come when I can´ is a subordinating conjunction'
+  - '‘when’ in ‘I will come when I can’ is a subordinating conjunction'
   ili: i3084
   members:
   - subordinating
@@ -38819,7 +38819,7 @@
   partOfSpeech: a
 00555061-a:
   definition:
-  - being in agreement or harmony; often followed by `with´
+  - being in agreement or harmony; often followed by ‘with’
   example:
   - source: Thomas Hardy
     text: a place perfectly accordant with man's nature
@@ -38835,7 +38835,7 @@
   - 00555952-s
 00555360-s:
   definition:
-  - (followed by `to´) in agreement with or accordant with
+  - (followed by ‘to’) in agreement with or accordant with
   example:
   - according to instructions
   ili: i3086
@@ -39560,7 +39560,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`and´ is a copulative conjunction'
+  - '‘and’ is a copulative conjunction'
   ili: i3146
   members:
   - copulative
@@ -39598,7 +39598,7 @@
   definition:
   - expressing antithesis or opposition
   example:
-  - the adversative conjunction `but´ in `poor but happy´
+  - the adversative conjunction ‘but’ in ‘poor but happy’
   ili: i3149
   members:
   - adversative
@@ -39624,7 +39624,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - disjunctive conjunctions like `but´, `or´, or `though´ serve a contrastive function
+  - disjunctive conjunctions like ‘but’, ‘or’, or ‘though’ serve a contrastive function
   ili: i3151
   members:
   - contrastive
@@ -40430,7 +40430,7 @@
   also:
   - 02515761-a
   definition:
-  - (sometimes followed by `with´) in agreement or consistent or reliable
+  - (sometimes followed by ‘with’) in agreement or consistent or reliable
   example:
   - testimony consistent with the known facts
   - source: FDR
@@ -40465,7 +40465,7 @@
   - 00579031-a
 00579756-s:
   definition:
-  - (followed by `to´) in conformance to or agreement with
+  - (followed by ‘to’) in conformance to or agreement with
   example:
   - pursuant to our agreement
   - pursuant to the dictates of one's conscience
@@ -41680,7 +41680,7 @@
   definition:
   - having no interruptions
   example:
-  - '`continual´ is often used interchangeably with `continuous´'
+  - '‘continual’ is often used interchangeably with ‘continuous’'
   ili: i3306
   members:
   - continual
@@ -44143,7 +44143,7 @@
   - source: Shakespeare
     text: what seemed corporal melted as breath into the wind
   - an incarnate spirit
-  - '`corporate´ is an archaic term'
+  - '‘corporate’ is an archaic term'
   ili: i3508
   members:
   - bodied
@@ -44794,7 +44794,7 @@
   - without care or thought for others
   example:
   - the thoughtless saying of a great princess on being informed that the people had
-    no bread; `Let them eat cake´
+    no bread; ‘Let them eat cake’
   ili: i3558
   members:
   - thoughtless
@@ -45272,7 +45272,7 @@
   - 00650003-s
 00649713-s:
   definition:
-  - (a common but incorrect usage where `credulous´ would be appropriate) credulous
+  - (a common but incorrect usage where ‘credulous’ would be appropriate) credulous
   example:
   - she was not the … credible fool he expected
   ili: i3594
@@ -47665,7 +47665,7 @@
   - 00682414-a
 00683423-s:
   definition:
-  - out of working order (`busted´ is an informal substitute for `broken´)
+  - out of working order (‘busted’ is an informal substitute for ‘broken’)
   example:
   - a broken washing machine
   - the coke machine is broken
@@ -47716,7 +47716,7 @@
   - 00682414-a
 00684067-s:
   definition:
-  - (often followed by `with´) damaged throughout by numerous perforations or holes
+  - (often followed by ‘with’) damaged throughout by numerous perforations or holes
   example:
   - a sweater riddled with moth holes
   - cliffs riddled with caves
@@ -48997,7 +48997,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - '`boys´ and `swam´ are inflected English words'
+  - '‘boys’ and ‘swam’ are inflected English words'
   - German is an inflected language
   ili: i3892
   members:
@@ -49009,7 +49009,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - '`boy´ and `swim´ are uninflected English words'
+  - '‘boy’ and ‘swim’ are uninflected English words'
   ili: i3893
   members:
   - uninflected
@@ -49570,7 +49570,7 @@
   example:
   - brittle bones
   - glass is brittle
-  - '`brickle´ and `brickly´ are dialectal'
+  - '‘brickle’ and ‘brickly’ are dialectal'
   ili: i3933
   members:
   - brittle
@@ -49908,7 +49908,7 @@
   - compelling immediate action
   example:
   - too pressing to permit of longer delay
-  - the urgent words `Hurry! Hurry!´
+  - the urgent words ‘Hurry! Hurry!’
   - bridges in urgent need of repair
   ili: i3958
   members:
@@ -50856,7 +50856,7 @@
   - 00731008-a
 00732270-s:
   definition:
-  - '(of a binary operation) independent of order; as in e.g.: `a x b´ = `b x a´'
+  - '(of a binary operation) independent of order; as in e.g.: ‘a x b’ = ‘b x a’'
   domain_topic:
   - 06009822-n
   ili: i4031
@@ -51217,7 +51217,7 @@
   - more desirable than another
   example:
   - coffee is preferable to tea
-  - Danny's preferred name is `Dan´
+  - Danny's preferred name is ‘Dan’
   ili: i4063
   members:
   - preferable
@@ -55097,7 +55097,7 @@
   - 00794782-a
 00796324-s:
   definition:
-  - (sometimes followed by `to´) not subject to or influenced by
+  - (sometimes followed by ‘to’) not subject to or influenced by
   example:
   - overcome by a superior opponent
   - trust magnates who felt themselves superior to law
@@ -55521,7 +55521,7 @@
   - 00800854-a
 00802700-s:
   definition:
-  - British informal for `intoxicated´
+  - British informal for ‘intoxicated’
   ili: i4397
   members:
   - half-seas-over
@@ -56006,7 +56006,7 @@
   - 90010621-s
 00808685-s:
   definition:
-  - (often followed by `with´) full of life and spirit
+  - (often followed by ‘with’) full of life and spirit
   example:
   - she was wonderfully alive for her age
   - a face alive with mischief
@@ -56447,7 +56447,7 @@
   - 00814485-a
 00815105-s:
   definition:
-  - (usually followed by `to´) full of eagerness
+  - (usually followed by ‘to’) full of eagerness
   example:
   - impatient to begin
   - raring to go
@@ -56669,7 +56669,7 @@
   - 00816521-a
 00818180-s:
   definition:
-  - (comparative and superlative of `early´) more early than; most early
+  - (comparative and superlative of ‘early’) more early than; most early
   example:
   - a fashion popular in earlier times
   - his earlier work reflects the influence of his teacher
@@ -56737,7 +56737,7 @@
   definition:
   - indicating the first or earliest or original
   example:
-  - '`proto´ is a combining form in a word like `protolanguage´ that refers to the
+  - '‘proto’ is a combining form in a word like ‘protolanguage’ that refers to the
     hypothetical ancestor of another language or group of languages'
   exemplifies:
   - 06318142-n
@@ -57879,7 +57879,7 @@
   - being in effect or operation
   example:
   - source: Leslie Marmon Silko
-    text: de facto apartheid is still operational even in the `new´ African nations
+    text: de facto apartheid is still operational even in the ‘new’ African nations
   - bus service is in operation during the emergency
   - the company had several operating divisions
   ili: i4578
@@ -60448,7 +60448,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - when `three blind mice´ serves as a noun it is an endocentric construction
+  - when ‘three blind mice’ serves as a noun it is an endocentric construction
   ili: i4777
   members:
   - endocentric
@@ -60459,7 +60459,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - when `until last Easter´ serves as an adverb it is an exocentric construction
+  - when ‘until last Easter’ serves as an adverb it is an exocentric construction
   ili: i4778
   members:
   - exocentric
@@ -61594,7 +61594,7 @@
   - 00891011-a
 00891492-s:
   definition:
-  - (usually followed by `for´) extremely desirous
+  - (usually followed by ‘for’) extremely desirous
   example:
   - athirst for knowledge
   - hungry for recognition
@@ -61609,7 +61609,7 @@
   - 00891011-a
 00891770-s:
   definition:
-  - (often followed by `for´) ardently or excessively desirous
+  - (often followed by ‘for’) ardently or excessively desirous
   example:
   - avid for adventure
   - an avid ambition to succeed
@@ -62811,7 +62811,7 @@
   definition:
   - expressing disapproval
   example:
-  - dyslogistic terms like `nitwit´ and `scalawag´
+  - dyslogistic terms like ‘nitwit’ and ‘scalawag’
   ili: i4966
   members:
   - dyslogistic
@@ -62900,7 +62900,7 @@
   definition:
   - of or the nature of euphemism
   example:
-  - '`peepee´ is a common euphemistic term'
+  - '‘peepee’ is a common euphemistic term'
   ili: i4973
   members:
   - euphemistic
@@ -62909,7 +62909,7 @@
   definition:
   - of or the nature of dysphemism
   example:
-  - '`kick the bucket´ is a dysphemistic term for `die´'
+  - '‘kick the bucket’ is a dysphemistic term for ‘die’'
   ili: i4974
   members:
   - dysphemistic
@@ -67198,7 +67198,7 @@
   domain_topic:
   - 06376048-n
   example:
-  - gothic novels like `Frankenstein´
+  - gothic novels like ‘Frankenstein’
   ili: i5305
   members:
   - gothic
@@ -68567,7 +68567,7 @@
   - 00989218-a
 00991265-s:
   definition:
-  - euphemisms for `fat´
+  - euphemisms for ‘fat’
   example:
   - men are portly and women are stout
   ili: i5409
@@ -70441,7 +70441,7 @@
   - being the last or concluding element of a series
   example:
   - the ultimate sonata of that opus
-  - a distinction between the verb and noun senses of `conflict´ is that in the verb
+  - a distinction between the verb and noun senses of ‘conflict’ is that in the verb
     the stress is on the ultimate (or last) syllable
   ili: i5548
   members:
@@ -73449,7 +73449,7 @@
   - 01058772-a
 01060596-s:
   definition:
-  - (used with `of´ or `with´) noticeably odorous
+  - (used with ‘of’ or ‘with’) noticeably odorous
   example:
   - the hall was redolent of floor wax
   - air redolent with the fumes of beer and whiskey
@@ -74521,7 +74521,7 @@
   - touched by rot or decay
   example:
   - tainted bacon
-  - '`corrupt´ is archaic'
+  - '‘corrupt’ is archaic'
   ili: i5871
   members:
   - corrupt
@@ -75569,7 +75569,7 @@
   - 01086845-a
 01088332-s:
   definition:
-  - (usually followed by `with´ or used as a combining form) generously supplied with
+  - (usually followed by ‘with’ or used as a combining form) generously supplied with
   example:
   - theirs was a house filled with laughter
   - a large hall filled with rows of desks
@@ -75632,7 +75632,7 @@
   - 01086845-a
 01089130-s:
   definition:
-  - (followed by `with´) deeply filled or permeated
+  - (followed by ‘with’) deeply filled or permeated
   example:
   - imbued with the spirit of the Reformation
   - words instinct with love
@@ -75651,7 +75651,7 @@
   example:
   - a tray loaded with dishes
   - table laden with food
-  - '`ladened´ is not current usage'
+  - '‘ladened’ is not current usage'
   ili: i5960
   members:
   - laden
@@ -76937,7 +76937,7 @@
   attribute:
   - 04771667-n
   definition:
-  - (sometimes followed by `to´) applying to or characterized by or distinguishing
+  - (sometimes followed by ‘to’) applying to or characterized by or distinguishing
     something particular or special or unique
   example:
   - rules with specific application
@@ -77047,7 +77047,7 @@
   - 01106714-a
 01108735-s:
   definition:
-  - (followed by `to´) applying exclusively to a given category or condition or locality
+  - (followed by ‘to’) applying exclusively to a given category or condition or locality
   example:
   - a species unique to Australia
   ili: i6075
@@ -77301,7 +77301,7 @@
   domain_topic:
   - 03252323-n
   example:
-  - '`Acetaminophen´ is the generic form of the proprietary drug `Tylenol´'
+  - '‘Acetaminophen’ is the generic form of the proprietary drug ‘Tylenol’'
   ili: i6095
   members:
   - generic
@@ -77324,7 +77324,7 @@
   - protected by trademark or patent or copyright; made or produced or distributed
     by one having exclusive rights
   example:
-  - '`Tylenol´ is a proprietary drug of which `acetaminophen´ is the generic form'
+  - '‘Tylenol’ is a proprietary drug of which ‘acetaminophen’ is the generic form'
   ili: i6097
   members:
   - proprietary
@@ -80544,8 +80544,8 @@
   - 01160257-s
 01160257-s:
   definition:
-  - produced with the back of the tongue touching or near the soft palate (as `k´
-    in `cat´ and `g´ in `gun´ and `ng´ in `sing´)
+  - produced with the back of the tongue touching or near the soft palate (as ‘k’
+    in ‘cat’ and ‘g’ in ‘gun’ and ‘ng’ in ‘sing’)
   ili: i6329
   members:
   - velar
@@ -80555,7 +80555,7 @@
 01160432-a:
   definition:
   - (of speech sounds); produced with the back of the tongue raised toward the hard
-    palate; characterized by a hissing or hushing sound (as `s´ and `sh´)
+    palate; characterized by a hissing or hushing sound (as ‘s’ and ‘sh’)
   ili: i6330
   members:
   - soft
@@ -80565,8 +80565,8 @@
   - 01161001-s
 01160686-s:
   definition:
-  - of speech sounds produced by forcing air through a constricted passage (as `f´,
-    `s´, `z´, or `th´ in both `thin´ and `then´)
+  - of speech sounds produced by forcing air through a constricted passage (as ‘f’,
+    ‘s’, ‘z’, or ‘th’ in both ‘thin’ and ‘then’)
   ili: i6331
   members:
   - fricative
@@ -80579,9 +80579,9 @@
   - 01160432-a
 01161001-s:
   definition:
-  - produced with the front of the tongue near or touching the hard palate (as `y´)
-    or with the blade of the tongue near the hard palate (as `ch´ in `chin´ or `j´
-    in `gin´)
+  - produced with the front of the tongue near or touching the hard palate (as ‘y’)
+    or with the blade of the tongue near the hard palate (as ‘ch’ in ‘chin’ or ‘j’
+    in ‘gin’)
   ili: i6332
   members:
   - palatal
@@ -80882,7 +80882,7 @@
   - 01163575-a
 01165528-s:
   definition:
-  - (sometimes followed by `to´) causing harm or injury
+  - (sometimes followed by ‘to’) causing harm or injury
   example:
   - damaging to career and reputation
   - the reporter's coverage resulted in prejudicial publicity for the defendant
@@ -83097,7 +83097,7 @@
   - 01197871-s
 01197642-s:
   definition:
-  - (usually followed by `of´) without due thought or consideration
+  - (usually followed by ‘of’) without due thought or consideration
   example:
   - careless of the consequences
   - crushing the blooms with regardless tread
@@ -83110,7 +83110,7 @@
   - 01197257-a
 01197871-s:
   definition:
-  - (usually followed by `to´) unwilling or refusing to pay heed
+  - (usually followed by ‘to’) unwilling or refusing to pay heed
   example:
   - deaf to her warnings
   ili: i6530
@@ -83735,7 +83735,7 @@
   - 05144430-n
   definition:
   - (literal meaning) being at or having a relatively great or specific elevation
-    or upward extension (sometimes used in combinations like `knee-high´)
+    or upward extension (sometimes used in combinations like ‘knee-high’)
   example:
   - a high mountain
   - high ceilings
@@ -86899,7 +86899,7 @@
   - 01250274-a
 01252393-s:
   definition:
-  - made warm or hot (`het´ is a dialectal variant of `heated´)
+  - made warm or hot (‘het’ is a dialectal variant of ‘heated’)
   example:
   - a heated swimming pool
   - wiped his heated-up face with a large bandana
@@ -89025,7 +89025,7 @@
   - 01283088-a
 01283686-s:
   definition:
-  - (often followed by `to´) lacking importance; not mattering one way or the other
+  - (often followed by ‘to’) lacking importance; not mattering one way or the other
   example:
   - whether you choose to do it or not is a matter that is quite immaterial (or indifferent)
   - what others think is altogether indifferent to him
@@ -89737,7 +89737,7 @@
   also:
   - 02575716-a
   definition:
-  - (often followed by `to´) having a preference, disposition, or tendency
+  - (often followed by ‘to’) having a preference, disposition, or tendency
   example:
   - wasn't inclined to believe the excuse
   - inclined to be moody
@@ -89752,7 +89752,7 @@
   - 01296172-s
 01295534-s:
   definition:
-  - (usually followed by `to´) naturally disposed toward
+  - (usually followed by ‘to’) naturally disposed toward
   example:
   - he is apt to ignore matters he considers unimportant
   - I am not minded to answer any questions
@@ -89768,7 +89768,7 @@
   - 01295251-a
 01295806-s:
   definition:
-  - (followed by `of´ or `to´) having a strong preference or liking for
+  - (followed by ‘of’ or ‘to’) having a strong preference or liking for
   example:
   - fond of chocolate
   - partial to horror movies
@@ -89830,7 +89830,7 @@
   - 01296281-a
 01296665-s:
   definition:
-  - (usually followed by `to´) strongly opposed
+  - (usually followed by ‘to’) strongly opposed
   example:
   - antipathetic to new ideas
   - averse to taking risks
@@ -90091,7 +90091,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`therefore´ is an illative word'
+  - '‘therefore’ is an illative word'
   ili: i7070
   members:
   - illative
@@ -90757,7 +90757,7 @@
   - 01309228-a
 01310022-s:
   definition:
-  - (usually followed by `with´) well informed about or knowing thoroughly
+  - (usually followed by ‘with’) well informed about or knowing thoroughly
   example:
   - conversant with business trends
   - familiar with the complex machinery
@@ -90821,7 +90821,7 @@
   - 01309228-a
 01311044-s:
   definition:
-  - (followed by `to´) informed about something secret or not generally known
+  - (followed by ‘to’) informed about something secret or not generally known
   example:
   - privy to the details of the conspiracy
   ili: i7127
@@ -91321,7 +91321,7 @@
   - 01316883-a
 01318293-s:
   definition:
-  - (meaning literally `born´) used to indicate the maiden or family name of a married
+  - (meaning literally ‘born’) used to indicate the maiden or family name of a married
     woman
   example:
   - Hillary Clinton nee Rodham
@@ -93273,7 +93273,7 @@
   example:
   - a dismissive shrug
   - the firm is dismissive of the competitor's product
-  - '`chronic fatigue syndrome´ was known by the dismissive term `housewife syndrome´'
+  - '‘chronic fatigue syndrome’ was known by the dismissive term ‘housewife syndrome’'
   ili: i7322
   members:
   - dismissive
@@ -95500,7 +95500,7 @@
   definition:
   - most familiar or renowned
   example:
-  - Stevenson's best-known work is probably `Treasure Island´
+  - Stevenson's best-known work is probably ‘Treasure Island’
   ili: i7492
   members:
   - best-known
@@ -95638,7 +95638,7 @@
   - 01379820-a
 01380414-s:
   definition:
-  - (usually used with `to´) occurring or existing without the knowledge of
+  - (usually used with ‘to’) occurring or existing without the knowledge of
   example:
   - a crisis unbeknown to me
   - she had been ill for months, unbeknownst to the family
@@ -98713,7 +98713,7 @@
   definition:
   - beyond the literal or primary sense
   example:
-  - '`hot off the press´ shows an extended sense of `hot´'
+  - '‘hot off the press’ shows an extended sense of ‘hot’'
   ili: i7747
   members:
   - extended
@@ -98737,7 +98737,7 @@
   definition:
   - using the name of one thing for that of another with which it is closely associated
   example:
-  - to say `he spent the evening reading Shakespeare´ is metonymic because it substitutes
+  - to say ‘he spent the evening reading Shakespeare’ is metonymic because it substitutes
     the author himself for the author's works
   ili: i7749
   members:
@@ -98763,7 +98763,7 @@
     special for the general or the general for the special; or the material for the
     thing made of it
   example:
-  - to use `hand´ for `worker´ or `ten sails´ for `ten ships´ or `steel´ for `sword´
+  - to use ‘hand’ for ‘worker’ or ‘ten sails’ for ‘ten ships’ or ‘steel’ for ‘sword’
     is to use a synecdochic figure of speech
   ili: i7751
   members:
@@ -100498,7 +100498,7 @@
   domain_topic:
   - 06186749-n
   example:
-  - the English vowel sounds in `bate´, `beat´, `bite´, `boat´, `boot´ are long
+  - the English vowel sounds in ‘bate’, ‘beat’, ‘bite’, ‘boat’, ‘boot’ are long
   ili: i7893
   members:
   - long
@@ -100509,7 +100509,7 @@
   domain_topic:
   - 06186749-n
   example:
-  - the English vowel sounds in `pat´, `pet´, `pit´, `pot´, `putt´ are short
+  - the English vowel sounds in ‘pat’, ‘pet’, ‘pit’, ‘pot’, ‘putt’ are short
   ili: i7894
   members:
   - short
@@ -103672,7 +103672,7 @@
   definition:
   - neither male nor female (of grammatical gender)
   example:
-  - '`it´ is the third-person singular neuter pronoun'
+  - '‘it’ is the third-person singular neuter pronoun'
   ili: i8150
   members:
   - neuter
@@ -104169,7 +104169,7 @@
   - 01496955-s
 01496571-s:
   definition:
-  - of wines, fruit, cheeses; having reached a desired or final condition; (`aged´
+  - of wines, fruit, cheeses; having reached a desired or final condition; (‘aged’
     pronounced as one syllable)
   example:
   - mature well-aged cheeses
@@ -104406,7 +104406,7 @@
   - 01499316-a
 01499887-s:
   definition:
-  - insignificantly small; a matter of form only (`tokenish´ is informal)
+  - insignificantly small; a matter of form only (‘tokenish’ is informal)
   example:
   - the fee was nominal
   - a token gesture of resistance
@@ -104666,7 +104666,7 @@
   definition:
   - resembling the unthinking functioning of a machine
   example:
-  - an automatic `thank you´
+  - an automatic ‘thank you’
   - machinelike efficiency
   ili: i8228
   members:
@@ -106618,7 +106618,7 @@
   example:
   - takeout pizza
   - the takeout counter
-  - '`take-away´ is chiefly British'
+  - '‘take-away’ is chiefly British'
   ili: i8380
   members:
   - takeout
@@ -107302,7 +107302,7 @@
   definition:
   - (used as a combining form) recent or new
   example:
-  - '`neo´ is a combining form in words like `neocolonialism´'
+  - '‘neo’ is a combining form in words like ‘neocolonialism’'
   exemplifies:
   - 06318142-n
   ili: i8433
@@ -107611,7 +107611,7 @@
   - 01544533-a
 01545039-s:
   definition:
-  - restricted in meaning; (as e.g. `man´ in `a tall man´)
+  - restricted in meaning; (as e.g. ‘man’ in ‘a tall man’)
   domain_topic:
   - 06184139-n
   ili: i8457
@@ -108357,8 +108357,8 @@
   attribute:
   - 05129173-n
   definition:
-  - a quantifier that can be used with count nouns and is often preceded by `as´ or
-    `too´ or `so´ or `that´; amounting to a large but indefinite number; quantifier,
+  - a quantifier that can be used with count nouns and is often preceded by ‘as’ or
+    ‘too’ or ‘so’ or ‘that’; amounting to a large but indefinite number; quantifier,
     plural pronoun; quantifier, plural
   example:
   - many temptations
@@ -108447,7 +108447,7 @@
   attribute:
   - 05129173-n
   definition:
-  - a quantifier that can be used with count nouns and is often preceded by `a´; a
+  - a quantifier that can be used with count nouns and is often preceded by ‘a’; a
     small but indefinite number
   example:
   - a few weeks ago
@@ -108548,7 +108548,7 @@
   - 01559809-a
   definition:
   - (quantifier used with mass nouns) small in quantity or degree; not much or almost
-    none or (with `a´) at least some
+    none or (with ‘a’) at least some
   example:
   - little rain fell in May
   - gave it little thought
@@ -108581,7 +108581,7 @@
   also:
   - 01557986-a
   definition:
-  - (comparative of `much´ used with mass nouns) a quantifier meaning greater in size
+  - (comparative of ‘much’ used with mass nouns) a quantifier meaning greater in size
     or amount or extent or degree; above; more than
   example:
   - more land
@@ -108599,7 +108599,7 @@
   also:
   - 01558903-a
   definition:
-  - (comparative of `little´ usually used with mass nouns) a quantifier meaning not
+  - (comparative of ‘little’ usually used with mass nouns) a quantifier meaning not
     as great in amount or degree
   example:
   - of less importance
@@ -108614,8 +108614,8 @@
   partOfSpeech: a
 01560125-a:
   definition:
-  - the superlative of `much´ that can be used with mass nouns and is usually preceded
-    by `the´; a quantifier meaning the greatest in amount or extent or degree
+  - the superlative of ‘much’ that can be used with mass nouns and is usually preceded
+    by ‘the’; a quantifier meaning the greatest in amount or extent or degree
   example:
   - made the most money he could
   - what attracts the most attention?
@@ -108628,8 +108628,8 @@
   partOfSpeech: a
 01560454-a:
   definition:
-  - the superlative of `little´ that can be used with mass nouns and is usually preceded
-    by `the´; a quantifier meaning smallest in amount or extent or degree
+  - the superlative of ‘little’ that can be used with mass nouns and is usually preceded
+    by ‘the’; a quantifier meaning smallest in amount or extent or degree
   example:
   - didn't care the least bit
   - he has the least talent of anyone
@@ -108644,7 +108644,7 @@
   - 01555990-a
   - 01559526-a
   definition:
-  - (comparative of `many´ used with count nouns) quantifier meaning greater in number
+  - (comparative of ‘many’ used with count nouns) quantifier meaning greater in number
   example:
   - a hall with more seats
   - we have no more bananas
@@ -108660,7 +108660,7 @@
   - 01557242-a
   - 01559809-a
   definition:
-  - (comparative of `few´ used with count nouns) quantifier meaning a smaller number
+  - (comparative of ‘few’ used with count nouns) quantifier meaning a smaller number
     of
   example:
   - fewer birds came this year
@@ -108689,7 +108689,7 @@
   - 01561009-a
 01561513-a:
   definition:
-  - (superlative of `many´ used with count nouns and often preceded by `the´) quantifier
+  - (superlative of ‘many’ used with count nouns and often preceded by ‘the’) quantifier
     meaning the greatest in number
   example:
   - who has the most apples?
@@ -108703,7 +108703,7 @@
   partOfSpeech: a
 01561779-a:
   definition:
-  - (superlative of `few´ used with count nouns and usually preceded by `the´) quantifier
+  - (superlative of ‘few’ used with count nouns and usually preceded by ‘the’) quantifier
     meaning the smallest in number
   example:
   - the fewest birds in recent memory
@@ -109324,7 +109324,7 @@
   definition:
   - used of a series of photographs presented so as to create the illusion of motion
   example:
-  - Her ambition was to be in moving pictures or `the movies´
+  - Her ambition was to be in moving pictures or ‘the movies’
   ili: i8593
   members:
   - moving
@@ -111081,7 +111081,7 @@
   - 01598062-s
 01597282-s:
   definition:
-  - of low birth or station (`base´ is archaic in this sense)
+  - of low birth or station (‘base’ is archaic in this sense)
   example:
   - baseborn wretches with dirty faces
   - of humble (or lowly) birth
@@ -112153,7 +112153,7 @@
   - disregarded
   example:
   - his cries were unheeded
-  - Shaw's neglected one-act comedy, `A Village Wooing´
+  - Shaw's neglected one-act comedy, ‘A Village Wooing’
   - her ignored advice
   ili: i8805
   members:
@@ -113124,7 +113124,7 @@
 01627541-s:
   definition:
   - (of facilities such as telephones or lavatories) unavailable for use by anyone
-    else or indicating unavailability; (`engaged´ is a British term for a busy telephone
+    else or indicating unavailability; (‘engaged’ is a British term for a busy telephone
     line)
   example:
   - her line is busy
@@ -114618,7 +114618,7 @@
   - 01651236-s
 01648667-s:
   definition:
-  - advanced in years; (`aged´ is pronounced as two syllables)
+  - advanced in years; (‘aged’ is pronounced as two syllables)
   example:
   - aged members of the society
   - elderly residents could remember the construction of the first skyscraper
@@ -114634,7 +114634,7 @@
   - 01648062-a
 01648983-s:
   definition:
-  - having attained a specific age; (`aged´ is pronounced as one syllable)
+  - having attained a specific age; (‘aged’ is pronounced as one syllable)
   example:
   - aged ten
   - ten years of age
@@ -114713,7 +114713,7 @@
 01649932-s:
   definition:
   - honorably retired from assigned duties and retaining your title along with the
-    additional title `emeritus´ as in `professor emeritus´
+    additional title ‘emeritus’ as in ‘professor emeritus’
   ili: i9008
   members:
   - emeritus
@@ -117340,7 +117340,7 @@
 01687482-s:
   definition:
   - headed or intending to head in a certain direction; often used as a combining
-    form as in `college-bound students´
+    form as in ‘college-bound students’
   example:
   - children bound for school
   - a flight destined for New York
@@ -117706,7 +117706,7 @@
   - a stock answer
   - repeating threadbare jokes
   - parroting some timeworn axiom
-  - the trite metaphor `hard as nails´
+  - the trite metaphor ‘hard as nails’
   ili: i9245
   members:
   - banal
@@ -118658,7 +118658,7 @@
   domain_topic:
   - 06076105-n
   example:
-  - '`foliate´ is combined with the prefix `tri´ to form the word `trifoliate´'
+  - '‘foliate’ is combined with the prefix ‘tri’ to form the word ‘trifoliate’'
   ili: i9320
   members:
   - foliate
@@ -118672,7 +118672,7 @@
   domain_topic:
   - 06076105-n
   example:
-  - '`foliolate´ is combined with the prefix `bi´ to form the word `bifoliolate´'
+  - '‘foliolate’ is combined with the prefix ‘bi’ to form the word ‘bifoliolate’'
   ili: i9321
   members:
   - foliolate
@@ -119844,7 +119844,7 @@
   definition:
   - not paintable especially not suitable for artistic representation on canvas
   example:
-  - the inexpressible, unpaintable `tick´ in the unconscious
+  - the inexpressible, unpaintable ‘tick’ in the unconscious
   ili: i9415
   members:
   - unpaintable
@@ -120697,7 +120697,7 @@
   - gone by; or in the past
   example:
   - two years ago
-  - '`agone´ is an archaic word for `ago´'
+  - '‘agone’ is an archaic word for ‘ago’'
   ili: i9484
   members:
   - ago
@@ -123530,7 +123530,7 @@
   - for your own use
   - do your own thing
   - she makes her own clothes
-  - '`ain´ is Scottish'
+  - '‘ain’ is Scottish'
   ili: i9704
   members:
   - own
@@ -128695,7 +128695,7 @@
   definition:
   - farther along in physical or mental development
   example:
-  - the child's skeletal age was classified as `advanced´
+  - the child's skeletal age was classified as ‘advanced’
   - children in the advanced classes in elementary school read far above grade average
   ili: i10109
   members:
@@ -129055,7 +129055,7 @@
   - 01849304-a
 01850926-s:
   definition:
-  - (usually followed by `on´ or `for´) in readiness
+  - (usually followed by ‘on’ or ‘for’) in readiness
   example:
   - he was up on his homework
   - had to be up for the game
@@ -129861,7 +129861,7 @@
   - 01861659-a
 01862869-a:
   definition:
-  - (sometimes followed by `to´) minor or casual or subordinate in significance or
+  - (sometimes followed by ‘to’) minor or casual or subordinate in significance or
     nature or occurring as a chance concomitant or consequence
   example:
   - incidental expenses
@@ -133394,7 +133394,7 @@
   - 01914420-a
 01915458-s:
   definition:
-  - (of color) discolored by impurities; not bright and clear; `dirty´ is often used
+  - (of color) discolored by impurities; not bright and clear; ‘dirty’ is often used
     in combination
   example:
   - a dirty (or dingy) white
@@ -133628,7 +133628,7 @@
   - (of pets) trained to urinate and defecate outside or in a special place
   example:
   - housebroken pets
-  - '`house-trained´ is chiefly British'
+  - '‘house-trained’ is chiefly British'
   ili: i10486
   members:
   - housebroken
@@ -134047,7 +134047,7 @@
   definition:
   - as claimed by and for yourself often without justification
   example:
-  - the self-styled `doctor´ has no degree of any kind
+  - the self-styled ‘doctor’ has no degree of any kind
   ili: i10518
   members:
   - self-styled
@@ -134319,7 +134319,7 @@
   - 01926330-a
 01928267-s:
   definition:
-  - resembling a sustained `sh´ or soft whistle
+  - resembling a sustained ‘sh’ or soft whistle
   example:
   - swishing windshield wipers
   - a swishy skirt
@@ -134952,7 +134952,7 @@
   - 01936911-a
 01937602-s:
   definition:
-  - (usually followed by `to´ or `for´) on the point of or strongly disposed
+  - (usually followed by ‘to’ or ‘for’) on the point of or strongly disposed
   example:
   - in no fit state to continue
   - fit to drop
@@ -136757,7 +136757,7 @@
   definition:
   - listed or recorded officially
   example:
-  - record is made of `registered mail´ at each point on its route to assure safe
+  - record is made of ‘registered mail’ at each point on its route to assure safe
     delivery
   - registered bonds
   ili: i10721
@@ -137034,7 +137034,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - '`sing´ is a strong verb'
+  - '‘sing’ is a strong verb'
   ili: i10742
   members:
   - strong
@@ -139348,7 +139348,7 @@
   - derisive laughter
   - a jeering crowd
   - her mocking smile
-  - taunting shouts of `coward´ and `sissy´
+  - taunting shouts of ‘coward’ and ‘sissy’
   ili: i10928
   members:
   - derisive
@@ -139957,7 +139957,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - the restrictive clause in `Each made a list of the books that had influenced him´
+  - the restrictive clause in ‘Each made a list of the books that had influenced him’
     limits the books on the list to only those particular ones defined by the clause
   ili: i10974
   members:
@@ -140025,8 +140025,8 @@
   domain_topic:
   - 06184139-n
   example:
-  - the nonrestrictive clause in `I always buy his books, which have influenced me
-    greatly´ refers to his books generally and adds an additional fact about them
+  - the nonrestrictive clause in ‘I always buy his books, which have influenced me
+    greatly’ refers to his books generally and adds an additional fact about them
   ili: i10980
   members:
   - nonrestrictive
@@ -140603,7 +140603,7 @@
   - brought back
   example:
   - the Victorian era redux
-  - '`Rabbit Redux´ by John Updike'
+  - '‘Rabbit Redux’ by John Updike'
   ili: i11028
   members:
   - redux
@@ -141303,7 +141303,7 @@
   definition:
   - lacking funds
   example:
-  - '`skint´ is a British slang term'
+  - '‘skint’ is a British slang term'
   ili: i11084
   members:
   - broke
@@ -142337,7 +142337,7 @@
   - had a tall burly frame
   - clothing sizes for husky boys
   - a strapping boy of eighteen
-  - '`buirdly´ is a Scottish term'
+  - '‘buirdly’ is a Scottish term'
   ili: i11165
   members:
   - beefy
@@ -144222,7 +144222,7 @@
   domain_topic:
   - 07111327-n
   example:
-  - note the assonant words and syllables in `tilting at windmills´
+  - note the assonant words and syllables in ‘tilting at windmills’
   ili: i11317
   members:
   - assonant
@@ -144440,10 +144440,10 @@
   - 02072149-a
 02074467-s:
   definition:
-  - (often followed by `from´) not alike; different in nature or quality
+  - (often followed by ‘from’) not alike; different in nature or quality
   example:
   - plants of several distinct types
-  - the word `nationalism´ is used in at least two distinct senses
+  - the word ‘nationalism’ is used in at least two distinct senses
   - gold is distinct from iron
   - a tree related to but quite distinct from the European beech
   - management had interests quite distinct from those of their employees
@@ -146085,7 +146085,7 @@
   - 02098722-s
 02098448-s:
   definition:
-  - (usually followed by `of´) pointing out or revealing clearly
+  - (usually followed by ‘of’) pointing out or revealing clearly
   example:
   - actions indicative of fear
   ili: i11461
@@ -147123,7 +147123,7 @@
   - 02113931-s
 02113646-s:
   definition:
-  - (followed by `to´ or `of´) aware of
+  - (followed by ‘to’ or ‘of’) aware of
   example:
   - is alive to the moods of others
   ili: i11542
@@ -147192,7 +147192,7 @@
   - 02114041-a
 02114666-s:
   definition:
-  - (followed by `to´) not showing human feeling or sensitivity; unresponsive
+  - (followed by ‘to’) not showing human feeling or sensitivity; unresponsive
   example:
   - passersby were dead to our plea for help
   - numb to the cries for mercy
@@ -152223,8 +152223,8 @@
   definition:
   - having only one part or element
   example:
-  - a simplex word has no affixes and is not part of a compound — like `boy´ compared
-    with `boyish´ or `house´ compared with `houseboat´
+  - a simplex word has no affixes and is not part of a compound — like ‘boy’ compared
+    with ‘boyish’ or ‘house’ compared with ‘houseboat’
   ili: i11963
   members:
   - simplex
@@ -152403,7 +152403,7 @@
   - 02183738-a
 02185861-s:
   definition:
-  - extremely intricate; usually in phrase `Gordian knot´
+  - extremely intricate; usually in phrase ‘Gordian knot’
   ili: i11975
   members:
   - Gordian
@@ -152930,7 +152930,7 @@
   definition:
   - used of a single unit or thing; not two or more
   example:
-  - '`ane´ is Scottish'
+  - '‘ane’ is Scottish'
   ili: i12006
   members:
   - one
@@ -159454,8 +159454,8 @@
   - 02276900-s
 02276640-s:
   definition:
-  - (used with singular count nouns) colloquial for `not a´ or `not one´ or `never
-    a´
+  - (used with singular count nouns) colloquial for ‘not a’ or ‘not one’ or ‘never
+    a’
   example:
   - heard nary a sound
   ili: i12558
@@ -159585,7 +159585,7 @@
   definition:
   - very sophisticated especially because of surfeit; versed in the ways of the world
   example:
-  - the blase traveler refers to the ocean he has crossed as `the pond´
+  - the blase traveler refers to the ocean he has crossed as ‘the pond’
   - the benefits of his worldly wisdom
   ili: i12567
   members:
@@ -160692,7 +160692,7 @@
   definition:
   - produced with vibration of the vocal cords
   example:
-  - voiced consonants such as `b´ and `g´ and `z´
+  - voiced consonants such as ‘b’ and ‘g’ and ‘z’
   ili: i12653
   members:
   - voiced
@@ -160703,7 +160703,7 @@
   definition:
   - produced without vibration of the vocal cords
   example:
-  - unvoiced consonants such as `p´ and `k´ and `s´
+  - unvoiced consonants such as ‘p’ and ‘k’ and ‘s’
   ili: i12654
   members:
   - unvoiced
@@ -160790,7 +160790,7 @@
   definition:
   - having characteristics of a vowel sound
   example:
-  - the vowellike nature of `r´
+  - the vowellike nature of ‘r’
   ili: i12661
   members:
   - vowellike
@@ -160855,7 +160855,7 @@
   definition:
   - (of speech sounds) forming the nucleus of a syllable
   example:
-  - the syllabic `nl´ in `riddle´
+  - the syllabic ‘nl’ in ‘riddle’
   ili: i12667
   members:
   - syllabic
@@ -160864,7 +160864,7 @@
   definition:
   - (of speech sounds) not forming or capable of forming the nucleus of a syllable
   example:
-  - initial `l´ in `little´ is nonsyllabic
+  - initial ‘l’ in ‘little’ is nonsyllabic
   ili: i12668
   members:
   - nonsyllabic
@@ -160954,8 +160954,8 @@
     sound dominated by other vowel sounds in a syllable (as the second vowel in a
     falling diphthong)
   example:
-  - the nonsyllabic `n´ in `botany´ when it is pronounced `botny´
-  - the nonsyllabic `i´ in `oi´
+  - the nonsyllabic ‘n’ in ‘botany’ when it is pronounced ‘botny’
+  - the nonsyllabic ‘i’ in ‘oi’
   ili: i12677
   members:
   - nonsyllabic
@@ -161551,8 +161551,8 @@
   domain_topic:
   - 06182505-n
   example:
-  - 'the following use of `access´ was judged unacceptable by a panel of linguists:
-    `You can access your cash at any of 300 automatic tellers´'
+  - 'the following use of ‘access’ was judged unacceptable by a panel of linguists:
+    ‘You can access your cash at any of 300 automatic tellers’'
   ili: i12724
   members:
   - unacceptable
@@ -163116,7 +163116,7 @@
   - bearing a stress or accent
   example:
   - an iambic foot consists of an unstressed syllable followed by a stressed syllable
-    as in `delay´
+    as in ‘delay’
   ili: i12848
   members:
   - stressed
@@ -163145,7 +163145,7 @@
   - 07034009-n
   example:
   - a masculine cadence
-  - the masculine rhyme of `annoy, enjoy´
+  - the masculine rhyme of ‘annoy, enjoy’
   ili: i12850
   members:
   - masculine
@@ -164917,7 +164917,7 @@
   - considered of the highest quality and lasting significance or worth
   example:
   - a classic car
-  - '`War and Peace´ is a classic novel'
+  - '‘War and Peace’ is a classic novel'
   members:
   - classic
   partOfSpeech: s
@@ -165192,7 +165192,7 @@
   - 02353767-a
 02355910-s:
   definition:
-  - (usually preceded by `no´) lower in quality
+  - (usually preceded by ‘no’) lower in quality
   example:
   - no less than perfect
   ili: i13000
@@ -166101,7 +166101,7 @@
   attribute:
   - 14553663-n
   definition:
-  - (often followed by `of´ or `to´) yielding readily to or capable of
+  - (often followed by ‘of’ or ‘to’) yielding readily to or capable of
   example:
   - susceptible to colds
   - susceptible of proof
@@ -166197,7 +166197,7 @@
   - 02369003-a
 02370732-s:
   definition:
-  - (often followed by `to´) likely to be affected with
+  - (often followed by ‘to’) likely to be affected with
   example:
   - liable to diabetes
   ili: i13079
@@ -166325,7 +166325,7 @@
   - 02371926-a
 02372634-s:
   definition:
-  - not being susceptible to or admitting of something (usually followed by `of´)
+  - not being susceptible to or admitting of something (usually followed by ‘of’)
   example:
   - incapable of solution
   ili: i13090
@@ -166980,7 +166980,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - the arguments of the symmetric relation, `is a sister of,´ are interchangeable
+  - the arguments of the symmetric relation, ‘is a sister of,’ are interchangeable
   ili: i13145
   members:
   - interchangeable
@@ -167065,7 +167065,7 @@
   - 06009822-n
   - 06173467-n
   example:
-  - the arguments of the symmetric relation, `is the father of´, are noninterchangeable
+  - the arguments of the symmetric relation, ‘is the father of’, are noninterchangeable
   ili: i13152
   members:
   - noninterchangeable
@@ -167529,7 +167529,7 @@
   definition:
   - of words or propositions so related that each is the negation of the other
   example:
-  - '`male´ and `female´ are complementary terms'
+  - '‘male’ and ‘female’ are complementary terms'
   ili: i13190
   members:
   - complementary
@@ -167541,7 +167541,7 @@
   - of words or propositions so related that both cannot be true and both cannot be
     false
   example:
-  - '`perfect´ and `imperfect´ are contradictory terms'
+  - '‘perfect’ and ‘imperfect’ are contradictory terms'
   ili: i13191
   members:
   - contradictory
@@ -167552,7 +167552,7 @@
   definition:
   - of words or propositions so related that both cannot be true but both may be false
   example:
-  - '`hot´ and `cold´ are contrary terms'
+  - '‘hot’ and ‘cold’ are contrary terms'
   ili: i13192
   members:
   - contrary
@@ -167563,7 +167563,7 @@
   definition:
   - of words so related that one contrasts with the other
   example:
-  - '`rich´ and `hard-up´ are contrastive terms'
+  - '‘rich’ and ‘hard-up’ are contrastive terms'
   ili: i13193
   members:
   - contrastive
@@ -167575,7 +167575,7 @@
   definition:
   - of words so related that one reverses the relation denoted by the other
   example:
-  - '`parental´ and `filial´ are converse terms'
+  - '‘parental’ and ‘filial’ are converse terms'
   ili: i13194
   members:
   - converse
@@ -169194,7 +169194,7 @@
   - 02412395-a
 02413664-a:
   definition:
-  - pronounced with relatively tense tongue muscles (e.g., the vowel sound in `beat´)
+  - pronounced with relatively tense tongue muscles (e.g., the vowel sound in ‘beat’)
   domain_topic:
   - 06186749-n
   ili: i13313
@@ -169217,7 +169217,7 @@
 02413956-a:
   definition:
   - pronounced with muscles of the tongue and jaw relatively relaxed (e.g., the vowel
-    sound in `bet´)
+    sound in ‘bet’)
   domain_topic:
   - 06186749-n
   ili: i13315
@@ -170238,8 +170238,8 @@
   definition:
   - deeply or seriously thoughtful
   example:
-  - Byron lives on not only in his poetry, but also in his creation of the `Byronic
-    hero´ - the persona of a brooding melancholy young man
+  - Byron lives on not only in his poetry, but also in his creation of the ‘Byronic
+    hero’ - the persona of a brooding melancholy young man
   ili: i13393
   members:
   - brooding
@@ -170361,7 +170361,7 @@
   - a sparing father and a spending son
   - sparing in their use of heat and light
   - stinting in bestowing gifts
-  - '`scotch´ is used only informally'
+  - '‘scotch’ is used only informally'
   exemplifies:
   - 07089193-n
   ili: i13402
@@ -171175,7 +171175,7 @@
   definition:
   - physically and mentally fatigued
   example:
-  - '`aweary´ is archaic'
+  - '‘aweary’ is archaic'
   ili: i13465
   members:
   - aweary
@@ -174546,7 +174546,7 @@
   - 02485330-a
 02487166-s:
   definition:
-  - (usually followed by `with´) united in effort as if in a league
+  - (usually followed by ‘with’) united in effort as if in a league
   example:
   - they found out that some policemen were in league with the criminals
   ili: i13733
@@ -177247,7 +177247,7 @@
   definition:
   - (of an actor or role) being or playing the villain
   example:
-  - Iago is the heavy role in `Othello´
+  - Iago is the heavy role in ‘Othello’
   ili: i13943
   members:
   - heavy
@@ -177529,7 +177529,7 @@
   definition:
   - giving no light
   example:
-  - lightless stars `visible´ only to radio antennae
+  - lightless stars ‘visible’ only to radio antennae
   ili: i13964
   members:
   - lightless
@@ -178484,7 +178484,7 @@
   definition:
   - providing coolness
   example:
-  - '`caller´ is a Scottish term as in `a caller breeze´'
+  - '‘caller’ is a Scottish term as in ‘a caller breeze’'
   ili: i14035
   members:
   - caller
@@ -178835,7 +178835,7 @@
   definition:
   - increasing or having the power to increase especially in size or amount or degree
   example:
-  - '`up´ is an augmentative word in `hurry up´'
+  - '‘up’ is an augmentative word in ‘hurry up’'
   ili: i14065
   members:
   - augmentative
@@ -181561,7 +181561,7 @@
   - covered with or consisting of bushes or thickets
   example:
   - brushy undergrowth
-  - '`bosky´ is a literary term'
+  - '‘bosky’ is a literary term'
   - source: Jack Beatty
     text: a bosky park leading to a modest yet majestic plaza
   ili: i14278
@@ -182954,7 +182954,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '`or´ is a syncategorematic term'
+  - '‘or’ is a syncategorematic term'
   ili: i14396
   members:
   - syncategorematic
@@ -183418,7 +183418,7 @@
   partOfSpeech: a
 87988931-s:
   definition:
-  - denoting or characteristic of countries of Asia; `oriental civilization´
+  - denoting or characteristic of countries of Asia; ‘oriental civilization’
   members:
   - oriental
   partOfSpeech: s

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -140026,7 +140026,7 @@
   - 06184139-n
   example:
   - the nonrestrictive clause in `I always buy his books, which have influenced me
-    greatly,´ refers to his books generally and adds an additional fact about them
+    greatly´ refers to his books generally and adds an additional fact about them
   ili: i10980
   members:
   - nonrestrictive

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -34795,7 +34795,7 @@
   - affecting the people or community as a whole
   example:
   - the public welfare
-  - 'Public interests '
+  - Public interests
   - Public leaders
   ili: i2773
   members:
@@ -74809,7 +74809,7 @@
   definition:
   - containing salt
   example:
-  - 'a saline substance '
+  - a saline substance
   - salty tears
   ili: i5895
   members:
@@ -143303,8 +143303,7 @@
   - 02057536-a
 02057872-a:
   definition:
-  - of or relating to the countryside as opposed to the city; living in or characteristic
-    of farming or country life
+  - of or relating to the countryside as opposed to the city
   - living in or characteristic of farming or country life
   example:
   - rural people

--- a/src/yaml/adj.pert.yaml
+++ b/src/yaml/adj.pert.yaml
@@ -1985,7 +1985,7 @@
 02644883-a:
   definition:
   - of or relating to the belief that God can be known to humans only in terms of
-    what He is not (such as `God is unknowable')
+    what He is not (such as `God is unknowable´)
   ili: i14689
   members:
   - apophatic
@@ -2846,7 +2846,7 @@
   definition:
   - of or relating to the atmospheric phenomenon auroras
   example:
-  - a prominent green line in the spectrum of the auroras is called the `auroral line'
+  - a prominent green line in the spectrum of the auroras is called the `auroral line´
   ili: i14789
   members:
   - auroral
@@ -7494,7 +7494,7 @@
   - 05955536-n
   - 00935235-n
   example:
-  - highly formalized plays like `Waiting for Godot'
+  - highly formalized plays like `Waiting for Godot´
   ili: i15358
   members:
   - formalistic
@@ -7908,7 +7908,7 @@
   definition:
   - relating to or articulated in the throat
   example:
-  - the glottal stop and uvular `r' and `ch' in German `Bach' are guttural sounds
+  - the glottal stop and uvular `r´ and `ch´ in German `Bach´ are guttural sounds
   ili: i15408
   members:
   - guttural
@@ -10205,7 +10205,7 @@
   definition:
   - of or relating to the feet
   example:
-  - the word for a pedal extremity is `foot'
+  - the word for a pedal extremity is `foot´
   ili: i15687
   members:
   - pedal
@@ -10679,7 +10679,7 @@
   - 06145709-n
   - 06168062-n
   example:
-  - what Whitehead calls `perception in the presentational immediacy'
+  - what Whitehead calls `perception in the presentational immediacy´
   ili: i15746
   members:
   - presentational
@@ -12931,7 +12931,7 @@
   definition:
   - of or relating to or formed from a verb
   example:
-  - verbal adjectives like `running' in `hot and cold running water'
+  - verbal adjectives like `running´ in `hot and cold running water´
   ili: i16011
   members:
   - verbal
@@ -14807,7 +14807,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - polyphonic letters such as `a'
+  - polyphonic letters such as `a´
   ili: i16225
   members:
   - polyphonic
@@ -15047,7 +15047,7 @@
   partOfSpeech: a
 02871063-a:
   definition:
-  - having cells with `good' or membrane-bound nuclei
+  - having cells with `good´ or membrane-bound nuclei
   ili: i16250
   members:
   - eukaryotic
@@ -19379,7 +19379,7 @@
   definition:
   - consisting of two morphemes
   example:
-  - the bimorphemic word `rays'
+  - the bimorphemic word `rays´
   ili: i16735
   members:
   - bimorphemic
@@ -19388,7 +19388,7 @@
   definition:
   - consisting of only one morpheme
   example:
-  - '`raise'' is monomorphemic but `rays'' is not'
+  - '`raise´ is monomorphemic but `rays´ is not'
   ili: i16736
   members:
   - monomorphemic
@@ -21329,7 +21329,7 @@
   example:
   - Nepalese troops massed at the border
   - Nepali mountains are among the highest in the world
-  - the different Nepali words for `rice'
+  - the different Nepali words for `rice´
   ili: i16953
   members:
   - Nepalese
@@ -22600,7 +22600,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - '`horse'' and `hoarse'' are homophonous words'
+  - '`horse´ and `hoarse´ are homophonous words'
   ili: i17100
   members:
   - homophonous
@@ -23068,7 +23068,7 @@
 03013361-a:
   definition:
   - pertaining to or characteristic of a body of rules and principles accepted as
-    axiomatic; e.g. `canonist communism'
+    axiomatic; e.g. `canonist communism´
   example:
   - canonist communism
   ili: i17154
@@ -24361,11 +24361,11 @@
   example:
   - Scots Gaelic
   - the Scots community in New York
-  - '`Scottish'' tends to be the more formal term as in `The Scottish Symphony'' or
-    `Scottish authors'' or `Scottish mountains'''
-  - '`Scotch'' is in disfavor with Scottish people and is used primarily outside Scotland
-    except in such frozen phrases as `Scotch broth'' or `Scotch whiskey'' or `Scotch
-    plaid'''
+  - '`Scottish´ tends to be the more formal term as in `The Scottish Symphony´ or
+    `Scottish authors´ or `Scottish mountains´'
+  - '`Scotch´ is in disfavor with Scottish people and is used primarily outside Scotland
+    except in such frozen phrases as `Scotch broth´ or `Scotch whiskey´ or `Scotch
+    plaid´'
   ili: i17308
   members:
   - Scots
@@ -29695,7 +29695,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - the gerundial suffix `-ing'
+  - the gerundial suffix `-ing´
   ili: i17909
   members:
   - gerundial

--- a/src/yaml/adj.pert.yaml
+++ b/src/yaml/adj.pert.yaml
@@ -1985,7 +1985,7 @@
 02644883-a:
   definition:
   - of or relating to the belief that God can be known to humans only in terms of
-    what He is not (such as `God is unknowable´)
+    what He is not (such as ‘God is unknowable’)
   ili: i14689
   members:
   - apophatic
@@ -2846,7 +2846,7 @@
   definition:
   - of or relating to the atmospheric phenomenon auroras
   example:
-  - a prominent green line in the spectrum of the auroras is called the `auroral line´
+  - a prominent green line in the spectrum of the auroras is called the ‘auroral line’
   ili: i14789
   members:
   - auroral
@@ -7494,7 +7494,7 @@
   - 05955536-n
   - 00935235-n
   example:
-  - highly formalized plays like `Waiting for Godot´
+  - highly formalized plays like ‘Waiting for Godot’
   ili: i15358
   members:
   - formalistic
@@ -7908,7 +7908,7 @@
   definition:
   - relating to or articulated in the throat
   example:
-  - the glottal stop and uvular `r´ and `ch´ in German `Bach´ are guttural sounds
+  - the glottal stop and uvular ‘r’ and ‘ch’ in German ‘Bach’ are guttural sounds
   ili: i15408
   members:
   - guttural
@@ -10205,7 +10205,7 @@
   definition:
   - of or relating to the feet
   example:
-  - the word for a pedal extremity is `foot´
+  - the word for a pedal extremity is ‘foot’
   ili: i15687
   members:
   - pedal
@@ -10679,7 +10679,7 @@
   - 06145709-n
   - 06168062-n
   example:
-  - what Whitehead calls `perception in the presentational immediacy´
+  - what Whitehead calls ‘perception in the presentational immediacy’
   ili: i15746
   members:
   - presentational
@@ -12931,7 +12931,7 @@
   definition:
   - of or relating to or formed from a verb
   example:
-  - verbal adjectives like `running´ in `hot and cold running water´
+  - verbal adjectives like ‘running’ in ‘hot and cold running water’
   ili: i16011
   members:
   - verbal
@@ -14807,7 +14807,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - polyphonic letters such as `a´
+  - polyphonic letters such as ‘a’
   ili: i16225
   members:
   - polyphonic
@@ -15047,7 +15047,7 @@
   partOfSpeech: a
 02871063-a:
   definition:
-  - having cells with `good´ or membrane-bound nuclei
+  - having cells with ‘good’ or membrane-bound nuclei
   ili: i16250
   members:
   - eukaryotic
@@ -19379,7 +19379,7 @@
   definition:
   - consisting of two morphemes
   example:
-  - the bimorphemic word `rays´
+  - the bimorphemic word ‘rays’
   ili: i16735
   members:
   - bimorphemic
@@ -19388,7 +19388,7 @@
   definition:
   - consisting of only one morpheme
   example:
-  - '`raise´ is monomorphemic but `rays´ is not'
+  - '‘raise’ is monomorphemic but ‘rays’ is not'
   ili: i16736
   members:
   - monomorphemic
@@ -21329,7 +21329,7 @@
   example:
   - Nepalese troops massed at the border
   - Nepali mountains are among the highest in the world
-  - the different Nepali words for `rice´
+  - the different Nepali words for ‘rice’
   ili: i16953
   members:
   - Nepalese
@@ -22600,7 +22600,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - '`horse´ and `hoarse´ are homophonous words'
+  - '‘horse’ and ‘hoarse’ are homophonous words'
   ili: i17100
   members:
   - homophonous
@@ -23068,7 +23068,7 @@
 03013361-a:
   definition:
   - pertaining to or characteristic of a body of rules and principles accepted as
-    axiomatic; e.g. `canonist communism´
+    axiomatic; e.g. ‘canonist communism’
   example:
   - canonist communism
   ili: i17154
@@ -24361,11 +24361,11 @@
   example:
   - Scots Gaelic
   - the Scots community in New York
-  - '`Scottish´ tends to be the more formal term as in `The Scottish Symphony´ or
-    `Scottish authors´ or `Scottish mountains´'
-  - '`Scotch´ is in disfavor with Scottish people and is used primarily outside Scotland
-    except in such frozen phrases as `Scotch broth´ or `Scotch whiskey´ or `Scotch
-    plaid´'
+  - '‘Scottish’ tends to be the more formal term as in ‘The Scottish Symphony’ or
+    ‘Scottish authors’ or ‘Scottish mountains’'
+  - '‘Scotch’ is in disfavor with Scottish people and is used primarily outside Scotland
+    except in such frozen phrases as ‘Scotch broth’ or ‘Scotch whiskey’ or ‘Scotch
+    plaid’'
   ili: i17308
   members:
   - Scots
@@ -29695,7 +29695,7 @@
   domain_topic:
   - 06184139-n
   example:
-  - the gerundial suffix `-ing´
+  - the gerundial suffix ‘-ing’
   ili: i17909
   members:
   - gerundial

--- a/src/yaml/adj.pert.yaml
+++ b/src/yaml/adj.pert.yaml
@@ -19388,7 +19388,7 @@
   definition:
   - consisting of only one morpheme
   example:
-  - '‘raise’ is monomorphemic but ‘rays’ is not'
+  - ‘raise’ is monomorphemic but ‘rays’ is not
   ili: i16736
   members:
   - monomorphemic
@@ -22600,7 +22600,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - '‘horse’ and ‘hoarse’ are homophonous words'
+  - ‘horse’ and ‘hoarse’ are homophonous words
   ili: i17100
   members:
   - homophonous
@@ -24361,11 +24361,11 @@
   example:
   - Scots Gaelic
   - the Scots community in New York
-  - '‘Scottish’ tends to be the more formal term as in ‘The Scottish Symphony’ or
-    ‘Scottish authors’ or ‘Scottish mountains’'
-  - '‘Scotch’ is in disfavor with Scottish people and is used primarily outside Scotland
+  - ‘Scottish’ tends to be the more formal term as in ‘The Scottish Symphony’ or ‘Scottish
+    authors’ or ‘Scottish mountains’
+  - ‘Scotch’ is in disfavor with Scottish people and is used primarily outside Scotland
     except in such frozen phrases as ‘Scotch broth’ or ‘Scotch whiskey’ or ‘Scotch
-    plaid’'
+    plaid’
   ili: i17308
   members:
   - Scots

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -20439,7 +20439,7 @@
   definition:
   - in a cryptic manner
   example:
-  - '`we will meet again´, he said cryptically'
+  - '`we will meet again,´ he said cryptically'
   ili: i20210
   members:
   - cryptically
@@ -23185,7 +23185,7 @@
   definition:
   - in an inflexible manner
   example:
-  - '`You will — because you must!,´ Madam told her inflexibly'
+  - '`You will — because you must!´ Madam told her inflexibly'
   ili: i20491
   members:
   - inflexibly
@@ -23993,7 +23993,7 @@
   definition:
   - in a harsh or unkind manner
   example:
-  - '`That''s enough!,´ he cut in harshly'
+  - '`That''s enough!´ he cut in harshly'
   ili: i20577
   members:
   - harshly

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -580,7 +580,7 @@
   partOfSpeech: r
 00010928-r:
   definition:
-  - to the greatest degree or extent; completely or entirely; (`full' in this sense
+  - to the greatest degree or extent; completely or entirely; (`full´ in this sense
     is used as a combining form)
   example:
   - fully grown
@@ -627,7 +627,7 @@
 00011555-r:
   definition:
   - (often used as a combining form) in a good or proper or satisfactory manner or
-    to a high standard (`good' is a nonstandard dialectal variant for `well')
+    to a high standard (`good´ is a nonstandard dialectal variant for `well´)
   example:
   - the children behaved well
   - a task well done
@@ -646,7 +646,7 @@
   partOfSpeech: r
 00011978-r:
   definition:
-  - (`ill' is often used as a combining form) in a poor or improper or unsatisfactory
+  - (`ill´ is often used as a combining form) in a poor or improper or unsatisfactory
     manner; not well
   example:
   - he was ill prepared
@@ -930,7 +930,7 @@
   partOfSpeech: r
 00016920-r:
   definition:
-  - with great intensity (`bad' is a nonstandard variant for `badly')
+  - with great intensity (`bad´ is a nonstandard variant for `badly´)
   example:
   - the injury hurt badly
   - the buildings were badly shaken
@@ -966,7 +966,7 @@
   partOfSpeech: r
 00017539-r:
   definition:
-  - (comparative of `ill') in a less effective or successful or desirable manner
+  - (comparative of `ill´) in a less effective or successful or desirable manner
   example:
   - he did worse on the second exam
   exemplifies:
@@ -1274,7 +1274,7 @@
   partOfSpeech: r
 00022585-r:
   definition:
-  - to the same degree (often followed by `as')
+  - to the same degree (often followed by `as´)
   example:
   - they were equally beautiful
   - birds were singing and the child sang as sweetly
@@ -1295,7 +1295,7 @@
   - left for work long ago
   - he has long since given up mountain climbing
   - This name has long since been forgotten
-  - '`lang syne'' is Scottish'
+  - '`lang syne´ is Scottish'
   ili: i18268
   members:
   - long ago
@@ -1455,8 +1455,8 @@
   partOfSpeech: r
 00025252-r:
   definition:
-  - after a negative statement used as an intensive meaning something like `likewise'
-    or `also'
+  - after a negative statement used as an intensive meaning something like `likewise´
+    or `also´
   example:
   - he isn't stupid, but he isn't exactly a genius either
   - I don't know either
@@ -1749,8 +1749,8 @@
   partOfSpeech: r
 00030035-r:
   definition:
-  - to or at a greater distance in time or space (`farther' is used more frequently
-    than `further' in this physical sense)
+  - to or at a greater distance in time or space (`farther´ is used more frequently
+    than `further´ in this physical sense)
   example:
   - farther north
   - moved farther away
@@ -1765,8 +1765,8 @@
   partOfSpeech: r
 00030381-r:
   definition:
-  - to or at a greater extent or degree or a more advanced stage (`further' is used
-    more often than `farther' in this abstract sense)
+  - to or at a greater extent or degree or a more advanced stage (`further´ is used
+    more often than `farther´ in this abstract sense)
   example:
   - further complicated by uncertainty about the future
   - let's not discuss it further
@@ -1792,8 +1792,8 @@
   partOfSpeech: r
 00031050-r:
   definition:
-  - to the greatest distance in space or time (`farthest' is used more often than
-    `furthest' in this physical sense)
+  - to the greatest distance in space or time (`farthest´ is used more often than
+    `furthest´ in this physical sense)
   example:
   - see who could jump the farthest
   - chose the farthest seat from the door
@@ -1805,8 +1805,8 @@
   partOfSpeech: r
 00031310-r:
   definition:
-  - to the greatest degree or extent or most advanced stage (`furthest' is used more
-    often than `farthest' in this abstract sense)
+  - to the greatest degree or extent or most advanced stage (`furthest´ is used more
+    often than `farthest´ in this abstract sense)
   example:
   - went the furthest of all the children in her education
   - furthest removed from reality
@@ -2319,7 +2319,7 @@
   partOfSpeech: r
 00038658-r:
   definition:
-  - an archaic word originally meaning `in truth' but now usually used to express
+  - an archaic word originally meaning `in truth´ but now usually used to express
     disbelief
   ili: i18362
   members:
@@ -2388,7 +2388,7 @@
   partOfSpeech: r
 00039730-r:
   definition:
-  - unmistakably (`plain' is often used informally for `plainly')
+  - unmistakably (`plain´ is often used informally for `plainly´)
   example:
   - the answer is obviously wrong
   - she was in bed and evidently in great pain
@@ -2740,7 +2740,7 @@
   partOfSpeech: r
 00045532-r:
   definition:
-  - face-to-face with; literally `face to face'
+  - face-to-face with; literally `face to face´
   example:
   - they sat vis-a-vis at the table
   - I found myself vis-a-vis a burly policeman
@@ -3594,7 +3594,7 @@
   partOfSpeech: r
 00057926-r:
   definition:
-  - completely and absolutely (`good' is sometimes used informally for `thoroughly')
+  - completely and absolutely (`good´ is sometimes used informally for `thoroughly´)
   example:
   - he was soundly defeated
   - we beat him good
@@ -3762,7 +3762,7 @@
   partOfSpeech: r
 00060145-r:
   definition:
-  - comparative of `well'; in a better or more excellent manner or more advantageously
+  - comparative of `well´; in a better or more excellent manner or more advantageously
     or attractively or to a greater degree etc.
   example:
   - She had never sung better
@@ -4005,8 +4005,8 @@
   partOfSpeech: r
 00064312-r:
   definition:
-  - used of a group whose members acted or were acted upon collectively and when `all'
-    and `together' can be separated by other words
+  - used of a group whose members acted or were acted upon collectively and when `all´
+    and `together´ can be separated by other words
   example:
   - they were herded all together
   - they were all herded together
@@ -4328,7 +4328,7 @@
   partOfSpeech: r
 00069153-r:
   definition:
-  - in addition (usually followed by `with')
+  - in addition (usually followed by `with´)
   example:
   - we sent them food and some clothing went along in the package
   - along with the package came a bill
@@ -4351,7 +4351,7 @@
   partOfSpeech: r
 00069564-r:
   definition:
-  - in line with a length or direction (often followed by `by' or `beside')
+  - in line with a length or direction (often followed by `by´ or `beside´)
   example:
   - pass the word along
   - ran along beside me
@@ -4794,7 +4794,7 @@
   definition:
   - in a manner or order or direction the reverse of normal
   example:
-  - it's easy to get the `i' and the `e' backward in words like `seize' and `siege'
+  - it's easy to get the `i´ and the `e´ backward in words like `seize´ and `siege´
   - the child put her jersey on backward
   ili: i18595
   members:
@@ -5223,7 +5223,7 @@
   partOfSpeech: r
 00082658-r:
   definition:
-  - at or in an indicated (usually distant) place (`yon' is archaic and dialectal)
+  - at or in an indicated (usually distant) place (`yon´ is archaic and dialectal)
   example:
   - the house yonder
   - source: Calder Willingham
@@ -6616,7 +6616,7 @@
   partOfSpeech: r
 00102302-r:
   definition:
-  - to a great degree or by a great distance; very much (`right smart' is regional
+  - to a great degree or by a great distance; very much (`right smart´ is regional
     in the United States)
   example:
   - way over budget
@@ -6855,7 +6855,7 @@
   partOfSpeech: r
 00105348-r:
   definition:
-  - if nothing else (`leastwise' is informal and `leastways' is colloquial)
+  - if nothing else (`leastwise´ is informal and `leastways´ is colloquial)
   example:
   - at least he survived
   - they felt — at any rate Jim felt — relieved though still wary
@@ -9823,7 +9823,7 @@
   partOfSpeech: r
 00145758-r:
   definition:
-  - definitely or positively (`sure' is sometimes used informally for `surely')
+  - definitely or positively (`sure´ is sometimes used informally for `surely´)
   example:
   - the results are surely encouraging
   - she certainly is a hard worker
@@ -9886,7 +9886,7 @@
   - as much as necessary
   example:
   - have I eaten enough?
-  - (`plenty' is nonstandard) I've had plenty, thanks
+  - (`plenty´ is nonstandard) I've had plenty, thanks
   ili: i19117
   members:
   - enough
@@ -9964,7 +9964,7 @@
   partOfSpeech: r
 00147799-r:
   definition:
-  - (usually followed by `that') to an extent or degree as expressed
+  - (usually followed by `that´) to an extent or degree as expressed
   example:
   - he was so tired he could hardly stand
   - so dirty that it smells
@@ -10053,7 +10053,7 @@
   partOfSpeech: r
 00148912-r:
   definition:
-  - with ease (`easy' is sometimes used informally for `easily')
+  - with ease (`easy´ is sometimes used informally for `easily´)
   example:
   - she was easily excited
   - was easily confused
@@ -11062,7 +11062,7 @@
   partOfSpeech: r
 00162829-r:
   definition:
-  - without speed (`slow' is sometimes used informally for `slowly')
+  - without speed (`slow´ is sometimes used informally for `slowly´)
   example:
   - he spoke slowly
   - go easy here — the road is slippery
@@ -13195,8 +13195,8 @@
   partOfSpeech: r
 00192785-r:
   definition:
-  - and others (`et al.' is used as an abbreviation of `et alii' (masculine plural)
-    or `et aliae' (feminine plural) or `et alia' (neuter plural) when referring to
+  - and others (`et al.´ is used as an abbreviation of `et alii´ (masculine plural)
+    or `et aliae´ (feminine plural) or `et alia´ (neuter plural) when referring to
     a number of people)
   example:
   - the data reported by Smith et al.
@@ -13825,7 +13825,7 @@
   - without hope; desperate because there seems no possibility of comfort or success
   example:
   - he hung his head hopelessly
-  - '`I must die,'' he said hopelessly'
+  - '`I must die,´ he said hopelessly'
   ili: i19522
   members:
   - hopelessly
@@ -14864,7 +14864,7 @@
   definition:
   - in a stolid manner
   example:
-  - he said `no' stolidly
+  - he said `no´ stolidly
   ili: i19630
   members:
   - stolidly
@@ -14885,7 +14885,7 @@
   definition:
   - in a petulant manner
   example:
-  - 'he said testily: `Go away!'''
+  - 'he said testily: `Go away!´'
   ili: i19632
   members:
   - testily
@@ -14965,7 +14965,7 @@
   definition:
   - in a rueful manner
   example:
-  - '`I made a big mistake,'' he said ruefully'
+  - '`I made a big mistake,´ he said ruefully'
   ili: i19640
   members:
   - ruefully
@@ -15003,7 +15003,7 @@
   definition:
   - in a polite manner
   example:
-  - the policeman answered politely, `Now look here, lady … '
+  - the policeman answered politely, `Now look here, lady … ´
   ili: i19644
   members:
   - politely
@@ -15047,7 +15047,7 @@
   definition:
   - in a good-humoured manner
   example:
-  - '`I''ll do the dishes,'' he said pleasantly'
+  - '`I''ll do the dishes,´ he said pleasantly'
   ili: i19648
   members:
   - pleasantly
@@ -15085,7 +15085,7 @@
   definition:
   - in a hearty manner
   example:
-  - '`Yes,'' the children chorused heartily'
+  - '`Yes,´ the children chorused heartily'
   - We welcomed her warmly
   ili: i19652
   members:
@@ -15097,7 +15097,7 @@
   definition:
   - in an affable manner
   example:
-  - '`Come and visit me,'' he said amiably'
+  - '`Come and visit me,´ he said amiably'
   ili: i19653
   members:
   - affably
@@ -15395,7 +15395,7 @@
   definition:
   - in a wry manner
   example:
-  - '`I see,'' he commented wryly'
+  - '`I see,´ he commented wryly'
   ili: i19682
   members:
   - wryly
@@ -15751,8 +15751,8 @@
   partOfSpeech: r
 00231184-r:
   definition:
-  - with little or no activity or no agitation (`quiet' is a nonstandard variant for
-    `quietly')
+  - with little or no activity or no agitation (`quiet´ is a nonstandard variant for
+    `quietly´)
   example:
   - her hands rested quietly in her lap
   - the rock star was quietly led out the back door
@@ -15886,7 +15886,7 @@
   definition:
   - in a dry laconic manner
   example:
-  - '`I know that'', he said dryly'
+  - '`I know that´, he said dryly'
   ili: i19734
   members:
   - laconically
@@ -15997,7 +15997,7 @@
   partOfSpeech: r
 00234667-r:
   definition:
-  - from a particular thing or place or position (`forth' is obsolete)
+  - from a particular thing or place or position (`forth´ is obsolete)
   example:
   - ran away from the lion
   - wanted to get away from there
@@ -16362,7 +16362,7 @@
   definition:
   - with equanimity
   example:
-  - '`I bought it,'' she said contentedly'
+  - '`I bought it,´ she said contentedly'
   ili: i19781
   members:
   - contentedly
@@ -16439,7 +16439,7 @@
   definition:
   - with modesty; in a modest manner
   example:
-  - the dissertation was entitled, modestly, `Remarks about a play by Shakespeare'
+  - the dissertation was entitled, modestly, `Remarks about a play by Shakespeare´
   ili: i19789
   members:
   - modestly
@@ -16448,7 +16448,7 @@
   definition:
   - without modesty; in an immodest manner
   example:
-  - the book was entitled, immodestly, `All about Wisdom'
+  - the book was entitled, immodestly, `All about Wisdom´
   ili: i19790
   members:
   - immodestly
@@ -16541,7 +16541,7 @@
   definition:
   - with sternness; in a severe manner
   example:
-  - '`No,'' she said sternly'
+  - '`No,´ she said sternly'
   - peered severely over her glasses
   ili: i19801
   members:
@@ -17906,7 +17906,7 @@
   partOfSpeech: r
 00260528-r:
   definition:
-  - comparatives of `soon' or `early'
+  - comparatives of `soon´ or `early´
   example:
   - Come a little sooner, if you can
   - came earlier than I expected
@@ -18437,7 +18437,7 @@
   definition:
   - in an assertive manner
   example:
-  - '`I will take care of my own life,'' she said assertively'
+  - '`I will take care of my own life,´ she said assertively'
   ili: i20002
   members:
   - assertively
@@ -19309,7 +19309,7 @@
   definition:
   - in a beseeching manner
   example:
-  - '`You must help me,'' she said imploringly'
+  - '`You must help me,´ she said imploringly'
   ili: i20094
   members:
   - beseechingly
@@ -19426,7 +19426,7 @@
   - in a brisk manner
   example:
   - she walked briskly in the cold air
-  - '`after lunch,'' she said briskly'
+  - '`after lunch,´ she said briskly'
   ili: i20105
   members:
   - briskly
@@ -19492,7 +19492,7 @@
   definition:
   - in a cagey manner
   example:
-  - '`I don''t know yet,'' he answered cagily'
+  - '`I don''t know yet,´ he answered cagily'
   ili: i20112
   members:
   - cagily
@@ -19653,7 +19653,7 @@
   definition:
   - in a chatty manner
   example:
-  - '`when I was a girl,'' she said chattily, `I used to ride a bicycle'''
+  - '`when I was a girl,´ she said chattily, `I used to ride a bicycle´'
   ili: i20128
   members:
   - chattily
@@ -19794,7 +19794,7 @@
   definition:
   - in a cajoling manner
   example:
-  - '`Come here,'' she said coaxingly'
+  - '`Come here,´ she said coaxingly'
   ili: i20143
   members:
   - coaxingly
@@ -19852,7 +19852,7 @@
   definition:
   - in a bellicose contentious manner
   example:
-  - '`Don''t trespass onto my property,'' the neighbor shouted combatively'
+  - '`Don''t trespass onto my property,´ the neighbor shouted combatively'
   ili: i20149
   members:
   - combatively
@@ -20003,7 +20003,7 @@
   definition:
   - in a manner showing concern
   example:
-  - '`Are you all right,'' he asked concernedly'
+  - '`Are you all right,´ he asked concernedly'
   ili: i20166
   members:
   - concernedly
@@ -20341,8 +20341,8 @@
   definition:
   - lacking consequence
   example:
-  - '`You''re so beautifully dressed,'' she said and added quite inconsequentially,
-    `Can you stay the night?'''
+  - '`You''re so beautifully dressed,´ she said and added quite inconsequentially,
+    `Can you stay the night?´'
   ili: i20201
   members:
   - inconsequentially
@@ -20439,7 +20439,7 @@
   definition:
   - in a cryptic manner
   example:
-  - '`we will meet again'', he said cryptically'
+  - '`we will meet again´, he said cryptically'
   ili: i20210
   members:
   - cryptically
@@ -20551,7 +20551,7 @@
   definition:
   - with firmness of purpose
   example:
-  - '`I will come along,'' she said decisively'
+  - '`I will come along,´ she said decisively'
   ili: i20221
   members:
   - decisively
@@ -20561,7 +20561,7 @@
   definition:
   - lacking firmness or resoluteness
   example:
-  - '`I don''t know,'' he said indecisively'
+  - '`I don''t know,´ he said indecisively'
   ili: i20222
   members:
   - indecisively
@@ -20708,7 +20708,7 @@
   definition:
   - in a disrespectful and mocking manner
   example:
-  - '`Sorry,'' she repeated derisively'
+  - '`Sorry,´ she repeated derisively'
   ili: i20236
   members:
   - derisively
@@ -20748,7 +20748,7 @@
   definition:
   - with desperation
   example:
-  - '`Why can''t you understand?,'' she asked despairingly'
+  - '`Why can''t you understand?,´ she asked despairingly'
   ili: i20240
   members:
   - despairingly
@@ -20778,7 +20778,7 @@
   definition:
   - in a congenial manner
   example:
-  - '`Let''s all have a drink together,'' he said congenially'
+  - '`Let''s all have a drink together,´ he said congenially'
   ili: i20243
   members:
   - congenially
@@ -20814,7 +20814,7 @@
   definition:
   - in a convivial manner
   example:
-  - '`Let''s go and have a drink,'' she said convivially'
+  - '`Let''s go and have a drink,´ she said convivially'
   ili: i20247
   members:
   - convivially
@@ -21058,7 +21058,7 @@
   definition:
   - in an apologetic and defensive manner
   example:
-  - '`I felt it better you should know,'' said Sir Cedric defensively'
+  - '`I felt it better you should know,´ said Sir Cedric defensively'
   ili: i20272
   members:
   - defensively
@@ -21067,7 +21067,7 @@
   definition:
   - aggressively
   example:
-  - '`In this crisis, we must act offensively,'' the President said'
+  - '`In this crisis, we must act offensively,´ the President said'
   - the admiral intends to act offensively in the Mediterranean
   ili: i20273
   members:
@@ -21124,7 +21124,7 @@
   definition:
   - in a distracted manner
   example:
-  - '`Come in,'' he said distractedly'
+  - '`Come in,´ he said distractedly'
   ili: i20279
   members:
   - distractedly
@@ -21209,7 +21209,7 @@
   definition:
   - in a diffident manner
   example:
-  - '`Oh, well,'' he shrugged diffidently, `I like the work.'''
+  - '`Oh, well,´ he shrugged diffidently, `I like the work.´'
   ili: i20288
   members:
   - diffidently
@@ -21416,7 +21416,7 @@
   definition:
   - in a disagreeable manner
   example:
-  - '`I took no harm from the journey, thank you,'' she said disagreeably'
+  - '`I took no harm from the journey, thank you,´ she said disagreeably'
   ili: i20309
   members:
   - disagreeably
@@ -21594,7 +21594,7 @@
   definition:
   - in a disjointed manner
   example:
-  - '`We''re not married, not really married,'' she said, and slowly, reluctantly,
+  - '`We''re not married, not really married,´ she said, and slowly, reluctantly,
     disjointedly it came out'
   ili: i20326
   members:
@@ -21676,7 +21676,7 @@
   - in a disparaging manner
   example:
   - these mythological figures are described disparagingly as belonging `only to a
-    story'
+    story´
   ili: i20334
   members:
   - disparagingly
@@ -21812,7 +21812,7 @@
   definition:
   - with distress
   example:
-  - '`Doctor Rother says it''s his only chance,'' she added distressfully'
+  - '`Doctor Rother says it''s his only chance,´ she added distressfully'
   ili: i20349
   members:
   - distressfully
@@ -21998,7 +21998,7 @@
   definition:
   - in a dreamy manner
   example:
-  - '`She would look beautiful in the new dress,'' Tommy said dreamily'
+  - '`She would look beautiful in the new dress,´ Tommy said dreamily'
   ili: i20369
   members:
   - dreamily
@@ -22018,7 +22018,7 @@
   definition:
   - in a drowsy manner
   example:
-  - '`Time to get up,'' she said drowsily'
+  - '`Time to get up,´ she said drowsily'
   ili: i20371
   members:
   - drowsily
@@ -22372,7 +22372,7 @@
   definition:
   - in an encouraging manner
   example:
-  - '`Go on,'' he said encouragingly to his student'
+  - '`Go on,´ he said encouragingly to his student'
   ili: i20408
   members:
   - encouragingly
@@ -22421,7 +22421,7 @@
   definition:
   - in an enterprising manner
   example:
-  - '`Let''s go up that mountain,'' she said enterprisingly'
+  - '`Let''s go up that mountain,´ she said enterprisingly'
   ili: i20413
   members:
   - enterprisingly
@@ -23176,7 +23176,7 @@
   definition:
   - with flexibility
   example:
-  - '`Come whenever you are free,'' he said flexibly'
+  - '`Come whenever you are free,´ he said flexibly'
   ili: i20490
   members:
   - flexibly
@@ -23185,7 +23185,7 @@
   definition:
   - in an inflexible manner
   example:
-  - '`You will — because you must!,'' Madam told her inflexibly'
+  - '`You will — because you must!,´ Madam told her inflexibly'
   ili: i20491
   members:
   - inflexibly
@@ -23287,7 +23287,7 @@
   definition:
   - with forgiveness; in a forgiving manner
   example:
-  - '`Never mind,'' she said forgivingly'
+  - '`Never mind,´ she said forgivingly'
   ili: i20502
   members:
   - forgivingly
@@ -23478,7 +23478,7 @@
   definition:
   - without warmth or enthusiasm
   example:
-  - '`Come in if you have to,'' he said frostily'
+  - '`Come in if you have to,´ he said frostily'
   ili: i20523
   members:
   - frostily
@@ -23892,7 +23892,7 @@
   definition:
   - in a gruff manner
   example:
-  - '`No,'' he replied gruffly'
+  - '`No,´ he replied gruffly'
   ili: i20566
   members:
   - gruffly
@@ -23993,7 +23993,7 @@
   definition:
   - in a harsh or unkind manner
   example:
-  - '`That''s enough!,'' he cut in harshly'
+  - '`That''s enough!,´ he cut in harshly'
   ili: i20577
   members:
   - harshly
@@ -24010,7 +24010,7 @@
   partOfSpeech: r
 00355829-r:
   definition:
-  - with roughness or violence (`rough' is an informal variant for `roughly')
+  - with roughness or violence (`rough´ is an informal variant for `roughly´)
   example:
   - he was pushed roughly aside
   - they treated him rough
@@ -24114,7 +24114,7 @@
   definition:
   - in a heated manner
   example:
-  - '`To say I am behind the strike is so much nonsense,'' declared Mr Harvey heatedly'
+  - '`To say I am behind the strike is so much nonsense,´ declared Mr Harvey heatedly'
   - the children were arguing hotly
   ili: i20590
   members:
@@ -24327,7 +24327,7 @@
   definition:
   - in a hoarse or husky voice
   example:
-  - '`Excuse me,'' he said hoarsely'
+  - '`Excuse me,´ he said hoarsely'
   ili: i20612
   members:
   - hoarsely
@@ -24382,7 +24382,7 @@
   definition:
   - in a huffy manner
   example:
-  - '`Don''t bother to call me back,'' he said huffily'
+  - '`Don''t bother to call me back,´ he said huffily'
   ili: i20618
   members:
   - huffily
@@ -24497,7 +24497,7 @@
   - in a cold and icy manner
   example:
   - '`Mr. Powell finds it easier to take it out of mothers, children and sick people
-    than to take on this vast industry,'' Mr Brown commented icily'
+    than to take on this vast industry,´ Mr Brown commented icily'
   ili: i20630
   members:
   - icily
@@ -24949,7 +24949,7 @@
   definition:
   - just as it should be
   example:
-  - '`Precisely, my lord,'' he said'
+  - '`Precisely, my lord,´ he said'
   ili: i20677
   members:
   - precisely
@@ -25266,7 +25266,7 @@
   definition:
   - in an uninformative manner
   example:
-  - '`I can''t tell you when the manager will arrive,'' he said rather uninformatively'
+  - '`I can''t tell you when the manager will arrive,´ he said rather uninformatively'
   ili: i20710
   members:
   - uninformatively
@@ -25288,7 +25288,7 @@
   - in an ingenious manner
   example:
   - a Hampshire farmer had fowls of different breeds, including Dorkings, and he discriminated
-    ingeniously between the `dark ones' and the `white ones'
+    ingeniously between the `dark ones´ and the `white ones´
   ili: i20712
   members:
   - ingeniously
@@ -25667,7 +25667,7 @@
   definition:
   - in a transitive manner
   example:
-  - you can use the verb `eat' transitively or intransitively
+  - you can use the verb `eat´ transitively or intransitively
   ili: i20753
   members:
   - transitively
@@ -25676,7 +25676,7 @@
   definition:
   - in an intransitive manner
   example:
-  - you can use the verb `drink' intransitively, without a direct object
+  - you can use the verb `drink´ intransitively, without a direct object
   ili: i20754
   members:
   - intransitively
@@ -25747,7 +25747,7 @@
   definition:
   - in an irate manner
   example:
-  - '`Get out,'' he shouted irately'
+  - '`Get out,´ he shouted irately'
   ili: i20762
   members:
   - irately
@@ -25962,7 +25962,7 @@
   definition:
   - in a weak and unconvincing manner
   example:
-  - '`I don''t know, Edward,'' she answered lamely'
+  - '`I don''t know, Edward,´ she answered lamely'
   ili: i20785
   members:
   - lamely
@@ -26206,7 +26206,7 @@
   - in a yearning manner
   example:
   - he spent the rest of the act gazing longingly over my right shoulder at the illuminated
-    word `Exit'
+    word `Exit´
   ili: i20811
   members:
   - longingly
@@ -26266,7 +26266,7 @@
   definition:
   - so as to be unmanageable
   example:
-  - '`This house is unmanageably large,'' she complained'
+  - '`This house is unmanageably large,´ she complained'
   ili: i20817
   members:
   - unmanageably
@@ -26442,8 +26442,8 @@
   definition:
   - in a chatty loquacious manner
   example:
-  - '`When I was young,'' she continued loquaciously, `I used to do all sorts of naughty
-    things'''
+  - '`When I was young,´ she continued loquaciously, `I used to do all sorts of naughty
+    things´'
   ili: i20837
   members:
   - loquaciously
@@ -27166,7 +27166,7 @@
   definition:
   - with sadness; in a sad manner
   example:
-  - '`She died last night,'' he said sadly'
+  - '`She died last night,´ he said sadly'
   ili: i20915
   members:
   - sadly
@@ -27239,7 +27239,7 @@
   definition:
   - in a meditative manner
   example:
-  - '`It''s funny about that bar,'' he said musingly'
+  - '`It''s funny about that bar,´ he said musingly'
   ili: i20923
   members:
   - musingly
@@ -27257,7 +27257,7 @@
   partOfSpeech: r
 00407778-r:
   definition:
-  - (often followed by `for') in exchange or in reciprocation
+  - (often followed by `for´) in exchange or in reciprocation
   example:
   - gave up our seats on the plane and in return received several hundred dollars
     and seats on the next plane out
@@ -27319,7 +27319,7 @@
   definition:
   - in a nasty ill-tempered manner
   example:
-  - '`Don''t expect me to help you,'' he added nastily'
+  - '`Don''t expect me to help you,´ he added nastily'
   ili: i20931
   members:
   - nastily
@@ -27367,7 +27367,7 @@
   partOfSpeech: r
 00409712-r:
   definition:
-  - (comparative of `near' or `close') within a shorter distance
+  - (comparative of `near´ or `close´) within a shorter distance
   example:
   - come closer, my dear!
   - they drew nearer
@@ -27382,7 +27382,7 @@
   partOfSpeech: r
 00409931-r:
   definition:
-  - (superlative of `near' or `close') within the shortest distance
+  - (superlative of `near´ or `close´) within the shortest distance
   example:
   - that was the time he came nearest to death
   exemplifies:
@@ -27812,7 +27812,7 @@
   definition:
   - with optimism; in an optimistic manner
   example:
-  - '`We have a good chance of winning,'' he exclaimed optimistically'
+  - '`We have a good chance of winning,´ he exclaimed optimistically'
   ili: i20982
   members:
   - optimistically
@@ -28121,7 +28121,7 @@
   definition:
   - in a pedantic manner
   example:
-  - these interpretations are called `schemas' or, more pedantically, `schemata'
+  - these interpretations are called `schemas´ or, more pedantically, `schemata´
   ili: i21016
   members:
   - pedantically
@@ -28335,7 +28335,7 @@
   definition:
   - in a picturesque manner
   example:
-  - in the building trade such a trader is picturesquely described as a `brass plate'
+  - in the building trade such a trader is picturesquely described as a `brass plate´
     merchant
   ili: i21040
   members:
@@ -29174,7 +29174,7 @@
   definition:
   - in a provocative manner
   example:
-  - '`Try it,'' he said provocatively'
+  - '`Try it,´ he said provocatively'
   ili: i21129
   members:
   - provocatively
@@ -29201,7 +29201,7 @@
   definition:
   - in a curious and prying manner
   example:
-  - '`Do you have a boyfriend,'' she asked her prospective tenant pryingly'
+  - '`Do you have a boyfriend,´ she asked her prospective tenant pryingly'
   ili: i21132
   members:
   - pryingly
@@ -29353,7 +29353,7 @@
   definition:
   - in a queasy manner
   example:
-  - '`Do I have to remove the liver,'' the medical student asked queasily'
+  - '`Do I have to remove the liver,´ the medical student asked queasily'
   ili: i21149
   members:
   - queasily
@@ -29799,7 +29799,7 @@
   definition:
   - in a rhetorical manner
   example:
-  - '`What can be done?'' he asked rhetorically'
+  - '`What can be done?´ he asked rhetorically'
   ili: i21198
   members:
   - rhetorically
@@ -29958,7 +29958,7 @@
   definition:
   - in a sarcastic manner
   example:
-  - '`Ah, now we''re getting at the truth,'' he interposed sarcastically'
+  - '`Ah, now we''re getting at the truth,´ he interposed sarcastically'
   ili: i21215
   members:
   - sarcastically
@@ -30044,7 +30044,7 @@
   definition:
   - in a searching manner
   example:
-  - '`Are you really happy with him,'' asked her mother, gazing at Vera searchingly'
+  - '`Are you really happy with him,´ asked her mother, gazing at Vera searchingly'
   ili: i21224
   members:
   - searchingly
@@ -30208,7 +30208,7 @@
   definition:
   - in a sentimental manner
   example:
-  - '`I miss the good old days,'' she added sentimentally'
+  - '`I miss the good old days,´ she added sentimentally'
   ili: i21242
   members:
   - sentimentally
@@ -30308,7 +30308,7 @@
   definition:
   - in a manner characterized by trembling or shaking
   example:
-  - '`I — I''m going to make you a cup of tea'', she explained shakily'
+  - '`I — I''m going to make you a cup of tea´, she explained shakily'
   ili: i21253
   members:
   - shakily
@@ -30606,7 +30606,7 @@
   - in a silky manner
   example:
   - the young wheat shone silkily
-  - '`Darling,'' she said silkily'
+  - '`Darling,´ she said silkily'
   ili: i21283
   members:
   - silkily
@@ -30742,7 +30742,7 @@
   partOfSpeech: r
 00458908-r:
   definition:
-  - (with verb `to blow') destroyed completely; blown apart or to pieces
+  - (with verb `to blow´) destroyed completely; blown apart or to pieces
   example:
   - they blew the bridge sky-high
   - the committee blew the thesis sky-high
@@ -30873,7 +30873,7 @@
   definition:
   - in a smooth and diplomatic manner
   example:
-  - '`And now,'' he said smoothly, `we will continue the conversation'''
+  - '`And now,´ he said smoothly, `we will continue the conversation´'
   ili: i21310
   members:
   - smoothly
@@ -30955,7 +30955,7 @@
   definition:
   - in an ill-natured and snappish manner
   example:
-  - '`Don''t talk to me now,'' she said snappishly'
+  - '`Don''t talk to me now,´ she said snappishly'
   ili: i21319
   members:
   - snappishly
@@ -30973,7 +30973,7 @@
   definition:
   - with a sneer; in an uncomplimentary sneering manner
   example:
-  - '`I don''t believe in these customs,'' he said sneeringly'
+  - '`I don''t believe in these customs,´ he said sneeringly'
   ili: i21321
   members:
   - sneeringly
@@ -31031,7 +31031,7 @@
   definition:
   - in a concerned and solicitous manner
   example:
-  - '`Don''t you feel well?'' his mother asked solicitously'
+  - '`Don''t you feel well?´ his mother asked solicitously'
   ili: i21327
   members:
   - solicitously
@@ -31049,7 +31049,7 @@
   definition:
   - in a somber manner
   example:
-  - '`That''s sure bad news,'' said Dowd, somberly'
+  - '`That''s sure bad news,´ said Dowd, somberly'
   ili: i21329
   members:
   - somberly
@@ -31105,7 +31105,7 @@
   definition:
   - all at the same time
   example:
-  - Let's say `Yes!' all at once
+  - Let's say `Yes!´ all at once
   ili: i21335
   members:
   - all together
@@ -31310,7 +31310,7 @@
   definition:
   - in a squeamish manner
   example:
-  - '`I would rather not touch,'' he said squeamishly'
+  - '`I would rather not touch,´ he said squeamishly'
   ili: i21360
   members:
   - squeamishly
@@ -31319,7 +31319,7 @@
   definition:
   - in a stagy and theatrical manner
   example:
-  - '`I cannot show my face at her house,'' he declared theatrically'
+  - '`I cannot show my face at her house,´ he declared theatrically'
   ili: i21361
   members:
   - stagily
@@ -31651,7 +31651,7 @@
   definition:
   - in a stuffy manner
   example:
-  - '`Come in please,'' he said stuffily'
+  - '`Come in please,´ he said stuffily'
   ili: i21397
   members:
   - stuffily
@@ -31745,7 +31745,7 @@
   definition:
   - in a sulky manner
   example:
-  - '`What else could I do?'' said Graham sulkily'
+  - '`What else could I do?´ said Graham sulkily'
   ili: i21407
   members:
   - sulkily
@@ -31843,8 +31843,8 @@
   partOfSpeech: r
 00474454-r:
   definition:
-  - in an affectionate or loving manner (`sweet' is sometimes a poetic or informal
-    variant of `sweetly')
+  - in an affectionate or loving manner (`sweet´ is sometimes a poetic or informal
+    variant of `sweetly´)
   domain_topic:
   - 07107220-n
   example:
@@ -31937,7 +31937,7 @@
   definition:
   - in a tart manner
   example:
-  - '`Never mind your immortal soul,'' she said tartly'
+  - '`Never mind your immortal soul,´ she said tartly'
   ili: i21427
   members:
   - tartly
@@ -31974,7 +31974,7 @@
   definition:
   - in a playfully teasing manner
   example:
-  - '`You hate things to be out of order, don''t you?'' she said teasingly'
+  - '`You hate things to be out of order, don''t you?´ she said teasingly'
   ili: i21431
   members:
   - tauntingly
@@ -32076,7 +32076,7 @@
   definition:
   - in an ill-natured and tetchy manner
   example:
-  - '`Are you sure?'' he asked her tetchily'
+  - '`Are you sure?´ he asked her tetchily'
   ili: i21442
   members:
   - tetchily
@@ -32306,7 +32306,7 @@
   definition:
   - in a monotone
   example:
-  - '`Come in,'' she said tonelessly'
+  - '`Come in,´ she said tonelessly'
   ili: i21467
   members:
   - tonelessly
@@ -33120,7 +33120,7 @@
   definition:
   - in an urbane manner
   example:
-  - '`I had tea occasionally with the Duke,'' said Mr. Eggers urbanely'
+  - '`I had tea occasionally with the Duke,´ said Mr. Eggers urbanely'
   ili: i21557
   members:
   - urbanely
@@ -33564,7 +33564,7 @@
   definition:
   - in a worried manner
   example:
-  - '`I wonder what to do,'' she said worriedly'
+  - '`I wonder what to do,´ she said worriedly'
   - he paused worriedly before calling the bank
   ili: i21606
   members:
@@ -33597,7 +33597,7 @@
   definition:
   - in a wretched manner
   example:
-  - '`I can''t remember who I am,'' I said, wretchedly'
+  - '`I can''t remember who I am,´ I said, wretchedly'
   ili: i21610
   members:
   - wretchedly
@@ -34052,7 +34052,7 @@
   definition:
   - with barely repressed anger
   example:
-  - '`I can''t wait,'' she answered smolderingly'
+  - '`I can''t wait,´ she answered smolderingly'
   ili: i21662
   members:
   - smolderingly
@@ -34419,7 +34419,7 @@
   partOfSpeech: r
 00510690-r:
   definition:
-  - comparative of the adverb `late'
+  - comparative of the adverb `late´
   example:
   - he stayed later than you did
   ili: i21700

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -20003,7 +20003,7 @@
   definition:
   - in a manner showing concern
   example:
-  - '`Are you all right,´ he asked concernedly'
+  - '`Are you all right?´ he asked concernedly'
   ili: i20166
   members:
   - concernedly
@@ -20748,7 +20748,7 @@
   definition:
   - with desperation
   example:
-  - '`Why can''t you understand?,´ she asked despairingly'
+  - '`Why can''t you understand?´ she asked despairingly'
   ili: i20240
   members:
   - despairingly
@@ -29201,7 +29201,7 @@
   definition:
   - in a curious and prying manner
   example:
-  - '`Do you have a boyfriend,´ she asked her prospective tenant pryingly'
+  - '`Do you have a boyfriend?´ she asked her prospective tenant pryingly'
   ili: i21132
   members:
   - pryingly
@@ -29353,7 +29353,7 @@
   definition:
   - in a queasy manner
   example:
-  - '`Do I have to remove the liver,´ the medical student asked queasily'
+  - '`Do I have to remove the liver?´ the medical student asked queasily'
   ili: i21149
   members:
   - queasily
@@ -30044,7 +30044,7 @@
   definition:
   - in a searching manner
   example:
-  - '`Are you really happy with him,´ asked her mother, gazing at Vera searchingly'
+  - '`Are you really happy with him?´ asked her mother, gazing at Vera searchingly'
   ili: i21224
   members:
   - searchingly

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -1295,7 +1295,7 @@
   - left for work long ago
   - he has long since given up mountain climbing
   - This name has long since been forgotten
-  - "`lang syne' is Scottish"
+  - '`lang syne'' is Scottish'
   ili: i18268
   members:
   - long ago

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -580,7 +580,7 @@
   partOfSpeech: r
 00010928-r:
   definition:
-  - to the greatest degree or extent; completely or entirely; (`full´ in this sense
+  - to the greatest degree or extent; completely or entirely; (‘full’ in this sense
     is used as a combining form)
   example:
   - fully grown
@@ -627,7 +627,7 @@
 00011555-r:
   definition:
   - (often used as a combining form) in a good or proper or satisfactory manner or
-    to a high standard (`good´ is a nonstandard dialectal variant for `well´)
+    to a high standard (‘good’ is a nonstandard dialectal variant for ‘well’)
   example:
   - the children behaved well
   - a task well done
@@ -646,7 +646,7 @@
   partOfSpeech: r
 00011978-r:
   definition:
-  - (`ill´ is often used as a combining form) in a poor or improper or unsatisfactory
+  - (‘ill’ is often used as a combining form) in a poor or improper or unsatisfactory
     manner; not well
   example:
   - he was ill prepared
@@ -930,7 +930,7 @@
   partOfSpeech: r
 00016920-r:
   definition:
-  - with great intensity (`bad´ is a nonstandard variant for `badly´)
+  - with great intensity (‘bad’ is a nonstandard variant for ‘badly’)
   example:
   - the injury hurt badly
   - the buildings were badly shaken
@@ -966,7 +966,7 @@
   partOfSpeech: r
 00017539-r:
   definition:
-  - (comparative of `ill´) in a less effective or successful or desirable manner
+  - (comparative of ‘ill’) in a less effective or successful or desirable manner
   example:
   - he did worse on the second exam
   exemplifies:
@@ -1274,7 +1274,7 @@
   partOfSpeech: r
 00022585-r:
   definition:
-  - to the same degree (often followed by `as´)
+  - to the same degree (often followed by ‘as’)
   example:
   - they were equally beautiful
   - birds were singing and the child sang as sweetly
@@ -1295,7 +1295,7 @@
   - left for work long ago
   - he has long since given up mountain climbing
   - This name has long since been forgotten
-  - '`lang syne´ is Scottish'
+  - '‘lang syne’ is Scottish'
   ili: i18268
   members:
   - long ago
@@ -1455,8 +1455,8 @@
   partOfSpeech: r
 00025252-r:
   definition:
-  - after a negative statement used as an intensive meaning something like `likewise´
-    or `also´
+  - after a negative statement used as an intensive meaning something like ‘likewise’
+    or ‘also’
   example:
   - he isn't stupid, but he isn't exactly a genius either
   - I don't know either
@@ -1749,8 +1749,8 @@
   partOfSpeech: r
 00030035-r:
   definition:
-  - to or at a greater distance in time or space (`farther´ is used more frequently
-    than `further´ in this physical sense)
+  - to or at a greater distance in time or space (‘farther’ is used more frequently
+    than ‘further’ in this physical sense)
   example:
   - farther north
   - moved farther away
@@ -1765,8 +1765,8 @@
   partOfSpeech: r
 00030381-r:
   definition:
-  - to or at a greater extent or degree or a more advanced stage (`further´ is used
-    more often than `farther´ in this abstract sense)
+  - to or at a greater extent or degree or a more advanced stage (‘further’ is used
+    more often than ‘farther’ in this abstract sense)
   example:
   - further complicated by uncertainty about the future
   - let's not discuss it further
@@ -1792,8 +1792,8 @@
   partOfSpeech: r
 00031050-r:
   definition:
-  - to the greatest distance in space or time (`farthest´ is used more often than
-    `furthest´ in this physical sense)
+  - to the greatest distance in space or time (‘farthest’ is used more often than
+    ‘furthest’ in this physical sense)
   example:
   - see who could jump the farthest
   - chose the farthest seat from the door
@@ -1805,8 +1805,8 @@
   partOfSpeech: r
 00031310-r:
   definition:
-  - to the greatest degree or extent or most advanced stage (`furthest´ is used more
-    often than `farthest´ in this abstract sense)
+  - to the greatest degree or extent or most advanced stage (‘furthest’ is used more
+    often than ‘farthest’ in this abstract sense)
   example:
   - went the furthest of all the children in her education
   - furthest removed from reality
@@ -2319,7 +2319,7 @@
   partOfSpeech: r
 00038658-r:
   definition:
-  - an archaic word originally meaning `in truth´ but now usually used to express
+  - an archaic word originally meaning ‘in truth’ but now usually used to express
     disbelief
   ili: i18362
   members:
@@ -2388,7 +2388,7 @@
   partOfSpeech: r
 00039730-r:
   definition:
-  - unmistakably (`plain´ is often used informally for `plainly´)
+  - unmistakably (‘plain’ is often used informally for ‘plainly’)
   example:
   - the answer is obviously wrong
   - she was in bed and evidently in great pain
@@ -2740,7 +2740,7 @@
   partOfSpeech: r
 00045532-r:
   definition:
-  - face-to-face with; literally `face to face´
+  - face-to-face with; literally ‘face to face’
   example:
   - they sat vis-a-vis at the table
   - I found myself vis-a-vis a burly policeman
@@ -3594,7 +3594,7 @@
   partOfSpeech: r
 00057926-r:
   definition:
-  - completely and absolutely (`good´ is sometimes used informally for `thoroughly´)
+  - completely and absolutely (‘good’ is sometimes used informally for ‘thoroughly’)
   example:
   - he was soundly defeated
   - we beat him good
@@ -3762,7 +3762,7 @@
   partOfSpeech: r
 00060145-r:
   definition:
-  - comparative of `well´; in a better or more excellent manner or more advantageously
+  - comparative of ‘well’; in a better or more excellent manner or more advantageously
     or attractively or to a greater degree etc.
   example:
   - She had never sung better
@@ -4005,8 +4005,8 @@
   partOfSpeech: r
 00064312-r:
   definition:
-  - used of a group whose members acted or were acted upon collectively and when `all´
-    and `together´ can be separated by other words
+  - used of a group whose members acted or were acted upon collectively and when ‘all’
+    and ‘together’ can be separated by other words
   example:
   - they were herded all together
   - they were all herded together
@@ -4328,7 +4328,7 @@
   partOfSpeech: r
 00069153-r:
   definition:
-  - in addition (usually followed by `with´)
+  - in addition (usually followed by ‘with’)
   example:
   - we sent them food and some clothing went along in the package
   - along with the package came a bill
@@ -4351,7 +4351,7 @@
   partOfSpeech: r
 00069564-r:
   definition:
-  - in line with a length or direction (often followed by `by´ or `beside´)
+  - in line with a length or direction (often followed by ‘by’ or ‘beside’)
   example:
   - pass the word along
   - ran along beside me
@@ -4794,7 +4794,7 @@
   definition:
   - in a manner or order or direction the reverse of normal
   example:
-  - it's easy to get the `i´ and the `e´ backward in words like `seize´ and `siege´
+  - it's easy to get the ‘i’ and the ‘e’ backward in words like ‘seize’ and ‘siege’
   - the child put her jersey on backward
   ili: i18595
   members:
@@ -5223,7 +5223,7 @@
   partOfSpeech: r
 00082658-r:
   definition:
-  - at or in an indicated (usually distant) place (`yon´ is archaic and dialectal)
+  - at or in an indicated (usually distant) place (‘yon’ is archaic and dialectal)
   example:
   - the house yonder
   - source: Calder Willingham
@@ -6616,7 +6616,7 @@
   partOfSpeech: r
 00102302-r:
   definition:
-  - to a great degree or by a great distance; very much (`right smart´ is regional
+  - to a great degree or by a great distance; very much (‘right smart’ is regional
     in the United States)
   example:
   - way over budget
@@ -6855,7 +6855,7 @@
   partOfSpeech: r
 00105348-r:
   definition:
-  - if nothing else (`leastwise´ is informal and `leastways´ is colloquial)
+  - if nothing else (‘leastwise’ is informal and ‘leastways’ is colloquial)
   example:
   - at least he survived
   - they felt — at any rate Jim felt — relieved though still wary
@@ -9823,7 +9823,7 @@
   partOfSpeech: r
 00145758-r:
   definition:
-  - definitely or positively (`sure´ is sometimes used informally for `surely´)
+  - definitely or positively (‘sure’ is sometimes used informally for ‘surely’)
   example:
   - the results are surely encouraging
   - she certainly is a hard worker
@@ -9886,7 +9886,7 @@
   - as much as necessary
   example:
   - have I eaten enough?
-  - (`plenty´ is nonstandard) I've had plenty, thanks
+  - (‘plenty’ is nonstandard) I've had plenty, thanks
   ili: i19117
   members:
   - enough
@@ -9964,7 +9964,7 @@
   partOfSpeech: r
 00147799-r:
   definition:
-  - (usually followed by `that´) to an extent or degree as expressed
+  - (usually followed by ‘that’) to an extent or degree as expressed
   example:
   - he was so tired he could hardly stand
   - so dirty that it smells
@@ -10053,7 +10053,7 @@
   partOfSpeech: r
 00148912-r:
   definition:
-  - with ease (`easy´ is sometimes used informally for `easily´)
+  - with ease (‘easy’ is sometimes used informally for ‘easily’)
   example:
   - she was easily excited
   - was easily confused
@@ -11062,7 +11062,7 @@
   partOfSpeech: r
 00162829-r:
   definition:
-  - without speed (`slow´ is sometimes used informally for `slowly´)
+  - without speed (‘slow’ is sometimes used informally for ‘slowly’)
   example:
   - he spoke slowly
   - go easy here — the road is slippery
@@ -13195,8 +13195,8 @@
   partOfSpeech: r
 00192785-r:
   definition:
-  - and others (`et al.´ is used as an abbreviation of `et alii´ (masculine plural)
-    or `et aliae´ (feminine plural) or `et alia´ (neuter plural) when referring to
+  - and others (‘et al.’ is used as an abbreviation of ‘et alii’ (masculine plural)
+    or ‘et aliae’ (feminine plural) or ‘et alia’ (neuter plural) when referring to
     a number of people)
   example:
   - the data reported by Smith et al.
@@ -13825,7 +13825,7 @@
   - without hope; desperate because there seems no possibility of comfort or success
   example:
   - he hung his head hopelessly
-  - '`I must die,´ he said hopelessly'
+  - '‘I must die,’ he said hopelessly'
   ili: i19522
   members:
   - hopelessly
@@ -14864,7 +14864,7 @@
   definition:
   - in a stolid manner
   example:
-  - he said `no´ stolidly
+  - he said ‘no’ stolidly
   ili: i19630
   members:
   - stolidly
@@ -14885,7 +14885,7 @@
   definition:
   - in a petulant manner
   example:
-  - 'he said testily: `Go away!´'
+  - 'he said testily: ‘Go away!’'
   ili: i19632
   members:
   - testily
@@ -14965,7 +14965,7 @@
   definition:
   - in a rueful manner
   example:
-  - '`I made a big mistake,´ he said ruefully'
+  - '‘I made a big mistake,’ he said ruefully'
   ili: i19640
   members:
   - ruefully
@@ -15003,7 +15003,7 @@
   definition:
   - in a polite manner
   example:
-  - the policeman answered politely, `Now look here, lady … ´
+  - the policeman answered politely, ‘Now look here, lady … ’
   ili: i19644
   members:
   - politely
@@ -15047,7 +15047,7 @@
   definition:
   - in a good-humoured manner
   example:
-  - '`I''ll do the dishes,´ he said pleasantly'
+  - '‘I''ll do the dishes,’ he said pleasantly'
   ili: i19648
   members:
   - pleasantly
@@ -15085,7 +15085,7 @@
   definition:
   - in a hearty manner
   example:
-  - '`Yes,´ the children chorused heartily'
+  - '‘Yes,’ the children chorused heartily'
   - We welcomed her warmly
   ili: i19652
   members:
@@ -15097,7 +15097,7 @@
   definition:
   - in an affable manner
   example:
-  - '`Come and visit me,´ he said amiably'
+  - '‘Come and visit me,’ he said amiably'
   ili: i19653
   members:
   - affably
@@ -15395,7 +15395,7 @@
   definition:
   - in a wry manner
   example:
-  - '`I see,´ he commented wryly'
+  - '‘I see,’ he commented wryly'
   ili: i19682
   members:
   - wryly
@@ -15751,8 +15751,8 @@
   partOfSpeech: r
 00231184-r:
   definition:
-  - with little or no activity or no agitation (`quiet´ is a nonstandard variant for
-    `quietly´)
+  - with little or no activity or no agitation (‘quiet’ is a nonstandard variant for
+    ‘quietly’)
   example:
   - her hands rested quietly in her lap
   - the rock star was quietly led out the back door
@@ -15886,7 +15886,7 @@
   definition:
   - in a dry laconic manner
   example:
-  - '`I know that´, he said dryly'
+  - '‘I know that’, he said dryly'
   ili: i19734
   members:
   - laconically
@@ -15997,7 +15997,7 @@
   partOfSpeech: r
 00234667-r:
   definition:
-  - from a particular thing or place or position (`forth´ is obsolete)
+  - from a particular thing or place or position (‘forth’ is obsolete)
   example:
   - ran away from the lion
   - wanted to get away from there
@@ -16362,7 +16362,7 @@
   definition:
   - with equanimity
   example:
-  - '`I bought it,´ she said contentedly'
+  - '‘I bought it,’ she said contentedly'
   ili: i19781
   members:
   - contentedly
@@ -16439,7 +16439,7 @@
   definition:
   - with modesty; in a modest manner
   example:
-  - the dissertation was entitled, modestly, `Remarks about a play by Shakespeare´
+  - the dissertation was entitled, modestly, ‘Remarks about a play by Shakespeare’
   ili: i19789
   members:
   - modestly
@@ -16448,7 +16448,7 @@
   definition:
   - without modesty; in an immodest manner
   example:
-  - the book was entitled, immodestly, `All about Wisdom´
+  - the book was entitled, immodestly, ‘All about Wisdom’
   ili: i19790
   members:
   - immodestly
@@ -16541,7 +16541,7 @@
   definition:
   - with sternness; in a severe manner
   example:
-  - '`No,´ she said sternly'
+  - '‘No,’ she said sternly'
   - peered severely over her glasses
   ili: i19801
   members:
@@ -17906,7 +17906,7 @@
   partOfSpeech: r
 00260528-r:
   definition:
-  - comparatives of `soon´ or `early´
+  - comparatives of ‘soon’ or ‘early’
   example:
   - Come a little sooner, if you can
   - came earlier than I expected
@@ -18437,7 +18437,7 @@
   definition:
   - in an assertive manner
   example:
-  - '`I will take care of my own life,´ she said assertively'
+  - '‘I will take care of my own life,’ she said assertively'
   ili: i20002
   members:
   - assertively
@@ -19309,7 +19309,7 @@
   definition:
   - in a beseeching manner
   example:
-  - '`You must help me,´ she said imploringly'
+  - '‘You must help me,’ she said imploringly'
   ili: i20094
   members:
   - beseechingly
@@ -19426,7 +19426,7 @@
   - in a brisk manner
   example:
   - she walked briskly in the cold air
-  - '`after lunch,´ she said briskly'
+  - '‘after lunch,’ she said briskly'
   ili: i20105
   members:
   - briskly
@@ -19492,7 +19492,7 @@
   definition:
   - in a cagey manner
   example:
-  - '`I don''t know yet,´ he answered cagily'
+  - '‘I don''t know yet,’ he answered cagily'
   ili: i20112
   members:
   - cagily
@@ -19653,7 +19653,7 @@
   definition:
   - in a chatty manner
   example:
-  - '`when I was a girl,´ she said chattily, `I used to ride a bicycle´'
+  - '‘when I was a girl,’ she said chattily, ‘I used to ride a bicycle’'
   ili: i20128
   members:
   - chattily
@@ -19794,7 +19794,7 @@
   definition:
   - in a cajoling manner
   example:
-  - '`Come here,´ she said coaxingly'
+  - '‘Come here,’ she said coaxingly'
   ili: i20143
   members:
   - coaxingly
@@ -19852,7 +19852,7 @@
   definition:
   - in a bellicose contentious manner
   example:
-  - '`Don''t trespass onto my property,´ the neighbor shouted combatively'
+  - '‘Don''t trespass onto my property,’ the neighbor shouted combatively'
   ili: i20149
   members:
   - combatively
@@ -20003,7 +20003,7 @@
   definition:
   - in a manner showing concern
   example:
-  - '`Are you all right?´ he asked concernedly'
+  - '‘Are you all right?’ he asked concernedly'
   ili: i20166
   members:
   - concernedly
@@ -20341,8 +20341,8 @@
   definition:
   - lacking consequence
   example:
-  - '`You''re so beautifully dressed,´ she said and added quite inconsequentially,
-    `Can you stay the night?´'
+  - '‘You''re so beautifully dressed,’ she said and added quite inconsequentially,
+    ‘Can you stay the night?’'
   ili: i20201
   members:
   - inconsequentially
@@ -20439,7 +20439,7 @@
   definition:
   - in a cryptic manner
   example:
-  - '`we will meet again,´ he said cryptically'
+  - '‘we will meet again,’ he said cryptically'
   ili: i20210
   members:
   - cryptically
@@ -20551,7 +20551,7 @@
   definition:
   - with firmness of purpose
   example:
-  - '`I will come along,´ she said decisively'
+  - '‘I will come along,’ she said decisively'
   ili: i20221
   members:
   - decisively
@@ -20561,7 +20561,7 @@
   definition:
   - lacking firmness or resoluteness
   example:
-  - '`I don''t know,´ he said indecisively'
+  - '‘I don''t know,’ he said indecisively'
   ili: i20222
   members:
   - indecisively
@@ -20708,7 +20708,7 @@
   definition:
   - in a disrespectful and mocking manner
   example:
-  - '`Sorry,´ she repeated derisively'
+  - '‘Sorry,’ she repeated derisively'
   ili: i20236
   members:
   - derisively
@@ -20748,7 +20748,7 @@
   definition:
   - with desperation
   example:
-  - '`Why can''t you understand?´ she asked despairingly'
+  - '‘Why can''t you understand?’ she asked despairingly'
   ili: i20240
   members:
   - despairingly
@@ -20778,7 +20778,7 @@
   definition:
   - in a congenial manner
   example:
-  - '`Let''s all have a drink together,´ he said congenially'
+  - '‘Let''s all have a drink together,’ he said congenially'
   ili: i20243
   members:
   - congenially
@@ -20814,7 +20814,7 @@
   definition:
   - in a convivial manner
   example:
-  - '`Let''s go and have a drink,´ she said convivially'
+  - '‘Let''s go and have a drink,’ she said convivially'
   ili: i20247
   members:
   - convivially
@@ -21058,7 +21058,7 @@
   definition:
   - in an apologetic and defensive manner
   example:
-  - '`I felt it better you should know,´ said Sir Cedric defensively'
+  - '‘I felt it better you should know,’ said Sir Cedric defensively'
   ili: i20272
   members:
   - defensively
@@ -21067,7 +21067,7 @@
   definition:
   - aggressively
   example:
-  - '`In this crisis, we must act offensively,´ the President said'
+  - '‘In this crisis, we must act offensively,’ the President said'
   - the admiral intends to act offensively in the Mediterranean
   ili: i20273
   members:
@@ -21124,7 +21124,7 @@
   definition:
   - in a distracted manner
   example:
-  - '`Come in,´ he said distractedly'
+  - '‘Come in,’ he said distractedly'
   ili: i20279
   members:
   - distractedly
@@ -21209,7 +21209,7 @@
   definition:
   - in a diffident manner
   example:
-  - '`Oh, well,´ he shrugged diffidently, `I like the work.´'
+  - '‘Oh, well,’ he shrugged diffidently, ‘I like the work.’'
   ili: i20288
   members:
   - diffidently
@@ -21416,7 +21416,7 @@
   definition:
   - in a disagreeable manner
   example:
-  - '`I took no harm from the journey, thank you,´ she said disagreeably'
+  - '‘I took no harm from the journey, thank you,’ she said disagreeably'
   ili: i20309
   members:
   - disagreeably
@@ -21594,7 +21594,7 @@
   definition:
   - in a disjointed manner
   example:
-  - '`We''re not married, not really married,´ she said, and slowly, reluctantly,
+  - '‘We''re not married, not really married,’ she said, and slowly, reluctantly,
     disjointedly it came out'
   ili: i20326
   members:
@@ -21675,8 +21675,8 @@
   definition:
   - in a disparaging manner
   example:
-  - these mythological figures are described disparagingly as belonging `only to a
-    story´
+  - these mythological figures are described disparagingly as belonging ‘only to a
+    story’
   ili: i20334
   members:
   - disparagingly
@@ -21812,7 +21812,7 @@
   definition:
   - with distress
   example:
-  - '`Doctor Rother says it''s his only chance,´ she added distressfully'
+  - '‘Doctor Rother says it''s his only chance,’ she added distressfully'
   ili: i20349
   members:
   - distressfully
@@ -21998,7 +21998,7 @@
   definition:
   - in a dreamy manner
   example:
-  - '`She would look beautiful in the new dress,´ Tommy said dreamily'
+  - '‘She would look beautiful in the new dress,’ Tommy said dreamily'
   ili: i20369
   members:
   - dreamily
@@ -22018,7 +22018,7 @@
   definition:
   - in a drowsy manner
   example:
-  - '`Time to get up,´ she said drowsily'
+  - '‘Time to get up,’ she said drowsily'
   ili: i20371
   members:
   - drowsily
@@ -22372,7 +22372,7 @@
   definition:
   - in an encouraging manner
   example:
-  - '`Go on,´ he said encouragingly to his student'
+  - '‘Go on,’ he said encouragingly to his student'
   ili: i20408
   members:
   - encouragingly
@@ -22421,7 +22421,7 @@
   definition:
   - in an enterprising manner
   example:
-  - '`Let''s go up that mountain,´ she said enterprisingly'
+  - '‘Let''s go up that mountain,’ she said enterprisingly'
   ili: i20413
   members:
   - enterprisingly
@@ -23176,7 +23176,7 @@
   definition:
   - with flexibility
   example:
-  - '`Come whenever you are free,´ he said flexibly'
+  - '‘Come whenever you are free,’ he said flexibly'
   ili: i20490
   members:
   - flexibly
@@ -23185,7 +23185,7 @@
   definition:
   - in an inflexible manner
   example:
-  - '`You will — because you must!´ Madam told her inflexibly'
+  - '‘You will — because you must!’ Madam told her inflexibly'
   ili: i20491
   members:
   - inflexibly
@@ -23287,7 +23287,7 @@
   definition:
   - with forgiveness; in a forgiving manner
   example:
-  - '`Never mind,´ she said forgivingly'
+  - '‘Never mind,’ she said forgivingly'
   ili: i20502
   members:
   - forgivingly
@@ -23478,7 +23478,7 @@
   definition:
   - without warmth or enthusiasm
   example:
-  - '`Come in if you have to,´ he said frostily'
+  - '‘Come in if you have to,’ he said frostily'
   ili: i20523
   members:
   - frostily
@@ -23892,7 +23892,7 @@
   definition:
   - in a gruff manner
   example:
-  - '`No,´ he replied gruffly'
+  - '‘No,’ he replied gruffly'
   ili: i20566
   members:
   - gruffly
@@ -23993,7 +23993,7 @@
   definition:
   - in a harsh or unkind manner
   example:
-  - '`That''s enough!´ he cut in harshly'
+  - '‘That''s enough!’ he cut in harshly'
   ili: i20577
   members:
   - harshly
@@ -24010,7 +24010,7 @@
   partOfSpeech: r
 00355829-r:
   definition:
-  - with roughness or violence (`rough´ is an informal variant for `roughly´)
+  - with roughness or violence (‘rough’ is an informal variant for ‘roughly’)
   example:
   - he was pushed roughly aside
   - they treated him rough
@@ -24114,7 +24114,7 @@
   definition:
   - in a heated manner
   example:
-  - '`To say I am behind the strike is so much nonsense,´ declared Mr Harvey heatedly'
+  - '‘To say I am behind the strike is so much nonsense,’ declared Mr Harvey heatedly'
   - the children were arguing hotly
   ili: i20590
   members:
@@ -24327,7 +24327,7 @@
   definition:
   - in a hoarse or husky voice
   example:
-  - '`Excuse me,´ he said hoarsely'
+  - '‘Excuse me,’ he said hoarsely'
   ili: i20612
   members:
   - hoarsely
@@ -24382,7 +24382,7 @@
   definition:
   - in a huffy manner
   example:
-  - '`Don''t bother to call me back,´ he said huffily'
+  - '‘Don''t bother to call me back,’ he said huffily'
   ili: i20618
   members:
   - huffily
@@ -24496,8 +24496,8 @@
   definition:
   - in a cold and icy manner
   example:
-  - '`Mr. Powell finds it easier to take it out of mothers, children and sick people
-    than to take on this vast industry,´ Mr Brown commented icily'
+  - '‘Mr. Powell finds it easier to take it out of mothers, children and sick people
+    than to take on this vast industry,’ Mr Brown commented icily'
   ili: i20630
   members:
   - icily
@@ -24949,7 +24949,7 @@
   definition:
   - just as it should be
   example:
-  - '`Precisely, my lord,´ he said'
+  - '‘Precisely, my lord,’ he said'
   ili: i20677
   members:
   - precisely
@@ -25266,7 +25266,7 @@
   definition:
   - in an uninformative manner
   example:
-  - '`I can''t tell you when the manager will arrive,´ he said rather uninformatively'
+  - '‘I can''t tell you when the manager will arrive,’ he said rather uninformatively'
   ili: i20710
   members:
   - uninformatively
@@ -25288,7 +25288,7 @@
   - in an ingenious manner
   example:
   - a Hampshire farmer had fowls of different breeds, including Dorkings, and he discriminated
-    ingeniously between the `dark ones´ and the `white ones´
+    ingeniously between the ‘dark ones’ and the ‘white ones’
   ili: i20712
   members:
   - ingeniously
@@ -25667,7 +25667,7 @@
   definition:
   - in a transitive manner
   example:
-  - you can use the verb `eat´ transitively or intransitively
+  - you can use the verb ‘eat’ transitively or intransitively
   ili: i20753
   members:
   - transitively
@@ -25676,7 +25676,7 @@
   definition:
   - in an intransitive manner
   example:
-  - you can use the verb `drink´ intransitively, without a direct object
+  - you can use the verb ‘drink’ intransitively, without a direct object
   ili: i20754
   members:
   - intransitively
@@ -25747,7 +25747,7 @@
   definition:
   - in an irate manner
   example:
-  - '`Get out,´ he shouted irately'
+  - '‘Get out,’ he shouted irately'
   ili: i20762
   members:
   - irately
@@ -25962,7 +25962,7 @@
   definition:
   - in a weak and unconvincing manner
   example:
-  - '`I don''t know, Edward,´ she answered lamely'
+  - '‘I don''t know, Edward,’ she answered lamely'
   ili: i20785
   members:
   - lamely
@@ -26206,7 +26206,7 @@
   - in a yearning manner
   example:
   - he spent the rest of the act gazing longingly over my right shoulder at the illuminated
-    word `Exit´
+    word ‘Exit’
   ili: i20811
   members:
   - longingly
@@ -26266,7 +26266,7 @@
   definition:
   - so as to be unmanageable
   example:
-  - '`This house is unmanageably large,´ she complained'
+  - '‘This house is unmanageably large,’ she complained'
   ili: i20817
   members:
   - unmanageably
@@ -26442,8 +26442,8 @@
   definition:
   - in a chatty loquacious manner
   example:
-  - '`When I was young,´ she continued loquaciously, `I used to do all sorts of naughty
-    things´'
+  - '‘When I was young,’ she continued loquaciously, ‘I used to do all sorts of naughty
+    things’'
   ili: i20837
   members:
   - loquaciously
@@ -27166,7 +27166,7 @@
   definition:
   - with sadness; in a sad manner
   example:
-  - '`She died last night,´ he said sadly'
+  - '‘She died last night,’ he said sadly'
   ili: i20915
   members:
   - sadly
@@ -27239,7 +27239,7 @@
   definition:
   - in a meditative manner
   example:
-  - '`It''s funny about that bar,´ he said musingly'
+  - '‘It''s funny about that bar,’ he said musingly'
   ili: i20923
   members:
   - musingly
@@ -27257,7 +27257,7 @@
   partOfSpeech: r
 00407778-r:
   definition:
-  - (often followed by `for´) in exchange or in reciprocation
+  - (often followed by ‘for’) in exchange or in reciprocation
   example:
   - gave up our seats on the plane and in return received several hundred dollars
     and seats on the next plane out
@@ -27319,7 +27319,7 @@
   definition:
   - in a nasty ill-tempered manner
   example:
-  - '`Don''t expect me to help you,´ he added nastily'
+  - '‘Don''t expect me to help you,’ he added nastily'
   ili: i20931
   members:
   - nastily
@@ -27367,7 +27367,7 @@
   partOfSpeech: r
 00409712-r:
   definition:
-  - (comparative of `near´ or `close´) within a shorter distance
+  - (comparative of ‘near’ or ‘close’) within a shorter distance
   example:
   - come closer, my dear!
   - they drew nearer
@@ -27382,7 +27382,7 @@
   partOfSpeech: r
 00409931-r:
   definition:
-  - (superlative of `near´ or `close´) within the shortest distance
+  - (superlative of ‘near’ or ‘close’) within the shortest distance
   example:
   - that was the time he came nearest to death
   exemplifies:
@@ -27812,7 +27812,7 @@
   definition:
   - with optimism; in an optimistic manner
   example:
-  - '`We have a good chance of winning,´ he exclaimed optimistically'
+  - '‘We have a good chance of winning,’ he exclaimed optimistically'
   ili: i20982
   members:
   - optimistically
@@ -28121,7 +28121,7 @@
   definition:
   - in a pedantic manner
   example:
-  - these interpretations are called `schemas´ or, more pedantically, `schemata´
+  - these interpretations are called ‘schemas’ or, more pedantically, ‘schemata’
   ili: i21016
   members:
   - pedantically
@@ -28335,7 +28335,7 @@
   definition:
   - in a picturesque manner
   example:
-  - in the building trade such a trader is picturesquely described as a `brass plate´
+  - in the building trade such a trader is picturesquely described as a ‘brass plate’
     merchant
   ili: i21040
   members:
@@ -29174,7 +29174,7 @@
   definition:
   - in a provocative manner
   example:
-  - '`Try it,´ he said provocatively'
+  - '‘Try it,’ he said provocatively'
   ili: i21129
   members:
   - provocatively
@@ -29201,7 +29201,7 @@
   definition:
   - in a curious and prying manner
   example:
-  - '`Do you have a boyfriend?´ she asked her prospective tenant pryingly'
+  - '‘Do you have a boyfriend?’ she asked her prospective tenant pryingly'
   ili: i21132
   members:
   - pryingly
@@ -29353,7 +29353,7 @@
   definition:
   - in a queasy manner
   example:
-  - '`Do I have to remove the liver?´ the medical student asked queasily'
+  - '‘Do I have to remove the liver?’ the medical student asked queasily'
   ili: i21149
   members:
   - queasily
@@ -29799,7 +29799,7 @@
   definition:
   - in a rhetorical manner
   example:
-  - '`What can be done?´ he asked rhetorically'
+  - '‘What can be done?’ he asked rhetorically'
   ili: i21198
   members:
   - rhetorically
@@ -29958,7 +29958,7 @@
   definition:
   - in a sarcastic manner
   example:
-  - '`Ah, now we''re getting at the truth,´ he interposed sarcastically'
+  - '‘Ah, now we''re getting at the truth,’ he interposed sarcastically'
   ili: i21215
   members:
   - sarcastically
@@ -30044,7 +30044,7 @@
   definition:
   - in a searching manner
   example:
-  - '`Are you really happy with him?´ asked her mother, gazing at Vera searchingly'
+  - '‘Are you really happy with him?’ asked her mother, gazing at Vera searchingly'
   ili: i21224
   members:
   - searchingly
@@ -30208,7 +30208,7 @@
   definition:
   - in a sentimental manner
   example:
-  - '`I miss the good old days,´ she added sentimentally'
+  - '‘I miss the good old days,’ she added sentimentally'
   ili: i21242
   members:
   - sentimentally
@@ -30308,7 +30308,7 @@
   definition:
   - in a manner characterized by trembling or shaking
   example:
-  - '`I — I''m going to make you a cup of tea´, she explained shakily'
+  - '‘I — I''m going to make you a cup of tea’, she explained shakily'
   ili: i21253
   members:
   - shakily
@@ -30606,7 +30606,7 @@
   - in a silky manner
   example:
   - the young wheat shone silkily
-  - '`Darling,´ she said silkily'
+  - '‘Darling,’ she said silkily'
   ili: i21283
   members:
   - silkily
@@ -30742,7 +30742,7 @@
   partOfSpeech: r
 00458908-r:
   definition:
-  - (with verb `to blow´) destroyed completely; blown apart or to pieces
+  - (with verb ‘to blow’) destroyed completely; blown apart or to pieces
   example:
   - they blew the bridge sky-high
   - the committee blew the thesis sky-high
@@ -30873,7 +30873,7 @@
   definition:
   - in a smooth and diplomatic manner
   example:
-  - '`And now,´ he said smoothly, `we will continue the conversation´'
+  - '‘And now,’ he said smoothly, ‘we will continue the conversation’'
   ili: i21310
   members:
   - smoothly
@@ -30955,7 +30955,7 @@
   definition:
   - in an ill-natured and snappish manner
   example:
-  - '`Don''t talk to me now,´ she said snappishly'
+  - '‘Don''t talk to me now,’ she said snappishly'
   ili: i21319
   members:
   - snappishly
@@ -30973,7 +30973,7 @@
   definition:
   - with a sneer; in an uncomplimentary sneering manner
   example:
-  - '`I don''t believe in these customs,´ he said sneeringly'
+  - '‘I don''t believe in these customs,’ he said sneeringly'
   ili: i21321
   members:
   - sneeringly
@@ -31031,7 +31031,7 @@
   definition:
   - in a concerned and solicitous manner
   example:
-  - '`Don''t you feel well?´ his mother asked solicitously'
+  - '‘Don''t you feel well?’ his mother asked solicitously'
   ili: i21327
   members:
   - solicitously
@@ -31049,7 +31049,7 @@
   definition:
   - in a somber manner
   example:
-  - '`That''s sure bad news,´ said Dowd, somberly'
+  - '‘That''s sure bad news,’ said Dowd, somberly'
   ili: i21329
   members:
   - somberly
@@ -31105,7 +31105,7 @@
   definition:
   - all at the same time
   example:
-  - Let's say `Yes!´ all at once
+  - Let's say ‘Yes!’ all at once
   ili: i21335
   members:
   - all together
@@ -31310,7 +31310,7 @@
   definition:
   - in a squeamish manner
   example:
-  - '`I would rather not touch,´ he said squeamishly'
+  - '‘I would rather not touch,’ he said squeamishly'
   ili: i21360
   members:
   - squeamishly
@@ -31319,7 +31319,7 @@
   definition:
   - in a stagy and theatrical manner
   example:
-  - '`I cannot show my face at her house,´ he declared theatrically'
+  - '‘I cannot show my face at her house,’ he declared theatrically'
   ili: i21361
   members:
   - stagily
@@ -31651,7 +31651,7 @@
   definition:
   - in a stuffy manner
   example:
-  - '`Come in please,´ he said stuffily'
+  - '‘Come in please,’ he said stuffily'
   ili: i21397
   members:
   - stuffily
@@ -31745,7 +31745,7 @@
   definition:
   - in a sulky manner
   example:
-  - '`What else could I do?´ said Graham sulkily'
+  - '‘What else could I do?’ said Graham sulkily'
   ili: i21407
   members:
   - sulkily
@@ -31843,8 +31843,8 @@
   partOfSpeech: r
 00474454-r:
   definition:
-  - in an affectionate or loving manner (`sweet´ is sometimes a poetic or informal
-    variant of `sweetly´)
+  - in an affectionate or loving manner (‘sweet’ is sometimes a poetic or informal
+    variant of ‘sweetly’)
   domain_topic:
   - 07107220-n
   example:
@@ -31937,7 +31937,7 @@
   definition:
   - in a tart manner
   example:
-  - '`Never mind your immortal soul,´ she said tartly'
+  - '‘Never mind your immortal soul,’ she said tartly'
   ili: i21427
   members:
   - tartly
@@ -31974,7 +31974,7 @@
   definition:
   - in a playfully teasing manner
   example:
-  - '`You hate things to be out of order, don''t you?´ she said teasingly'
+  - '‘You hate things to be out of order, don''t you?’ she said teasingly'
   ili: i21431
   members:
   - tauntingly
@@ -32076,7 +32076,7 @@
   definition:
   - in an ill-natured and tetchy manner
   example:
-  - '`Are you sure?´ he asked her tetchily'
+  - '‘Are you sure?’ he asked her tetchily'
   ili: i21442
   members:
   - tetchily
@@ -32306,7 +32306,7 @@
   definition:
   - in a monotone
   example:
-  - '`Come in,´ she said tonelessly'
+  - '‘Come in,’ she said tonelessly'
   ili: i21467
   members:
   - tonelessly
@@ -33120,7 +33120,7 @@
   definition:
   - in an urbane manner
   example:
-  - '`I had tea occasionally with the Duke,´ said Mr. Eggers urbanely'
+  - '‘I had tea occasionally with the Duke,’ said Mr. Eggers urbanely'
   ili: i21557
   members:
   - urbanely
@@ -33564,7 +33564,7 @@
   definition:
   - in a worried manner
   example:
-  - '`I wonder what to do,´ she said worriedly'
+  - '‘I wonder what to do,’ she said worriedly'
   - he paused worriedly before calling the bank
   ili: i21606
   members:
@@ -33597,7 +33597,7 @@
   definition:
   - in a wretched manner
   example:
-  - '`I can''t remember who I am,´ I said, wretchedly'
+  - '‘I can''t remember who I am,’ I said, wretchedly'
   ili: i21610
   members:
   - wretchedly
@@ -34052,7 +34052,7 @@
   definition:
   - with barely repressed anger
   example:
-  - '`I can''t wait,´ she answered smolderingly'
+  - '‘I can''t wait,’ she answered smolderingly'
   ili: i21662
   members:
   - smolderingly
@@ -34419,7 +34419,7 @@
   partOfSpeech: r
 00510690-r:
   definition:
-  - comparative of the adverb `late´
+  - comparative of the adverb ‘late’
   example:
   - he stayed later than you did
   ili: i21700

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -1295,7 +1295,7 @@
   - left for work long ago
   - he has long since given up mountain climbing
   - This name has long since been forgotten
-  - '‘lang syne’ is Scottish'
+  - ‘lang syne’ is Scottish
   ili: i18268
   members:
   - long ago
@@ -13825,7 +13825,7 @@
   - without hope; desperate because there seems no possibility of comfort or success
   example:
   - he hung his head hopelessly
-  - '‘I must die,’ he said hopelessly'
+  - ‘I must die,’ he said hopelessly
   ili: i19522
   members:
   - hopelessly
@@ -14965,7 +14965,7 @@
   definition:
   - in a rueful manner
   example:
-  - '‘I made a big mistake,’ he said ruefully'
+  - ‘I made a big mistake,’ he said ruefully
   ili: i19640
   members:
   - ruefully
@@ -15047,7 +15047,7 @@
   definition:
   - in a good-humoured manner
   example:
-  - '‘I''ll do the dishes,’ he said pleasantly'
+  - ‘I'll do the dishes,’ he said pleasantly
   ili: i19648
   members:
   - pleasantly
@@ -15085,7 +15085,7 @@
   definition:
   - in a hearty manner
   example:
-  - '‘Yes,’ the children chorused heartily'
+  - ‘Yes,’ the children chorused heartily
   - We welcomed her warmly
   ili: i19652
   members:
@@ -15097,7 +15097,7 @@
   definition:
   - in an affable manner
   example:
-  - '‘Come and visit me,’ he said amiably'
+  - ‘Come and visit me,’ he said amiably
   ili: i19653
   members:
   - affably
@@ -15395,7 +15395,7 @@
   definition:
   - in a wry manner
   example:
-  - '‘I see,’ he commented wryly'
+  - ‘I see,’ he commented wryly
   ili: i19682
   members:
   - wryly
@@ -15886,7 +15886,7 @@
   definition:
   - in a dry laconic manner
   example:
-  - '‘I know that’, he said dryly'
+  - ‘I know that’, he said dryly
   ili: i19734
   members:
   - laconically
@@ -16362,7 +16362,7 @@
   definition:
   - with equanimity
   example:
-  - '‘I bought it,’ she said contentedly'
+  - ‘I bought it,’ she said contentedly
   ili: i19781
   members:
   - contentedly
@@ -16541,7 +16541,7 @@
   definition:
   - with sternness; in a severe manner
   example:
-  - '‘No,’ she said sternly'
+  - ‘No,’ she said sternly
   - peered severely over her glasses
   ili: i19801
   members:
@@ -18437,7 +18437,7 @@
   definition:
   - in an assertive manner
   example:
-  - '‘I will take care of my own life,’ she said assertively'
+  - ‘I will take care of my own life,’ she said assertively
   ili: i20002
   members:
   - assertively
@@ -19309,7 +19309,7 @@
   definition:
   - in a beseeching manner
   example:
-  - '‘You must help me,’ she said imploringly'
+  - ‘You must help me,’ she said imploringly
   ili: i20094
   members:
   - beseechingly
@@ -19426,7 +19426,7 @@
   - in a brisk manner
   example:
   - she walked briskly in the cold air
-  - '‘after lunch,’ she said briskly'
+  - ‘after lunch,’ she said briskly
   ili: i20105
   members:
   - briskly
@@ -19492,7 +19492,7 @@
   definition:
   - in a cagey manner
   example:
-  - '‘I don''t know yet,’ he answered cagily'
+  - ‘I don't know yet,’ he answered cagily
   ili: i20112
   members:
   - cagily
@@ -19653,7 +19653,7 @@
   definition:
   - in a chatty manner
   example:
-  - '‘when I was a girl,’ she said chattily, ‘I used to ride a bicycle’'
+  - ‘when I was a girl,’ she said chattily, ‘I used to ride a bicycle’
   ili: i20128
   members:
   - chattily
@@ -19794,7 +19794,7 @@
   definition:
   - in a cajoling manner
   example:
-  - '‘Come here,’ she said coaxingly'
+  - ‘Come here,’ she said coaxingly
   ili: i20143
   members:
   - coaxingly
@@ -19852,7 +19852,7 @@
   definition:
   - in a bellicose contentious manner
   example:
-  - '‘Don''t trespass onto my property,’ the neighbor shouted combatively'
+  - ‘Don't trespass onto my property,’ the neighbor shouted combatively
   ili: i20149
   members:
   - combatively
@@ -20003,7 +20003,7 @@
   definition:
   - in a manner showing concern
   example:
-  - '‘Are you all right?’ he asked concernedly'
+  - ‘Are you all right?’ he asked concernedly
   ili: i20166
   members:
   - concernedly
@@ -20341,8 +20341,8 @@
   definition:
   - lacking consequence
   example:
-  - '‘You''re so beautifully dressed,’ she said and added quite inconsequentially,
-    ‘Can you stay the night?’'
+  - ‘You're so beautifully dressed,’ she said and added quite inconsequentially, ‘Can
+    you stay the night?’
   ili: i20201
   members:
   - inconsequentially
@@ -20439,7 +20439,7 @@
   definition:
   - in a cryptic manner
   example:
-  - '‘we will meet again,’ he said cryptically'
+  - ‘we will meet again,’ he said cryptically
   ili: i20210
   members:
   - cryptically
@@ -20551,7 +20551,7 @@
   definition:
   - with firmness of purpose
   example:
-  - '‘I will come along,’ she said decisively'
+  - ‘I will come along,’ she said decisively
   ili: i20221
   members:
   - decisively
@@ -20561,7 +20561,7 @@
   definition:
   - lacking firmness or resoluteness
   example:
-  - '‘I don''t know,’ he said indecisively'
+  - ‘I don't know,’ he said indecisively
   ili: i20222
   members:
   - indecisively
@@ -20708,7 +20708,7 @@
   definition:
   - in a disrespectful and mocking manner
   example:
-  - '‘Sorry,’ she repeated derisively'
+  - ‘Sorry,’ she repeated derisively
   ili: i20236
   members:
   - derisively
@@ -20748,7 +20748,7 @@
   definition:
   - with desperation
   example:
-  - '‘Why can''t you understand?’ she asked despairingly'
+  - ‘Why can't you understand?’ she asked despairingly
   ili: i20240
   members:
   - despairingly
@@ -20778,7 +20778,7 @@
   definition:
   - in a congenial manner
   example:
-  - '‘Let''s all have a drink together,’ he said congenially'
+  - ‘Let's all have a drink together,’ he said congenially
   ili: i20243
   members:
   - congenially
@@ -20814,7 +20814,7 @@
   definition:
   - in a convivial manner
   example:
-  - '‘Let''s go and have a drink,’ she said convivially'
+  - ‘Let's go and have a drink,’ she said convivially
   ili: i20247
   members:
   - convivially
@@ -21058,7 +21058,7 @@
   definition:
   - in an apologetic and defensive manner
   example:
-  - '‘I felt it better you should know,’ said Sir Cedric defensively'
+  - ‘I felt it better you should know,’ said Sir Cedric defensively
   ili: i20272
   members:
   - defensively
@@ -21067,7 +21067,7 @@
   definition:
   - aggressively
   example:
-  - '‘In this crisis, we must act offensively,’ the President said'
+  - ‘In this crisis, we must act offensively,’ the President said
   - the admiral intends to act offensively in the Mediterranean
   ili: i20273
   members:
@@ -21124,7 +21124,7 @@
   definition:
   - in a distracted manner
   example:
-  - '‘Come in,’ he said distractedly'
+  - ‘Come in,’ he said distractedly
   ili: i20279
   members:
   - distractedly
@@ -21209,7 +21209,7 @@
   definition:
   - in a diffident manner
   example:
-  - '‘Oh, well,’ he shrugged diffidently, ‘I like the work.’'
+  - ‘Oh, well,’ he shrugged diffidently, ‘I like the work.’
   ili: i20288
   members:
   - diffidently
@@ -21416,7 +21416,7 @@
   definition:
   - in a disagreeable manner
   example:
-  - '‘I took no harm from the journey, thank you,’ she said disagreeably'
+  - ‘I took no harm from the journey, thank you,’ she said disagreeably
   ili: i20309
   members:
   - disagreeably
@@ -21594,8 +21594,8 @@
   definition:
   - in a disjointed manner
   example:
-  - '‘We''re not married, not really married,’ she said, and slowly, reluctantly,
-    disjointedly it came out'
+  - ‘We're not married, not really married,’ she said, and slowly, reluctantly, disjointedly
+    it came out
   ili: i20326
   members:
   - disjointedly
@@ -21812,7 +21812,7 @@
   definition:
   - with distress
   example:
-  - '‘Doctor Rother says it''s his only chance,’ she added distressfully'
+  - ‘Doctor Rother says it's his only chance,’ she added distressfully
   ili: i20349
   members:
   - distressfully
@@ -21998,7 +21998,7 @@
   definition:
   - in a dreamy manner
   example:
-  - '‘She would look beautiful in the new dress,’ Tommy said dreamily'
+  - ‘She would look beautiful in the new dress,’ Tommy said dreamily
   ili: i20369
   members:
   - dreamily
@@ -22018,7 +22018,7 @@
   definition:
   - in a drowsy manner
   example:
-  - '‘Time to get up,’ she said drowsily'
+  - ‘Time to get up,’ she said drowsily
   ili: i20371
   members:
   - drowsily
@@ -22372,7 +22372,7 @@
   definition:
   - in an encouraging manner
   example:
-  - '‘Go on,’ he said encouragingly to his student'
+  - ‘Go on,’ he said encouragingly to his student
   ili: i20408
   members:
   - encouragingly
@@ -22421,7 +22421,7 @@
   definition:
   - in an enterprising manner
   example:
-  - '‘Let''s go up that mountain,’ she said enterprisingly'
+  - ‘Let's go up that mountain,’ she said enterprisingly
   ili: i20413
   members:
   - enterprisingly
@@ -23176,7 +23176,7 @@
   definition:
   - with flexibility
   example:
-  - '‘Come whenever you are free,’ he said flexibly'
+  - ‘Come whenever you are free,’ he said flexibly
   ili: i20490
   members:
   - flexibly
@@ -23185,7 +23185,7 @@
   definition:
   - in an inflexible manner
   example:
-  - '‘You will — because you must!’ Madam told her inflexibly'
+  - ‘You will — because you must!’ Madam told her inflexibly
   ili: i20491
   members:
   - inflexibly
@@ -23287,7 +23287,7 @@
   definition:
   - with forgiveness; in a forgiving manner
   example:
-  - '‘Never mind,’ she said forgivingly'
+  - ‘Never mind,’ she said forgivingly
   ili: i20502
   members:
   - forgivingly
@@ -23478,7 +23478,7 @@
   definition:
   - without warmth or enthusiasm
   example:
-  - '‘Come in if you have to,’ he said frostily'
+  - ‘Come in if you have to,’ he said frostily
   ili: i20523
   members:
   - frostily
@@ -23892,7 +23892,7 @@
   definition:
   - in a gruff manner
   example:
-  - '‘No,’ he replied gruffly'
+  - ‘No,’ he replied gruffly
   ili: i20566
   members:
   - gruffly
@@ -23993,7 +23993,7 @@
   definition:
   - in a harsh or unkind manner
   example:
-  - '‘That''s enough!’ he cut in harshly'
+  - ‘That's enough!’ he cut in harshly
   ili: i20577
   members:
   - harshly
@@ -24114,7 +24114,7 @@
   definition:
   - in a heated manner
   example:
-  - '‘To say I am behind the strike is so much nonsense,’ declared Mr Harvey heatedly'
+  - ‘To say I am behind the strike is so much nonsense,’ declared Mr Harvey heatedly
   - the children were arguing hotly
   ili: i20590
   members:
@@ -24327,7 +24327,7 @@
   definition:
   - in a hoarse or husky voice
   example:
-  - '‘Excuse me,’ he said hoarsely'
+  - ‘Excuse me,’ he said hoarsely
   ili: i20612
   members:
   - hoarsely
@@ -24382,7 +24382,7 @@
   definition:
   - in a huffy manner
   example:
-  - '‘Don''t bother to call me back,’ he said huffily'
+  - ‘Don't bother to call me back,’ he said huffily
   ili: i20618
   members:
   - huffily
@@ -24496,8 +24496,8 @@
   definition:
   - in a cold and icy manner
   example:
-  - '‘Mr. Powell finds it easier to take it out of mothers, children and sick people
-    than to take on this vast industry,’ Mr Brown commented icily'
+  - ‘Mr. Powell finds it easier to take it out of mothers, children and sick people
+    than to take on this vast industry,’ Mr Brown commented icily
   ili: i20630
   members:
   - icily
@@ -24949,7 +24949,7 @@
   definition:
   - just as it should be
   example:
-  - '‘Precisely, my lord,’ he said'
+  - ‘Precisely, my lord,’ he said
   ili: i20677
   members:
   - precisely
@@ -25266,7 +25266,7 @@
   definition:
   - in an uninformative manner
   example:
-  - '‘I can''t tell you when the manager will arrive,’ he said rather uninformatively'
+  - ‘I can't tell you when the manager will arrive,’ he said rather uninformatively
   ili: i20710
   members:
   - uninformatively
@@ -25747,7 +25747,7 @@
   definition:
   - in an irate manner
   example:
-  - '‘Get out,’ he shouted irately'
+  - ‘Get out,’ he shouted irately
   ili: i20762
   members:
   - irately
@@ -25962,7 +25962,7 @@
   definition:
   - in a weak and unconvincing manner
   example:
-  - '‘I don''t know, Edward,’ she answered lamely'
+  - ‘I don't know, Edward,’ she answered lamely
   ili: i20785
   members:
   - lamely
@@ -26266,7 +26266,7 @@
   definition:
   - so as to be unmanageable
   example:
-  - '‘This house is unmanageably large,’ she complained'
+  - ‘This house is unmanageably large,’ she complained
   ili: i20817
   members:
   - unmanageably
@@ -26442,8 +26442,8 @@
   definition:
   - in a chatty loquacious manner
   example:
-  - '‘When I was young,’ she continued loquaciously, ‘I used to do all sorts of naughty
-    things’'
+  - ‘When I was young,’ she continued loquaciously, ‘I used to do all sorts of naughty
+    things’
   ili: i20837
   members:
   - loquaciously
@@ -27166,7 +27166,7 @@
   definition:
   - with sadness; in a sad manner
   example:
-  - '‘She died last night,’ he said sadly'
+  - ‘She died last night,’ he said sadly
   ili: i20915
   members:
   - sadly
@@ -27239,7 +27239,7 @@
   definition:
   - in a meditative manner
   example:
-  - '‘It''s funny about that bar,’ he said musingly'
+  - ‘It's funny about that bar,’ he said musingly
   ili: i20923
   members:
   - musingly
@@ -27319,7 +27319,7 @@
   definition:
   - in a nasty ill-tempered manner
   example:
-  - '‘Don''t expect me to help you,’ he added nastily'
+  - ‘Don't expect me to help you,’ he added nastily
   ili: i20931
   members:
   - nastily
@@ -27812,7 +27812,7 @@
   definition:
   - with optimism; in an optimistic manner
   example:
-  - '‘We have a good chance of winning,’ he exclaimed optimistically'
+  - ‘We have a good chance of winning,’ he exclaimed optimistically
   ili: i20982
   members:
   - optimistically
@@ -29174,7 +29174,7 @@
   definition:
   - in a provocative manner
   example:
-  - '‘Try it,’ he said provocatively'
+  - ‘Try it,’ he said provocatively
   ili: i21129
   members:
   - provocatively
@@ -29201,7 +29201,7 @@
   definition:
   - in a curious and prying manner
   example:
-  - '‘Do you have a boyfriend?’ she asked her prospective tenant pryingly'
+  - ‘Do you have a boyfriend?’ she asked her prospective tenant pryingly
   ili: i21132
   members:
   - pryingly
@@ -29353,7 +29353,7 @@
   definition:
   - in a queasy manner
   example:
-  - '‘Do I have to remove the liver?’ the medical student asked queasily'
+  - ‘Do I have to remove the liver?’ the medical student asked queasily
   ili: i21149
   members:
   - queasily
@@ -29799,7 +29799,7 @@
   definition:
   - in a rhetorical manner
   example:
-  - '‘What can be done?’ he asked rhetorically'
+  - ‘What can be done?’ he asked rhetorically
   ili: i21198
   members:
   - rhetorically
@@ -29958,7 +29958,7 @@
   definition:
   - in a sarcastic manner
   example:
-  - '‘Ah, now we''re getting at the truth,’ he interposed sarcastically'
+  - ‘Ah, now we're getting at the truth,’ he interposed sarcastically
   ili: i21215
   members:
   - sarcastically
@@ -30044,7 +30044,7 @@
   definition:
   - in a searching manner
   example:
-  - '‘Are you really happy with him?’ asked her mother, gazing at Vera searchingly'
+  - ‘Are you really happy with him?’ asked her mother, gazing at Vera searchingly
   ili: i21224
   members:
   - searchingly
@@ -30208,7 +30208,7 @@
   definition:
   - in a sentimental manner
   example:
-  - '‘I miss the good old days,’ she added sentimentally'
+  - ‘I miss the good old days,’ she added sentimentally
   ili: i21242
   members:
   - sentimentally
@@ -30308,7 +30308,7 @@
   definition:
   - in a manner characterized by trembling or shaking
   example:
-  - '‘I — I''m going to make you a cup of tea’, she explained shakily'
+  - ‘I — I'm going to make you a cup of tea’, she explained shakily
   ili: i21253
   members:
   - shakily
@@ -30606,7 +30606,7 @@
   - in a silky manner
   example:
   - the young wheat shone silkily
-  - '‘Darling,’ she said silkily'
+  - ‘Darling,’ she said silkily
   ili: i21283
   members:
   - silkily
@@ -30873,7 +30873,7 @@
   definition:
   - in a smooth and diplomatic manner
   example:
-  - '‘And now,’ he said smoothly, ‘we will continue the conversation’'
+  - ‘And now,’ he said smoothly, ‘we will continue the conversation’
   ili: i21310
   members:
   - smoothly
@@ -30955,7 +30955,7 @@
   definition:
   - in an ill-natured and snappish manner
   example:
-  - '‘Don''t talk to me now,’ she said snappishly'
+  - ‘Don't talk to me now,’ she said snappishly
   ili: i21319
   members:
   - snappishly
@@ -30973,7 +30973,7 @@
   definition:
   - with a sneer; in an uncomplimentary sneering manner
   example:
-  - '‘I don''t believe in these customs,’ he said sneeringly'
+  - ‘I don't believe in these customs,’ he said sneeringly
   ili: i21321
   members:
   - sneeringly
@@ -31031,7 +31031,7 @@
   definition:
   - in a concerned and solicitous manner
   example:
-  - '‘Don''t you feel well?’ his mother asked solicitously'
+  - ‘Don't you feel well?’ his mother asked solicitously
   ili: i21327
   members:
   - solicitously
@@ -31049,7 +31049,7 @@
   definition:
   - in a somber manner
   example:
-  - '‘That''s sure bad news,’ said Dowd, somberly'
+  - ‘That's sure bad news,’ said Dowd, somberly
   ili: i21329
   members:
   - somberly
@@ -31310,7 +31310,7 @@
   definition:
   - in a squeamish manner
   example:
-  - '‘I would rather not touch,’ he said squeamishly'
+  - ‘I would rather not touch,’ he said squeamishly
   ili: i21360
   members:
   - squeamishly
@@ -31319,7 +31319,7 @@
   definition:
   - in a stagy and theatrical manner
   example:
-  - '‘I cannot show my face at her house,’ he declared theatrically'
+  - ‘I cannot show my face at her house,’ he declared theatrically
   ili: i21361
   members:
   - stagily
@@ -31651,7 +31651,7 @@
   definition:
   - in a stuffy manner
   example:
-  - '‘Come in please,’ he said stuffily'
+  - ‘Come in please,’ he said stuffily
   ili: i21397
   members:
   - stuffily
@@ -31745,7 +31745,7 @@
   definition:
   - in a sulky manner
   example:
-  - '‘What else could I do?’ said Graham sulkily'
+  - ‘What else could I do?’ said Graham sulkily
   ili: i21407
   members:
   - sulkily
@@ -31937,7 +31937,7 @@
   definition:
   - in a tart manner
   example:
-  - '‘Never mind your immortal soul,’ she said tartly'
+  - ‘Never mind your immortal soul,’ she said tartly
   ili: i21427
   members:
   - tartly
@@ -31974,7 +31974,7 @@
   definition:
   - in a playfully teasing manner
   example:
-  - '‘You hate things to be out of order, don''t you?’ she said teasingly'
+  - ‘You hate things to be out of order, don't you?’ she said teasingly
   ili: i21431
   members:
   - tauntingly
@@ -32076,7 +32076,7 @@
   definition:
   - in an ill-natured and tetchy manner
   example:
-  - '‘Are you sure?’ he asked her tetchily'
+  - ‘Are you sure?’ he asked her tetchily
   ili: i21442
   members:
   - tetchily
@@ -32306,7 +32306,7 @@
   definition:
   - in a monotone
   example:
-  - '‘Come in,’ she said tonelessly'
+  - ‘Come in,’ she said tonelessly
   ili: i21467
   members:
   - tonelessly
@@ -33120,7 +33120,7 @@
   definition:
   - in an urbane manner
   example:
-  - '‘I had tea occasionally with the Duke,’ said Mr. Eggers urbanely'
+  - ‘I had tea occasionally with the Duke,’ said Mr. Eggers urbanely
   ili: i21557
   members:
   - urbanely
@@ -33564,7 +33564,7 @@
   definition:
   - in a worried manner
   example:
-  - '‘I wonder what to do,’ she said worriedly'
+  - ‘I wonder what to do,’ she said worriedly
   - he paused worriedly before calling the bank
   ili: i21606
   members:
@@ -33597,7 +33597,7 @@
   definition:
   - in a wretched manner
   example:
-  - '‘I can''t remember who I am,’ I said, wretchedly'
+  - ‘I can't remember who I am,’ I said, wretchedly
   ili: i21610
   members:
   - wretchedly
@@ -34052,7 +34052,7 @@
   definition:
   - with barely repressed anger
   example:
-  - '‘I can''t wait,’ she answered smolderingly'
+  - ‘I can't wait,’ she answered smolderingly
   ili: i21662
   members:
   - smolderingly

--- a/src/yaml/entries-a.yaml
+++ b/src/yaml/entries-a.yaml
@@ -77487,10 +77487,10 @@ asynchronous motor:
     sense:
     - id: 'asynchronous_motor%1:06:01::'
       synset: 92459652-n
-asynchronous nazalisation:
+asynchronous nasalization:
   n:
     sense:
-    - id: 'asynchronous_nazalisation%1:10:01::'
+    - id: 'asynchronous_nasalization%1:10:01::'
       synset: 92462764-n
 asynchronous operation:
   n:

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -43454,8 +43454,8 @@
   partOfSpeech: n
 00806369-n:
   definition:
-  - (engineering) the art or technique of trying to control rivers with dams etc. in
-    order to minimize the occurrence of floods
+  - (engineering) the art or technique of trying to control rivers with dams etc.
+    in order to minimize the occurrence of floods
   domain_topic:
   - 06134474-n
   hypernym:

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -8435,7 +8435,7 @@
   definition:
   - an expedient adopted only in desperation
   example:
-  - '‘pis aller’ is French for ‘worst going’'
+  - ‘pis aller’ is French for ‘worst going’
   hypernym:
   - 00178297-n
   ili: i36352

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -168,7 +168,7 @@
   partOfSpeech: n
 00037921-n:
   definition:
-  - used in the phrase `to your credit´ in order to indicate an achievement deserving
+  - used in the phrase ‘to your credit’ in order to indicate an achievement deserving
     praise
   example:
   - she already had several performances to her credit
@@ -346,7 +346,7 @@
   partOfSpeech: n
 00041542-n:
   definition:
-  - social or verbal interchange (usually followed by `with´)
+  - social or verbal interchange (usually followed by ‘with’)
   hypernym:
   - 00040890-n
   ili: i35625
@@ -2326,8 +2326,8 @@
   partOfSpeech: n
 00076291-n:
   definition:
-  - a blunder that makes you look ridiculous; used in the phrase `make a spectacle
-    of´ yourself
+  - a blunder that makes you look ridiculous; used in the phrase ‘make a spectacle
+    of’ yourself
   hypernym:
   - 00075610-n
   ili: i35803
@@ -7374,7 +7374,7 @@
   definition:
   - a seduction culminating in sexual intercourse
   example:
-  - calling his seduction of the girl a `score´ was a typical example of male slang
+  - calling his seduction of the girl a ‘score’ was a typical example of male slang
   hypernym:
   - 00161352-n
   ili: i36256
@@ -8108,7 +8108,7 @@
   partOfSpeech: n
 00174021-n:
   definition:
-  - interchangeable with `means´ in the expression `by means of´
+  - interchangeable with ‘means’ in the expression ‘by means of’
   hypernym:
   - 00173531-n
   ili: i36322
@@ -8435,7 +8435,7 @@
   definition:
   - an expedient adopted only in desperation
   example:
-  - '`pis aller´ is French for `worst going´'
+  - '‘pis aller’ is French for ‘worst going’'
   hypernym:
   - 00178297-n
   ili: i36352
@@ -12274,7 +12274,7 @@
   partOfSpeech: n
 00250854-n:
   definition:
-  - significant progress (especially in the phrase `make strides´)
+  - significant progress (especially in the phrase ‘make strides’)
   example:
   - they made big strides in productivity
   hypernym:
@@ -25740,7 +25740,7 @@
   definition:
   - a card game using a pack of cards from which one queen has been removed; players
     match cards and the player holding the unmatched queen at the end of the game
-    is the loser (or `old maid´)
+    is the loser (or ‘old maid’)
   hypernym:
   - 00489236-n
   ili: i37975
@@ -38892,8 +38892,8 @@
   partOfSpeech: n
 00722912-n:
   definition:
-  - as the agent of or on someone's part (usually expressed as `on behalf of´ rather
-    than `in behalf of´)
+  - as the agent of or on someone's part (usually expressed as ‘on behalf of’ rather
+    than ‘in behalf of’)
   example:
   - the guardian signed the contract on behalf of the minor child
   - this letter is written on behalf of my client
@@ -44221,7 +44221,7 @@
   partOfSpeech: n
 00820339-n:
   definition:
-  - (with `in´) guardianship over; in divorce cases it is the right to house and care
+  - (with ‘in’) guardianship over; in divorce cases it is the right to house and care
     for and discipline a child
   example:
   - my fate is in your hands
@@ -52907,7 +52907,7 @@
 00977160-n:
   definition:
   - a mass attack of troops without concern for casualties; originated by Japanese
-    who accompanied it with yells of `banzai´
+    who accompanied it with yells of ‘banzai’
   hypernym:
   - 00974725-n
   ili: i40505
@@ -61321,7 +61321,7 @@
   definition:
   - a headlong rush of people on a common impulse
   example:
-  - when he shouted `fire´ there was a stampede to the exits
+  - when he shouted ‘fire’ there was a stampede to the exits
   hypernym:
   - 01082290-n
   ili: i41294
@@ -66754,7 +66754,7 @@
   partOfSpeech: n
 01222212-n:
   definition:
-  - promise of reward as in `carrot and stick´
+  - promise of reward as in ‘carrot and stick’
   example:
   - used the carrot of subsidized housing for the workers to get their vote
   hypernym:
@@ -69047,7 +69047,7 @@
 01259362-n:
   definition:
   - a position of being the initiator of something and an example that others will
-    follow (especially in the phrase `take the lead´)
+    follow (especially in the phrase ‘take the lead’)
   example:
   - he takes the lead in any group
   - we were just waiting for someone to take the lead
@@ -73509,7 +73509,7 @@
     and rapidly increasing difficulty.
   example:
   - source: https://en.wikipedia.org
-    text: The term `arcade game´ is also used to refer to an action video game that
+    text: The term ‘arcade game’ is also used to refer to an action video game that
       was designed to play similarly to an arcade game with frantic, addictive gameplay.
   hypernym:
   - 00459914-n

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -168,7 +168,7 @@
   partOfSpeech: n
 00037921-n:
   definition:
-  - used in the phrase `to your credit' in order to indicate an achievement deserving
+  - used in the phrase `to your credit´ in order to indicate an achievement deserving
     praise
   example:
   - she already had several performances to her credit
@@ -346,7 +346,7 @@
   partOfSpeech: n
 00041542-n:
   definition:
-  - social or verbal interchange (usually followed by `with')
+  - social or verbal interchange (usually followed by `with´)
   hypernym:
   - 00040890-n
   ili: i35625
@@ -2327,7 +2327,7 @@
 00076291-n:
   definition:
   - a blunder that makes you look ridiculous; used in the phrase `make a spectacle
-    of' yourself
+    of´ yourself
   hypernym:
   - 00075610-n
   ili: i35803
@@ -7374,7 +7374,7 @@
   definition:
   - a seduction culminating in sexual intercourse
   example:
-  - calling his seduction of the girl a `score' was a typical example of male slang
+  - calling his seduction of the girl a `score´ was a typical example of male slang
   hypernym:
   - 00161352-n
   ili: i36256
@@ -8108,7 +8108,7 @@
   partOfSpeech: n
 00174021-n:
   definition:
-  - interchangeable with `means' in the expression `by means of'
+  - interchangeable with `means´ in the expression `by means of´
   hypernym:
   - 00173531-n
   ili: i36322
@@ -8435,7 +8435,7 @@
   definition:
   - an expedient adopted only in desperation
   example:
-  - '`pis aller'' is French for `worst going'''
+  - '`pis aller´ is French for `worst going´'
   hypernym:
   - 00178297-n
   ili: i36352
@@ -12274,7 +12274,7 @@
   partOfSpeech: n
 00250854-n:
   definition:
-  - significant progress (especially in the phrase `make strides')
+  - significant progress (especially in the phrase `make strides´)
   example:
   - they made big strides in productivity
   hypernym:
@@ -25740,7 +25740,7 @@
   definition:
   - a card game using a pack of cards from which one queen has been removed; players
     match cards and the player holding the unmatched queen at the end of the game
-    is the loser (or `old maid')
+    is the loser (or `old maid´)
   hypernym:
   - 00489236-n
   ili: i37975
@@ -38892,8 +38892,8 @@
   partOfSpeech: n
 00722912-n:
   definition:
-  - as the agent of or on someone's part (usually expressed as `on behalf of' rather
-    than `in behalf of')
+  - as the agent of or on someone's part (usually expressed as `on behalf of´ rather
+    than `in behalf of´)
   example:
   - the guardian signed the contract on behalf of the minor child
   - this letter is written on behalf of my client
@@ -44221,7 +44221,7 @@
   partOfSpeech: n
 00820339-n:
   definition:
-  - (with `in') guardianship over; in divorce cases it is the right to house and care
+  - (with `in´) guardianship over; in divorce cases it is the right to house and care
     for and discipline a child
   example:
   - my fate is in your hands
@@ -52907,7 +52907,7 @@
 00977160-n:
   definition:
   - a mass attack of troops without concern for casualties; originated by Japanese
-    who accompanied it with yells of `banzai'
+    who accompanied it with yells of `banzai´
   hypernym:
   - 00974725-n
   ili: i40505
@@ -61321,7 +61321,7 @@
   definition:
   - a headlong rush of people on a common impulse
   example:
-  - when he shouted `fire' there was a stampede to the exits
+  - when he shouted `fire´ there was a stampede to the exits
   hypernym:
   - 01082290-n
   ili: i41294
@@ -66754,7 +66754,7 @@
   partOfSpeech: n
 01222212-n:
   definition:
-  - promise of reward as in `carrot and stick'
+  - promise of reward as in `carrot and stick´
   example:
   - used the carrot of subsidized housing for the workers to get their vote
   hypernym:
@@ -69047,7 +69047,7 @@
 01259362-n:
   definition:
   - a position of being the initiator of something and an example that others will
-    follow (especially in the phrase `take the lead')
+    follow (especially in the phrase `take the lead´)
   example:
   - he takes the lead in any group
   - we were just waiting for someone to take the lead
@@ -73509,7 +73509,7 @@
     and rapidly increasing difficulty.
   example:
   - source: https://en.wikipedia.org
-    text: The term `arcade game' is also used to refer to an action video game that
+    text: The term `arcade game´ is also used to refer to an action video game that
       was designed to play similarly to an arcade game with frantic, addictive gameplay.
   hypernym:
   - 00459914-n

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -24069,9 +24069,8 @@
   partOfSpeech: n
 01717327-n:
   definition:
-  - primitive theropod found in Argentina;
-    early Triassic; its name means `Herrera's lizard' after the rancher who discovered
-    the first specimen (Herrerasaurus)
+  - primitive theropod found in Argentina; early Triassic; its name means `Herrera's
+    lizard' after the rancher who discovered the first specimen (Herrerasaurus)
   hypernym:
   - 01660364-n
   ili: i44321
@@ -24092,8 +24091,8 @@
   partOfSpeech: n
 01717623-n:
   definition:
-  - primitive theropod found in Argentina;
-    early Triassic; its name is derived from the Greek word Eos, meaning `dawn' (Eoraptor)
+  - primitive theropod found in Argentina; early Triassic; its name is derived from
+    the Greek word Eos, meaning `dawn' (Eoraptor)
   hypernym:
   - 01660364-n
   ili: i44323
@@ -86846,8 +86845,8 @@
   partOfSpeech: n
 82475871-n:
   definition:
-  - a canid living in the deserts of Northern Africa related to the golden jackal and
-    the grey wolf
+  - a canid living in the deserts of Northern Africa related to the golden jackal
+    and the grey wolf
   hypernym:
   - 02117748-n
   members:

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -91,7 +91,7 @@
   partOfSpeech: n
 01317154-n:
   definition:
-  - a regional term for `creature' (especially for domestic animals)
+  - a regional term for `creature´ (especially for domestic animals)
   hypernym:
   - 00015568-n
   ili: i42251
@@ -5874,7 +5874,7 @@
 01418267-n:
   definition:
   - an organism with cells characteristic of all life forms except primitive microorganisms
-    such as bacteria; i.e. an organism with `good' or membrane-bound nuclei in its
+    such as bacteria; i.e. an organism with `good´ or membrane-bound nuclei in its
     cells
   hypernym:
   - 00004475-n
@@ -7032,7 +7032,7 @@
   partOfSpeech: n
 01444807-n:
   definition:
-  - shiner of eastern North America having golden glints; sometimes also called `bream'
+  - shiner of eastern North America having golden glints; sometimes also called `bream´
   hypernym:
   - 01444066-n
   ili: i42870
@@ -10739,7 +10739,7 @@
   wikidata: Q6629661
 01501630-n:
   definition:
-  - powerful free-swimming tropical ray noted for `soaring' by flapping winglike fins;
+  - powerful free-swimming tropical ray noted for `soaring´ by flapping winglike fins;
     usually harmless but has venomous tissue near base of the tail as in stingrays
   hypernym:
   - 01498342-n
@@ -15355,7 +15355,7 @@
   partOfSpeech: n
 01580459-n:
   definition:
-  - a genus containing the `typical' mynas (Acridotheres)
+  - a genus containing the `typical´ mynas (Acridotheres)
   hypernym:
   - 01509816-n
   ili: i43575
@@ -24070,7 +24070,7 @@
 01717327-n:
   definition:
   - primitive theropod found in Argentina; early Triassic; its name means `Herrera's
-    lizard' after the rancher who discovered the first specimen (Herrerasaurus)
+    lizard´ after the rancher who discovered the first specimen (Herrerasaurus)
   hypernym:
   - 01660364-n
   ili: i44321
@@ -24092,7 +24092,7 @@
 01717623-n:
   definition:
   - primitive theropod found in Argentina; early Triassic; its name is derived from
-    the Greek word Eos, meaning `dawn' (Eoraptor)
+    the Greek word Eos, meaning `dawn´ (Eoraptor)
   hypernym:
   - 01660364-n
   ili: i44323
@@ -25653,7 +25653,7 @@
 01741372-n:
   definition:
   - a sand snake of southwestern United States; lives in fine to coarse sand or loamy
-    soil in which it `swims'; banding resembles that of coral snakes
+    soil in which it `swims´; banding resembles that of coral snakes
   hypernym:
   - 01741242-n
   ili: i44458
@@ -27425,7 +27425,7 @@
   definition:
   - an orange and tan spider with darkly banded legs that spins an orb web daily
   example:
-  - the barn spider was made famous in E. B. White's book `Charlotte's Web'
+  - the barn spider was made famous in E. B. White's book `Charlotte's Web´
   hypernym:
   - 01774863-n
   ili: i44608
@@ -34656,7 +34656,7 @@
   partOfSpeech: n
 01890264-n:
   definition:
-  - mature male of various mammals of which the female is called `cow'; e.g. whales
+  - mature male of various mammals of which the female is called `cow´; e.g. whales
     or elephants or especially cattle
   hypernym:
   - 01889397-n
@@ -34666,7 +34666,7 @@
   partOfSpeech: n
 01890428-n:
   definition:
-  - mature female of mammals of which the male is called `bull'
+  - mature female of mammals of which the male is called `bull´
   hypernym:
   - 01889397-n
   ili: i45233
@@ -34714,7 +34714,7 @@
   partOfSpeech: n
 01891052-n:
   definition:
-  - mature female of mammals of which the male is called `buck'
+  - mature female of mammals of which the male is called `buck´
   hypernym:
   - 01889397-n
   ili: i45238
@@ -46418,7 +46418,7 @@
   partOfSpeech: n
 02066315-n:
   definition:
-  - large Arctic whalebone whale; allegedly the `right' whale to hunt because of its
+  - large Arctic whalebone whale; allegedly the `right´ whale to hunt because of its
     valuable whalebone and oil
   hypernym:
   - 02065877-n
@@ -50017,7 +50017,7 @@
 02121359-n:
   definition:
   - a conventional name for a fox used in tales following usage in the old epic `Reynard
-    the Fox'
+    the Fox´
   hypernym:
   - 02120985-n
   ili: i46577
@@ -50946,7 +50946,7 @@
 02134972-n:
   definition:
   - a conventional name for a bear used in tales following usage in the old epic `Reynard
-    the Fox'
+    the Fox´
   hypernym:
   - 02134305-n
   ili: i46661
@@ -61268,7 +61268,7 @@
   partOfSpeech: n
 02288561-n:
   definition:
-  - type genus of the Lymantriidae; a pest (Lymantria means `destroyer')
+  - type genus of the Lymantriidae; a pest (Lymantria means `destroyer´)
   hypernym:
   - 01765166-n
   ili: i47550
@@ -69692,7 +69692,7 @@
   definition:
   - uncastrated adult male sheep
   example:
-  - a British term is `tup'
+  - a British term is `tup´
   hypernym:
   - 02414351-n
   ili: i48293
@@ -71159,8 +71159,8 @@
   partOfSpeech: n
 02435629-n:
   definition:
-  - large northern deer with enormous flattened antlers in the male; called `elk'
-    in Europe and `moose' in North America
+  - large northern deer with enormous flattened antlers in the male; called `elk´
+    in Europe and `moose´ in North America
   hypernym:
   - 02432691-n
   ili: i48424
@@ -71236,8 +71236,8 @@
   partOfSpeech: n
 02436556-n:
   definition:
-  - Arctic deer with large antlers in both sexes; called `reindeer' in Eurasia and
-    `caribou' in North America
+  - Arctic deer with large antlers in both sexes; called `reindeer´ in Eurasia and
+    `caribou´ in North America
   hypernym:
   - 02432691-n
   ili: i48431
@@ -73816,7 +73816,7 @@
   - all of the living human inhabitants of the earth
   example:
   - all the world loves a lover
-  - she always used `humankind' because `mankind' seemed to slight the women
+  - she always used `humankind´ because `mankind´ seemed to slight the women
   hypernym:
   - 02474924-n
   - 00031563-n
@@ -81376,7 +81376,7 @@
   wikidata: Q2717632
 02590110-n:
   definition:
-  - similar to and often marketed as `red snapper'
+  - similar to and often marketed as `red snapper´
   hypernym:
   - 02589174-n
   ili: i49296

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -91,7 +91,7 @@
   partOfSpeech: n
 01317154-n:
   definition:
-  - a regional term for `creature´ (especially for domestic animals)
+  - a regional term for ‘creature’ (especially for domestic animals)
   hypernym:
   - 00015568-n
   ili: i42251
@@ -5874,7 +5874,7 @@
 01418267-n:
   definition:
   - an organism with cells characteristic of all life forms except primitive microorganisms
-    such as bacteria; i.e. an organism with `good´ or membrane-bound nuclei in its
+    such as bacteria; i.e. an organism with ‘good’ or membrane-bound nuclei in its
     cells
   hypernym:
   - 00004475-n
@@ -7032,7 +7032,7 @@
   partOfSpeech: n
 01444807-n:
   definition:
-  - shiner of eastern North America having golden glints; sometimes also called `bream´
+  - shiner of eastern North America having golden glints; sometimes also called ‘bream’
   hypernym:
   - 01444066-n
   ili: i42870
@@ -10739,7 +10739,7 @@
   wikidata: Q6629661
 01501630-n:
   definition:
-  - powerful free-swimming tropical ray noted for `soaring´ by flapping winglike fins;
+  - powerful free-swimming tropical ray noted for ‘soaring’ by flapping winglike fins;
     usually harmless but has venomous tissue near base of the tail as in stingrays
   hypernym:
   - 01498342-n
@@ -15355,7 +15355,7 @@
   partOfSpeech: n
 01580459-n:
   definition:
-  - a genus containing the `typical´ mynas (Acridotheres)
+  - a genus containing the ‘typical’ mynas (Acridotheres)
   hypernym:
   - 01509816-n
   ili: i43575
@@ -24069,8 +24069,8 @@
   partOfSpeech: n
 01717327-n:
   definition:
-  - primitive theropod found in Argentina; early Triassic; its name means `Herrera's
-    lizard´ after the rancher who discovered the first specimen (Herrerasaurus)
+  - primitive theropod found in Argentina; early Triassic; its name means ‘Herrera's
+    lizard’ after the rancher who discovered the first specimen (Herrerasaurus)
   hypernym:
   - 01660364-n
   ili: i44321
@@ -24092,7 +24092,7 @@
 01717623-n:
   definition:
   - primitive theropod found in Argentina; early Triassic; its name is derived from
-    the Greek word Eos, meaning `dawn´ (Eoraptor)
+    the Greek word Eos, meaning ‘dawn’ (Eoraptor)
   hypernym:
   - 01660364-n
   ili: i44323
@@ -25653,7 +25653,7 @@
 01741372-n:
   definition:
   - a sand snake of southwestern United States; lives in fine to coarse sand or loamy
-    soil in which it `swims´; banding resembles that of coral snakes
+    soil in which it ‘swims’; banding resembles that of coral snakes
   hypernym:
   - 01741242-n
   ili: i44458
@@ -27425,7 +27425,7 @@
   definition:
   - an orange and tan spider with darkly banded legs that spins an orb web daily
   example:
-  - the barn spider was made famous in E. B. White's book `Charlotte's Web´
+  - the barn spider was made famous in E. B. White's book ‘Charlotte's Web’
   hypernym:
   - 01774863-n
   ili: i44608
@@ -34656,7 +34656,7 @@
   partOfSpeech: n
 01890264-n:
   definition:
-  - mature male of various mammals of which the female is called `cow´; e.g. whales
+  - mature male of various mammals of which the female is called ‘cow’; e.g. whales
     or elephants or especially cattle
   hypernym:
   - 01889397-n
@@ -34666,7 +34666,7 @@
   partOfSpeech: n
 01890428-n:
   definition:
-  - mature female of mammals of which the male is called `bull´
+  - mature female of mammals of which the male is called ‘bull’
   hypernym:
   - 01889397-n
   ili: i45233
@@ -34714,7 +34714,7 @@
   partOfSpeech: n
 01891052-n:
   definition:
-  - mature female of mammals of which the male is called `buck´
+  - mature female of mammals of which the male is called ‘buck’
   hypernym:
   - 01889397-n
   ili: i45238
@@ -46418,7 +46418,7 @@
   partOfSpeech: n
 02066315-n:
   definition:
-  - large Arctic whalebone whale; allegedly the `right´ whale to hunt because of its
+  - large Arctic whalebone whale; allegedly the ‘right’ whale to hunt because of its
     valuable whalebone and oil
   hypernym:
   - 02065877-n
@@ -50016,8 +50016,8 @@
   partOfSpeech: n
 02121359-n:
   definition:
-  - a conventional name for a fox used in tales following usage in the old epic `Reynard
-    the Fox´
+  - a conventional name for a fox used in tales following usage in the old epic ‘Reynard
+    the Fox’
   hypernym:
   - 02120985-n
   ili: i46577
@@ -50945,8 +50945,8 @@
   partOfSpeech: n
 02134972-n:
   definition:
-  - a conventional name for a bear used in tales following usage in the old epic `Reynard
-    the Fox´
+  - a conventional name for a bear used in tales following usage in the old epic ‘Reynard
+    the Fox’
   hypernym:
   - 02134305-n
   ili: i46661
@@ -61268,7 +61268,7 @@
   partOfSpeech: n
 02288561-n:
   definition:
-  - type genus of the Lymantriidae; a pest (Lymantria means `destroyer´)
+  - type genus of the Lymantriidae; a pest (Lymantria means ‘destroyer’)
   hypernym:
   - 01765166-n
   ili: i47550
@@ -69692,7 +69692,7 @@
   definition:
   - uncastrated adult male sheep
   example:
-  - a British term is `tup´
+  - a British term is ‘tup’
   hypernym:
   - 02414351-n
   ili: i48293
@@ -71159,8 +71159,8 @@
   partOfSpeech: n
 02435629-n:
   definition:
-  - large northern deer with enormous flattened antlers in the male; called `elk´
-    in Europe and `moose´ in North America
+  - large northern deer with enormous flattened antlers in the male; called ‘elk’
+    in Europe and ‘moose’ in North America
   hypernym:
   - 02432691-n
   ili: i48424
@@ -71236,8 +71236,8 @@
   partOfSpeech: n
 02436556-n:
   definition:
-  - Arctic deer with large antlers in both sexes; called `reindeer´ in Eurasia and
-    `caribou´ in North America
+  - Arctic deer with large antlers in both sexes; called ‘reindeer’ in Eurasia and
+    ‘caribou’ in North America
   hypernym:
   - 02432691-n
   ili: i48431
@@ -73816,7 +73816,7 @@
   - all of the living human inhabitants of the earth
   example:
   - all the world loves a lover
-  - she always used `humankind´ because `mankind´ seemed to slight the women
+  - she always used ‘humankind’ because ‘mankind’ seemed to slight the women
   hypernym:
   - 02474924-n
   - 00031563-n
@@ -81376,7 +81376,7 @@
   wikidata: Q2717632
 02590110-n:
   definition:
-  - similar to and often marketed as `red snapper´
+  - similar to and often marketed as ‘red snapper’
   hypernym:
   - 02589174-n
   ili: i49296

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -2213,7 +2213,7 @@
   partOfSpeech: n
 02704119-n:
   definition:
-  - area reserved for persons leading the responsive `amens'
+  - area reserved for persons leading the responsive `amens´
   hypernym:
   - 03114532-n
   ili: i49959
@@ -3735,7 +3735,7 @@
 02732289-n:
   definition:
   - (classical mythology) a golden apple thrown into a banquet of the gods by Eris
-    (goddess of discord — who had not been invited); the apple had `for the fairest'
+    (goddess of discord — who had not been invited); the apple had `for the fairest´
     written on it and Hera and Athena and Aphrodite all claimed it; when Paris (prince
     of Troy) awarded it to Aphrodite it began a chain of events that led to the Trojan
     War
@@ -6116,7 +6116,7 @@
   definition:
   - the part of a garment that covers the back of your body
   example:
-  - they pinned a `kick me' sign on his back
+  - they pinned a `kick me´ sign on his back
   hypernym:
   - 03054011-n
   ili: i50322
@@ -12703,7 +12703,7 @@
   definition:
   - an unexploded bomblet
   example:
-  - unexploded bomblets known in Laos as `bombies' caused farmers to fear cultivating
+  - unexploded bomblets known in Laos as `bombies´ caused farmers to fear cultivating
     their fields
   hypernym:
   - 02871580-n
@@ -16350,7 +16350,7 @@
   partOfSpeech: n
 02927407-n:
   definition:
-  - a variant of `burden'
+  - a variant of `burden´
   hypernym:
   - 03685312-n
   ili: i51284
@@ -20488,7 +20488,7 @@
   partOfSpeech: n
 02992418-n:
   definition:
-  - a drive that is connected to a computer and on which a CD-ROM can be `played'
+  - a drive that is connected to a computer and on which a CD-ROM can be `played´
   hypernym:
   - 03247921-n
   ili: i51675
@@ -21759,7 +21759,7 @@
   partOfSpeech: n
 03013131-n:
   definition:
-  - the navy yard in Boston where the frigate `Constitution' is anchored
+  - the navy yard in Boston where the frigate `Constitution´ is anchored
   ili: i51793
   instance_hypernym:
   - 03819244-n
@@ -32761,7 +32761,7 @@
   definition:
   - (computer science) a small temporary window in a graphical user interface that
     appears in order to request information from the user; after the information has
-    been provided the user dismisses the box with `okay' or `cancel'
+    been provided the user dismisses the box with `okay´ or `cancel´
   domain_topic:
   - 06138021-n
   hypernym:
@@ -35051,7 +35051,7 @@
   partOfSpeech: n
 03227662-n:
   definition:
-  - a knob used to release the catch when opening a door (often called `doorhandle'
+  - a knob used to release the catch when opening a door (often called `doorhandle´
     in Great Britain)
   domain_region:
   - 08879115-n
@@ -41880,7 +41880,7 @@
   - 06056961-n
   example:
   - when he yawned I could see the gold fillings in his teeth
-  - an informal British term for `filling' is `stopping'
+  - an informal British term for `filling´ is `stopping´
   hypernym:
   - 03180270-n
   ili: i53698
@@ -53539,7 +53539,7 @@
   definition:
   - tower consisting of a multistoried building of offices or apartments
   example:
-  - '`tower block'' is the British term for `high-rise'''
+  - '`tower block´ is the British term for `high-rise´'
   hypernym:
   - 04467365-n
   ili: i54806
@@ -55837,7 +55837,7 @@
   partOfSpeech: n
 03561353-n:
   definition:
-  - girder having a cross section resembling the letter `I'
+  - girder having a cross section resembling the letter `I´
   hypernym:
   - 03442851-n
   ili: i55023
@@ -58448,7 +58448,7 @@
   partOfSpeech: n
 03604821-n:
   definition:
-  - a workplace; as in the expression `on the job'
+  - a workplace; as in the expression `on the job´
   hypernym:
   - 04609402-n
   ili: i55272
@@ -68150,8 +68150,8 @@
   definition:
   - an electric railway operating below the surface of the ground (usually in a city)
   example:
-  - in Paris the subway system is called the `metro' and in London it is called the
-    `tube' or the `underground'
+  - in Paris the subway system is called the `metro´ and in London it is called the
+    `tube´ or the `underground´
   hypernym:
   - 04055680-n
   ili: i56197
@@ -75661,7 +75661,7 @@
   - a substance used as a coating to protect or decorate a surface (especially a mixture
     of pigment suspended in a liquid); dries to form a hard coating
   example:
-  - artists use `paint' and `pigment' interchangeably
+  - artists use `paint´ and `pigment´ interchangeably
   hypernym:
   - 03062092-n
   - 15009532-n
@@ -78659,7 +78659,7 @@
 03927621-n:
   definition:
   - a drug used as an anesthetic by veterinarians; illicitly taken (originally in
-    the form of powder or `dust') for its effects as a hallucinogen
+    the form of powder or `dust´) for its effects as a hallucinogen
   hypernym:
   - 03484730-n
   ili: i57190
@@ -80117,7 +80117,7 @@
   definition:
   - a wheel that has numerous pins that are set at right angles to its rim
   example:
-  - he spun the pinwheel and it stopped with the pointer on `Go'
+  - he spun the pinwheel and it stopped with the pointer on `Go´
   hypernym:
   - 04582285-n
   ili: i57328
@@ -80426,7 +80426,7 @@
   definition:
   - a surface excavation for extracting stone or slate
   example:
-  - a British term for `quarry' is `stone pit'
+  - a British term for `quarry´ is `stone pit´
   hypernym:
   - 03307066-n
   ili: i57357
@@ -102914,7 +102914,7 @@
   partOfSpeech: n
 04315721-n:
   definition:
-  - a room that can be filled with steam in which people bathe; `vapour bath' is a
+  - a room that can be filled with steam in which people bathe; `vapour bath´ is a
     British term
   hypernym:
   - 04112987-n
@@ -105913,7 +105913,7 @@
   definition:
   - an automobile roof having a sliding or raisable panel
   example:
-  - '`sunshine-roof'' is a British term for `sunroof'''
+  - '`sunshine-roof´ is a British term for `sunroof´'
   hypernym:
   - 04112162-n
   ili: i59799
@@ -106757,7 +106757,7 @@
   definition:
   - pool that provides a facility for swimming
   example:
-  - '`swimming bath'' is a British term'
+  - '`swimming bath´ is a British term'
   hypernym:
   - 03988418-n
   - 02755316-n
@@ -111241,7 +111241,7 @@
   partOfSpeech: n
 04448662-n:
   definition:
-  - 'a hat (Cockney rhyming slang: `tit for tat'' rhymes with `hat'')'
+  - 'a hat (Cockney rhyming slang: `tit for tat´ rhymes with `hat´)'
   domain_region:
   - 08879115-n
   hypernym:
@@ -118075,8 +118075,8 @@
   partOfSpeech: n
 04558126-n:
   definition:
-  - 'articles of the same kind or material; usually used in combination: `silverware'',
-    `software'''
+  - 'articles of the same kind or material; usually used in combination: `silverware´,
+    `software´'
   hypernym:
   - 00023083-n
   ili: i60950
@@ -118350,7 +118350,7 @@
 04562686-n:
   definition:
   - 'furniture consisting of a table or stand to hold a basin and pitcher of water
-    for washing: `wash-hand stand'' is a British term'
+    for washing: `wash-hand stand´ is a British term'
   hypernym:
   - 03410635-n
   ili: i60975
@@ -122810,7 +122810,7 @@
     sounds.
   example:
   - source: https://en.wikipedia.org
-    text: Guitarists derive their signature sound or `tone' from their choice of instrument,
+    text: Guitarists derive their signature sound or `tone´ from their choice of instrument,
       pickups, effects units, and guitar amp.
   hypernym:
   - 03282682-n
@@ -124840,7 +124840,7 @@
   example:
   - The introduction of the tilt barrier seems to have originated in the south, as
     it only became a standard feature of jousting in Germany in the 16th century,
-    and was there called the Italian or `welsch' mode.
+    and was there called the Italian or `welsch´ mode.
   hypernym:
   - 02799782-n
   members:
@@ -125460,7 +125460,7 @@
   example:
   - source: https://en.wikipedia.org
     text: Prince William's royal yards are the highest and smallest yards on the ship,
-      are made of wood, and are `lifting yards' that can be raised along a section
+      are made of wood, and are `lifting yards´ that can be raised along a section
       of the mast.
   hypernym:
   - 04618033-n
@@ -125561,7 +125561,7 @@
     out, or dug into a hillside.
   example:
   - Dugouts are one of the most ancient types of human housing known to archeologists,
-    and the same methods have evolved into modern `earth shelter' technology.
+    and the same methods have evolved into modern `earth shelter´ technology.
   hypernym:
   - 04198638-n
   - 03264208-n
@@ -125779,7 +125779,7 @@
   - An axial flow turbine operates in the exactly reverse of an axial flow compressor,
   example:
   - source: https://en.wikipedia.org
-    text: Whereas for an axial turbine the rotor is `impacted' by the air flow, for
+    text: Whereas for an axial turbine the rotor is `impacted´ by the air flow, for
       a radial turbine, the flow is smoothly orientated at 90 degrees by the compressor
       towards the combustion chamber and driving the turbine in the same way water
       drives a watermill.
@@ -126075,7 +126075,7 @@
   example:
   - source: https://en.wikipedia.org
     text: Vibratory hammers can either drive in or extract a pile; extraction is commonly
-      used to recover steel `H' piles used in temporary foundation shoring.
+      used to recover steel `H´ piles used in temporary foundation shoring.
   hypernym:
   - 92460211-n
   members:
@@ -126183,7 +126183,7 @@
       electronic drum kit, consisting of a set of drum pads mounted on a stand or
       rack in a configuration similar to that of an acoustic drum kit layout, with
       rubberized (Roland, Yamaha, Alesis, for example) or specialized acoustic/electronic
-      cymbals (e.g. Zildjian's `Gen 16').
+      cymbals (e.g. Zildjian's `Gen 16´).
   hypernym:
   - 03921556-n
   - 03284064-n
@@ -126747,7 +126747,7 @@
 92461496-n:
   definition:
   - a sensitive photographic paper with pure silver bromide emulsions that produce
-    neutral black or `cold' blue-black image tones.
+    neutral black or `cold´ blue-black image tones.
   hypernym:
   - 03932650-n
   members:
@@ -126941,7 +126941,7 @@
 92461769-n:
   definition:
   - a printing press used for offset printing, in which the inked image is transferred
-    (or `offset') from a plate to a rubber blanket, then to the printing surface.
+    (or `offset´) from a plate to a rubber blanket, then to the printing surface.
   example:
   - source: https://en.wikipedia.org
     text: Many modern offset presses use computer-to-plate systems as opposed to the
@@ -127352,7 +127352,7 @@
 92462427-n:
   definition:
   - a sewing machine that binds fabric together using two threads, upper and lower,
-    and `locking' (entwining) them together in the hole in the fabric through which
+    and `locking´ (entwining) them together in the hole in the fabric through which
     they pass.
   example:
   - source: https://en.wikipedia.org

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -53539,7 +53539,7 @@
   definition:
   - tower consisting of a multistoried building of offices or apartments
   example:
-  - '‘tower block’ is the British term for ‘high-rise’'
+  - ‘tower block’ is the British term for ‘high-rise’
   hypernym:
   - 04467365-n
   ili: i54806
@@ -105913,7 +105913,7 @@
   definition:
   - an automobile roof having a sliding or raisable panel
   example:
-  - '‘sunshine-roof’ is a British term for ‘sunroof’'
+  - ‘sunshine-roof’ is a British term for ‘sunroof’
   hypernym:
   - 04112162-n
   ili: i59799
@@ -106757,7 +106757,7 @@
   definition:
   - pool that provides a facility for swimming
   example:
-  - '‘swimming bath’ is a British term'
+  - ‘swimming bath’ is a British term
   hypernym:
   - 03988418-n
   - 02755316-n

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -2213,7 +2213,7 @@
   partOfSpeech: n
 02704119-n:
   definition:
-  - area reserved for persons leading the responsive `amens´
+  - area reserved for persons leading the responsive ‘amens’
   hypernym:
   - 03114532-n
   ili: i49959
@@ -3735,7 +3735,7 @@
 02732289-n:
   definition:
   - (classical mythology) a golden apple thrown into a banquet of the gods by Eris
-    (goddess of discord — who had not been invited); the apple had `for the fairest´
+    (goddess of discord — who had not been invited); the apple had ‘for the fairest’
     written on it and Hera and Athena and Aphrodite all claimed it; when Paris (prince
     of Troy) awarded it to Aphrodite it began a chain of events that led to the Trojan
     War
@@ -6116,7 +6116,7 @@
   definition:
   - the part of a garment that covers the back of your body
   example:
-  - they pinned a `kick me´ sign on his back
+  - they pinned a ‘kick me’ sign on his back
   hypernym:
   - 03054011-n
   ili: i50322
@@ -12703,7 +12703,7 @@
   definition:
   - an unexploded bomblet
   example:
-  - unexploded bomblets known in Laos as `bombies´ caused farmers to fear cultivating
+  - unexploded bomblets known in Laos as ‘bombies’ caused farmers to fear cultivating
     their fields
   hypernym:
   - 02871580-n
@@ -16350,7 +16350,7 @@
   partOfSpeech: n
 02927407-n:
   definition:
-  - a variant of `burden´
+  - a variant of ‘burden’
   hypernym:
   - 03685312-n
   ili: i51284
@@ -20488,7 +20488,7 @@
   partOfSpeech: n
 02992418-n:
   definition:
-  - a drive that is connected to a computer and on which a CD-ROM can be `played´
+  - a drive that is connected to a computer and on which a CD-ROM can be ‘played’
   hypernym:
   - 03247921-n
   ili: i51675
@@ -21759,7 +21759,7 @@
   partOfSpeech: n
 03013131-n:
   definition:
-  - the navy yard in Boston where the frigate `Constitution´ is anchored
+  - the navy yard in Boston where the frigate ‘Constitution’ is anchored
   ili: i51793
   instance_hypernym:
   - 03819244-n
@@ -32761,7 +32761,7 @@
   definition:
   - (computer science) a small temporary window in a graphical user interface that
     appears in order to request information from the user; after the information has
-    been provided the user dismisses the box with `okay´ or `cancel´
+    been provided the user dismisses the box with ‘okay’ or ‘cancel’
   domain_topic:
   - 06138021-n
   hypernym:
@@ -35051,7 +35051,7 @@
   partOfSpeech: n
 03227662-n:
   definition:
-  - a knob used to release the catch when opening a door (often called `doorhandle´
+  - a knob used to release the catch when opening a door (often called ‘doorhandle’
     in Great Britain)
   domain_region:
   - 08879115-n
@@ -41880,7 +41880,7 @@
   - 06056961-n
   example:
   - when he yawned I could see the gold fillings in his teeth
-  - an informal British term for `filling´ is `stopping´
+  - an informal British term for ‘filling’ is ‘stopping’
   hypernym:
   - 03180270-n
   ili: i53698
@@ -53539,7 +53539,7 @@
   definition:
   - tower consisting of a multistoried building of offices or apartments
   example:
-  - '`tower block´ is the British term for `high-rise´'
+  - '‘tower block’ is the British term for ‘high-rise’'
   hypernym:
   - 04467365-n
   ili: i54806
@@ -55837,7 +55837,7 @@
   partOfSpeech: n
 03561353-n:
   definition:
-  - girder having a cross section resembling the letter `I´
+  - girder having a cross section resembling the letter ‘I’
   hypernym:
   - 03442851-n
   ili: i55023
@@ -58448,7 +58448,7 @@
   partOfSpeech: n
 03604821-n:
   definition:
-  - a workplace; as in the expression `on the job´
+  - a workplace; as in the expression ‘on the job’
   hypernym:
   - 04609402-n
   ili: i55272
@@ -68150,8 +68150,8 @@
   definition:
   - an electric railway operating below the surface of the ground (usually in a city)
   example:
-  - in Paris the subway system is called the `metro´ and in London it is called the
-    `tube´ or the `underground´
+  - in Paris the subway system is called the ‘metro’ and in London it is called the
+    ‘tube’ or the ‘underground’
   hypernym:
   - 04055680-n
   ili: i56197
@@ -75661,7 +75661,7 @@
   - a substance used as a coating to protect or decorate a surface (especially a mixture
     of pigment suspended in a liquid); dries to form a hard coating
   example:
-  - artists use `paint´ and `pigment´ interchangeably
+  - artists use ‘paint’ and ‘pigment’ interchangeably
   hypernym:
   - 03062092-n
   - 15009532-n
@@ -78659,7 +78659,7 @@
 03927621-n:
   definition:
   - a drug used as an anesthetic by veterinarians; illicitly taken (originally in
-    the form of powder or `dust´) for its effects as a hallucinogen
+    the form of powder or ‘dust’) for its effects as a hallucinogen
   hypernym:
   - 03484730-n
   ili: i57190
@@ -80117,7 +80117,7 @@
   definition:
   - a wheel that has numerous pins that are set at right angles to its rim
   example:
-  - he spun the pinwheel and it stopped with the pointer on `Go´
+  - he spun the pinwheel and it stopped with the pointer on ‘Go’
   hypernym:
   - 04582285-n
   ili: i57328
@@ -80426,7 +80426,7 @@
   definition:
   - a surface excavation for extracting stone or slate
   example:
-  - a British term for `quarry´ is `stone pit´
+  - a British term for ‘quarry’ is ‘stone pit’
   hypernym:
   - 03307066-n
   ili: i57357
@@ -102914,7 +102914,7 @@
   partOfSpeech: n
 04315721-n:
   definition:
-  - a room that can be filled with steam in which people bathe; `vapour bath´ is a
+  - a room that can be filled with steam in which people bathe; ‘vapour bath’ is a
     British term
   hypernym:
   - 04112987-n
@@ -105913,7 +105913,7 @@
   definition:
   - an automobile roof having a sliding or raisable panel
   example:
-  - '`sunshine-roof´ is a British term for `sunroof´'
+  - '‘sunshine-roof’ is a British term for ‘sunroof’'
   hypernym:
   - 04112162-n
   ili: i59799
@@ -106757,7 +106757,7 @@
   definition:
   - pool that provides a facility for swimming
   example:
-  - '`swimming bath´ is a British term'
+  - '‘swimming bath’ is a British term'
   hypernym:
   - 03988418-n
   - 02755316-n
@@ -111241,7 +111241,7 @@
   partOfSpeech: n
 04448662-n:
   definition:
-  - 'a hat (Cockney rhyming slang: `tit for tat´ rhymes with `hat´)'
+  - 'a hat (Cockney rhyming slang: ‘tit for tat’ rhymes with ‘hat’)'
   domain_region:
   - 08879115-n
   hypernym:
@@ -118075,8 +118075,8 @@
   partOfSpeech: n
 04558126-n:
   definition:
-  - 'articles of the same kind or material; usually used in combination: `silverware´,
-    `software´'
+  - 'articles of the same kind or material; usually used in combination: ‘silverware’,
+    ‘software’'
   hypernym:
   - 00023083-n
   ili: i60950
@@ -118350,7 +118350,7 @@
 04562686-n:
   definition:
   - 'furniture consisting of a table or stand to hold a basin and pitcher of water
-    for washing: `wash-hand stand´ is a British term'
+    for washing: ‘wash-hand stand’ is a British term'
   hypernym:
   - 03410635-n
   ili: i60975
@@ -122810,7 +122810,7 @@
     sounds.
   example:
   - source: https://en.wikipedia.org
-    text: Guitarists derive their signature sound or `tone´ from their choice of instrument,
+    text: Guitarists derive their signature sound or ‘tone’ from their choice of instrument,
       pickups, effects units, and guitar amp.
   hypernym:
   - 03282682-n
@@ -124840,7 +124840,7 @@
   example:
   - The introduction of the tilt barrier seems to have originated in the south, as
     it only became a standard feature of jousting in Germany in the 16th century,
-    and was there called the Italian or `welsch´ mode.
+    and was there called the Italian or ‘welsch’ mode.
   hypernym:
   - 02799782-n
   members:
@@ -125460,7 +125460,7 @@
   example:
   - source: https://en.wikipedia.org
     text: Prince William's royal yards are the highest and smallest yards on the ship,
-      are made of wood, and are `lifting yards´ that can be raised along a section
+      are made of wood, and are ‘lifting yards’ that can be raised along a section
       of the mast.
   hypernym:
   - 04618033-n
@@ -125561,7 +125561,7 @@
     out, or dug into a hillside.
   example:
   - Dugouts are one of the most ancient types of human housing known to archeologists,
-    and the same methods have evolved into modern `earth shelter´ technology.
+    and the same methods have evolved into modern ‘earth shelter’ technology.
   hypernym:
   - 04198638-n
   - 03264208-n
@@ -125779,7 +125779,7 @@
   - An axial flow turbine operates in the exactly reverse of an axial flow compressor,
   example:
   - source: https://en.wikipedia.org
-    text: Whereas for an axial turbine the rotor is `impacted´ by the air flow, for
+    text: Whereas for an axial turbine the rotor is ‘impacted’ by the air flow, for
       a radial turbine, the flow is smoothly orientated at 90 degrees by the compressor
       towards the combustion chamber and driving the turbine in the same way water
       drives a watermill.
@@ -126075,7 +126075,7 @@
   example:
   - source: https://en.wikipedia.org
     text: Vibratory hammers can either drive in or extract a pile; extraction is commonly
-      used to recover steel `H´ piles used in temporary foundation shoring.
+      used to recover steel ‘H’ piles used in temporary foundation shoring.
   hypernym:
   - 92460211-n
   members:
@@ -126183,7 +126183,7 @@
       electronic drum kit, consisting of a set of drum pads mounted on a stand or
       rack in a configuration similar to that of an acoustic drum kit layout, with
       rubberized (Roland, Yamaha, Alesis, for example) or specialized acoustic/electronic
-      cymbals (e.g. Zildjian's `Gen 16´).
+      cymbals (e.g. Zildjian's ‘Gen 16’).
   hypernym:
   - 03921556-n
   - 03284064-n
@@ -126747,7 +126747,7 @@
 92461496-n:
   definition:
   - a sensitive photographic paper with pure silver bromide emulsions that produce
-    neutral black or `cold´ blue-black image tones.
+    neutral black or ‘cold’ blue-black image tones.
   hypernym:
   - 03932650-n
   members:
@@ -126941,7 +126941,7 @@
 92461769-n:
   definition:
   - a printing press used for offset printing, in which the inked image is transferred
-    (or `offset´) from a plate to a rubber blanket, then to the printing surface.
+    (or ‘offset’) from a plate to a rubber blanket, then to the printing surface.
   example:
   - source: https://en.wikipedia.org
     text: Many modern offset presses use computer-to-plate systems as opposed to the
@@ -127352,7 +127352,7 @@
 92462427-n:
   definition:
   - a sewing machine that binds fabric together using two threads, upper and lower,
-    and `locking´ (entwining) them together in the hole in the fabric through which
+    and ‘locking’ (entwining) them together in the hole in the fabric through which
     they pass.
   example:
   - source: https://en.wikipedia.org

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -122195,8 +122195,8 @@
   partOfSpeech: n
 80290977-n:
   definition:
-  - a telephone line that provides direct and prompt information or advice to the caller
-    in relation to a specific subject
+  - a telephone line that provides direct and prompt information or advice to the
+    caller in relation to a specific subject
   hypernym:
   - 00578562-n
   members:
@@ -122240,8 +122240,8 @@
   partOfSpeech: n
 81260722-n:
   definition:
-  - a type of shoe in which the heel is tall or raised, resulting in the heel of
-    the wearer's foot being significantly off the ground than the wearer's toes
+  - a type of shoe in which the heel is tall or raised, resulting in the heel of the
+    wearer's foot being significantly off the ground than the wearer's toes
   hypernym:
   - 04206070-n
   members:
@@ -122955,7 +122955,8 @@
   source: plWordNet 4.0
 92435345-n:
   definition:
-  - (mountaineering) a tool for extracting a nut, chock, etc., from a crack after use.
+  - (mountaineering) a tool for extracting a nut, chock, etc., from a crack after
+    use.
   hypernym:
   - 04459089-n
   - 92435347-n

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -122371,8 +122371,8 @@
   partOfSpeech: n
 88571022-n:
   definition:
-  - 'a large rubber ball used in various playground games including four square, kickball,
-    and dodgeball '
+  - a large rubber ball used in various playground games including four square, kickball,
+    and dodgeball
   hypernym:
   - 02781674-n
   members:

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -10693,7 +10693,7 @@
   - the quality of being magnificent or splendid or grand
   example:
   - for magnificence and personal service there is the Queen's hotel
-  - his `Hamlet' lacks the brilliance that one expects
+  - his `Hamlet´ lacks the brilliance that one expects
   - it is the university that gives the scene its stately splendor
   - an imaginative mix of old-fashioned grandeur and colorful art
   - advertisers capitalize on the grandness and elegance it brings to their products
@@ -29617,7 +29617,7 @@
   partOfSpeech: n
 05150547-n:
   definition:
-  - for someone's benefit (usually expressed as `in behalf' rather than `on behalf'
+  - for someone's benefit (usually expressed as `in behalf´ rather than `on behalf´
     and usually with a possessive)
   example:
   - in your behalf
@@ -35246,7 +35246,7 @@
   - The state or quality of being Serbian.
   example:
   - The linking thread between the groups is the rejection of the EU, Nato and other
-    western influences which could endanger `Serbianness'.
+    western influences which could endanger `Serbianness´.
   hypernym:
   - 04923519-n
   members:
@@ -35400,7 +35400,7 @@
   example:
   - Most obvious, perhaps, is the contemporariness of her language, for example, when
     wishing to instil organisational members with `a feel for the modern 1990s arm
-    of brewing.'
+    of brewing.´
   hypernym:
   - 05057819-n
   members:
@@ -35465,7 +35465,7 @@
   example:
   - '`We, the intellectually curious, may soon find ourselves trapped in a pen, fenced
     in by rule-bound sticklerism and overzealous concern for our personal safety,
-    unless we exercise our civil liberties and our curiosity,'' he declaims.'
+    unless we exercise our civil liberties and our curiosity,´ he declaims.'
   hypernym:
   - 04679712-n
   - 04667618-n
@@ -36255,7 +36255,7 @@
   - A moderate reddish purple that is bluer, stronger, and slightly lighter than heliotrope
     see heliotrope and bluer and duller than eupatorium purple.
   example:
-  - He wrote that it turned `the colour of bishop's violet' and that he would bear
+  - He wrote that it turned `the colour of bishop's violet´ and that he would bear
     the signs of it for weeks.
   hypernym:
   - 04978025-n
@@ -36345,7 +36345,7 @@
   - The quality or state of being a distinguishing feature of a person or thing.
   example:
   - The behaviours generated in this study were rated for characteristicness of an
-    `ideally intelligent person' by a group of lay people (not students) and a group
+    `ideally intelligent person´ by a group of lay people (not students) and a group
     of experts (PhD psychologists studying intelligence).
   hypernym:
   - 04770548-n
@@ -36537,8 +36537,8 @@
   - the state or quality of being Scottish.
   example:
   - Indeed the formation of these regiments helped to unite the Highlanders and Lowlanders,
-    and give them a shared sense of `Scottishness', by changing the image of Highlanders
-    from being backward and savage, to being `the very embodiment of Scotland' (which
+    and give them a shared sense of `Scottishness´, by changing the image of Highlanders
+    from being backward and savage, to being `the very embodiment of Scotland´ (which
     became clearly evident during the Romanticist period in Scotland).
   hypernym:
   - 04923519-n
@@ -36855,7 +36855,7 @@
   - The state or quality of behaving like a troublemaker, often violent; like a rude
     violent person; like a yob.
   example:
-  - True, this is hardly the drink to inspire `Girls Gone Wild' loutishness.
+  - True, this is hardly the drink to inspire `Girls Gone Wild´ loutishness.
   hypernym:
   - 04921753-n
   members:
@@ -37067,7 +37067,7 @@
   definition:
   - The state of being able to be dismissed from office.
   example:
-  - The `democratic revolution' emphasized the delegation of authority and the removability
+  - The `democratic revolution´ emphasized the delegation of authority and the removability
     of officials, precisely because, as we shall see, neither delegation nor removability
     were much recognized in actual institutions.
   hypernym:

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -10693,7 +10693,7 @@
   - the quality of being magnificent or splendid or grand
   example:
   - for magnificence and personal service there is the Queen's hotel
-  - his `Hamlet´ lacks the brilliance that one expects
+  - his ‘Hamlet’ lacks the brilliance that one expects
   - it is the university that gives the scene its stately splendor
   - an imaginative mix of old-fashioned grandeur and colorful art
   - advertisers capitalize on the grandness and elegance it brings to their products
@@ -29617,7 +29617,7 @@
   partOfSpeech: n
 05150547-n:
   definition:
-  - for someone's benefit (usually expressed as `in behalf´ rather than `on behalf´
+  - for someone's benefit (usually expressed as ‘in behalf’ rather than ‘on behalf’
     and usually with a possessive)
   example:
   - in your behalf
@@ -35246,7 +35246,7 @@
   - The state or quality of being Serbian.
   example:
   - The linking thread between the groups is the rejection of the EU, Nato and other
-    western influences which could endanger `Serbianness´.
+    western influences which could endanger ‘Serbianness’.
   hypernym:
   - 04923519-n
   members:
@@ -35399,8 +35399,8 @@
   - The state or quality of being contemporary, modern, of the present age.
   example:
   - Most obvious, perhaps, is the contemporariness of her language, for example, when
-    wishing to instil organisational members with `a feel for the modern 1990s arm
-    of brewing.´
+    wishing to instil organisational members with ‘a feel for the modern 1990s arm
+    of brewing.’
   hypernym:
   - 05057819-n
   members:
@@ -35463,9 +35463,9 @@
   definition:
   - The behaviour of a stickler; inflexible adherence to rules.
   example:
-  - '`We, the intellectually curious, may soon find ourselves trapped in a pen, fenced
+  - '‘We, the intellectually curious, may soon find ourselves trapped in a pen, fenced
     in by rule-bound sticklerism and overzealous concern for our personal safety,
-    unless we exercise our civil liberties and our curiosity,´ he declaims.'
+    unless we exercise our civil liberties and our curiosity,’ he declaims.'
   hypernym:
   - 04679712-n
   - 04667618-n
@@ -36255,7 +36255,7 @@
   - A moderate reddish purple that is bluer, stronger, and slightly lighter than heliotrope
     see heliotrope and bluer and duller than eupatorium purple.
   example:
-  - He wrote that it turned `the colour of bishop's violet´ and that he would bear
+  - He wrote that it turned ‘the colour of bishop's violet’ and that he would bear
     the signs of it for weeks.
   hypernym:
   - 04978025-n
@@ -36345,7 +36345,7 @@
   - The quality or state of being a distinguishing feature of a person or thing.
   example:
   - The behaviours generated in this study were rated for characteristicness of an
-    `ideally intelligent person´ by a group of lay people (not students) and a group
+    ‘ideally intelligent person’ by a group of lay people (not students) and a group
     of experts (PhD psychologists studying intelligence).
   hypernym:
   - 04770548-n
@@ -36537,8 +36537,8 @@
   - the state or quality of being Scottish.
   example:
   - Indeed the formation of these regiments helped to unite the Highlanders and Lowlanders,
-    and give them a shared sense of `Scottishness´, by changing the image of Highlanders
-    from being backward and savage, to being `the very embodiment of Scotland´ (which
+    and give them a shared sense of ‘Scottishness’, by changing the image of Highlanders
+    from being backward and savage, to being ‘the very embodiment of Scotland’ (which
     became clearly evident during the Romanticist period in Scotland).
   hypernym:
   - 04923519-n
@@ -36855,7 +36855,7 @@
   - The state or quality of behaving like a troublemaker, often violent; like a rude
     violent person; like a yob.
   example:
-  - True, this is hardly the drink to inspire `Girls Gone Wild´ loutishness.
+  - True, this is hardly the drink to inspire ‘Girls Gone Wild’ loutishness.
   hypernym:
   - 04921753-n
   members:
@@ -37067,7 +37067,7 @@
   definition:
   - The state of being able to be dismissed from office.
   example:
-  - The `democratic revolution´ emphasized the delegation of authority and the removability
+  - The ‘democratic revolution’ emphasized the delegation of authority and the removability
     of officials, precisely because, as we shall see, neither delegation nor removability
     were much recognized in actual institutions.
   hypernym:

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -65,8 +65,8 @@
   partOfSpeech: n
 04624919-n:
   definition:
-  - the complex of all the attributes — behavioral, temperamental, emotional and mental — that
-    characterize a unique individual
+  - the complex of all the attributes — behavioral, temperamental, emotional and mental
+    — that characterize a unique individual
   example:
   - their different reactions reflected their very different personalities
   hypernym:
@@ -35463,9 +35463,9 @@
   definition:
   - The behaviour of a stickler; inflexible adherence to rules.
   example:
-  - "`We, the intellectually curious, may soon find ourselves trapped in a pen, fenced
+  - '`We, the intellectually curious, may soon find ourselves trapped in a pen, fenced
     in by rule-bound sticklerism and overzealous concern for our personal safety,
-    unless we exercise our civil liberties and our curiosity,' he declaims."
+    unless we exercise our civil liberties and our curiosity,'' he declaims.'
   hypernym:
   - 04679712-n
   - 04667618-n
@@ -35580,10 +35580,10 @@
   definition:
   - Quality of being spectral or ghostly.
   example:
-  - "Seen in this light, it is the spectrality of the figure, the fact that it's neither\
-    \ (completely) here nor there, that keeps the figure alive - or, more precisely,\
-    \ undead - never quite exhausted by a single, definitive instantiation but always\
-    \ at least potentially available for yet another serial iteration."
+  - Seen in this light, it is the spectrality of the figure, the fact that it's neither
+    (completely) here nor there, that keeps the figure alive - or, more precisely,
+    undead - never quite exhausted by a single, definitive instantiation but always
+    at least potentially available for yet another serial iteration.
   hypernym:
   - 04769747-n
   members:
@@ -36916,9 +36916,9 @@
   source: plWordNet 4.0
 92437061-n:
   definition:
-  - the property of occurring regularly at equal time intervals, of maintaining a constant
-    period or interval, despite variations in other measurable factors in the same
-    system.
+  - the property of occurring regularly at equal time intervals, of maintaining a
+    constant period or interval, despite variations in other measurable factors in
+    the same system.
   example:
   - Galileo's discovery was that the period of swing of a pendulum is independent
     of its amplitude — the arc of the swing — the isochronism of the pendulum.

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -35463,9 +35463,9 @@
   definition:
   - The behaviour of a stickler; inflexible adherence to rules.
   example:
-  - '‘We, the intellectually curious, may soon find ourselves trapped in a pen, fenced
+  - ‘We, the intellectually curious, may soon find ourselves trapped in a pen, fenced
     in by rule-bound sticklerism and overzealous concern for our personal safety,
-    unless we exercise our civil liberties and our curiosity,’ he declaims.'
+    unless we exercise our civil liberties and our curiosity,’ he declaims.
   hypernym:
   - 04679712-n
   - 04667618-n

--- a/src/yaml/noun.body.yaml
+++ b/src/yaml/noun.body.yaml
@@ -3764,7 +3764,7 @@
   partOfSpeech: n
 05290997-n:
   definition:
-  - informal terms for a human `tooth'
+  - informal terms for a human `tooth´
   hypernym:
   - 05290245-n
   ili: i64726
@@ -4597,7 +4597,7 @@
   definition:
   - internal organs collectively (especially those in the abdominal cavity)
   example:
-  - '`viscera'' is the plural form of `viscus'''
+  - '`viscera´ is the plural form of `viscus´'
   hypernym:
   - 05306228-n
   ili: i64806
@@ -11712,7 +11712,7 @@
   domain_topic:
   - 08458195-n
   example:
-  - '`in venter'' is legal terminology for `conceived but not yet born'''
+  - '`in venter´ is legal terminology for `conceived but not yet born´'
   hypernym:
   - 05526736-n
   ili: i65460
@@ -15702,7 +15702,7 @@
   partOfSpeech: n
 05502823-n:
   definition:
-  - lower or hindmost part of the brain; continuous with spinal cord; (`bulb' is an
+  - lower or hindmost part of the brain; continuous with spinal cord; (`bulb´ is an
     old term for medulla oblongata)
   example:
   - the medulla oblongata is the most vital part of the brain because it contains
@@ -16778,7 +16778,7 @@
   domain_topic:
   - 00845915-n
   example:
-  - in England `fanny' is vulgar slang for female genitals
+  - in England `fanny´ is vulgar slang for female genitals
   hypernym:
   - 05521732-n
   ili: i65906
@@ -22020,8 +22020,8 @@
   partOfSpeech: n
 05609112-n:
   definition:
-  - the human face (`kisser' and `smiler' and `mug' are informal terms for `face'
-    and `phiz' is British)
+  - the human face (`kisser´ and `smiler´ and `mug´ are informal terms for `face´
+    and `phiz´ is British)
   domain_region:
   - 08879115-n
   exemplifies:

--- a/src/yaml/noun.body.yaml
+++ b/src/yaml/noun.body.yaml
@@ -4597,7 +4597,7 @@
   definition:
   - internal organs collectively (especially those in the abdominal cavity)
   example:
-  - '‘viscera’ is the plural form of ‘viscus’'
+  - ‘viscera’ is the plural form of ‘viscus’
   hypernym:
   - 05306228-n
   ili: i64806
@@ -11712,7 +11712,7 @@
   domain_topic:
   - 08458195-n
   example:
-  - '‘in venter’ is legal terminology for ‘conceived but not yet born’'
+  - ‘in venter’ is legal terminology for ‘conceived but not yet born’
   hypernym:
   - 05526736-n
   ili: i65460

--- a/src/yaml/noun.body.yaml
+++ b/src/yaml/noun.body.yaml
@@ -3764,7 +3764,7 @@
   partOfSpeech: n
 05290997-n:
   definition:
-  - informal terms for a human `tooth´
+  - informal terms for a human ‘tooth’
   hypernym:
   - 05290245-n
   ili: i64726
@@ -4597,7 +4597,7 @@
   definition:
   - internal organs collectively (especially those in the abdominal cavity)
   example:
-  - '`viscera´ is the plural form of `viscus´'
+  - '‘viscera’ is the plural form of ‘viscus’'
   hypernym:
   - 05306228-n
   ili: i64806
@@ -11712,7 +11712,7 @@
   domain_topic:
   - 08458195-n
   example:
-  - '`in venter´ is legal terminology for `conceived but not yet born´'
+  - '‘in venter’ is legal terminology for ‘conceived but not yet born’'
   hypernym:
   - 05526736-n
   ili: i65460
@@ -15702,7 +15702,7 @@
   partOfSpeech: n
 05502823-n:
   definition:
-  - lower or hindmost part of the brain; continuous with spinal cord; (`bulb´ is an
+  - lower or hindmost part of the brain; continuous with spinal cord; (‘bulb’ is an
     old term for medulla oblongata)
   example:
   - the medulla oblongata is the most vital part of the brain because it contains
@@ -16778,7 +16778,7 @@
   domain_topic:
   - 00845915-n
   example:
-  - in England `fanny´ is vulgar slang for female genitals
+  - in England ‘fanny’ is vulgar slang for female genitals
   hypernym:
   - 05521732-n
   ili: i65906
@@ -22020,8 +22020,8 @@
   partOfSpeech: n
 05609112-n:
   definition:
-  - the human face (`kisser´ and `smiler´ and `mug´ are informal terms for `face´
-    and `phiz´ is British)
+  - the human face (‘kisser’ and ‘smiler’ and ‘mug’ are informal terms for ‘face’
+    and ‘phiz’ is British)
   domain_region:
   - 08879115-n
   exemplifies:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -1007,7 +1007,7 @@
   definition:
   - phrases used to refer to Heaven
   example:
-  - the Celestial City was Christian's goal in Bunyan's `Pilgrim's Progress´
+  - the Celestial City was Christian's goal in Bunyan's ‘Pilgrim's Progress’
   hypernym:
   - 05635568-n
   ili: i66483
@@ -10499,7 +10499,7 @@
   partOfSpeech: n
 05803843-n:
   definition:
-  - the planning that is disrupted when someone `upsets the applecart´
+  - the planning that is disrupted when someone ‘upsets the applecart’
   hypernym:
   - 05802702-n
   ili: i67344
@@ -11853,7 +11853,7 @@
   partOfSpeech: n
 05828314-n:
   definition:
-  - (usually preceded by `in´) a detail or point
+  - (usually preceded by ‘in’) a detail or point
   example:
   - it differs in that respect
   hypernym:
@@ -12957,7 +12957,7 @@
   definition:
   - category name
   example:
-  - it is usually discussed under the rubric of `functional obesity´
+  - it is usually discussed under the rubric of ‘functional obesity’
   hypernym:
   - 05847274-n
   ili: i67562
@@ -12966,7 +12966,7 @@
   partOfSpeech: n
 05848419-n:
   definition:
-  - a general category of things; used in the expression `in the way of´
+  - a general category of things; used in the expression ‘in the way of’
   example:
   - they didn't have much in the way of clothing
   hypernym:
@@ -14634,7 +14634,7 @@
   definition:
   - the first part or section of something
   example:
-  - '`It was a dark and stormy night´ is a hackneyed beginning for a story'
+  - '‘It was a dark and stormy night’ is a hackneyed beginning for a story'
   hypernym:
   - 05876035-n
   ili: i67712
@@ -15959,8 +15959,8 @@
   wikidata: Q737677
 05903238-n:
   definition:
-  - the fallacy of attributing human feelings to inanimate objects; `the friendly
-    sun´ is an example of the pathetic fallacy
+  - the fallacy of attributing human feelings to inanimate objects; ‘the friendly
+    sun’ is an example of the pathetic fallacy
   hypernym:
   - 05902523-n
   ili: i67822
@@ -17395,7 +17395,7 @@
   definition:
   - a unifying idea that is a recurrent element in literary or artistic work
   example:
-  - it was the usual `boy gets girl´ theme
+  - it was the usual ‘boy gets girl’ theme
   hypernym:
   - 05842164-n
   ili: i67946
@@ -17562,7 +17562,7 @@
   - the most direct or specific meaning of a word or expression; the class of objects
     that an expression refers to
   example:
-  - the extension of `satellite of Mars´ is the set containing only Demos and Phobos
+  - the extension of ‘satellite of Mars’ is the set containing only Demos and Phobos
   hypernym:
   - 05928460-n
   ili: i67959
@@ -18669,7 +18669,7 @@
   partOfSpeech: n
 05950822-n:
   definition:
-  - the religious belief that God cannot be known but is completely `other´ and must
+  - the religious belief that God cannot be known but is completely ‘other’ and must
     be described in negative terms (in terms of what God is not)
   hypernym:
   - 05955536-n
@@ -18688,7 +18688,7 @@
 05951187-n:
   definition:
   - the religious belief that God has given enough clues to be known to humans positively
-    and affirmatively (e.g., God created Adam `in his own image´)
+    and affirmatively (e.g., God created Adam ‘in his own image’)
   hypernym:
   - 05955536-n
   ili: i68063
@@ -20916,8 +20916,8 @@
   partOfSpeech: n
 05992348-n:
   definition:
-  - purpose; the phrase `with a view to´ means `with the intention of´ or `for the
-    purpose of´
+  - purpose; the phrase ‘with a view to’ means ‘with the intention of’ or ‘for the
+    purpose of’
   example:
   - he took the computer with a view to pawning it
   hypernym:
@@ -28431,7 +28431,7 @@
 06175339-n:
   definition:
   - a limitation imposed on the variables of a proposition (as by the quantifiers
-    `some´ or `all´ or `no´)
+    ‘some’ or ‘all’ or ‘no’)
   hypernym:
   - 05854882-n
   ili: i68956
@@ -28868,8 +28868,8 @@
   partOfSpeech: n
 06186553-n:
   definition:
-  - a term formerly used for the part of phonology that dealt with the `correct´ pronunciation
-    of words and its relation to `correct´ orthography
+  - a term formerly used for the part of phonology that dealt with the ‘correct’ pronunciation
+    of words and its relation to ‘correct’ orthography
   hypernym:
   - 06187166-n
   ili: i68998
@@ -29145,7 +29145,7 @@
 06191609-n:
   definition:
   - an account of how a language should be used instead of how it is actually used;
-    a prescription for the `correct´ phonology and morphology and syntax and semantics
+    a prescription for the ‘correct’ phonology and morphology and syntax and semantics
   hypernym:
   - 06182505-n
   ili: i69026
@@ -29996,7 +29996,7 @@
   partOfSpeech: n
 06208611-n:
   definition:
-  - an inclination or desire; used in the plural in the phrase `left to your own devices´
+  - an inclination or desire; used in the plural in the phrase ‘left to your own devices’
   example:
   - eventually the family left the house to the devices of this malevolent force
   - the children were left to their own devices
@@ -31660,7 +31660,7 @@
 06239523-n:
   definition:
   - principles of the founders of the Oxford movement as expounded in pamphlets called
-    `Tracts for the Times´
+    ‘Tracts for the Times’
   hypernym:
   - 06236188-n
   ili: i69264
@@ -32017,7 +32017,7 @@
   partOfSpeech: n
 06248172-n:
   definition:
-  - (from the Sanskrit word for `to see´) one of six orthodox philosophical systems
+  - (from the Sanskrit word for ‘to see’) one of six orthodox philosophical systems
     or viewpoints on the nature of reality and the release from bondage to karma
   domain_topic:
   - 06981803-n
@@ -32029,7 +32029,7 @@
   partOfSpeech: n
 06248401-n:
   definition:
-  - (from the Sanskrit word for `reflection´ or `interpretation´) one of six orthodox
+  - (from the Sanskrit word for ‘reflection’ or ‘interpretation’) one of six orthodox
     philosophical systems or viewpoints on ritual traditions rooted in the Vedas and
     the Brahmanas as opposed to Vedanta which relies mostly on the Upanishads
   domain_topic:
@@ -32043,7 +32043,7 @@
   wikidata: Q847918
 06248710-n:
   definition:
-  - (from the Sanskrit for `end of the Veda´) one of six orthodox philosophical systems
+  - (from the Sanskrit for ‘end of the Veda’) one of six orthodox philosophical systems
     or viewpoints rooted in the Upanishads as opposed to Mimamsa which relies on the
     Vedas and Brahmanas
   domain_topic:
@@ -33053,7 +33053,7 @@
     toleration along with Jews and Christians and usually identified with the Mandaeans
     or the Elkesaites.
   example:
-  - 'The `olah´, or burnt offering, suppresses the wrong view: Sabianism in the broad
+  - 'The ‘olah’, or burnt offering, suppresses the wrong view: Sabianism in the broad
     sense of belief in astrology, magic, and superstition.'
   hypernym:
   - 05957131-n
@@ -33348,8 +33348,8 @@
   - (Stoic philosophy) a matter having no moral merit or demerit.
   example:
   - Esteem (or reputation, fame, glory) was for Stoics an adiaphoron, and though it
-    could be classed as prolegomenon with a certain `value´, it was only after Diogenes'
-    time that they conceded that its `value´ was more than instrumental.
+    could be classed as prolegomenon with a certain ‘value’, it was only after Diogenes'
+    time that they conceded that its ‘value’ was more than instrumental.
   hypernym:
   - 05844071-n
   members:
@@ -33389,7 +33389,7 @@
   - a philosophy or media theory dedicated to studying what lies beyond the realm
     of metaphysics.
   example:
-  - Of all the French cultural exports over the last 150 years or so, `pataphysics´
+  - Of all the French cultural exports over the last 150 years or so, ‘pataphysics’
     — the science of imaginary solutions and the laws governing exceptions — has proven
     to be one of the most durable.
   hypernym:
@@ -33473,7 +33473,7 @@
   source: plWordNet 4.0
 92439250-n:
   definition:
-  - the scientific philosophy where laws are `induced´ from sets of data.
+  - the scientific philosophy where laws are ‘induced’ from sets of data.
   hypernym:
   - 06177044-n
   members:
@@ -33521,8 +33521,8 @@
     have visited Earth and made contact with humans in antiquity and prehistory.
   example:
   - Sagan argued that while many legends, artifacts and purported out-of-place artifacts
-    were cited in support of ancient astronaut theories, `very few require more than
-    passing mention´ and could be easily explained with more conventional theories.
+    were cited in support of ancient astronaut theories, ‘very few require more than
+    passing mention’ and could be easily explained with more conventional theories.
   hypernym:
   - 05786951-n
   members:
@@ -33571,7 +33571,7 @@
   definition:
   - the study of Etruscan civilization, especially its artifacts and language.
   example:
-  - Half a century ago, however, Massimo Pallottino, the father figure of modern `Etruscology´,
+  - Half a century ago, however, Massimo Pallottino, the father figure of modern ‘Etruscology’,
     demolished this thesis once and for all, and today it is accepted that the origins
     of the Etruscan city states must be found in the internal social transformations
     that took place among the indigenous late prehistoric societies of Etruria in
@@ -33587,7 +33587,7 @@
   - the philology of Classical Sanskrit, Greek and Classical Latin.
   example:
   - Classical philology was a major preoccupation of the 19th-century German education
-    system, which became `the paradigm for higher education´ throughout Western culture.
+    system, which became ‘the paradigm for higher education’ throughout Western culture.
   hypernym:
   - 06180756-n
   members:
@@ -33908,7 +33908,7 @@
   definition:
   - the classical synthesis of Islamic philosophical theology, formulated by al-Ash'ari.
   example:
-  - Ash'arism, the `middle-road´ theology, combined the logical methodology of the
+  - Ash'arism, the ‘middle-road’ theology, combined the logical methodology of the
     Mu'tazilites and the beliefs of the Traditionalists.
   hypernym:
   - 06244979-n
@@ -34022,7 +34022,7 @@
   definition:
   - in physics, the theory that describes the weak force.
   example:
-  - Fermi's `theory of β rays´ or, as it came to be called, the theory of weak interaction,
+  - Fermi's ‘theory of β rays’ or, as it came to be called, the theory of weak interaction,
     was decisively advanced by two experimental discoveries.
   hypernym:
   - 92437059-n
@@ -34413,7 +34413,7 @@
     religious attitude, opposition to intolerance, and castigation of bigotry.
   example:
   - Declarations of pan-Voltairianism will prove no panacea, but rather simply capture
-    an aspirational bonhomie reflected in `unity´ marches that, however impressive,
+    an aspirational bonhomie reflected in ‘unity’ marches that, however impressive,
     conceal seeds of future violent explosions given a still elusive and unfinished
     accounting of the broader equities at play.
   hypernym:
@@ -34440,8 +34440,8 @@
   - in logic, the formal analysis of logical terms and operators and the structures
     that make it possible to infer true conclusions from given premises.
   example:
-  - Aristotelian syllogistic became known as `categorical syllogistic´ and the Peripatetic
-    adaptation of Stoic syllogistic as `hypothetical syllogistic´.
+  - Aristotelian syllogistic became known as ‘categorical syllogistic’ and the Peripatetic
+    adaptation of Stoic syllogistic as ‘hypothetical syllogistic’.
   hypernym:
   - 06173467-n
   members:
@@ -34484,7 +34484,7 @@
   - An obsolete term for ritualistic act or sequence of acts performed by a person
     with obsessive-compulsive neurosis.
   example:
-  - The conceptual history of `anancasm´ in psychiatry remains almost unexplored and
+  - The conceptual history of ‘anancasm’ in psychiatry remains almost unexplored and
     this article will help to remove this deficit.
   hypernym:
   - 05708366-n
@@ -34623,7 +34623,7 @@
   definition:
   - A form of collectivism proposed by François-Noël Babeuf.
   example:
-  - But Herzen's attack on its advocacy of terror that frees by `despotism´, on its
+  - But Herzen's attack on its advocacy of terror that frees by ‘despotism’, on its
     Babeufism, was quite explicit.
   hypernym:
   - 06230561-n
@@ -34975,7 +34975,7 @@
   - a conflict of the soul (as with the body or between good and evil).
   example:
   - Later echoes of medieval psychomachy can be found in Shakespeare's 144th sonnet
-    and in Tennyson's poem `The Two Voices´ (1842).
+    and in Tennyson's poem ‘The Two Voices’ (1842).
   hypernym:
   - 05929076-n
   members:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -1007,7 +1007,7 @@
   definition:
   - phrases used to refer to Heaven
   example:
-  - the Celestial City was Christian's goal in Bunyan's `Pilgrim's Progress'
+  - the Celestial City was Christian's goal in Bunyan's `Pilgrim's Progress´
   hypernym:
   - 05635568-n
   ili: i66483
@@ -10499,7 +10499,7 @@
   partOfSpeech: n
 05803843-n:
   definition:
-  - the planning that is disrupted when someone `upsets the applecart'
+  - the planning that is disrupted when someone `upsets the applecart´
   hypernym:
   - 05802702-n
   ili: i67344
@@ -11853,7 +11853,7 @@
   partOfSpeech: n
 05828314-n:
   definition:
-  - (usually preceded by `in') a detail or point
+  - (usually preceded by `in´) a detail or point
   example:
   - it differs in that respect
   hypernym:
@@ -12957,7 +12957,7 @@
   definition:
   - category name
   example:
-  - it is usually discussed under the rubric of `functional obesity'
+  - it is usually discussed under the rubric of `functional obesity´
   hypernym:
   - 05847274-n
   ili: i67562
@@ -12966,7 +12966,7 @@
   partOfSpeech: n
 05848419-n:
   definition:
-  - a general category of things; used in the expression `in the way of'
+  - a general category of things; used in the expression `in the way of´
   example:
   - they didn't have much in the way of clothing
   hypernym:
@@ -14632,7 +14632,7 @@
   definition:
   - the first part or section of something
   example:
-  - '`It was a dark and stormy night'' is a hackneyed beginning for a story'
+  - '`It was a dark and stormy night´ is a hackneyed beginning for a story'
   hypernym:
   - 05876035-n
   ili: i67712
@@ -15958,7 +15958,7 @@
 05903238-n:
   definition:
   - the fallacy of attributing human feelings to inanimate objects; `the friendly
-    sun' is an example of the pathetic fallacy
+    sun´ is an example of the pathetic fallacy
   hypernym:
   - 05902523-n
   ili: i67822
@@ -17393,7 +17393,7 @@
   definition:
   - a unifying idea that is a recurrent element in literary or artistic work
   example:
-  - it was the usual `boy gets girl' theme
+  - it was the usual `boy gets girl´ theme
   hypernym:
   - 05842164-n
   ili: i67946
@@ -17560,7 +17560,7 @@
   - the most direct or specific meaning of a word or expression; the class of objects
     that an expression refers to
   example:
-  - the extension of `satellite of Mars' is the set containing only Demos and Phobos
+  - the extension of `satellite of Mars´ is the set containing only Demos and Phobos
   hypernym:
   - 05928460-n
   ili: i67959
@@ -18667,7 +18667,7 @@
   partOfSpeech: n
 05950822-n:
   definition:
-  - the religious belief that God cannot be known but is completely `other' and must
+  - the religious belief that God cannot be known but is completely `other´ and must
     be described in negative terms (in terms of what God is not)
   hypernym:
   - 05955536-n
@@ -18686,7 +18686,7 @@
 05951187-n:
   definition:
   - the religious belief that God has given enough clues to be known to humans positively
-    and affirmatively (e.g., God created Adam `in his own image')
+    and affirmatively (e.g., God created Adam `in his own image´)
   hypernym:
   - 05955536-n
   ili: i68063
@@ -20914,8 +20914,8 @@
   partOfSpeech: n
 05992348-n:
   definition:
-  - purpose; the phrase `with a view to' means `with the intention of' or `for the
-    purpose of'
+  - purpose; the phrase `with a view to´ means `with the intention of´ or `for the
+    purpose of´
   example:
   - he took the computer with a view to pawning it
   hypernym:
@@ -28429,7 +28429,7 @@
 06175339-n:
   definition:
   - a limitation imposed on the variables of a proposition (as by the quantifiers
-    `some' or `all' or `no')
+    `some´ or `all´ or `no´)
   hypernym:
   - 05854882-n
   ili: i68956
@@ -28866,8 +28866,8 @@
   partOfSpeech: n
 06186553-n:
   definition:
-  - a term formerly used for the part of phonology that dealt with the `correct' pronunciation
-    of words and its relation to `correct' orthography
+  - a term formerly used for the part of phonology that dealt with the `correct´ pronunciation
+    of words and its relation to `correct´ orthography
   hypernym:
   - 06187166-n
   ili: i68998
@@ -29143,7 +29143,7 @@
 06191609-n:
   definition:
   - an account of how a language should be used instead of how it is actually used;
-    a prescription for the `correct' phonology and morphology and syntax and semantics
+    a prescription for the `correct´ phonology and morphology and syntax and semantics
   hypernym:
   - 06182505-n
   ili: i69026
@@ -29994,7 +29994,7 @@
   partOfSpeech: n
 06208611-n:
   definition:
-  - an inclination or desire; used in the plural in the phrase `left to your own devices'
+  - an inclination or desire; used in the plural in the phrase `left to your own devices´
   example:
   - eventually the family left the house to the devices of this malevolent force
   - the children were left to their own devices
@@ -31658,7 +31658,7 @@
 06239523-n:
   definition:
   - principles of the founders of the Oxford movement as expounded in pamphlets called
-    `Tracts for the Times'
+    `Tracts for the Times´
   hypernym:
   - 06236188-n
   ili: i69264
@@ -32015,7 +32015,7 @@
   partOfSpeech: n
 06248172-n:
   definition:
-  - (from the Sanskrit word for `to see') one of six orthodox philosophical systems
+  - (from the Sanskrit word for `to see´) one of six orthodox philosophical systems
     or viewpoints on the nature of reality and the release from bondage to karma
   domain_topic:
   - 06981803-n
@@ -32027,7 +32027,7 @@
   partOfSpeech: n
 06248401-n:
   definition:
-  - (from the Sanskrit word for `reflection' or `interpretation') one of six orthodox
+  - (from the Sanskrit word for `reflection´ or `interpretation´) one of six orthodox
     philosophical systems or viewpoints on ritual traditions rooted in the Vedas and
     the Brahmanas as opposed to Vedanta which relies mostly on the Upanishads
   domain_topic:
@@ -32041,7 +32041,7 @@
   wikidata: Q847918
 06248710-n:
   definition:
-  - (from the Sanskrit for `end of the Veda') one of six orthodox philosophical systems
+  - (from the Sanskrit for `end of the Veda´) one of six orthodox philosophical systems
     or viewpoints rooted in the Upanishads as opposed to Mimamsa which relies on the
     Vedas and Brahmanas
   domain_topic:
@@ -33051,7 +33051,7 @@
     toleration along with Jews and Christians and usually identified with the Mandaeans
     or the Elkesaites.
   example:
-  - 'The `olah'', or burnt offering, suppresses the wrong view: Sabianism in the broad
+  - 'The `olah´, or burnt offering, suppresses the wrong view: Sabianism in the broad
     sense of belief in astrology, magic, and superstition.'
   hypernym:
   - 05957131-n
@@ -33346,8 +33346,8 @@
   - (Stoic philosophy) a matter having no moral merit or demerit.
   example:
   - Esteem (or reputation, fame, glory) was for Stoics an adiaphoron, and though it
-    could be classed as prolegomenon with a certain `value', it was only after Diogenes'
-    time that they conceded that its `value' was more than instrumental.
+    could be classed as prolegomenon with a certain `value´, it was only after Diogenes'
+    time that they conceded that its `value´ was more than instrumental.
   hypernym:
   - 05844071-n
   members:
@@ -33387,7 +33387,7 @@
   - a philosophy or media theory dedicated to studying what lies beyond the realm
     of metaphysics.
   example:
-  - Of all the French cultural exports over the last 150 years or so, `pataphysics'
+  - Of all the French cultural exports over the last 150 years or so, `pataphysics´
     — the science of imaginary solutions and the laws governing exceptions — has proven
     to be one of the most durable.
   hypernym:
@@ -33471,7 +33471,7 @@
   source: plWordNet 4.0
 92439250-n:
   definition:
-  - the scientific philosophy where laws are `induced' from sets of data.
+  - the scientific philosophy where laws are `induced´ from sets of data.
   hypernym:
   - 06177044-n
   members:
@@ -33520,7 +33520,7 @@
   example:
   - Sagan argued that while many legends, artifacts and purported out-of-place artifacts
     were cited in support of ancient astronaut theories, `very few require more than
-    passing mention' and could be easily explained with more conventional theories.
+    passing mention´ and could be easily explained with more conventional theories.
   hypernym:
   - 05786951-n
   members:
@@ -33569,7 +33569,7 @@
   definition:
   - the study of Etruscan civilization, especially its artifacts and language.
   example:
-  - Half a century ago, however, Massimo Pallottino, the father figure of modern `Etruscology',
+  - Half a century ago, however, Massimo Pallottino, the father figure of modern `Etruscology´,
     demolished this thesis once and for all, and today it is accepted that the origins
     of the Etruscan city states must be found in the internal social transformations
     that took place among the indigenous late prehistoric societies of Etruria in
@@ -33585,7 +33585,7 @@
   - the philology of Classical Sanskrit, Greek and Classical Latin.
   example:
   - Classical philology was a major preoccupation of the 19th-century German education
-    system, which became `the paradigm for higher education' throughout Western culture.
+    system, which became `the paradigm for higher education´ throughout Western culture.
   hypernym:
   - 06180756-n
   members:
@@ -33906,7 +33906,7 @@
   definition:
   - the classical synthesis of Islamic philosophical theology, formulated by al-Ash'ari.
   example:
-  - Ash'arism, the `middle-road' theology, combined the logical methodology of the
+  - Ash'arism, the `middle-road´ theology, combined the logical methodology of the
     Mu'tazilites and the beliefs of the Traditionalists.
   hypernym:
   - 06244979-n
@@ -34020,7 +34020,7 @@
   definition:
   - in physics, the theory that describes the weak force.
   example:
-  - Fermi's `theory of β rays' or, as it came to be called, the theory of weak interaction,
+  - Fermi's `theory of β rays´ or, as it came to be called, the theory of weak interaction,
     was decisively advanced by two experimental discoveries.
   hypernym:
   - 92437059-n
@@ -34411,7 +34411,7 @@
     religious attitude, opposition to intolerance, and castigation of bigotry.
   example:
   - Declarations of pan-Voltairianism will prove no panacea, but rather simply capture
-    an aspirational bonhomie reflected in `unity' marches that, however impressive,
+    an aspirational bonhomie reflected in `unity´ marches that, however impressive,
     conceal seeds of future violent explosions given a still elusive and unfinished
     accounting of the broader equities at play.
   hypernym:
@@ -34438,8 +34438,8 @@
   - in logic, the formal analysis of logical terms and operators and the structures
     that make it possible to infer true conclusions from given premises.
   example:
-  - Aristotelian syllogistic became known as `categorical syllogistic' and the Peripatetic
-    adaptation of Stoic syllogistic as `hypothetical syllogistic'.
+  - Aristotelian syllogistic became known as `categorical syllogistic´ and the Peripatetic
+    adaptation of Stoic syllogistic as `hypothetical syllogistic´.
   hypernym:
   - 06173467-n
   members:
@@ -34482,7 +34482,7 @@
   - An obsolete term for ritualistic act or sequence of acts performed by a person
     with obsessive-compulsive neurosis.
   example:
-  - The conceptual history of `anancasm' in psychiatry remains almost unexplored and
+  - The conceptual history of `anancasm´ in psychiatry remains almost unexplored and
     this article will help to remove this deficit.
   hypernym:
   - 05708366-n
@@ -34621,7 +34621,7 @@
   definition:
   - A form of collectivism proposed by François-Noël Babeuf.
   example:
-  - But Herzen's attack on its advocacy of terror that frees by `despotism', on its
+  - But Herzen's attack on its advocacy of terror that frees by `despotism´, on its
     Babeufism, was quite explicit.
   hypernym:
   - 06230561-n
@@ -34973,7 +34973,7 @@
   - a conflict of the soul (as with the body or between good and evil).
   example:
   - Later echoes of medieval psychomachy can be found in Shakespeare's 144th sonnet
-    and in Tennyson's poem `The Two Voices' (1842).
+    and in Tennyson's poem `The Two Voices´ (1842).
   hypernym:
   - 05929076-n
   members:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -14634,7 +14634,7 @@
   definition:
   - the first part or section of something
   example:
-  - '‘It was a dark and stormy night’ is a hackneyed beginning for a story'
+  - ‘It was a dark and stormy night’ is a hackneyed beginning for a story
   hypernym:
   - 05876035-n
   ili: i67712

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -14002,7 +14002,9 @@
 05866365-n:
   definition:
   - a variable in a logical or mathematical expression whose value determines the
-    dependent variable; if f(x)=y, x is the independent variable
+    dependent variable
+  example:
+  - if f(x)=y, x is the independent variable
   hypernym:
   - 05866043-n
   ili: i67653

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -33051,8 +33051,8 @@
     toleration along with Jews and Christians and usually identified with the Mandaeans
     or the Elkesaites.
   example:
-  - "The `olah', or burnt offering, suppresses the wrong view: Sabianism in the broad
-    sense of belief in astrology, magic, and superstition."
+  - 'The `olah'', or burnt offering, suppresses the wrong view: Sabianism in the broad
+    sense of belief in astrology, magic, and superstition.'
   hypernym:
   - 05957131-n
   members:
@@ -33125,8 +33125,8 @@
     values.
   example:
   - The main results include a necessary and sufficient condition for asymptotic normality
-    of the Winsorized mean under the assumption that rn->∞, sn->∞, rnn−1->0,
-    snn−1->0 and F is convex at infinity.
+    of the Winsorized mean under the assumption that rn->∞, sn->∞, rnn−1->0, snn−1->0
+    and F is convex at infinity.
   hypernym:
   - 06033377-n
   members:
@@ -33387,9 +33387,9 @@
   - a philosophy or media theory dedicated to studying what lies beyond the realm
     of metaphysics.
   example:
-  - Of all the French cultural exports over the last 150 years or so, `pataphysics' — the
-    science of imaginary solutions and the laws governing exceptions — has proven to
-    be one of the most durable.
+  - Of all the French cultural exports over the last 150 years or so, `pataphysics'
+    — the science of imaginary solutions and the laws governing exceptions — has proven
+    to be one of the most durable.
   hypernym:
   - 05786951-n
   members:
@@ -33552,12 +33552,12 @@
     all fields of research.
   example:
   - Contemporary ideas from systems theory have grown with diverse areas, exemplified
-    by the work of biologist Ludwig von Bertalanffy, linguist Béla H. Bánáthy,
-    sociologist Talcott Parsons, ecological systems with Howard T. Odum, Eugene Odum
-    and Fritjof Capra, organizational theory and management with individuals such
-    as Peter Senge, interdisciplinary study with areas like Human Resource Development
-    from the work of Richard A. Swanson, and insights from educators such as Debora
-    Hammond and Alfonso Montuori.
+    by the work of biologist Ludwig von Bertalanffy, linguist Béla H. Bánáthy, sociologist
+    Talcott Parsons, ecological systems with Howard T. Odum, Eugene Odum and Fritjof
+    Capra, organizational theory and management with individuals such as Peter Senge,
+    interdisciplinary study with areas like Human Resource Development from the work
+    of Richard A. Swanson, and insights from educators such as Debora Hammond and
+    Alfonso Montuori.
   hypernym:
   - 06005806-n
   members:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -32460,7 +32460,7 @@
 06825973-n:
   definition:
   - the positive fractional part of the representation of a logarithm; in the expression
-    log 643 = 2.808 the mantissa is .808
+    `log 643 = 2.808´ the mantissa is .808
   hypernym:
   - 13754218-n
   ili: i72299
@@ -32471,7 +32471,7 @@
 06826168-n:
   definition:
   - the integer part (positive or negative) of the representation of a logarithm;
-    in the expression log 643 = 2.808 the characteristic is 2
+    in the expression `log 643 = 2.808´ the characteristic is 2
   hypernym:
   - 13750609-n
   ili: i72300
@@ -63150,7 +63150,7 @@
     the alveolar ridge.
   example:
   - The sibilant postalveolars (i.e. fricatives and affricates) are sometimes called
-    `hush consonants´ because they include the sound of English `Shhh!´ (as distinguished
+    `hush consonants´ because they include the sound [ʃ] of English `Shhh!´ (as distinguished
     from the `hiss´ consonant [s], as in `Ssss!´).
   hypernym:
   - 07129729-n

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -723,7 +723,7 @@
   example:
   - the mail handles billions of items every day
   - he works for the United States mail service
-  - in England they call mail `the post'
+  - in England they call mail `the post´
   hypernym:
   - 06262268-n
   ili: i69425
@@ -1425,8 +1425,8 @@
   partOfSpeech: n
 06286794-n:
   definition:
-  - third-class mail consisting of advertising and often addressed to `resident' or
-    `occupant'
+  - third-class mail consisting of advertising and often addressed to `resident´ or
+    `occupant´
   hypernym:
   - 06286630-n
   ili: i69491
@@ -2043,7 +2043,7 @@
   - a word that expresses a meaning opposed to the meaning of another word, in which
     case the two words are antonyms of each other
   example:
-  - to him the antonym of `gay' was `depressed'
+  - to him the antonym of `gay´ was `depressed´
   hypernym:
   - 06297048-n
   ili: i69547
@@ -2074,9 +2074,9 @@
   definition:
   - a new word formed by joining two others and combining their meanings
   example:
-  - '`smog'' is a blend of `smoke'' and `fog'''
-  - '`motel'' is a portmanteau word made by combining `motor'' and `hotel'''
-  - '`brunch'' is a well-known portmanteau'
+  - '`smog´ is a blend of `smoke´ and `fog´'
+  - '`motel´ is a portmanteau word made by combining `motor´ and `hotel´'
+  - '`brunch´ is a well-known portmanteau'
   hypernym:
   - 06305222-n
   ili: i69549
@@ -2121,8 +2121,8 @@
   definition:
   - a word formed from two or more words by omitting or combining some sounds
   example:
-  - '`won''t'' is a contraction of `will not'''
-  - '`o''clock'' is a contraction of `of the clock'''
+  - '`won''t´ is a contraction of `will not´'
+  - '`o''clock´ is a contraction of `of the clock´'
   hypernym:
   - 06297048-n
   ili: i69553
@@ -2150,7 +2150,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - '`electricity'' is a derivative of `electric'''
+  - '`electricity´ is a derivative of `electric´'
   hypernym:
   - 06297048-n
   ili: i69555
@@ -2170,7 +2170,7 @@
   definition:
   - a word that is considered to be unmentionable
   example:
-  - '`failure'' is a dirty word to him'
+  - '`failure´ is a dirty word to him'
   hypernym:
   - 06297048-n
   ili: i69557
@@ -2277,7 +2277,7 @@
   definition:
   - two words are heteronyms if they are spelled the same way but differ in pronunciation
   example:
-  - the word `bow' is an example of a heteronym
+  - the word `bow´ is an example of a heteronym
   hypernym:
   - 06297048-n
   ili: i69566
@@ -2288,7 +2288,7 @@
   definition:
   - a word that names the whole of which a given word is a part
   example:
-  - '`hat'' is a holonym for `brim'' and `crown'''
+  - '`hat´ is a holonym for `brim´ and `crown´'
   hypernym:
   - 06297048-n
   ili: i69567
@@ -2339,7 +2339,7 @@
   partOfSpeech: n
 06304010-n:
   definition:
-  - a word that is composed of parts from different languages (e.g., `monolingual'
+  - a word that is composed of parts from different languages (e.g., `monolingual´
     has a Greek prefix and a Latin root)
   domain_region:
   - 08798733-n
@@ -2355,7 +2355,7 @@
   partOfSpeech: n
 06304241-n:
   definition:
-  - a word borrowed from another language; e.g. `blitz' is a German word borrowed
+  - a word borrowed from another language; e.g. `blitz´ is a German word borrowed
     into modern English
   hypernym:
   - 06297048-n
@@ -2378,7 +2378,7 @@
   definition:
   - a word that names a part of a larger whole
   example:
-  - '`brim'' and `crown'' are meronyms of `hat'''
+  - '`brim´ and `crown´ are meronyms of `hat´'
   hypernym:
   - 06297048-n
   ili: i69575
@@ -2402,7 +2402,7 @@
   definition:
   - an anagram that means the opposite of the original word or phrase
   example:
-  - '`restful'' is the antigram of `fluster'''
+  - '`restful´ is the antigram of `fluster´'
   hypernym:
   - 06298291-n
   ili: i69577
@@ -2463,7 +2463,7 @@
   definition:
   - a word serving as the basis for inflected or derived forms
   example:
-  - '`pick'' is the primitive from which `picket'' is derived'
+  - '`pick´ is the primitive from which `picket´ is derived'
   hypernym:
   - 06297048-n
   ili: i69583
@@ -2570,9 +2570,9 @@
 06312002-n:
   definition:
   - one of the eight sayings of Jesus at the beginning of the Sermon on the Mount;
-    in Latin each saying begins with `beatus' (blessed)
+    in Latin each saying begins with `beatus´ (blessed)
   example:
-  - her favorite Beatitude is `Blessed are the meek for they shall inherit the earth'
+  - her favorite Beatitude is `Blessed are the meek for they shall inherit the earth´
   hypernym:
   - 07166088-n
   ili: i69592
@@ -2593,7 +2593,7 @@
   definition:
   - an expression introduced into one language by translating it from another language
   example:
-  - '`superman'' is a calque for the German `Ubermensch'''
+  - '`superman´ is a calque for the German `Ubermensch´'
   hypernym:
   - 07166088-n
   ili: i69594
@@ -2613,7 +2613,7 @@
   partOfSpeech: n
 06312782-n:
   definition:
-  - word (such a `some' or `less') that is used to indicate a part as distinct from
+  - word (such a `some´ or `less´) that is used to indicate a part as distinct from
     a whole
   hypernym:
   - 06297048-n
@@ -2653,7 +2653,7 @@
   partOfSpeech: n
 06313371-n:
   definition:
-  - (grammar) a word that expresses a quantity (as `fifteen' or `many')
+  - (grammar) a word that expresses a quantity (as `fifteen´ or `many´)
   domain_topic:
   - 06184139-n
   hypernym:
@@ -2664,7 +2664,7 @@
   partOfSpeech: n
 06313532-n:
   definition:
-  - (logic) a word (such as `some' or `all' or `no') that binds the variables in a
+  - (logic) a word (such as `some´ or `all´ or `no´) that binds the variables in a
     logical proposition
   domain_topic:
   - 06173467-n
@@ -2711,7 +2711,7 @@
   - a word introduced because an existing term has become inadequate
   example:
   - Nobody ever heard of analog clocks until digital clocks became common, so `analog
-    clock' is a retronym
+    clock´ is a retronym
   hypernym:
   - 06297048-n
   ili: i69605
@@ -2777,7 +2777,7 @@
   definition:
   - a word that denotes a manner of doing something
   example:
-  - '`march'' is a troponym of `walk'''
+  - '`march´ is a troponym of `walk´'
   hypernym:
   - 06297048-n
   ili: i69611
@@ -2799,7 +2799,7 @@
   definition:
   - a unit of spoken language larger than a phoneme
   example:
-  - the word `pocket' has two syllables
+  - the word `pocket´ has two syllables
   hypernym:
   - 06294878-n
   ili: i69613
@@ -2867,7 +2867,7 @@
   partOfSpeech: n
 06316706-n:
   definition:
-  - antonyms that are commonly associated (e.g., `wet' and `dry')
+  - antonyms that are commonly associated (e.g., `wet´ and `dry´)
   hypernym:
   - 06298695-n
   ili: i69620
@@ -2876,8 +2876,8 @@
   partOfSpeech: n
 06316828-n:
   definition:
-  - antonyms whose opposition is mediated (e.g., the antonymy of `wet' and `parched'
-    is mediated by the similarity of `parched' to `dry')
+  - antonyms whose opposition is mediated (e.g., the antonymy of `wet´ and `parched´
+    is mediated by the similarity of `parched´ to `dry´)
   hypernym:
   - 06298695-n
   ili: i69621
@@ -2886,8 +2886,8 @@
   partOfSpeech: n
 06317024-n:
   definition:
-  - a minimal unit (as a word or stem) in the lexicon of a language; `go' and `went'
-    and `gone' and `going' are all members of the English lexeme `go'
+  - a minimal unit (as a word or stem) in the lexicon of a language; `go´ and `went´
+    and `gone´ and `going´ are all members of the English lexeme `go´
   hypernym:
   - 06294878-n
   ili: i69622
@@ -2918,7 +2918,7 @@
   definition:
   - a variant phonological representation of a morpheme
   example:
-  - the final sounds of `bets' and `beds' and `horses' and `oxen' are allomorphs of
+  - the final sounds of `bets´ and `beds´ and `horses´ and `oxen´ are allomorphs of
     the English plural morpheme
   hypernym:
   - 06317223-n
@@ -2951,7 +2951,7 @@
   definition:
   - a bound form used only in compounds
   example:
-  - '`hemato-'' is a combining form in words like `hematology'''
+  - '`hemato-´ is a combining form in words like `hematology´'
   hypernym:
   - 06317935-n
   ili: i69628
@@ -3208,7 +3208,7 @@
   definition:
   - a word in the genitive case that is used as an attributive adjective
   example:
-  - an example of the attributive genetive is `John's' in `John's mother'
+  - an example of the attributive genetive is `John's´ in `John's mother´
   hypernym:
   - 06322842-n
   ili: i69652
@@ -3361,8 +3361,8 @@
   definition:
   - a clause introduced by a relative pronoun
   example:
-  - '`who visits frequently'' is a relative clause in the sentence `John, who visits
-    frequently, is ill'''
+  - '`who visits frequently´ is a relative clause in the sentence `John, who visits
+    frequently, is ill´'
   hypernym:
   - 06325134-n
   ili: i69666
@@ -3472,7 +3472,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '`Socrates is a man'' predicates manhood of Socrates'
+  - '`Socrates is a man´ predicates manhood of Socrates'
   hypernym:
   - 06764688-n
   ili: i69676
@@ -3481,7 +3481,7 @@
   partOfSpeech: n
 06328100-n:
   definition:
-  - an infinitive with an adverb between `to' and the verb (e.g., `to boldly go')
+  - an infinitive with an adverb between `to´ and the verb (e.g., `to boldly go´)
   hypernym:
   - 06329897-n
   ili: i69677
@@ -3549,7 +3549,7 @@
   partOfSpeech: n
 06329345-n:
   definition:
-  - a noun formed from a verb (such as the `-ing' form of an English verb when used
+  - a noun formed from a verb (such as the `-ing´ form of an English verb when used
     as a noun)
   hypernym:
   - 06331307-n
@@ -3569,7 +3569,7 @@
   partOfSpeech: n
 06329715-n:
   definition:
-  - an auxiliary verb (such as `can' or `will') that is used to express modality
+  - an auxiliary verb (such as `can´ or `will´) that is used to express modality
   hypernym:
   - 06329506-n
   ili: i69686
@@ -3688,7 +3688,7 @@
   definition:
   - an adjective used as a noun
   example:
-  - '`meek'' in `blessed are the meek'' is an adnoun'
+  - '`meek´ in `blessed are the meek´ is an adnoun'
   hypernym:
   - 06331146-n
   ili: i69698
@@ -3720,8 +3720,8 @@
   definition:
   - a modifier that has little meaning except to intensify the meaning it modifies
   example:
-  - '`up'' in `finished up'' is an intensifier'
-  - '`honestly'' in `I honestly don''t know'' is an intensifier'
+  - '`up´ in `finished up´ is an intensifier'
+  - '`honestly´ in `I honestly don''t know´ is an intensifier'
   hypernym:
   - 06331794-n
   ili: i69701
@@ -3743,7 +3743,7 @@
 06332925-n:
   definition:
   - an adjective that ascribes to its noun the value of an attribute of that noun
-    (e.g., `a nervous person' or `a musical speaking voice')
+    (e.g., `a nervous person´ or `a musical speaking voice´)
   hypernym:
   - 06332695-n
   ili: i69703
@@ -3753,8 +3753,8 @@
   partOfSpeech: n
 06333150-n:
   definition:
-  - an adjective that classifies its noun (e.g., `a nervous disease' or `a musical
-    instrument')
+  - an adjective that classifies its noun (e.g., `a nervous disease´ or `a musical
+    instrument´)
   hypernym:
   - 06332695-n
   ili: i69704
@@ -3789,9 +3789,9 @@
   definition:
   - the comparative form of an adjective or adverb
   example:
-  - '`faster'' is the comparative of the adjective `fast'''
-  - '`less famous'' is the comparative degree of the adjective `famous'''
-  - '`more surely'' is the comparative of the adverb `surely'''
+  - '`faster´ is the comparative of the adjective `fast´'
+  - '`less famous´ is the comparative degree of the adjective `famous´'
+  - '`more surely´ is the comparative of the adverb `surely´'
   hypernym:
   - 06332695-n
   - 06334605-n
@@ -3804,9 +3804,9 @@
   definition:
   - the superlative form of an adjective or adverb
   example:
-  - '`fastest'' is the superlative of the adjective `fast'''
-  - '`least famous'' is the superlative degree of the adjective `famous'''
-  - '`most surely'' is the superlative of the adverb `surely'''
+  - '`fastest´ is the superlative of the adjective `fast´'
+  - '`least famous´ is the superlative degree of the adjective `famous´'
+  - '`most surely´ is the superlative of the adverb `surely´'
   hypernym:
   - 06332695-n
   - 06334605-n
@@ -3829,7 +3829,7 @@
 06334815-n:
   definition:
   - 'a word or phrase apparently modifying an unintended word because of its placement
-    in a sentence: e.g., `when young'' in `when young, circuses appeal to all of us'''
+    in a sentence: e.g., `when young´ in `when young, circuses appeal to all of us´'
   hypernym:
   - 06331794-n
   ili: i69710
@@ -3841,8 +3841,8 @@
 06335079-n:
   definition:
   - 'a participle (usually at the beginning of a sentence) apparently modifying a
-    word other than the word intended: e.g., `flying across the country'' in `flying
-    across the country the Rockies came into view'''
+    word other than the word intended: e.g., `flying across the country´ in `flying
+    across the country the Rockies came into view´'
   hypernym:
   - 06334815-n
   ili: i69711
@@ -3883,7 +3883,7 @@
   partOfSpeech: n
 06335857-n:
   definition:
-  - a determiner (as `the' in English) that indicates specificity of reference
+  - a determiner (as `the´ in English) that indicates specificity of reference
   hypernym:
   - 06335662-n
   ili: i69715
@@ -3892,7 +3892,7 @@
   partOfSpeech: n
 06335994-n:
   definition:
-  - a determiner (as `a' or `some' in English) that indicates nonspecific reference
+  - a determiner (as `a´ or `some´ in English) that indicates nonspecific reference
   hypernym:
   - 06335662-n
   ili: i69716
@@ -3953,7 +3953,7 @@
   partOfSpeech: n
 06337047-n:
   definition:
-  - a conjunction (like `and' or `or') that connects two identically constructed grammatical
+  - a conjunction (like `and´ or `or´) that connects two identically constructed grammatical
     constituents
   hypernym:
   - 06336819-n
@@ -3963,7 +3963,7 @@
   partOfSpeech: n
 06337219-n:
   definition:
-  - a conjunction (like `since' or `that' or `who') that introduces a dependent clause
+  - a conjunction (like `since´ or `that´ or `who´) that introduces a dependent clause
   hypernym:
   - 06336819-n
   ili: i69723
@@ -4016,10 +4016,10 @@
   partOfSpeech: n
 06338254-n:
   definition:
-  - a pronoun or pronominal phrase (as `each other') that expresses a mutual action
+  - a pronoun or pronominal phrase (as `each other´) that expresses a mutual action
     or relationship between the individuals indicated in the plural subject
   example:
-  - The sentence `They cared for each other' contains a reciprocal pronoun
+  - The sentence `They cared for each other´ contains a reciprocal pronoun
   hypernym:
   - 06336363-n
   ili: i69728
@@ -4028,7 +4028,7 @@
   partOfSpeech: n
 06338544-n:
   definition:
-  - a pronoun (as `that' or `which' or `who') that introduces a relative clause referring
+  - a pronoun (as `that´ or `which´ or `who´) that introduces a relative clause referring
     to some antecedent
   hypernym:
   - 06336363-n
@@ -4082,8 +4082,8 @@
   definition:
   - a verb whose agent performs an action that is directed at the agent
   example:
-  - the sentence `he washed' has a reflexive verb
-  - '`perjure'' is a reflexive verb because you cannot perjure anyone but yourself'
+  - the sentence `he washed´ has a reflexive verb
+  - '`perjure´ is a reflexive verb because you cannot perjure anyone but yourself'
   hypernym:
   - 06331562-n
   ili: i69734
@@ -4206,7 +4206,7 @@
   - an English verb followed by one or more particles where the combination behaves
     as a syntactic and semantic unit
   example:
-  - '`turn out'' is a phrasal verb in the question `how many turned out to vote?'''
+  - '`turn out´ is a phrasal verb in the question `how many turned out to vote?´'
   hypernym:
   - 06329055-n
   ili: i69746
@@ -4382,7 +4382,7 @@
   partOfSpeech: n
 06345388-n:
   definition:
-  - an additional name or an epithet appended to a name (as in `Ferdinand the Great')
+  - an additional name or an epithet appended to a name (as in `Ferdinand the Great´)
   hypernym:
   - 06344646-n
   ili: i69762
@@ -4528,7 +4528,7 @@
   definition:
   - slang for something (especially for an illegal drug)
   example:
-  - '`smack'' is a street name for heroin'
+  - '`smack´ is a street name for heroin'
   hypernym:
   - 06344646-n
   - 07171981-n
@@ -4631,7 +4631,7 @@
   definition:
   - a descriptive name for a place or thing
   example:
-  - the nickname for the U.S. Constitution is `Old Ironsides'
+  - the nickname for the U.S. Constitution is `Old Ironsides´
   hypernym:
   - 06344646-n
   ili: i69781
@@ -4716,7 +4716,7 @@
   definition:
   - a name of endearment (especially one using a diminutive suffix)
   example:
-  - '`Billy'' is a hypocorism for `William'''
+  - '`Billy´ is a hypocorism for `William´'
   hypernym:
   - 06344646-n
   ili: i69789
@@ -4726,7 +4726,7 @@
   partOfSpeech: n
 06350786-n:
   definition:
-  - 'an identifying appellation signifying status or function: e.g. `Mr.'' or `General'''
+  - 'an identifying appellation signifying status or function: e.g. `Mr.´ or `General´'
   example:
   - the professor didn't like his friends to use his formal title
   hypernym:
@@ -4892,7 +4892,7 @@
   partOfSpeech: n
 06353232-n:
   definition:
-  - a Spanish title or form of address for a man; similar to the English `Mr' or `sir'
+  - a Spanish title or form of address for a man; similar to the English `Mr´ or `sir´
   domain_topic:
   - 06979499-n
   hypernym:
@@ -4905,7 +4905,7 @@
 06353385-n:
   definition:
   - a Spanish title or form of address for a married woman; similar to the English
-    `Mrs' or `madam'
+    `Mrs´ or `madam´
   domain_topic:
   - 06979499-n
   hypernym:
@@ -4918,7 +4918,7 @@
 06353552-n:
   definition:
   - a Spanish title or form of address used to or of an unmarried girl or woman; similar
-    to the English `Miss'
+    to the English `Miss´
   domain_topic:
   - 06979499-n
   hypernym:
@@ -4989,7 +4989,7 @@
   definition:
   - an appellation signifying nobility
   example:
-  - '`your majesty'' is the appropriate title to use in addressing a king'
+  - '`your majesty´ is the appropriate title to use in addressing a king'
   hypernym:
   - 06350278-n
   ili: i69813
@@ -5018,7 +5018,7 @@
   definition:
   - the name of a work of art or literary composition etc.
   example:
-  - he looked for books with the word `jazz' in the title
+  - he looked for books with the word `jazz´ in the title
   - he refused to give titles to his paintings
   - I can never remember movie titles
   hypernym:
@@ -6052,7 +6052,7 @@
 06372853-n:
   definition:
   - 'an ancient writing system: having alternate lines written in opposite directions;
-    literally `as the ox ploughs'''
+    literally `as the ox ploughs´'
   hypernym:
   - 06362609-n
   ili: i69909
@@ -6975,7 +6975,7 @@
   - a witty satiric verse containing two rhymed couplets and mentioning a famous person
   example:
   - '`The president is George W. Bush, Who is happy to sit on his tush, While sending
-    his armies to fight, For anything he thinks is right'' is a clerihew'
+    his armies to fight, For anything he thinks is right´ is a clerihew'
   hypernym:
   - 06393492-n
   ili: i69998
@@ -7419,7 +7419,7 @@
   wikidata: Q1320248
 06397077-n:
   definition:
-  - (Roman Catholic Church) a Latin versicle meaning `lift up your hearts'
+  - (Roman Catholic Church) a Latin versicle meaning `lift up your hearts´
   domain_topic:
   - 08100476-n
   hypernym:
@@ -10067,7 +10067,7 @@
   partOfSpeech: n
 06442826-n:
   definition:
-  - (Hinduism) the sacred `song of God' composed about 200 BC and incorporated into
+  - (Hinduism) the sacred `song of God´ composed about 200 BC and incorporated into
     the Mahabharata (a Sanskrit epic); contains a discussion between Krishna and the
     Indian hero Arjuna on human nature and the purpose of life
   domain_topic:
@@ -11383,7 +11383,7 @@
   partOfSpeech: n
 06469466-n:
   definition:
-  - (Roman Catholic Church) the Lord's Prayer in Latin; translates as `our father'
+  - (Roman Catholic Church) the Lord's Prayer in Latin; translates as `our father´
   domain_topic:
   - 08100476-n
   ili: i70396
@@ -11762,7 +11762,7 @@
   partOfSpeech: n
 06476089-n:
   definition:
-  - (from the Sanskrit word for `knowledge') any of the most ancient sacred writings
+  - (from the Sanskrit word for `knowledge´) any of the most ancient sacred writings
     of Hinduism written in early Sanskrit; traditionally believed to comprise the
     Samhitas, the Brahmanas, the Aranyakas, and the Upanishads
   domain_topic:
@@ -11886,7 +11886,7 @@
   wikidata: Q6113985
 06478150-n:
   definition:
-  - (Sanskrit) literally a `sacred utterance' in Vedism; one of a collection of orally
+  - (Sanskrit) literally a `sacred utterance´ in Vedism; one of a collection of orally
     transmitted poetic hymns
   domain_topic:
   - 06246956-n
@@ -12072,7 +12072,7 @@
   partOfSpeech: n
 06481268-n:
   definition:
-  - a summary list; as in e.g. `a news roundup'
+  - a summary list; as in e.g. `a news roundup´
   example:
   - a news roundup
   hypernym:
@@ -12223,7 +12223,7 @@
   partOfSpeech: n
 06484495-n:
   definition:
-  - an equating verb (such as `be' or `become') that links the subject with the complement
+  - an equating verb (such as `be´ or `become´) that links the subject with the complement
     of a sentence
   hypernym:
   - 06331562-n
@@ -12800,8 +12800,8 @@
   domain_topic:
   - 06182505-n
   example:
-  - '`Those girls, they giggle when they see me'' and `Cigarettes, you couldn''t pay
-    me to smoke them'' are examples of topicalization'
+  - '`Those girls, they giggle when they see me´ and `Cigarettes, you couldn''t pay
+    me to smoke them´ are examples of topicalization'
   hypernym:
   - 07117611-n
   ili: i70523
@@ -17018,7 +17018,7 @@
 06564461-n:
   definition:
   - the opinion joined by a majority of the court (generally known simply as `the
-    opinion')
+    opinion´)
   domain_topic:
   - 08458195-n
   hypernym:
@@ -17459,7 +17459,7 @@
 06572245-n:
   definition:
   - the principal pleading by the defendant in response to plaintiff's complaint;
-    in criminal law it consists of the defendant's plea of `guilty' or `not guilty'
+    in criminal law it consists of the defendant's plea of `guilty´ or `not guilty´
     (or nolo contendere); in civil law it must contain denials of all allegations
     in the plaintiff's complaint that the defendant hopes to controvert and it can
     contain affirmative defenses or counterclaims
@@ -17485,7 +17485,7 @@
   partOfSpeech: n
 06572930-n:
   definition:
-  - (law) an answer of `no contest' by a defendant who does not admit guilt but that
+  - (law) an answer of `no contest´ by a defendant who does not admit guilt but that
     subjects him to conviction
   domain_topic:
   - 06551169-n
@@ -18909,7 +18909,7 @@
 06597379-n:
   definition:
   - a set of instructions inserted into a program that are designed to execute (or
-    `explode') if a particular condition is satisfied; when exploded it may delete
+    `explode´) if a particular condition is satisfied; when exploded it may delete
     or corrupt data, or print a spurious message, or have other harmful effects
   example:
   - a disgruntled employee planted a logic bomb
@@ -19137,7 +19137,7 @@
   partOfSpeech: n
 06601633-n:
   definition:
-  - a database management system that allows strings of text (`objects') to be processed
+  - a database management system that allows strings of text (`objects´) to be processed
     as a complex network of nodes that are linked together in an arbitrary way
   hypernym:
   - 06601432-n
@@ -20040,7 +20040,7 @@
   partOfSpeech: n
 06617096-n:
   definition:
-  - an ambiguous grammatical construction; e.g., `they are flying planes' can mean
+  - an ambiguous grammatical construction; e.g., `they are flying planes´ can mean
     either that someone is flying planes or that something is flying planes
   hypernym:
   - 06616672-n
@@ -20729,7 +20729,7 @@
   definition:
   - the principal (full-length) film in a program at a movie theater
   example:
-  - the feature tonight is `Casablanca'
+  - the feature tonight is `Casablanca´
   hypernym:
   - 06626039-n
   ili: i71227
@@ -21056,7 +21056,7 @@
   definition:
   - a program that is broadcast again
   example:
-  - she likes to watch `I love Lucy' reruns
+  - she likes to watch `I love Lucy´ reruns
   hypernym:
   - 06631935-n
   ili: i71259
@@ -22112,7 +22112,7 @@
   definition:
   - a compilation of the known facts regarding something or someone
   example:
-  - Al Smith used to say, `Let's look at the record'
+  - Al Smith used to say, `Let's look at the record´
   - his name is in all the record books
   hypernym:
   - 06648784-n
@@ -23797,7 +23797,7 @@
   wikidata: Q42283
 06678357-n:
   definition:
-  - a common way to make software available; users are allowed to log in as `guest'
+  - a common way to make software available; users are allowed to log in as `guest´
     without a password and copy whatever has been made available
   hypernym:
   - 06678115-n
@@ -26379,7 +26379,7 @@
 06720117-n:
   definition:
   - the highest U.S. military decoration awarded for bravery and valor in action `above
-    and beyond the call of duty'
+    and beyond the call of duty´
   hypernym:
   - 06719615-n
   ili: i71750
@@ -26864,7 +26864,7 @@
   partOfSpeech: n
 06727491-n:
   definition:
-  - (often used with `pay') a formal expression of esteem
+  - (often used with `pay´) a formal expression of esteem
   example:
   - he paid his respects to the mayor
   hypernym:
@@ -27192,7 +27192,7 @@
   definition:
   - an epithet that can be used to smear someone's reputation
   example:
-  - he used the smear word `communist' for everyone who disagreed with him
+  - he used the smear word `communist´ for everyone who disagreed with him
   hypernym:
   - 06733713-n
   ili: i71825
@@ -27368,7 +27368,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '`I always lie'' is a paradox because if it is true it must be false'
+  - '`I always lie´ is a paradox because if it is true it must be false'
   hypernym:
   - 07221547-n
   ili: i71840
@@ -28485,9 +28485,9 @@
   - a definition in which the term is used by embedding it in a larger expression
     containing its explanation
   example:
-  - a contextual definition of `legal duty' might be `X has a legal duty to do Y means
+  - a contextual definition of `legal duty´ might be `X has a legal duty to do Y means
     that X is required to do Y by a contract relationship that would be upheld in
-    a court of law'
+    a court of law´
   hypernym:
   - 06757091-n
   ili: i71938
@@ -28537,7 +28537,7 @@
   definition:
   - the act of giving a new definition
   example:
-  - words like `conservative' require periodic redefinition
+  - words like `conservative´ require periodic redefinition
   - she provided a redefinition of his duties
   hypernym:
   - 06757091-n
@@ -29446,7 +29446,7 @@
   definition:
   - an intentionally noncommittal or ambiguous statement
   example:
-  - when you say `maybe' you are just hedging
+  - when you say `maybe´ you are just hedging
   hypernym:
   - 06773810-n
   ili: i72025
@@ -29786,7 +29786,7 @@
   - an aggressive remark directed at a person like a missile and intended to have
     a telling effect
   example:
-  - his parting shot was `drop dead'
+  - his parting shot was `drop dead´
   - she threw shafts of sarcasm
   - she takes a dig at me every chance she gets
   hypernym:
@@ -31397,7 +31397,7 @@
   definition:
   - an individual instance of a type of symbol
   example:
-  - the word `error' contains three tokens of `r'
+  - the word `error´ contains three tokens of `r´
   hypernym:
   - 06819327-n
   ili: i72197
@@ -31409,7 +31409,7 @@
   definition:
   - all of the tokens of the same symbol
   example:
-  - the word `element' contains five different types of character
+  - the word `element´ contains five different types of character
   hypernym:
   - 06819327-n
   ili: i72198
@@ -32789,7 +32789,7 @@
   partOfSpeech: n
 06832423-n:
   definition:
-  - a variant form of a grapheme, as `m' or `M' or a handwritten version of that grapheme
+  - a variant form of a grapheme, as `m´ or `M´ or a handwritten version of that grapheme
   hypernym:
   - 06831828-n
   ili: i72329
@@ -33321,7 +33321,7 @@
   partOfSpeech: n
 06841249-n:
   definition:
-  - a sign (`%') used to indicate that the number preceding it should be understood
+  - a sign (`%´) used to indicate that the number preceding it should be understood
     as a proportion multiplied by 100
   hypernym:
   - 06831828-n
@@ -33397,7 +33397,7 @@
 06843888-n:
   definition:
   - 'two successive letters (especially two letters used to represent a single sound:
-    `sh'' in `shoe'')'
+    `sh´ in `shoe´)'
   hypernym:
   - 06841868-n
   ili: i72384
@@ -34126,8 +34126,8 @@
   definition:
   - a letter that has two or more pronunciations
   example:
-  - '`c'' is a polyphone because it is pronounced like `k'' in `car'' but like `s''
-    in `cell'''
+  - '`c´ is a polyphone because it is pronounced like `k´ in `car´ but like `s´ in
+    `cell´'
   hypernym:
   - 06841868-n
   ili: i72460
@@ -34224,7 +34224,7 @@
   - a single written symbol that represents an entire word or phrase without indicating
     its pronunciation
   example:
-  - '`7'' is a logogram that is pronounced `seven'' in English and `nanatsu'' in Japanese'
+  - '`7´ is a logogram that is pronounced `seven´ in English and `nanatsu´ in Japanese'
   hypernym:
   - 06853698-n
   ili: i72469
@@ -34263,7 +34263,7 @@
   partOfSpeech: n
 06854923-n:
   definition:
-  - a punctuation mark (`&') used to represent conjunction (and)
+  - a punctuation mark (`&´) used to represent conjunction (and)
   hypernym:
   - 06854415-n
   ili: i72473
@@ -34272,7 +34272,7 @@
   partOfSpeech: n
 06855037-n:
   definition:
-  - the mark (`'') used to indicate the omission of one or more letters from a printed
+  - the mark (`'´) used to indicate the omission of one or more letters from a printed
     word
   hypernym:
   - 06854415-n
@@ -34282,7 +34282,7 @@
   partOfSpeech: n
 06855215-n:
   definition:
-  - either of two punctuation marks (`{' or `}') used to enclose textual material
+  - either of two punctuation marks (`{´ or `}´) used to enclose textual material
   hypernym:
   - 06854415-n
   ili: i72475
@@ -34291,7 +34291,7 @@
   partOfSpeech: n
 06855340-n:
   definition:
-  - either of two punctuation marks (`[' or `]') used to enclose textual material
+  - either of two punctuation marks (`[´ or `]´) used to enclose textual material
   hypernym:
   - 06854415-n
   ili: i72476
@@ -34301,7 +34301,7 @@
   partOfSpeech: n
 06855502-n:
   definition:
-  - either of two punctuation marks (`<' or `>') used in computer programming and
+  - either of two punctuation marks (`<´ or `>´) used in computer programming and
     sometimes used to enclose textual material
   hypernym:
   - 06854415-n
@@ -34312,7 +34312,7 @@
   partOfSpeech: n
 06855710-n:
   definition:
-  - a punctuation mark (`:') used after a word introducing a series or an example
+  - a punctuation mark (`:´) used after a word introducing a series or an example
     or an explanation (or after the salutation of a business letter)
   hypernym:
   - 06854415-n
@@ -34322,7 +34322,7 @@
   partOfSpeech: n
 06855902-n:
   definition:
-  - a punctuation mark (`,') used to indicate the separation of elements within the
+  - a punctuation mark (`,´) used to indicate the separation of elements within the
     grammatical structure of a sentence
   hypernym:
   - 06854415-n
@@ -34332,7 +34332,7 @@
   partOfSpeech: n
 06856067-n:
   definition:
-  - a punctuation mark (`!') used after an exclamation
+  - a punctuation mark (`!´) used after an exclamation
   hypernym:
   - 06854415-n
   ili: i72480
@@ -34342,7 +34342,7 @@
   partOfSpeech: n
 06856198-n:
   definition:
-  - a punctuation mark (`-') used between parts of a compound word or between the
+  - a punctuation mark (`-´) used between parts of a compound word or between the
     syllables of a word when the word is divided at the end of a line of text
   hypernym:
   - 06854415-n
@@ -34353,7 +34353,7 @@
   partOfSpeech: n
 06856443-n:
   definition:
-  - either of two punctuation marks `(' or `)' used to enclose textual material
+  - either of two punctuation marks `(´ or `)´ used to enclose textual material
   hypernym:
   - 06854415-n
   ili: i72482
@@ -34362,7 +34362,7 @@
   partOfSpeech: n
 06856570-n:
   definition:
-  - a punctuation mark (`.') placed at the end of a declarative sentence to indicate
+  - a punctuation mark (`.´) placed at the end of a declarative sentence to indicate
     a full stop or after abbreviations
   example:
   - in England they call a period a stop
@@ -34378,7 +34378,7 @@
   partOfSpeech: n
 06856888-n:
   definition:
-  - (usually plural) one of a series of points (`…') indicating that something has
+  - (usually plural) one of a series of points (`…´) indicating that something has
     been omitted or that the sentence is incomplete
   exemplifies:
   - 06306016-n
@@ -34390,7 +34390,7 @@
   partOfSpeech: n
 06857090-n:
   definition:
-  - a punctuation mark (`?') placed at the end of a sentence to indicate a question
+  - a punctuation mark (`?´) placed at the end of a sentence to indicate a question
   hypernym:
   - 06854415-n
   ili: i72485
@@ -34438,7 +34438,7 @@
   partOfSpeech: n
 06857789-n:
   definition:
-  - a punctuation mark (`;') used to connect independent clauses; indicates a closer
+  - a punctuation mark (`;´) used to connect independent clauses; indicates a closer
     relation than does a period
   hypernym:
   - 06854415-n
@@ -34448,7 +34448,7 @@
   partOfSpeech: n
 06857953-n:
   definition:
-  - a punctuation mark (`/') used to separate related items of information
+  - a punctuation mark (`/´) used to separate related items of information
   hypernym:
   - 06854415-n
   ili: i72491
@@ -34462,7 +34462,7 @@
   partOfSpeech: n
 06858126-n:
   definition:
-  - a punctuation mark (`⁓') used in text to indicate the omission of a word
+  - a punctuation mark (`⁓´) used in text to indicate the omission of a word
   hypernym:
   - 06854415-n
   ili: i72492
@@ -34521,7 +34521,7 @@
   partOfSpeech: n
 06864792-n:
   definition:
-  - a formally registered symbol (`™') identifying the manufacturer or distributor
+  - a formally registered symbol (`™´) identifying the manufacturer or distributor
     of a product
   exemplifies:
   - 92433720-n
@@ -45151,7 +45151,7 @@
   partOfSpeech: n
 07019828-n:
   definition:
-  - the theater as a profession (usually `the stage')
+  - the theater as a profession (usually `the stage´)
   example:
   - an early movie simply showed a long kiss by two actors of the contemporary stage
   hypernym:
@@ -45519,7 +45519,7 @@
   definition:
   - persuasive but insincere talk that is usually intended to deceive or impress
   example:
-  - '`let me show you my etchings'' is a rather worn line'
+  - '`let me show you my etchings´ is a rather worn line'
   - he has a smooth line but I didn't fall for it
   - that salesman must have practiced his fast line of talk
   hypernym:
@@ -46783,7 +46783,7 @@
 07050292-n:
   definition:
   - the first words of a medieval Latin hymn describing the Last Judgment (literally
-    `day of wrath')
+    `day of wrath´)
   ili: i73634
   instance_hypernym:
   - 07049616-n
@@ -46826,7 +46826,7 @@
 07050805-n:
   definition:
   - (Luke) the canticle of the Virgin Mary (from Luke 1:46 beginning `Magnificat anima
-    mea Dominum')
+    mea Dominum´)
   domain_topic:
   - 06453643-n
   ili: i73638
@@ -48740,7 +48740,7 @@
 07081916-n:
   definition:
   - 'the use of closed-class words instead of inflections: e.g., `the father of the
-    bride'' instead of `the bride''s father'''
+    bride´ instead of `the bride''s father´'
   hypernym:
   - 07080699-n
   ili: i73822
@@ -49752,7 +49752,7 @@
   definition:
   - using more words than necessary
   example:
-  - plenoasms such as `a tiny little child'
+  - plenoasms such as `a tiny little child´
   hypernym:
   - 07103943-n
   ili: i73916
@@ -49763,7 +49763,7 @@
   definition:
   - useless and pointless repetition
   example:
-  - to say that something is `adequate enough' is a tautology
+  - to say that something is `adequate enough´ is a tautology
   hypernym:
   - 07104913-n
   ili: i73917
@@ -49776,7 +49776,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - the statement `he is brave or he is not brave' is a tautology
+  - the statement `he is brave or he is not brave´ is a tautology
   hypernym:
   - 06736815-n
   ili: i73918
@@ -49796,7 +49796,7 @@
   definition:
   - abbreviation of a word by omitting the final sound or sounds
   example:
-  - the British get `pud' from `pudding' by apocope
+  - the British get `pud´ from `pudding´ by apocope
   hypernym:
   - 07105779-n
   ili: i73920
@@ -49819,8 +49819,8 @@
   - a word formed from the initial letters of the several words in the name and pronounced
     as one word
   example:
-  - '`NATO'' is an initialism for North Atlantic Treaty Organization'
-  - the word `scuba' is an acronym for s(elf)-c(ontained) u(nderwater) b(reathing)
+  - '`NATO´ is an initialism for North Atlantic Treaty Organization'
+  - the word `scuba´ is an acronym for s(elf)-c(ontained) u(nderwater) b(reathing)
     a(pparatus)
   hypernym:
   - 06301417-n
@@ -50021,7 +50021,7 @@
   wikidata: Q465509
 07110182-n:
   definition:
-  - a metrical unit with unstressed-stressed-unstressed syllables (e.g., `remember')
+  - a metrical unit with unstressed-stressed-unstressed syllables (e.g., `remember´)
   hypernym:
   - 07109509-n
   ili: i73940
@@ -50136,7 +50136,7 @@
   - use of the same consonant at the beginning of each stressed syllable in a line
     of verse
   example:
-  - initial rhyme such as `around the rock the ragged rascal ran'
+  - initial rhyme such as `around the rock the ragged rascal ran´
   hypernym:
   - 07111327-n
   ili: i73952
@@ -50172,7 +50172,7 @@
   definition:
   - a two-syllable rhyme
   example:
-  - '`ended'' and `blended'' form a double rhyme'
+  - '`ended´ and `blended´ form a double rhyme'
   hypernym:
   - 07111327-n
   ili: i73955
@@ -50200,7 +50200,7 @@
   partOfSpeech: n
 07112759-n:
   definition:
-  - an imperfect rhyme (e.g., `love' and `move')
+  - an imperfect rhyme (e.g., `love´ and `move´)
   hypernym:
   - 07111327-n
   ili: i73958
@@ -50323,7 +50323,7 @@
   definition:
   - repetition of a word in a different case or inflection in the same sentence
   example:
-  - polyptoton such as `my own heart's heart'
+  - polyptoton such as `my own heart's heart´
   hypernym:
   - 07113937-n
   ili: i73970
@@ -50425,8 +50425,8 @@
   partOfSpeech: n
 07116700-n:
   definition:
-  - 'strained or paradoxical use of words either in error (as `blatant'' to mean `flagrant'')
-    or deliberately (as in a mixed metaphor: `blind mouths'')'
+  - 'strained or paradoxical use of words either in error (as `blatant´ to mean `flagrant´)
+    or deliberately (as in a mixed metaphor: `blind mouths´)'
   hypernym:
   - 07112859-n
   ili: i73981
@@ -50476,7 +50476,7 @@
   definition:
   - an exclamatory rhetorical device
   example:
-  - exclamation such as `O tempore! O mores'
+  - exclamation such as `O tempore! O mores´
   hypernym:
   - 07112859-n
   ili: i73986
@@ -50496,7 +50496,7 @@
 07117772-n:
   definition:
   - a substitution of part of speech or gender or number or tense etc. (e.g., editorial
-    `we' for `I')
+    `we´ for `I´)
   hypernym:
   - 07112859-n
   ili: i73988
@@ -50507,7 +50507,7 @@
   definition:
   - immediate rephrasing for intensification or justification
   example:
-  - epanorthosis such as `Seems, madam! Nay, it is'
+  - epanorthosis such as `Seems, madam! Nay, it is´
   hypernym:
   - 07112859-n
   ili: i73989
@@ -50535,7 +50535,7 @@
   partOfSpeech: n
 07118337-n:
   definition:
-  - reversal of the syntactic relation of two words (as in `her beauty's face')
+  - reversal of the syntactic relation of two words (as in `her beauty's face´)
   hypernym:
   - 07112859-n
   ili: i73992
@@ -50544,7 +50544,7 @@
   partOfSpeech: n
 07118468-n:
   definition:
-  - reversal of normal word order (as in `cheese I love')
+  - reversal of normal word order (as in `cheese I love´)
   hypernym:
   - 07112859-n
   ili: i73993
@@ -50562,7 +50562,7 @@
   partOfSpeech: n
 07118686-n:
   definition:
-  - use of a series of parallel clauses (as in `I came, I saw, I conquered')
+  - use of a series of parallel clauses (as in `I came, I saw, I conquered´)
   hypernym:
   - 07112859-n
   ili: i73995
@@ -50571,7 +50571,7 @@
   partOfSpeech: n
 07118815-n:
   definition:
-  - reversal of normal order of two words or sentences etc. (as in `bred and born')
+  - reversal of normal order of two words or sentences etc. (as in `bred and born´)
   hypernym:
   - 07112859-n
   ili: i73996
@@ -50583,7 +50583,7 @@
   - understatement for rhetorical effect (especially when expressing an affirmative
     by negating its contrary)
   example:
-  - saying `I was not a little upset' when you mean `I was very upset' is an example
+  - saying `I was not a little upset´ when you mean `I was very upset´ is an example
     of litotes
   hypernym:
   - 07112859-n
@@ -50616,7 +50616,7 @@
   partOfSpeech: n
 07119578-n:
   definition:
-  - juxtaposing words having a common derivation (as in `sense and sensibility')
+  - juxtaposing words having a common derivation (as in `sense and sensibility´)
   hypernym:
   - 07112859-n
   ili: i74000
@@ -50626,7 +50626,7 @@
 07119711-n:
   definition:
   - using several conjunctions in close succession, especially where some might be
-    omitted (as in `he ran and jumped and laughed for joy')
+    omitted (as in `he ran and jumped and laughed for joy´)
   hypernym:
   - 07112859-n
   ili: i74001
@@ -50717,8 +50717,8 @@
 07121768-n:
   definition:
   - a metaphor that has occurred so often that it has become a new meaning of the
-    expression (e.g., `he is a snake' may once have been a metaphor but after years
-    of use it has died and become a new sense of the word `snake')
+    expression (e.g., `he is a snake´ may once have been a metaphor but after years
+    of use it has died and become a new sense of the word `snake´)
   hypernym:
   - 07121485-n
   ili: i74010
@@ -50747,7 +50747,7 @@
 07122361-n:
   definition:
   - substituting the name of an attribute or feature for the name of the thing itself
-    (as in `they counted heads')
+    (as in `they counted heads´)
   hypernym:
   - 07120141-n
   ili: i74013
@@ -50765,7 +50765,7 @@
   partOfSpeech: n
 07122695-n:
   definition:
-  - conjoining contradictory terms (as in `deafening silence')
+  - conjoining contradictory terms (as in `deafening silence´)
   hypernym:
   - 07120141-n
   ili: i74015
@@ -50785,7 +50785,7 @@
 07122967-n:
   definition:
   - a figure of speech that expresses a resemblance between things of different kinds
-    (usually formed with `like' or `as')
+    (usually formed with `like´ or `as´)
   hypernym:
   - 07120141-n
   ili: i74017
@@ -50816,7 +50816,7 @@
   - use of a verb with two or more complements, playing on the verb's polysemy, for
     humorous effect
   example:
-  - '`Mr. Pickwick took his hat and his leave'' is an example of zeugma'
+  - '`Mr. Pickwick took his hat and his leave´ is an example of zeugma'
   hypernym:
   - 07120141-n
   ili: i74020
@@ -51124,7 +51124,7 @@
 07129243-n:
   definition:
   - a semivowel produced with the tongue near the palate (like the initial sound in
-    the English word `yeast')
+    the English word `yeast´)
   hypernym:
   - 07129117-n
   ili: i74048
@@ -51314,7 +51314,7 @@
   definition:
   - the insertion of a vowel or consonant into a word to make its pronunciation easier
   example:
-  - the insertion of a vowel in the plural of the word `bush' is epenthesis
+  - the insertion of a vowel in the plural of the word `bush´ is epenthesis
   hypernym:
   - 07146562-n
   ili: i74066
@@ -51379,7 +51379,7 @@
 07133698-n:
   definition:
   - a composite speech sound consisting of a stop and a fricative articulated at the
-    same point (as `ch' in `chair' and `j' in `joy')
+    same point (as `ch´ in `chair´ and `j´ in `joy´)
   hypernym:
   - 07130392-n
   ili: i74072
@@ -51420,7 +51420,7 @@
   partOfSpeech: n
 07134351-n:
   definition:
-  - a frictionless continuant that is not a nasal consonant (especially `l' and `r')
+  - a frictionless continuant that is not a nasal consonant (especially `l´ and `r´)
   hypernym:
   - 07129729-n
   ili: i74076
@@ -51431,7 +51431,7 @@
   definition:
   - a doubled or long consonant
   example:
-  - the `n' in `thinness' is a geminate
+  - the `n´ in `thinness´ is a geminate
   hypernym:
   - 07129729-n
   ili: i74077
@@ -52199,7 +52199,7 @@
   partOfSpeech: n
 07147437-n:
   definition:
-  - (phonology) the loss of sounds from within a word (as in `fo'c'sle' for `forecastle')
+  - (phonology) the loss of sounds from within a word (as in `fo'c'sle´ for `forecastle´)
   domain_topic:
   - 06187166-n
   hypernym:
@@ -52234,7 +52234,7 @@
   definition:
   - an expression that is difficult to articulate clearly
   example:
-  - '`rubber baby buggy bumper'' is a tongue twister'
+  - '`rubber baby buggy bumper´ is a tongue twister'
   hypernym:
   - 07166088-n
   ili: i74149
@@ -52243,7 +52243,7 @@
   partOfSpeech: n
 07148185-n:
   definition:
-  - the articulation of a consonant (especially the consonant `r') with a rapid flutter
+  - the articulation of a consonant (especially the consonant `r´) with a rapid flutter
     of the tongue against the palate or uvula
   example:
   - he pronounced his R's with a distinct trill
@@ -52550,7 +52550,7 @@
 07153212-n:
   definition:
   - a report of a discourse in which deictic terms are modified appropriately (e.g.,
-    `he said "I am a fool"' would be modified to `he said he is a fool')
+    `he said "I am a fool"´ would be modified to `he said he is a fool´)
   hypernym:
   - 07232584-n
   ili: i74177
@@ -52590,7 +52590,7 @@
   partOfSpeech: n
 07154024-n:
   definition:
-  - discussion; (`talk about' is a less formal alternative for `discussion of')
+  - discussion; (`talk about´ is a less formal alternative for `discussion of´)
   example:
   - his poetry contains much talk about love and anger
   hypernym:
@@ -53333,7 +53333,7 @@
   definition:
   - a commonly repeated word or phrase
   example:
-  - she repeated `So pleased with how it's going' at intervals like a mantra
+  - she repeated `So pleased with how it's going´ at intervals like a mantra
   hypernym:
   - 07166967-n
   ili: i74250
@@ -53345,7 +53345,7 @@
   - a slogan used to rally support for a cause
   example:
   - a cry to arms
-  - our watchword will be `democracy'
+  - our watchword will be `democracy´
   hypernym:
   - 07166967-n
   ili: i74251
@@ -54766,7 +54766,7 @@
   - an accommodation in which both sides make concessions
   example:
   - the newly elected congressmen rejected a compromise because they considered it
-    `business as usual'
+    `business as usual´
   hypernym:
   - 07192097-n
   ili: i74381
@@ -56303,7 +56303,7 @@
   definition:
   - a grammatically substandard but emphatic negative
   example:
-  - double negative such as `I don't never go'
+  - double negative such as `I don't never go´
   hypernym:
   - 07219571-n
   ili: i74521
@@ -56314,7 +56314,7 @@
   definition:
   - an affirmative constructed from two negatives
   example:
-  - double negative such as `a not unwelcome outcome'
+  - double negative such as `a not unwelcome outcome´
   hypernym:
   - 07218356-n
   ili: i74522
@@ -56409,7 +56409,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - the statement `he is brave and he is not brave' is a contradiction
+  - the statement `he is brave and he is not brave´ is a contradiction
   hypernym:
   - 06769118-n
   ili: i74531
@@ -61098,7 +61098,7 @@
   partOfSpeech: n
 80475027-n:
   definition:
-  - English orthography used in Canada (characterized by `analyze', `centre', `useable')
+  - English orthography used in Canada (characterized by `analyze´, `centre´, `useable´)
   hypernym:
   - 06364852-n
   members:
@@ -61157,7 +61157,7 @@
   partOfSpeech: n
 84746436-n:
   definition:
-  - English orthography used in Australia (characterized by `analyse', `centre', `usable')
+  - English orthography used in Australia (characterized by `analyse´, `centre´, `usable´)
   hypernym:
   - 06364852-n
   members:
@@ -61177,7 +61177,7 @@
 86712636-n:
   definition:
   - English orthography used in the UK, Ireland and most of the Commonwealth (characterized
-    by `analyse', `centre' and `useable')
+    by `analyse´, `centre´ and `useable´)
   hypernym:
   - 06364852-n
   members:
@@ -61196,8 +61196,8 @@
   partOfSpeech: n
 87027384-n:
   definition:
-  - English orthography used in the United States (characterized by `analyze', `center',
-    `usable')
+  - English orthography used in the United States (characterized by `analyze´, `center´,
+    `usable´)
   hypernym:
   - 06364852-n
   members:
@@ -61400,7 +61400,7 @@
   source: Colloquial WordNet
 90011161-n:
   definition:
-  - An expression meaning `praise God' in Arabic
+  - An expression meaning `praise God´ in Arabic
   hypernym:
   - 06642524-n
   members:
@@ -61485,7 +61485,7 @@
   definition:
   - A subgenre of alternative rock typified by significant use of guitar distortion,
     feedback, obscured vocals and the blurring of component musical parts into indistinguishable
-    `walls of sound'
+    `walls of sound´
   hypernym:
   - 07073295-n
   members:
@@ -61538,7 +61538,7 @@
   - a meter of poetry consisting of three iambic units per line.
   example:
   - In the dramatic forms of tragedy and comedy, iambic trimeter was used mainly for
-    the verses `spoken' by a character, that is, the dialogue rather than the choral
+    the verses `spoken´ by a character, that is, the dialogue rather than the choral
     passages.
   hypernym:
   - 07109509-n
@@ -61635,7 +61635,7 @@
   - The characteristic quality of poetry that is marked by departure from the subject,
     course, or idea at hand; or by an exploration of a different or unrelated concern.
   example:
-  - Eighteenth-century writers, says Stabler, were never `lost' in their digressiveness
+  - Eighteenth-century writers, says Stabler, were never `lost´ in their digressiveness
     and used it as a method of supporting their concepts.
   hypernym:
   - 07080699-n
@@ -62058,7 +62058,7 @@
 92444678-n:
   definition:
   - A direct mate with the stipulation `White to move and checkmate Black in no more
-    than n moves against any defence' where n is greater than 3.
+    than n moves against any defence´ where n is greater than 3.
   example:
   - This week's problem is a more-mover by a composer better known for his endgame
     study and theory work.
@@ -62071,7 +62071,7 @@
 92444679-n:
   definition:
   - A problem with the stipulation `White to move and checkmate Black in two moves
-    against any defence'.
+    against any defence´.
   example:
   - Although, if he was consistent, perhaps he should have said that a three-mover
     would be three times as difficult as a two-mover.
@@ -62084,7 +62084,7 @@
 92444680-n:
   definition:
   - A problem with the stipulation `White to move and checkmate Black in no more than
-    three moves against any defence'.
+    three moves against any defence´.
   example:
   - Accordingly, the solver usually takes it for granted that a three-mover has a
     threat, unless the setting definitely suggests a block position.
@@ -62169,8 +62169,8 @@
     features (it can modify verbs used with the noun, affect the noun's declension
     etc.).
   example:
-  - In other words, the inanimacy of a head noun like `evidence' appeared not to penetrate
-    the syntactic analysis of the verb `examined'.
+  - In other words, the inanimacy of a head noun like `evidence´ appeared not to penetrate
+    the syntactic analysis of the verb `examined´.
   hypernym:
   - 06320373-n
   members:
@@ -62238,7 +62238,7 @@
   example:
   - source: https://en.wikipedia.org
     text: As an information management tool, a PIM tool's purpose is to facilitate
-      the recording, tracking, and management of certain types of `personal information'.
+      the recording, tracking, and management of certain types of `personal information´.
   hypernym:
   - 06581154-n
   members:
@@ -62573,7 +62573,7 @@
   definition:
   - a symbol that represents peace, in the form of three lines within a circle.
   example:
-  - In the 1950s the `peace sign' as it is known today, was designed as the logo for
+  - In the 1950s the `peace sign´ as it is known today, was designed as the logo for
     the British Campaign for Nuclear Disarmament and adopted by anti-war and counterculture
     activists in the United States and elsewhere.
   hypernym:
@@ -62636,7 +62636,7 @@
   example:
   - The sotadic metre or sotadic verse, which has been classified by ancient and modern
     scholars as a form of ionic metre, is one that reads backwards and forwards the
-    same, as `llewd did I live, and evil I did dwell'.
+    same, as `llewd did I live, and evil I did dwell´.
   hypernym:
   - 06389065-n
   members:
@@ -62671,12 +62671,12 @@
 92460868-n:
   definition:
   - a large subgenre of trance music, named for the feeling which listeners claim
-    to get (often described as a `rush').
+    to get (often described as a `rush´).
   example:
   - Instead of the darker tone of Goa, uplifting trance uses similar chord progressions
     as progressive trance, but tracks' chord progressions usually rest on a major
     chord, and the balance between major and minor chords in a progression will determine
-    how `happy' or `sad' the progression sounds.
+    how `happy´ or `sad´ the progression sounds.
   hypernym:
   - 92460865-n
   members:
@@ -62690,7 +62690,7 @@
   example:
   - The en dash is commonly used to indicate a closed range of values — a range with
     clearly defined and finite upper and lower boundaries — roughly signifying what
-    might otherwise be communicated by the word `through'.
+    might otherwise be communicated by the word `through´.
   hypernym:
   - 06856198-n
   members:
@@ -62729,7 +62729,7 @@
   - a poem whose meaning is conveyed through its graphic shape or pattern on the printed
     page.
   example:
-  - '`The Mouse''s Tale'' is a concrete poem by Lewis Carroll which appears in his
+  - '`The Mouse''s Tale´ is a concrete poem by Lewis Carroll which appears in his
     novel Alice''s Adventures in Wonderland.'
   hypernym:
   - 06389065-n
@@ -62743,7 +62743,7 @@
     and using electronic instruments such as guitars and synthesizers.
   example:
   - Jazz Fusion incorporates elements of different genres while maintaining an element
-    that is distinctly `jazz'.
+    that is distinctly `jazz´.
   hypernym:
   - 07076737-n
   members:
@@ -62766,7 +62766,7 @@
 92460923-n:
   definition:
   - a type of operatic soprano voice that has the limpidity and easy high notes of
-    a lyric soprano, yet can be `pushed' on to achieve dramatic climaxes without strain.
+    a lyric soprano, yet can be `pushed´ on to achieve dramatic climaxes without strain.
   example:
   - The more dramatic sister of the lyric soprano is the spinto soprano, not quite
     a full-on dramatic soprano, but possessing a combination of qualities of both
@@ -62812,7 +62812,7 @@
   - a piece of music composed for the Hungarian Csárdás dance.
   example:
   - 'The Csárdás is characterized by a variation in tempo: it starts out slowly (lassú)
-    and ends in a very fast tempo (friss, literally `fresh'').'
+    and ends in a very fast tempo (friss, literally `fresh´).'
   hypernym:
   - 07068473-n
   members:
@@ -62910,7 +62910,7 @@
     couplets, sung antiphonally by cantors and followed by alternate Greek and Latin
     responses from the two halves of the choir; and nine other lines sung by the cantors,
     with the full choir responding after each with the refrain `Popule meus, quid
-    feci tibi? …'
+    feci tibi? …´
   hypernym:
   - 07046732-n
   members:
@@ -62948,11 +62948,11 @@
   - a meaningless chant or expression used in conjuring or incantation.
   example:
   - This claim is substantiated by the fact that in the Netherlands, the words `Hocus
-    pocus' are usually accompanied by the additional words `pilatus pas', and this
+    pocus´ are usually accompanied by the additional words `pilatus pas´, and this
     is said to be based on a post-Reformation parody of the traditional Catholic ritual
     of transubstantiation during mass, being a Dutch corruption of the Latin words
-    `Hoc est corpus', meaning `this is (my) body', and the credo `sub Pontio Pilato
-    passus et sepultus est', meaning `under Pontius Pilate he suffered and was buried'.
+    `Hoc est corpus´, meaning `this is (my) body´, and the credo `sub Pontio Pilato
+    passus et sepultus est´, meaning `under Pontius Pilate he suffered and was buried´.
   hypernym:
   - 07174442-n
   members:
@@ -62988,7 +62988,7 @@
   definition:
   - Etiquette practiced or advocated in electronic communication over a computer network.
   example:
-  - I know there is a UK political blog war going on at the moment about `netiquette'
+  - I know there is a UK political blog war going on at the moment about `netiquette´
     and lies and spin and deceit, and I have not wanted to join in.
   hypernym:
   - 06677590-n
@@ -63150,8 +63150,8 @@
     the alveolar ridge.
   example:
   - The sibilant postalveolars (i.e. fricatives and affricates) are sometimes called
-    `hush consonants' because they include the sound of English `Shhh!' (as distinguished
-    from the `hiss' consonant [s], as in `Ssss!').
+    `hush consonants´ because they include the sound of English `Shhh!´ (as distinguished
+    from the `hiss´ consonant [s], as in `Ssss!´).
   hypernym:
   - 07129729-n
   members:
@@ -63179,8 +63179,8 @@
   - the tense that is used to refer to events, actions, and conditions that are happening
     all the time, or exist now.
   example:
-  - The sentences `I live in Madrid', `She doesn't like cheese', and `I think you're
-    wrong' are all in the present simple.
+  - The sentences `I live in Madrid´, `She doesn't like cheese´, and `I think you're
+    wrong´ are all in the present simple.
   hypernym:
   - 06340727-n
   members:
@@ -63231,7 +63231,7 @@
   - a verb form expressing action as single in its occurrence without repetition or
     continuation.
   example:
-  - Semelfactive verbs include `blink', `sneeze', and `knock'.
+  - Semelfactive verbs include `blink´, `sneeze´, and `knock´.
   hypernym:
   - 92462256-n
   members:
@@ -63269,9 +63269,9 @@
   definition:
   - the name of an object which may be perceived by one or more of the five senses.
   example:
-  - '`Kitten'' is an example of a concrete noun. A kitten registers with the five
-    senses: you can see a kitten, pet its fur, smell its breath, hear it purr and
-    taste its kisses.'
+  - '`Kitten´ is an example of a concrete noun. A kitten registers with the five senses:
+    you can see a kitten, pet its fur, smell its breath, hear it purr and taste its
+    kisses.'
   hypernym:
   - 06330286-n
   members:
@@ -63319,7 +63319,7 @@
     to increase or diminution.
   example:
   - An example using a positive-degree adverb that doesn't end in -ly would be the
-    adverb `fast' in the sentence, `She drove fast'.
+    adverb `fast´ in the sentence, `She drove fast´.
   hypernym:
   - 06333461-n
   members:
@@ -63331,7 +63331,7 @@
   definition:
   - An adverb that describes how the action of a verb is carried out.
   example:
-  - Adverbs of manner (like `desperately') can modify verbs directly.
+  - Adverbs of manner (like `desperately´) can modify verbs directly.
   hypernym:
   - 06334605-n
   members:
@@ -63436,7 +63436,7 @@
 92462515-n:
   definition:
   - The Cyrillic letter Ь/ь, which in Old Church Slavonic represented a short (or
-    `reduced') front vowel, and in modern languages serves to denote a soft (palatalized)
+    `reduced´) front vowel, and in modern languages serves to denote a soft (palatalized)
     consonant.
   example:
   - The yers in weak position were lost, although not in some instances before palatalizing
@@ -63566,7 +63566,7 @@
   definition:
   - a poetic phrase, utterance, etc.
   example:
-  - Just as `hath' is a poeticism in Keats and an unmarked form for Shakespeare, `sogebided'
+  - Just as `hath´ is a poeticism in Keats and an unmarked form for Shakespeare, `sogebided´
     may have been a poeticism to Alfred and an unmarked form for Qedmon.
   hypernym:
   - 06297048-n
@@ -63578,7 +63578,7 @@
   definition:
   - an extreme form of tragicomedy.
   example:
-  - The Suicide of Solitude, a `tragifarce' production, is currently being performed
+  - The Suicide of Solitude, a `tragifarce´ production, is currently being performed
     by the local theatre troupe at Rochford Winery in Healesville.
   hypernym:
   - 07029911-n
@@ -63711,7 +63711,7 @@
   source: plWordNet 4.0
 92463196-n:
   definition:
-  - a name of a `minor' or small natural feature (e.g., a field, path, bridge, ditch,
+  - a name of a `minor´ or small natural feature (e.g., a field, path, bridge, ditch,
     etc.).
   example:
   - Larrain is the name of a farmhouse in Astigarraga (Gipuzkoa) and a microtoponym
@@ -63874,7 +63874,7 @@
   definition:
   - (phonetics) Any vowel sound produced in the front of the mouth.
   example:
-  - Examples of front vowels include `a' in `man' and `e' in `gel'.
+  - Examples of front vowels include `a´ in `man´ and `e´ in `gel´.
   hypernym:
   - 07127258-n
   members:
@@ -63885,7 +63885,7 @@
   definition:
   - (phonetics) Any vowel sound produced in the back of the mouth.
   example:
-  - Examples of back vowels include `u' in `rule' and `o' in `pole'.
+  - Examples of back vowels include `u´ in `rule´ and `o´ in `pole´.
   hypernym:
   - 07127258-n
   members:
@@ -64076,7 +64076,8 @@
   definition:
   - The name of a Saint taken as a proper name.
   example:
-  - This Native place name was used for a while in parallel with the hagionym Saint-Francois-Xavier (1850s) as well as another `official' toponym, Grantown, named after Cuthbert Grant.
+  - This Native place name was used for a while in parallel with the hagionym Saint-Francois-Xavier
+    (1850s) as well as another `official´ toponym, Grantown, named after Cuthbert Grant.
   hypernym:
   - 06349648-n
   members:
@@ -64087,7 +64088,7 @@
   definition:
   - a clitic that is associated with a following word.
   example:
-  - The indefinite article `a' is a proclitic, a word that wants to merge phonologically
+  - The indefinite article `a´ is a proclitic, a word that wants to merge phonologically
     with the word that follows it.
   hypernym:
   - 92460927-n
@@ -64127,7 +64128,7 @@
     is important to the text's interpretation.
   example:
   - What caught my eye about this is that it bears interesting relation to Bakhtin's
-    concept of the dialogism of the `living word' — in fact, capitalize that `w' and
+    concept of the dialogism of the `living word´ — in fact, capitalize that `w´ and
     it would be downright eerie.
   hypernym:
   - 07112859-n
@@ -64218,7 +64219,7 @@
   definition:
   - an adverbial that describes when the action of a verb is carried out.
   example:
-  - An adverb phrase that answers the question `when?' is called a temporal adverbial.
+  - An adverb phrase that answers the question `when?´ is called a temporal adverbial.
   hypernym:
   - 06335348-n
   members:
@@ -64280,8 +64281,8 @@
   - (grammar) a pronoun having no specific referent, such as someone, anybody, or
     nothing.
   example:
-  - In `many disagree with his views' the word `many' functions as an indefinite pronoun,
-    while in `many people disagree with his views' it functions as a quantifier.
+  - In `many disagree with his views´ the word `many´ functions as an indefinite pronoun,
+    while in `many people disagree with his views´ it functions as a quantifier.
   hypernym:
   - 06336363-n
   members:
@@ -64319,7 +64320,7 @@
     or on coins or medals.
   example:
   - One practice was rendering an over-used, formulaic phrase only as a siglum, e.g.
-    RIP for `requiescat in pace' (`Rest in Peace'), because the long-form written
+    RIP for `requiescat in pace´ (`Rest in Peace´), because the long-form written
     usage of the abbreviated phrase, itself, was rare.
   hypernym:
   - 06831828-n
@@ -64331,7 +64332,7 @@
   definition:
   - an act of describing oneself.
   example:
-  - His self-description as an `experimenter' puts him shoulder-to-shoulder with William
+  - His self-description as an `experimenter´ puts him shoulder-to-shoulder with William
     James and John Dewey.
   hypernym:
   - 07216025-n
@@ -64430,9 +64431,9 @@
 92464557-n:
   definition:
   - The subject of a sentence that expresses the actual agent of an expressed or implied
-    action (as father in `it is your father speaking') or that is the thing about
+    action (as father in `it is your father speaking´) or that is the thing about
     which something is otherwise predicated (as to do right in `it is sometimes hard
-    to do right').
+    to do right´).
   example:
   - The notion of a logical subject can be made more precise in terms of a definition
     of reference, for something is a logical subject only if it is a referent of a
@@ -64449,9 +64450,9 @@
     subject in normal English word order and anticipates a subsequent word or phrase
     that specifies the actual substantive content.
   example:
-  - In the sentence `the bear was killed by the hunter', the topicalized goal of the
-    action (`the bear') is the grammatical subject of the passive sentence and is
-    acted upon by the agent (`the hunter'), which is the logical, but not the grammatical,
+  - In the sentence `the bear was killed by the hunter´, the topicalized goal of the
+    action (`the bear´) is the grammatical subject of the passive sentence and is
+    acted upon by the agent (`the hunter´), which is the logical, but not the grammatical,
     subject of the passive sentence.
   hypernym:
   - 06320921-n
@@ -64510,7 +64511,7 @@
   - a word or line of verse of seven syllables.
   example:
   - On the other hand, this heptasyllable is not merely common in the Saturnian but
-    obviously the `regular' or `normal' form of the longer cola.
+    obviously the `regular´ or `normal´ form of the longer cola.
   hypernym:
   - 06396351-n
   members:
@@ -64561,7 +64562,7 @@
   - a constructed language designed for aesthetic pleasure.
   example:
   - By far the largest group of artistic languages are fictional languages (sometimes
-    also referred to as `professional artlangs'), intended to be the languages of
+    also referred to as `professional artlangs´), intended to be the languages of
     a fictional world, and often designed with the intent of giving more depth and
     an appearance of plausibility to the fictional worlds with which they are associated,
     and to have their characters communicate in a fashion which is both alien and
@@ -64590,12 +64591,12 @@
   - 'A rhetorical figure resulting from a reverted arrangement in the last clause
     of a sentence of the two principal words of the clause preceding; inversion of
     the members of an antithesis: as, `A poem is a speaking picture; a picture a mute
-    poem''.'
+    poem´.'
   example:
   - I am not of Paracelsus's mind, that boldly delivers a receipt to make a man without
     conjunction; yet cannot but wonder at the multitude of heads that do deny traduction,
     having no other arguments to confirm their belief than that rhetorical sentence
-    and antimetathesis of Augustine, `creando infunditur, infundendo creatur'.
+    and antimetathesis of Augustine, `creando infunditur, infundendo creatur´.
   hypernym:
   - 07112859-n
   members:
@@ -64722,7 +64723,7 @@
   source: plWordNet 4.0
 92470531-n:
   definition:
-  - a song associated with the dance `The Twist' and the associated cultural craze.
+  - a song associated with the dance `The Twist´ and the associated cultural craze.
   example:
   - There was Twist merchandise and memorabilia sold in those times, and many other
     music artists recorded twist songs.
@@ -64785,7 +64786,7 @@
   definition:
   - an indication of satisfaction or approval.
   example:
-  - The phrase `two thumbs up' has come to be used as an indication of very high quality
+  - The phrase `two thumbs up´ has come to be used as an indication of very high quality
     or unanimity of praise.
   hypernym:
   - 06699481-n

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -63561,7 +63561,7 @@
   hypernym:
   - 07132710-n
   members:
-  - asynchronous nazalisation
+  - asynchronous nasalization
   partOfSpeech: n
   source: plWordNet 4.0
 92462887-n:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -2074,9 +2074,9 @@
   definition:
   - a new word formed by joining two others and combining their meanings
   example:
-  - '‘smog’ is a blend of ‘smoke’ and ‘fog’'
-  - '‘motel’ is a portmanteau word made by combining ‘motor’ and ‘hotel’'
-  - '‘brunch’ is a well-known portmanteau'
+  - ‘smog’ is a blend of ‘smoke’ and ‘fog’
+  - ‘motel’ is a portmanteau word made by combining ‘motor’ and ‘hotel’
+  - ‘brunch’ is a well-known portmanteau
   hypernym:
   - 06305222-n
   ili: i69549
@@ -2121,8 +2121,8 @@
   definition:
   - a word formed from two or more words by omitting or combining some sounds
   example:
-  - '‘won''t’ is a contraction of ‘will not’'
-  - '‘o''clock’ is a contraction of ‘of the clock’'
+  - ‘won't’ is a contraction of ‘will not’
+  - ‘o'clock’ is a contraction of ‘of the clock’
   hypernym:
   - 06297048-n
   ili: i69553
@@ -2150,7 +2150,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - '‘electricity’ is a derivative of ‘electric’'
+  - ‘electricity’ is a derivative of ‘electric’
   hypernym:
   - 06297048-n
   ili: i69555
@@ -2170,7 +2170,7 @@
   definition:
   - a word that is considered to be unmentionable
   example:
-  - '‘failure’ is a dirty word to him'
+  - ‘failure’ is a dirty word to him
   hypernym:
   - 06297048-n
   ili: i69557
@@ -2288,7 +2288,7 @@
   definition:
   - a word that names the whole of which a given word is a part
   example:
-  - '‘hat’ is a holonym for ‘brim’ and ‘crown’'
+  - ‘hat’ is a holonym for ‘brim’ and ‘crown’
   hypernym:
   - 06297048-n
   ili: i69567
@@ -2378,7 +2378,7 @@
   definition:
   - a word that names a part of a larger whole
   example:
-  - '‘brim’ and ‘crown’ are meronyms of ‘hat’'
+  - ‘brim’ and ‘crown’ are meronyms of ‘hat’
   hypernym:
   - 06297048-n
   ili: i69575
@@ -2402,7 +2402,7 @@
   definition:
   - an anagram that means the opposite of the original word or phrase
   example:
-  - '‘restful’ is the antigram of ‘fluster’'
+  - ‘restful’ is the antigram of ‘fluster’
   hypernym:
   - 06298291-n
   ili: i69577
@@ -2463,7 +2463,7 @@
   definition:
   - a word serving as the basis for inflected or derived forms
   example:
-  - '‘pick’ is the primitive from which ‘picket’ is derived'
+  - ‘pick’ is the primitive from which ‘picket’ is derived
   hypernym:
   - 06297048-n
   ili: i69583
@@ -2593,7 +2593,7 @@
   definition:
   - an expression introduced into one language by translating it from another language
   example:
-  - '‘superman’ is a calque for the German ‘Ubermensch’'
+  - ‘superman’ is a calque for the German ‘Ubermensch’
   hypernym:
   - 07166088-n
   ili: i69594
@@ -2777,7 +2777,7 @@
   definition:
   - a word that denotes a manner of doing something
   example:
-  - '‘march’ is a troponym of ‘walk’'
+  - ‘march’ is a troponym of ‘walk’
   hypernym:
   - 06297048-n
   ili: i69611
@@ -2951,7 +2951,7 @@
   definition:
   - a bound form used only in compounds
   example:
-  - '‘hemato-’ is a combining form in words like ‘hematology’'
+  - ‘hemato-’ is a combining form in words like ‘hematology’
   hypernym:
   - 06317935-n
   ili: i69628
@@ -3361,8 +3361,8 @@
   definition:
   - a clause introduced by a relative pronoun
   example:
-  - '‘who visits frequently’ is a relative clause in the sentence ‘John, who visits
-    frequently, is ill’'
+  - ‘who visits frequently’ is a relative clause in the sentence ‘John, who visits
+    frequently, is ill’
   hypernym:
   - 06325134-n
   ili: i69666
@@ -3472,7 +3472,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '‘Socrates is a man’ predicates manhood of Socrates'
+  - ‘Socrates is a man’ predicates manhood of Socrates
   hypernym:
   - 06764688-n
   ili: i69676
@@ -3688,7 +3688,7 @@
   definition:
   - an adjective used as a noun
   example:
-  - '‘meek’ in ‘blessed are the meek’ is an adnoun'
+  - ‘meek’ in ‘blessed are the meek’ is an adnoun
   hypernym:
   - 06331146-n
   ili: i69698
@@ -3720,8 +3720,8 @@
   definition:
   - a modifier that has little meaning except to intensify the meaning it modifies
   example:
-  - '‘up’ in ‘finished up’ is an intensifier'
-  - '‘honestly’ in ‘I honestly don''t know’ is an intensifier'
+  - ‘up’ in ‘finished up’ is an intensifier
+  - ‘honestly’ in ‘I honestly don't know’ is an intensifier
   hypernym:
   - 06331794-n
   ili: i69701
@@ -3789,9 +3789,9 @@
   definition:
   - the comparative form of an adjective or adverb
   example:
-  - '‘faster’ is the comparative of the adjective ‘fast’'
-  - '‘less famous’ is the comparative degree of the adjective ‘famous’'
-  - '‘more surely’ is the comparative of the adverb ‘surely’'
+  - ‘faster’ is the comparative of the adjective ‘fast’
+  - ‘less famous’ is the comparative degree of the adjective ‘famous’
+  - ‘more surely’ is the comparative of the adverb ‘surely’
   hypernym:
   - 06332695-n
   - 06334605-n
@@ -3804,9 +3804,9 @@
   definition:
   - the superlative form of an adjective or adverb
   example:
-  - '‘fastest’ is the superlative of the adjective ‘fast’'
-  - '‘least famous’ is the superlative degree of the adjective ‘famous’'
-  - '‘most surely’ is the superlative of the adverb ‘surely’'
+  - ‘fastest’ is the superlative of the adjective ‘fast’
+  - ‘least famous’ is the superlative degree of the adjective ‘famous’
+  - ‘most surely’ is the superlative of the adverb ‘surely’
   hypernym:
   - 06332695-n
   - 06334605-n
@@ -4083,7 +4083,7 @@
   - a verb whose agent performs an action that is directed at the agent
   example:
   - the sentence ‘he washed’ has a reflexive verb
-  - '‘perjure’ is a reflexive verb because you cannot perjure anyone but yourself'
+  - ‘perjure’ is a reflexive verb because you cannot perjure anyone but yourself
   hypernym:
   - 06331562-n
   ili: i69734
@@ -4206,7 +4206,7 @@
   - an English verb followed by one or more particles where the combination behaves
     as a syntactic and semantic unit
   example:
-  - '‘turn out’ is a phrasal verb in the question ‘how many turned out to vote?’'
+  - ‘turn out’ is a phrasal verb in the question ‘how many turned out to vote?’
   hypernym:
   - 06329055-n
   ili: i69746
@@ -4528,7 +4528,7 @@
   definition:
   - slang for something (especially for an illegal drug)
   example:
-  - '‘smack’ is a street name for heroin'
+  - ‘smack’ is a street name for heroin
   hypernym:
   - 06344646-n
   - 07171981-n
@@ -4716,7 +4716,7 @@
   definition:
   - a name of endearment (especially one using a diminutive suffix)
   example:
-  - '‘Billy’ is a hypocorism for ‘William’'
+  - ‘Billy’ is a hypocorism for ‘William’
   hypernym:
   - 06344646-n
   ili: i69789
@@ -4989,7 +4989,7 @@
   definition:
   - an appellation signifying nobility
   example:
-  - '‘your majesty’ is the appropriate title to use in addressing a king'
+  - ‘your majesty’ is the appropriate title to use in addressing a king
   hypernym:
   - 06350278-n
   ili: i69813
@@ -6974,8 +6974,8 @@
   definition:
   - a witty satiric verse containing two rhymed couplets and mentioning a famous person
   example:
-  - '‘The president is George W. Bush, Who is happy to sit on his tush, While sending
-    his armies to fight, For anything he thinks is right’ is a clerihew'
+  - ‘The president is George W. Bush, Who is happy to sit on his tush, While sending
+    his armies to fight, For anything he thinks is right’ is a clerihew
   hypernym:
   - 06393492-n
   ili: i69998
@@ -12800,8 +12800,8 @@
   domain_topic:
   - 06182505-n
   example:
-  - '‘Those girls, they giggle when they see me’ and ‘Cigarettes, you couldn''t pay
-    me to smoke them’ are examples of topicalization'
+  - ‘Those girls, they giggle when they see me’ and ‘Cigarettes, you couldn't pay
+    me to smoke them’ are examples of topicalization
   hypernym:
   - 07117611-n
   ili: i70523
@@ -27368,7 +27368,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '‘I always lie’ is a paradox because if it is true it must be false'
+  - ‘I always lie’ is a paradox because if it is true it must be false
   hypernym:
   - 07221547-n
   ili: i71840
@@ -34126,8 +34126,8 @@
   definition:
   - a letter that has two or more pronunciations
   example:
-  - '‘c’ is a polyphone because it is pronounced like ‘k’ in ‘car’ but like ‘s’ in
-    ‘cell’'
+  - ‘c’ is a polyphone because it is pronounced like ‘k’ in ‘car’ but like ‘s’ in
+    ‘cell’
   hypernym:
   - 06841868-n
   ili: i72460
@@ -34224,7 +34224,7 @@
   - a single written symbol that represents an entire word or phrase without indicating
     its pronunciation
   example:
-  - '‘7’ is a logogram that is pronounced ‘seven’ in English and ‘nanatsu’ in Japanese'
+  - ‘7’ is a logogram that is pronounced ‘seven’ in English and ‘nanatsu’ in Japanese
   hypernym:
   - 06853698-n
   ili: i72469
@@ -45519,7 +45519,7 @@
   definition:
   - persuasive but insincere talk that is usually intended to deceive or impress
   example:
-  - '‘let me show you my etchings’ is a rather worn line'
+  - ‘let me show you my etchings’ is a rather worn line
   - he has a smooth line but I didn't fall for it
   - that salesman must have practiced his fast line of talk
   hypernym:
@@ -49819,7 +49819,7 @@
   - a word formed from the initial letters of the several words in the name and pronounced
     as one word
   example:
-  - '‘NATO’ is an initialism for North Atlantic Treaty Organization'
+  - ‘NATO’ is an initialism for North Atlantic Treaty Organization
   - the word ‘scuba’ is an acronym for s(elf)-c(ontained) u(nderwater) b(reathing)
     a(pparatus)
   hypernym:
@@ -50172,7 +50172,7 @@
   definition:
   - a two-syllable rhyme
   example:
-  - '‘ended’ and ‘blended’ form a double rhyme'
+  - ‘ended’ and ‘blended’ form a double rhyme
   hypernym:
   - 07111327-n
   ili: i73955
@@ -50816,7 +50816,7 @@
   - use of a verb with two or more complements, playing on the verb's polysemy, for
     humorous effect
   example:
-  - '‘Mr. Pickwick took his hat and his leave’ is an example of zeugma'
+  - ‘Mr. Pickwick took his hat and his leave’ is an example of zeugma
   hypernym:
   - 07120141-n
   ili: i74020
@@ -52234,7 +52234,7 @@
   definition:
   - an expression that is difficult to articulate clearly
   example:
-  - '‘rubber baby buggy bumper’ is a tongue twister'
+  - ‘rubber baby buggy bumper’ is a tongue twister
   hypernym:
   - 07166088-n
   ili: i74149
@@ -62729,8 +62729,8 @@
   - a poem whose meaning is conveyed through its graphic shape or pattern on the printed
     page.
   example:
-  - '‘The Mouse''s Tale’ is a concrete poem by Lewis Carroll which appears in his
-    novel Alice''s Adventures in Wonderland.'
+  - ‘The Mouse's Tale’ is a concrete poem by Lewis Carroll which appears in his novel
+    Alice's Adventures in Wonderland.
   hypernym:
   - 06389065-n
   members:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -34224,7 +34224,7 @@
   - a single written symbol that represents an entire word or phrase without indicating
     its pronunciation
   example:
-  - "`7' is a logogram that is pronounced `seven' in English and `nanatsu' in Japanese"
+  - '`7'' is a logogram that is pronounced `seven'' in English and `nanatsu'' in Japanese'
   hypernym:
   - 06853698-n
   ili: i72469
@@ -34312,8 +34312,8 @@
   partOfSpeech: n
 06855710-n:
   definition:
-  - a punctuation mark (`:') used after a word introducing a series or an example or
-    an explanation (or after the salutation of a business letter)
+  - a punctuation mark (`:') used after a word introducing a series or an example
+    or an explanation (or after the salutation of a business letter)
   hypernym:
   - 06854415-n
   ili: i72478
@@ -34342,8 +34342,8 @@
   partOfSpeech: n
 06856198-n:
   definition:
-  - a punctuation mark (`-') used between parts of a compound word or between the syllables
-    of a word when the word is divided at the end of a line of text
+  - a punctuation mark (`-') used between parts of a compound word or between the
+    syllables of a word when the word is divided at the end of a line of text
   hypernym:
   - 06854415-n
   ili: i72481
@@ -34378,8 +34378,8 @@
   partOfSpeech: n
 06856888-n:
   definition:
-  - (usually plural) one of a series of points (`…') indicating that something has been
-    omitted or that the sentence is incomplete
+  - (usually plural) one of a series of points (`…') indicating that something has
+    been omitted or that the sentence is incomplete
   exemplifies:
   - 06306016-n
   hypernym:
@@ -34521,8 +34521,8 @@
   partOfSpeech: n
 06864792-n:
   definition:
-  - a formally registered symbol (`™') identifying the manufacturer or distributor of a
-    product
+  - a formally registered symbol (`™') identifying the manufacturer or distributor
+    of a product
   exemplifies:
   - 92433720-n
   - 92460019-n
@@ -43777,8 +43777,8 @@
 06998382-n:
   definition:
   - a Chadic language spoken in Chad, in Guera Region, Guera department, Bitkine subprefecture,
-    below Guera massif, Moukoulou, Séguine, Doli, Morgué, Djarkatché (Mezimi),
-    and Gougué villages
+    below Guera massif, Moukoulou, Séguine, Doli, Morgué, Djarkatché (Mezimi), and
+    Gougué villages
   hypernym:
   - 06998552-n
   ili: i73353
@@ -62208,9 +62208,9 @@
   definition:
   - (linguistics, poetry) the use of isosyllabic verse.
   example:
-  - But it is likewise true that — especially in the context of the eighteenth century — anapestic
-    meter seemed somewhat flippant and irreverent in comparison with the staid isosyllabism
-    of iambic pentameter.
+  - But it is likewise true that — especially in the context of the eighteenth century
+    — anapestic meter seemed somewhat flippant and irreverent in comparison with the
+    staid isosyllabism of iambic pentameter.
   hypernym:
   - 07108269-n
   members:
@@ -62526,8 +62526,8 @@
   source: plWordNet 4.0
 92460709-n:
   definition:
-  - the variant readings, footnotes, etc. found in a scholarly work or a critical edition
-    of a text.
+  - the variant readings, footnotes, etc. found in a scholarly work or a critical
+    edition of a text.
   example:
   - The first printed edition of the New Testament with critical apparatus, noting
     variant readings among the manuscripts, was produced by the printer Robert Estienne
@@ -62573,8 +62573,8 @@
   definition:
   - a symbol that represents peace, in the form of three lines within a circle.
   example:
-  - In the 1950s the `peace sign' as it is known today, was designed as the logo
-    for the British Campaign for Nuclear Disarmament and adopted by anti-war and counterculture
+  - In the 1950s the `peace sign' as it is known today, was designed as the logo for
+    the British Campaign for Nuclear Disarmament and adopted by anti-war and counterculture
     activists in the United States and elsewhere.
   hypernym:
   - 06819327-n
@@ -62729,8 +62729,8 @@
   - a poem whose meaning is conveyed through its graphic shape or pattern on the printed
     page.
   example:
-  - "`The Mouse's Tale' is a concrete poem by Lewis Carroll which appears in his
-    novel Alice's Adventures in Wonderland."
+  - '`The Mouse''s Tale'' is a concrete poem by Lewis Carroll which appears in his
+    novel Alice''s Adventures in Wonderland.'
   hypernym:
   - 06389065-n
   members:
@@ -62783,9 +62783,9 @@
     and that is often unaccented or contracted.
   example:
   - Most languages can adopt theme-rheme structure idiosyncratically — as for English,
-    we often use as for theme constructions — but topic-prominent languages use
-    systematic changes in syntax or even dedicated morpological elements such as the
-    Japanese clitic particle -wa to mark themes and to set them apart from rhemes.
+    we often use as for theme constructions — but topic-prominent languages use systematic
+    changes in syntax or even dedicated morpological elements such as the Japanese
+    clitic particle -wa to mark themes and to set them apart from rhemes.
   hypernym:
   - 06317223-n
   members:
@@ -62811,8 +62811,8 @@
   definition:
   - a piece of music composed for the Hungarian Csárdás dance.
   example:
-  - "The Csárdás is characterized by a variation in tempo: it starts out slowly
-    (lassú) and ends in a very fast tempo (friss, literally `fresh')."
+  - 'The Csárdás is characterized by a variation in tempo: it starts out slowly (lassú)
+    and ends in a very fast tempo (friss, literally `fresh'').'
   hypernym:
   - 07068473-n
   members:
@@ -62825,8 +62825,8 @@
   - a piece of music in the rhythm of the Hungarian Csárdás dance.
   example:
   - Classical composers who have used csárdás themes in their works include Emmerich
-    Kálmán, Franz Liszt, Johannes Brahms, Léo Delibes, Johann Strauss, Pablo de
-    Sarasate, Pyotr Ilyich Tchaikovsky and others.
+    Kálmán, Franz Liszt, Johannes Brahms, Léo Delibes, Johann Strauss, Pablo de Sarasate,
+    Pyotr Ilyich Tchaikovsky and others.
   hypernym:
   - 07051211-n
   members:
@@ -62948,8 +62948,8 @@
   - a meaningless chant or expression used in conjuring or incantation.
   example:
   - This claim is substantiated by the fact that in the Netherlands, the words `Hocus
-    pocus' are usually accompanied by the additional words `pilatus pas', and this is
-    said to be based on a post-Reformation parody of the traditional Catholic ritual
+    pocus' are usually accompanied by the additional words `pilatus pas', and this
+    is said to be based on a post-Reformation parody of the traditional Catholic ritual
     of transubstantiation during mass, being a Dutch corruption of the Latin words
     `Hoc est corpus', meaning `this is (my) body', and the credo `sub Pontio Pilato
     passus et sepultus est', meaning `under Pontius Pilate he suffered and was buried'.
@@ -63085,9 +63085,9 @@
     of the Ethiopian Church.
   example:
   - Some linguists do not believe that Geʻez constitutes the common ancestor of modern
-    Ethiopian languages, but that Geʻez became a separate language early on from
-    some hypothetical, completely unattested language, and can thus be seen as an
-    extinct sister language of Tigre and Tigrinya.
+    Ethiopian languages, but that Geʻez became a separate language early on from some
+    hypothetical, completely unattested language, and can thus be seen as an extinct
+    sister language of Tigre and Tigrinya.
   hypernym:
   - 06999554-n
   members:
@@ -63100,8 +63100,7 @@
   example:
   - 'Standard Hungarian has 14 vowels in a symmetrical system: seven short vowels
     (a, e, i, o, ö, u, ü) and seven long ones, which are written with an acute accent
-    in the case of á, é, í, ó, ú, and with the double acute in the case of ő,
-    ű.'
+    in the case of á, é, í, ó, ú, and with the double acute in the case of ő, ű.'
   hypernym:
   - 06835082-n
   members:
@@ -63215,8 +63214,8 @@
   source: plWordNet 4.0
 92462179-n:
   definition:
-  - the form of a verb used to describe an action that happened before
-    the present time and is no longer happening.
+  - the form of a verb used to describe an action that happened before the present
+    time and is no longer happening.
   example:
   - Regular verbs form the simple past in -ed; however there are a few hundred irregular
     verbs with different forms.
@@ -63270,9 +63269,9 @@
   definition:
   - the name of an object which may be perceived by one or more of the five senses.
   example:
-  - "`Kitten' is an example of a concrete noun. A kitten registers with the five senses:
-    you can see a kitten, pet its fur, smell its breath, hear it purr and taste its
-    kisses."
+  - '`Kitten'' is an example of a concrete noun. A kitten registers with the five
+    senses: you can see a kitten, pet its fur, smell its breath, hear it purr and
+    taste its kisses.'
   hypernym:
   - 06330286-n
   members:
@@ -63986,8 +63985,8 @@
   - title of the member of any of several religious orders that cared for the sick
     in hospitals.
   example:
-  - The person who had the title of hospitaller was in charge of all the hospital staff,
-    its brothers on the wards, its sisters, lay brothers, servants, and specialized
+  - The person who had the title of hospitaller was in charge of all the hospital
+    staff, its brothers on the wards, its sisters, lay brothers, servants, and specialized
     employees.
   hypernym:
   - 06350786-n
@@ -64130,8 +64129,8 @@
     is important to the text's interpretation.
   example:
   - What caught my eye about this is that it bears interesting relation to Bakhtin's
-    concept of the dialogism of the `living word' — in fact, capitalize that `w'
-    and it would be downright eerie.
+    concept of the dialogism of the `living word' — in fact, capitalize that `w' and
+    it would be downright eerie.
   hypernym:
   - 07112859-n
   members:
@@ -64322,8 +64321,8 @@
     or on coins or medals.
   example:
   - One practice was rendering an over-used, formulaic phrase only as a siglum, e.g.
-    RIP for `requiescat in pace' (`Rest in Peace'), because the long-form written usage
-    of the abbreviated phrase, itself, was rare.
+    RIP for `requiescat in pace' (`Rest in Peace'), because the long-form written
+    usage of the abbreviated phrase, itself, was rare.
   hypernym:
   - 06831828-n
   members:
@@ -64590,10 +64589,10 @@
   source: plWordNet 4.0
 92465794-n:
   definition:
-  - "A rhetorical figure resulting from a reverted arrangement in the last clause
+  - 'A rhetorical figure resulting from a reverted arrangement in the last clause
     of a sentence of the two principal words of the clause preceding; inversion of
     the members of an antithesis: as, `A poem is a speaking picture; a picture a mute
-    poem'."
+    poem''.'
   example:
   - I am not of Paracelsus's mind, that boldly delivers a receipt to make a man without
     conjunction; yet cannot but wonder at the multitude of heads that do deny traduction,
@@ -64651,8 +64650,8 @@
     on a remote computer.
   example:
   - Your Web browser is a client program that has requested a service from a server;
-    in fact, the service and resource the server provided is the delivery of this Web
-    page.
+    in fact, the service and resource the server provided is the delivery of this
+    Web page.
   hypernym:
   - 06581154-n
   members:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -64076,9 +64076,7 @@
   definition:
   - The name of a Saint taken as a proper name.
   example:
-  - This Native place name was used for a while in parallel with the hagionym Saint-Francois-Xavier
-    (1850s) as well as another ”official” toponym, Grantown, named after Cuthbert
-    Grant.
+  - This Native place name was used for a while in parallel with the hagionym Saint-Francois-Xavier (1850s) as well as another `official' toponym, Grantown, named after Cuthbert Grant.
   hypernym:
   - 06349648-n
   members:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -64622,7 +64622,7 @@
   definition:
   - an Indo-European language that shows distinctive preservation of the Proto-Indo-European
     labiovelars and that shows a historical development of velar articulations, as
-    the sounds (k) or [kh] from Proto-Indo-European palatal phonemes.
+    the sounds [k] or [kh] from Proto-Indo-European palatal phonemes.
   example:
   - The Centum languages show characteristic plain velars and labiovelars articulated
     at the back of the mouth in inherited Indo-European lexical items.

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -63554,8 +63554,8 @@
   definition:
   - nasalization that consists of an oral vowel followed by a nasal semivowel.
   example:
-  - It is only before a fricative (and for `ą´ in word-final position) that `ę´ and `ą´
-    are pronounced as asynchronous nasal vowels, that is, /eu/ and /ou/.
+  - It is only before a fricative (and for `ą´ in word-final position) that `ę´ and
+    `ą´ are pronounced as asynchronous nasal vowels, that is, /eu/ and /ou/.
   - Before a fricative and in word-final position (in the case of ą) they are transcribed
     as an oral vowel /ɔ, ɛ/ followed by a nasal consonant /ɲ, ŋ/ or /j̃, w̃/
   hypernym:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -64077,7 +64077,8 @@
   - The name of a Saint taken as a proper name.
   example:
   - This Native place name was used for a while in parallel with the hagionym Saint-Francois-Xavier
-    (1850s) as well as another `official´ toponym, Grantown, named after Cuthbert Grant.
+    (1850s) as well as another `official´ toponym, Grantown, named after Cuthbert
+    Grant.
   hypernym:
   - 06349648-n
   members:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -61708,7 +61708,7 @@
 92423912-n:
   definition:
   - (phonetics, of a consonant) The property of being spoken without vibration of
-    the vocal cords, as [t], [s], or [f].
+    the vocal cords, as /t/, /s/, or /f/.
   example:
   - Instead, he plans to maintain voicelessness of the consonant and an unintended
     consequence of that effort is a pitch perturbation following release.
@@ -63150,8 +63150,8 @@
     the alveolar ridge.
   example:
   - The sibilant postalveolars (i.e. fricatives and affricates) are sometimes called
-    `hush consonants´ because they include the sound [ʃ] of English `Shhh!´ (as distinguished
-    from the `hiss´ consonant [s], as in `Ssss!´).
+    `hush consonants´ because they include the sound /ʃ/ of English `Shhh!´ (as distinguished
+    from the `hiss´ consonant /s/, as in `Ssss!´).
   hypernym:
   - 07129729-n
   members:
@@ -63554,8 +63554,10 @@
   definition:
   - nasalization that consists of an oral vowel followed by a nasal semivowel.
   example:
-  - It is only before a fricative (and for a in word-final position) that e and a
-    are pronounced as asynchronous nasal vowels, that is, [eu] and [ou].
+  - It is only before a fricative (and for `ą´ in word-final position) that `ę´ and `ą´
+    are pronounced as asynchronous nasal vowels, that is, /eu/ and /ou/.
+  - Before a fricative and in word-final position (in the case of ą) they are transcribed
+    as an oral vowel /ɔ, ɛ/ followed by a nasal consonant /ɲ, ŋ/ or /j̃, w̃/
   hypernym:
   - 07132710-n
   members:
@@ -64622,7 +64624,7 @@
   definition:
   - an Indo-European language that shows distinctive preservation of the Proto-Indo-European
     labiovelars and that shows a historical development of velar articulations, as
-    the sounds [k] or [kh] from Proto-Indo-European palatal phonemes.
+    the sounds /k/ or /kʰ/ (`kh´) from Proto-Indo-European palatal phonemes.
   example:
   - The Centum languages show characteristic plain velars and labiovelars articulated
     at the back of the mouth in inherited Indo-European lexical items.

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -2159,7 +2159,7 @@
   partOfSpeech: n
 06301026-n:
   definition:
-  - a word that is formed with a suffix (such as -let or -kin) to indicate smallness
+  - a word that is formed with a suffix (such as `-let´ or `-kin´) to indicate smallness
   hypernym:
   - 06297048-n
   ili: i69556
@@ -2938,8 +2938,8 @@
   partOfSpeech: n
 06317935-n:
   definition:
-  - a morpheme that occurs only as part of a larger construction; e.g. an -s at the
-    end of plural nouns
+  - a morpheme that occurs only as part of a larger construction; e.g. an `-s´ at
+    the end of plural nouns
   hypernym:
   - 06317223-n
   ili: i69627
@@ -3000,7 +3000,7 @@
   definition:
   - the end of a word (a suffix or inflectional ending or final morpheme)
   example:
-  - I don't like words that have -ism as an ending
+  - I don't like words that have `-ism´ as an ending
   hypernym:
   - 06317223-n
   ili: i69633
@@ -4069,8 +4069,8 @@
   partOfSpeech: n
 06339200-n:
   definition:
-  - a personal pronoun compounded with -self to show the agent's action affects the
-    agent
+  - a personal pronoun compounded with `-self´ to show the agent's action affects
+    the agent
   hypernym:
   - 06338129-n
   ili: i69733
@@ -4216,7 +4216,7 @@
   wikidata: Q1527589
 06342007-n:
   definition:
-  - a participle expressing present action; in English is formed by adding -ing
+  - a participle expressing present action; in English is formed by adding `-ing´
   hypernym:
   - 06341521-n
   ili: i69747
@@ -4483,8 +4483,8 @@
 06347202-n:
   definition:
   - a family name derived from name of your father or a paternal ancestor (especially
-    with an affix (such as -son in English or O'- in Irish) added to the name of your
-    father or a paternal ancestor)
+    with an affix (such as `-son´ in English or `O'-´ in Irish) added to the name
+    of your father or a paternal ancestor)
   domain_region:
   - 08878165-n
   hypernym:
@@ -62785,7 +62785,7 @@
   - Most languages can adopt theme-rheme structure idiosyncratically — as for English,
     we often use as for theme constructions — but topic-prominent languages use systematic
     changes in syntax or even dedicated morpological elements such as the Japanese
-    clitic particle -wa to mark themes and to set them apart from rhemes.
+    clitic particle `-wa´ to mark themes and to set them apart from rhemes.
   hypernym:
   - 06317223-n
   members:
@@ -63190,7 +63190,7 @@
   source: plWordNet 4.0
 92462177-n:
   definition:
-  - an aorist formed by adding sigma or -s to the stem.
+  - an aorist formed by adding sigma or `-s´ to the stem.
   example:
   - The sigmatic aorist has disappeared in Baltic, so our information on this category
     is limited to the Slavic data.
@@ -63202,7 +63202,7 @@
   source: plWordNet 4.0
 92462178-n:
   definition:
-  - an aorist that lacks the sigma or -s phoneme.
+  - an aorist that lacks the sigma or `-s´ phoneme.
   example:
   - Over time, the asigmatic aorist became increasingly marked as an archaic language
     feature and was eventually replaced by the other two aorist formations.
@@ -63217,7 +63217,7 @@
   - the form of a verb used to describe an action that happened before the present
     time and is no longer happening.
   example:
-  - Regular verbs form the simple past in -ed; however there are a few hundred irregular
+  - Regular verbs form the simple past in `-ed´; however there are a few hundred irregular
     verbs with different forms.
   hypernym:
   - 06341255-n
@@ -63318,7 +63318,7 @@
   - That state of an adverb indicating simple quality, without comparison or relation
     to increase or diminution.
   example:
-  - An example using a positive-degree adverb that doesn't end in -ly would be the
+  - An example using a positive-degree adverb that doesn't end in `-ly´ would be the
     adverb `fast´ in the sentence, `She drove fast´.
   hypernym:
   - 06333461-n
@@ -63529,7 +63529,7 @@
   definition:
   - a morpheme that signifies the past tense of a verb.
   example:
-  - In English, The most popular past tense morpheme is indicated by the suffix -ed
+  - In English, The most popular past tense morpheme is indicated by the suffix `-ed´
     added to regular verbs.
   hypernym:
   - 06317596-n
@@ -63789,7 +63789,7 @@
   - a syllable ended by a vowel or diphthong.
   example:
   - An open syllable occurs when a vowel is at the end of the syllable, resulting
-    in the long vowel sound, e.g. pa/per, e/ven, o/pen, go & we.
+    in the long vowel sound, e.g. `pa/per´, `e/ven´, `o/pen´, `go´ & `we´.
   hypernym:
   - 06315661-n
   members:
@@ -63946,9 +63946,9 @@
 92463361-n:
   definition:
   - a speech sound having as an obvious concomitant an audible puff of breath, as
-    initial stop consonants or initial h -sounds.
+    initial stop consonants or initial /h/ sounds.
   example:
-  - The p in English pot is an aspirate, but the p in spot is not.
+  - The `p´ in English `pot´ is an aspirate, but the `p´ in `spot´ is not.
   hypernym:
   - 07125755-n
   members:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -723,7 +723,7 @@
   example:
   - the mail handles billions of items every day
   - he works for the United States mail service
-  - in England they call mail `the post´
+  - in England they call mail ‘the post’
   hypernym:
   - 06262268-n
   ili: i69425
@@ -1425,8 +1425,8 @@
   partOfSpeech: n
 06286794-n:
   definition:
-  - third-class mail consisting of advertising and often addressed to `resident´ or
-    `occupant´
+  - third-class mail consisting of advertising and often addressed to ‘resident’ or
+    ‘occupant’
   hypernym:
   - 06286630-n
   ili: i69491
@@ -2043,7 +2043,7 @@
   - a word that expresses a meaning opposed to the meaning of another word, in which
     case the two words are antonyms of each other
   example:
-  - to him the antonym of `gay´ was `depressed´
+  - to him the antonym of ‘gay’ was ‘depressed’
   hypernym:
   - 06297048-n
   ili: i69547
@@ -2074,9 +2074,9 @@
   definition:
   - a new word formed by joining two others and combining their meanings
   example:
-  - '`smog´ is a blend of `smoke´ and `fog´'
-  - '`motel´ is a portmanteau word made by combining `motor´ and `hotel´'
-  - '`brunch´ is a well-known portmanteau'
+  - '‘smog’ is a blend of ‘smoke’ and ‘fog’'
+  - '‘motel’ is a portmanteau word made by combining ‘motor’ and ‘hotel’'
+  - '‘brunch’ is a well-known portmanteau'
   hypernym:
   - 06305222-n
   ili: i69549
@@ -2121,8 +2121,8 @@
   definition:
   - a word formed from two or more words by omitting or combining some sounds
   example:
-  - '`won''t´ is a contraction of `will not´'
-  - '`o''clock´ is a contraction of `of the clock´'
+  - '‘won''t’ is a contraction of ‘will not’'
+  - '‘o''clock’ is a contraction of ‘of the clock’'
   hypernym:
   - 06297048-n
   ili: i69553
@@ -2150,7 +2150,7 @@
   domain_topic:
   - 06182505-n
   example:
-  - '`electricity´ is a derivative of `electric´'
+  - '‘electricity’ is a derivative of ‘electric’'
   hypernym:
   - 06297048-n
   ili: i69555
@@ -2159,7 +2159,7 @@
   partOfSpeech: n
 06301026-n:
   definition:
-  - a word that is formed with a suffix (such as `-let´ or `-kin´) to indicate smallness
+  - a word that is formed with a suffix (such as ‘-let’ or ‘-kin’) to indicate smallness
   hypernym:
   - 06297048-n
   ili: i69556
@@ -2170,7 +2170,7 @@
   definition:
   - a word that is considered to be unmentionable
   example:
-  - '`failure´ is a dirty word to him'
+  - '‘failure’ is a dirty word to him'
   hypernym:
   - 06297048-n
   ili: i69557
@@ -2277,7 +2277,7 @@
   definition:
   - two words are heteronyms if they are spelled the same way but differ in pronunciation
   example:
-  - the word `bow´ is an example of a heteronym
+  - the word ‘bow’ is an example of a heteronym
   hypernym:
   - 06297048-n
   ili: i69566
@@ -2288,7 +2288,7 @@
   definition:
   - a word that names the whole of which a given word is a part
   example:
-  - '`hat´ is a holonym for `brim´ and `crown´'
+  - '‘hat’ is a holonym for ‘brim’ and ‘crown’'
   hypernym:
   - 06297048-n
   ili: i69567
@@ -2339,7 +2339,7 @@
   partOfSpeech: n
 06304010-n:
   definition:
-  - a word that is composed of parts from different languages (e.g., `monolingual´
+  - a word that is composed of parts from different languages (e.g., ‘monolingual’
     has a Greek prefix and a Latin root)
   domain_region:
   - 08798733-n
@@ -2355,7 +2355,7 @@
   partOfSpeech: n
 06304241-n:
   definition:
-  - a word borrowed from another language; e.g. `blitz´ is a German word borrowed
+  - a word borrowed from another language; e.g. ‘blitz’ is a German word borrowed
     into modern English
   hypernym:
   - 06297048-n
@@ -2378,7 +2378,7 @@
   definition:
   - a word that names a part of a larger whole
   example:
-  - '`brim´ and `crown´ are meronyms of `hat´'
+  - '‘brim’ and ‘crown’ are meronyms of ‘hat’'
   hypernym:
   - 06297048-n
   ili: i69575
@@ -2402,7 +2402,7 @@
   definition:
   - an anagram that means the opposite of the original word or phrase
   example:
-  - '`restful´ is the antigram of `fluster´'
+  - '‘restful’ is the antigram of ‘fluster’'
   hypernym:
   - 06298291-n
   ili: i69577
@@ -2463,7 +2463,7 @@
   definition:
   - a word serving as the basis for inflected or derived forms
   example:
-  - '`pick´ is the primitive from which `picket´ is derived'
+  - '‘pick’ is the primitive from which ‘picket’ is derived'
   hypernym:
   - 06297048-n
   ili: i69583
@@ -2570,9 +2570,9 @@
 06312002-n:
   definition:
   - one of the eight sayings of Jesus at the beginning of the Sermon on the Mount;
-    in Latin each saying begins with `beatus´ (blessed)
+    in Latin each saying begins with ‘beatus’ (blessed)
   example:
-  - her favorite Beatitude is `Blessed are the meek for they shall inherit the earth´
+  - her favorite Beatitude is ‘Blessed are the meek for they shall inherit the earth’
   hypernym:
   - 07166088-n
   ili: i69592
@@ -2593,7 +2593,7 @@
   definition:
   - an expression introduced into one language by translating it from another language
   example:
-  - '`superman´ is a calque for the German `Ubermensch´'
+  - '‘superman’ is a calque for the German ‘Ubermensch’'
   hypernym:
   - 07166088-n
   ili: i69594
@@ -2613,7 +2613,7 @@
   partOfSpeech: n
 06312782-n:
   definition:
-  - word (such a `some´ or `less´) that is used to indicate a part as distinct from
+  - word (such a ‘some’ or ‘less’) that is used to indicate a part as distinct from
     a whole
   hypernym:
   - 06297048-n
@@ -2653,7 +2653,7 @@
   partOfSpeech: n
 06313371-n:
   definition:
-  - (grammar) a word that expresses a quantity (as `fifteen´ or `many´)
+  - (grammar) a word that expresses a quantity (as ‘fifteen’ or ‘many’)
   domain_topic:
   - 06184139-n
   hypernym:
@@ -2664,7 +2664,7 @@
   partOfSpeech: n
 06313532-n:
   definition:
-  - (logic) a word (such as `some´ or `all´ or `no´) that binds the variables in a
+  - (logic) a word (such as ‘some’ or ‘all’ or ‘no’) that binds the variables in a
     logical proposition
   domain_topic:
   - 06173467-n
@@ -2710,8 +2710,8 @@
   definition:
   - a word introduced because an existing term has become inadequate
   example:
-  - Nobody ever heard of analog clocks until digital clocks became common, so `analog
-    clock´ is a retronym
+  - Nobody ever heard of analog clocks until digital clocks became common, so ‘analog
+    clock’ is a retronym
   hypernym:
   - 06297048-n
   ili: i69605
@@ -2777,7 +2777,7 @@
   definition:
   - a word that denotes a manner of doing something
   example:
-  - '`march´ is a troponym of `walk´'
+  - '‘march’ is a troponym of ‘walk’'
   hypernym:
   - 06297048-n
   ili: i69611
@@ -2799,7 +2799,7 @@
   definition:
   - a unit of spoken language larger than a phoneme
   example:
-  - the word `pocket´ has two syllables
+  - the word ‘pocket’ has two syllables
   hypernym:
   - 06294878-n
   ili: i69613
@@ -2867,7 +2867,7 @@
   partOfSpeech: n
 06316706-n:
   definition:
-  - antonyms that are commonly associated (e.g., `wet´ and `dry´)
+  - antonyms that are commonly associated (e.g., ‘wet’ and ‘dry’)
   hypernym:
   - 06298695-n
   ili: i69620
@@ -2876,8 +2876,8 @@
   partOfSpeech: n
 06316828-n:
   definition:
-  - antonyms whose opposition is mediated (e.g., the antonymy of `wet´ and `parched´
-    is mediated by the similarity of `parched´ to `dry´)
+  - antonyms whose opposition is mediated (e.g., the antonymy of ‘wet’ and ‘parched’
+    is mediated by the similarity of ‘parched’ to ‘dry’)
   hypernym:
   - 06298695-n
   ili: i69621
@@ -2886,8 +2886,8 @@
   partOfSpeech: n
 06317024-n:
   definition:
-  - a minimal unit (as a word or stem) in the lexicon of a language; `go´ and `went´
-    and `gone´ and `going´ are all members of the English lexeme `go´
+  - a minimal unit (as a word or stem) in the lexicon of a language; ‘go’ and ‘went’
+    and ‘gone’ and ‘going’ are all members of the English lexeme ‘go’
   hypernym:
   - 06294878-n
   ili: i69622
@@ -2918,7 +2918,7 @@
   definition:
   - a variant phonological representation of a morpheme
   example:
-  - the final sounds of `bets´ and `beds´ and `horses´ and `oxen´ are allomorphs of
+  - the final sounds of ‘bets’ and ‘beds’ and ‘horses’ and ‘oxen’ are allomorphs of
     the English plural morpheme
   hypernym:
   - 06317223-n
@@ -2938,7 +2938,7 @@
   partOfSpeech: n
 06317935-n:
   definition:
-  - a morpheme that occurs only as part of a larger construction; e.g. an `-s´ at
+  - a morpheme that occurs only as part of a larger construction; e.g. an ‘-s’ at
     the end of plural nouns
   hypernym:
   - 06317223-n
@@ -2951,7 +2951,7 @@
   definition:
   - a bound form used only in compounds
   example:
-  - '`hemato-´ is a combining form in words like `hematology´'
+  - '‘hemato-’ is a combining form in words like ‘hematology’'
   hypernym:
   - 06317935-n
   ili: i69628
@@ -3000,7 +3000,7 @@
   definition:
   - the end of a word (a suffix or inflectional ending or final morpheme)
   example:
-  - I don't like words that have `-ism´ as an ending
+  - I don't like words that have ‘-ism’ as an ending
   hypernym:
   - 06317223-n
   ili: i69633
@@ -3208,7 +3208,7 @@
   definition:
   - a word in the genitive case that is used as an attributive adjective
   example:
-  - an example of the attributive genetive is `John's´ in `John's mother´
+  - an example of the attributive genetive is ‘John's’ in ‘John's mother’
   hypernym:
   - 06322842-n
   ili: i69652
@@ -3361,8 +3361,8 @@
   definition:
   - a clause introduced by a relative pronoun
   example:
-  - '`who visits frequently´ is a relative clause in the sentence `John, who visits
-    frequently, is ill´'
+  - '‘who visits frequently’ is a relative clause in the sentence ‘John, who visits
+    frequently, is ill’'
   hypernym:
   - 06325134-n
   ili: i69666
@@ -3472,7 +3472,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '`Socrates is a man´ predicates manhood of Socrates'
+  - '‘Socrates is a man’ predicates manhood of Socrates'
   hypernym:
   - 06764688-n
   ili: i69676
@@ -3481,7 +3481,7 @@
   partOfSpeech: n
 06328100-n:
   definition:
-  - an infinitive with an adverb between `to´ and the verb (e.g., `to boldly go´)
+  - an infinitive with an adverb between ‘to’ and the verb (e.g., ‘to boldly go’)
   hypernym:
   - 06329897-n
   ili: i69677
@@ -3549,7 +3549,7 @@
   partOfSpeech: n
 06329345-n:
   definition:
-  - a noun formed from a verb (such as the `-ing´ form of an English verb when used
+  - a noun formed from a verb (such as the ‘-ing’ form of an English verb when used
     as a noun)
   hypernym:
   - 06331307-n
@@ -3569,7 +3569,7 @@
   partOfSpeech: n
 06329715-n:
   definition:
-  - an auxiliary verb (such as `can´ or `will´) that is used to express modality
+  - an auxiliary verb (such as ‘can’ or ‘will’) that is used to express modality
   hypernym:
   - 06329506-n
   ili: i69686
@@ -3688,7 +3688,7 @@
   definition:
   - an adjective used as a noun
   example:
-  - '`meek´ in `blessed are the meek´ is an adnoun'
+  - '‘meek’ in ‘blessed are the meek’ is an adnoun'
   hypernym:
   - 06331146-n
   ili: i69698
@@ -3720,8 +3720,8 @@
   definition:
   - a modifier that has little meaning except to intensify the meaning it modifies
   example:
-  - '`up´ in `finished up´ is an intensifier'
-  - '`honestly´ in `I honestly don''t know´ is an intensifier'
+  - '‘up’ in ‘finished up’ is an intensifier'
+  - '‘honestly’ in ‘I honestly don''t know’ is an intensifier'
   hypernym:
   - 06331794-n
   ili: i69701
@@ -3743,7 +3743,7 @@
 06332925-n:
   definition:
   - an adjective that ascribes to its noun the value of an attribute of that noun
-    (e.g., `a nervous person´ or `a musical speaking voice´)
+    (e.g., ‘a nervous person’ or ‘a musical speaking voice’)
   hypernym:
   - 06332695-n
   ili: i69703
@@ -3753,8 +3753,8 @@
   partOfSpeech: n
 06333150-n:
   definition:
-  - an adjective that classifies its noun (e.g., `a nervous disease´ or `a musical
-    instrument´)
+  - an adjective that classifies its noun (e.g., ‘a nervous disease’ or ‘a musical
+    instrument’)
   hypernym:
   - 06332695-n
   ili: i69704
@@ -3789,9 +3789,9 @@
   definition:
   - the comparative form of an adjective or adverb
   example:
-  - '`faster´ is the comparative of the adjective `fast´'
-  - '`less famous´ is the comparative degree of the adjective `famous´'
-  - '`more surely´ is the comparative of the adverb `surely´'
+  - '‘faster’ is the comparative of the adjective ‘fast’'
+  - '‘less famous’ is the comparative degree of the adjective ‘famous’'
+  - '‘more surely’ is the comparative of the adverb ‘surely’'
   hypernym:
   - 06332695-n
   - 06334605-n
@@ -3804,9 +3804,9 @@
   definition:
   - the superlative form of an adjective or adverb
   example:
-  - '`fastest´ is the superlative of the adjective `fast´'
-  - '`least famous´ is the superlative degree of the adjective `famous´'
-  - '`most surely´ is the superlative of the adverb `surely´'
+  - '‘fastest’ is the superlative of the adjective ‘fast’'
+  - '‘least famous’ is the superlative degree of the adjective ‘famous’'
+  - '‘most surely’ is the superlative of the adverb ‘surely’'
   hypernym:
   - 06332695-n
   - 06334605-n
@@ -3829,7 +3829,7 @@
 06334815-n:
   definition:
   - 'a word or phrase apparently modifying an unintended word because of its placement
-    in a sentence: e.g., `when young´ in `when young, circuses appeal to all of us´'
+    in a sentence: e.g., ‘when young’ in ‘when young, circuses appeal to all of us’'
   hypernym:
   - 06331794-n
   ili: i69710
@@ -3841,8 +3841,8 @@
 06335079-n:
   definition:
   - 'a participle (usually at the beginning of a sentence) apparently modifying a
-    word other than the word intended: e.g., `flying across the country´ in `flying
-    across the country the Rockies came into view´'
+    word other than the word intended: e.g., ‘flying across the country’ in ‘flying
+    across the country the Rockies came into view’'
   hypernym:
   - 06334815-n
   ili: i69711
@@ -3883,7 +3883,7 @@
   partOfSpeech: n
 06335857-n:
   definition:
-  - a determiner (as `the´ in English) that indicates specificity of reference
+  - a determiner (as ‘the’ in English) that indicates specificity of reference
   hypernym:
   - 06335662-n
   ili: i69715
@@ -3892,7 +3892,7 @@
   partOfSpeech: n
 06335994-n:
   definition:
-  - a determiner (as `a´ or `some´ in English) that indicates nonspecific reference
+  - a determiner (as ‘a’ or ‘some’ in English) that indicates nonspecific reference
   hypernym:
   - 06335662-n
   ili: i69716
@@ -3953,7 +3953,7 @@
   partOfSpeech: n
 06337047-n:
   definition:
-  - a conjunction (like `and´ or `or´) that connects two identically constructed grammatical
+  - a conjunction (like ‘and’ or ‘or’) that connects two identically constructed grammatical
     constituents
   hypernym:
   - 06336819-n
@@ -3963,7 +3963,7 @@
   partOfSpeech: n
 06337219-n:
   definition:
-  - a conjunction (like `since´ or `that´ or `who´) that introduces a dependent clause
+  - a conjunction (like ‘since’ or ‘that’ or ‘who’) that introduces a dependent clause
   hypernym:
   - 06336819-n
   ili: i69723
@@ -4016,10 +4016,10 @@
   partOfSpeech: n
 06338254-n:
   definition:
-  - a pronoun or pronominal phrase (as `each other´) that expresses a mutual action
+  - a pronoun or pronominal phrase (as ‘each other’) that expresses a mutual action
     or relationship between the individuals indicated in the plural subject
   example:
-  - The sentence `They cared for each other´ contains a reciprocal pronoun
+  - The sentence ‘They cared for each other’ contains a reciprocal pronoun
   hypernym:
   - 06336363-n
   ili: i69728
@@ -4028,7 +4028,7 @@
   partOfSpeech: n
 06338544-n:
   definition:
-  - a pronoun (as `that´ or `which´ or `who´) that introduces a relative clause referring
+  - a pronoun (as ‘that’ or ‘which’ or ‘who’) that introduces a relative clause referring
     to some antecedent
   hypernym:
   - 06336363-n
@@ -4069,7 +4069,7 @@
   partOfSpeech: n
 06339200-n:
   definition:
-  - a personal pronoun compounded with `-self´ to show the agent's action affects
+  - a personal pronoun compounded with ‘-self’ to show the agent's action affects
     the agent
   hypernym:
   - 06338129-n
@@ -4082,8 +4082,8 @@
   definition:
   - a verb whose agent performs an action that is directed at the agent
   example:
-  - the sentence `he washed´ has a reflexive verb
-  - '`perjure´ is a reflexive verb because you cannot perjure anyone but yourself'
+  - the sentence ‘he washed’ has a reflexive verb
+  - '‘perjure’ is a reflexive verb because you cannot perjure anyone but yourself'
   hypernym:
   - 06331562-n
   ili: i69734
@@ -4206,7 +4206,7 @@
   - an English verb followed by one or more particles where the combination behaves
     as a syntactic and semantic unit
   example:
-  - '`turn out´ is a phrasal verb in the question `how many turned out to vote?´'
+  - '‘turn out’ is a phrasal verb in the question ‘how many turned out to vote?’'
   hypernym:
   - 06329055-n
   ili: i69746
@@ -4216,7 +4216,7 @@
   wikidata: Q1527589
 06342007-n:
   definition:
-  - a participle expressing present action; in English is formed by adding `-ing´
+  - a participle expressing present action; in English is formed by adding ‘-ing’
   hypernym:
   - 06341521-n
   ili: i69747
@@ -4382,7 +4382,7 @@
   partOfSpeech: n
 06345388-n:
   definition:
-  - an additional name or an epithet appended to a name (as in `Ferdinand the Great´)
+  - an additional name or an epithet appended to a name (as in ‘Ferdinand the Great’)
   hypernym:
   - 06344646-n
   ili: i69762
@@ -4483,7 +4483,7 @@
 06347202-n:
   definition:
   - a family name derived from name of your father or a paternal ancestor (especially
-    with an affix (such as `-son´ in English or `O'-´ in Irish) added to the name
+    with an affix (such as ‘-son’ in English or ‘O'-’ in Irish) added to the name
     of your father or a paternal ancestor)
   domain_region:
   - 08878165-n
@@ -4528,7 +4528,7 @@
   definition:
   - slang for something (especially for an illegal drug)
   example:
-  - '`smack´ is a street name for heroin'
+  - '‘smack’ is a street name for heroin'
   hypernym:
   - 06344646-n
   - 07171981-n
@@ -4631,7 +4631,7 @@
   definition:
   - a descriptive name for a place or thing
   example:
-  - the nickname for the U.S. Constitution is `Old Ironsides´
+  - the nickname for the U.S. Constitution is ‘Old Ironsides’
   hypernym:
   - 06344646-n
   ili: i69781
@@ -4716,7 +4716,7 @@
   definition:
   - a name of endearment (especially one using a diminutive suffix)
   example:
-  - '`Billy´ is a hypocorism for `William´'
+  - '‘Billy’ is a hypocorism for ‘William’'
   hypernym:
   - 06344646-n
   ili: i69789
@@ -4726,7 +4726,7 @@
   partOfSpeech: n
 06350786-n:
   definition:
-  - 'an identifying appellation signifying status or function: e.g. `Mr.´ or `General´'
+  - 'an identifying appellation signifying status or function: e.g. ‘Mr.’ or ‘General’'
   example:
   - the professor didn't like his friends to use his formal title
   hypernym:
@@ -4892,7 +4892,7 @@
   partOfSpeech: n
 06353232-n:
   definition:
-  - a Spanish title or form of address for a man; similar to the English `Mr´ or `sir´
+  - a Spanish title or form of address for a man; similar to the English ‘Mr’ or ‘sir’
   domain_topic:
   - 06979499-n
   hypernym:
@@ -4905,7 +4905,7 @@
 06353385-n:
   definition:
   - a Spanish title or form of address for a married woman; similar to the English
-    `Mrs´ or `madam´
+    ‘Mrs’ or ‘madam’
   domain_topic:
   - 06979499-n
   hypernym:
@@ -4918,7 +4918,7 @@
 06353552-n:
   definition:
   - a Spanish title or form of address used to or of an unmarried girl or woman; similar
-    to the English `Miss´
+    to the English ‘Miss’
   domain_topic:
   - 06979499-n
   hypernym:
@@ -4989,7 +4989,7 @@
   definition:
   - an appellation signifying nobility
   example:
-  - '`your majesty´ is the appropriate title to use in addressing a king'
+  - '‘your majesty’ is the appropriate title to use in addressing a king'
   hypernym:
   - 06350278-n
   ili: i69813
@@ -5018,7 +5018,7 @@
   definition:
   - the name of a work of art or literary composition etc.
   example:
-  - he looked for books with the word `jazz´ in the title
+  - he looked for books with the word ‘jazz’ in the title
   - he refused to give titles to his paintings
   - I can never remember movie titles
   hypernym:
@@ -6052,7 +6052,7 @@
 06372853-n:
   definition:
   - 'an ancient writing system: having alternate lines written in opposite directions;
-    literally `as the ox ploughs´'
+    literally ‘as the ox ploughs’'
   hypernym:
   - 06362609-n
   ili: i69909
@@ -6974,8 +6974,8 @@
   definition:
   - a witty satiric verse containing two rhymed couplets and mentioning a famous person
   example:
-  - '`The president is George W. Bush, Who is happy to sit on his tush, While sending
-    his armies to fight, For anything he thinks is right´ is a clerihew'
+  - '‘The president is George W. Bush, Who is happy to sit on his tush, While sending
+    his armies to fight, For anything he thinks is right’ is a clerihew'
   hypernym:
   - 06393492-n
   ili: i69998
@@ -7419,7 +7419,7 @@
   wikidata: Q1320248
 06397077-n:
   definition:
-  - (Roman Catholic Church) a Latin versicle meaning `lift up your hearts´
+  - (Roman Catholic Church) a Latin versicle meaning ‘lift up your hearts’
   domain_topic:
   - 08100476-n
   hypernym:
@@ -10067,7 +10067,7 @@
   partOfSpeech: n
 06442826-n:
   definition:
-  - (Hinduism) the sacred `song of God´ composed about 200 BC and incorporated into
+  - (Hinduism) the sacred ‘song of God’ composed about 200 BC and incorporated into
     the Mahabharata (a Sanskrit epic); contains a discussion between Krishna and the
     Indian hero Arjuna on human nature and the purpose of life
   domain_topic:
@@ -11383,7 +11383,7 @@
   partOfSpeech: n
 06469466-n:
   definition:
-  - (Roman Catholic Church) the Lord's Prayer in Latin; translates as `our father´
+  - (Roman Catholic Church) the Lord's Prayer in Latin; translates as ‘our father’
   domain_topic:
   - 08100476-n
   ili: i70396
@@ -11762,7 +11762,7 @@
   partOfSpeech: n
 06476089-n:
   definition:
-  - (from the Sanskrit word for `knowledge´) any of the most ancient sacred writings
+  - (from the Sanskrit word for ‘knowledge’) any of the most ancient sacred writings
     of Hinduism written in early Sanskrit; traditionally believed to comprise the
     Samhitas, the Brahmanas, the Aranyakas, and the Upanishads
   domain_topic:
@@ -11886,7 +11886,7 @@
   wikidata: Q6113985
 06478150-n:
   definition:
-  - (Sanskrit) literally a `sacred utterance´ in Vedism; one of a collection of orally
+  - (Sanskrit) literally a ‘sacred utterance’ in Vedism; one of a collection of orally
     transmitted poetic hymns
   domain_topic:
   - 06246956-n
@@ -12072,7 +12072,7 @@
   partOfSpeech: n
 06481268-n:
   definition:
-  - a summary list; as in e.g. `a news roundup´
+  - a summary list; as in e.g. ‘a news roundup’
   example:
   - a news roundup
   hypernym:
@@ -12223,7 +12223,7 @@
   partOfSpeech: n
 06484495-n:
   definition:
-  - an equating verb (such as `be´ or `become´) that links the subject with the complement
+  - an equating verb (such as ‘be’ or ‘become’) that links the subject with the complement
     of a sentence
   hypernym:
   - 06331562-n
@@ -12800,8 +12800,8 @@
   domain_topic:
   - 06182505-n
   example:
-  - '`Those girls, they giggle when they see me´ and `Cigarettes, you couldn''t pay
-    me to smoke them´ are examples of topicalization'
+  - '‘Those girls, they giggle when they see me’ and ‘Cigarettes, you couldn''t pay
+    me to smoke them’ are examples of topicalization'
   hypernym:
   - 07117611-n
   ili: i70523
@@ -17017,8 +17017,8 @@
   wikidata: Q1092720
 06564461-n:
   definition:
-  - the opinion joined by a majority of the court (generally known simply as `the
-    opinion´)
+  - the opinion joined by a majority of the court (generally known simply as ‘the
+    opinion’)
   domain_topic:
   - 08458195-n
   hypernym:
@@ -17459,7 +17459,7 @@
 06572245-n:
   definition:
   - the principal pleading by the defendant in response to plaintiff's complaint;
-    in criminal law it consists of the defendant's plea of `guilty´ or `not guilty´
+    in criminal law it consists of the defendant's plea of ‘guilty’ or ‘not guilty’
     (or nolo contendere); in civil law it must contain denials of all allegations
     in the plaintiff's complaint that the defendant hopes to controvert and it can
     contain affirmative defenses or counterclaims
@@ -17485,7 +17485,7 @@
   partOfSpeech: n
 06572930-n:
   definition:
-  - (law) an answer of `no contest´ by a defendant who does not admit guilt but that
+  - (law) an answer of ‘no contest’ by a defendant who does not admit guilt but that
     subjects him to conviction
   domain_topic:
   - 06551169-n
@@ -18909,7 +18909,7 @@
 06597379-n:
   definition:
   - a set of instructions inserted into a program that are designed to execute (or
-    `explode´) if a particular condition is satisfied; when exploded it may delete
+    ‘explode’) if a particular condition is satisfied; when exploded it may delete
     or corrupt data, or print a spurious message, or have other harmful effects
   example:
   - a disgruntled employee planted a logic bomb
@@ -19137,7 +19137,7 @@
   partOfSpeech: n
 06601633-n:
   definition:
-  - a database management system that allows strings of text (`objects´) to be processed
+  - a database management system that allows strings of text (‘objects’) to be processed
     as a complex network of nodes that are linked together in an arbitrary way
   hypernym:
   - 06601432-n
@@ -20040,7 +20040,7 @@
   partOfSpeech: n
 06617096-n:
   definition:
-  - an ambiguous grammatical construction; e.g., `they are flying planes´ can mean
+  - an ambiguous grammatical construction; e.g., ‘they are flying planes’ can mean
     either that someone is flying planes or that something is flying planes
   hypernym:
   - 06616672-n
@@ -20729,7 +20729,7 @@
   definition:
   - the principal (full-length) film in a program at a movie theater
   example:
-  - the feature tonight is `Casablanca´
+  - the feature tonight is ‘Casablanca’
   hypernym:
   - 06626039-n
   ili: i71227
@@ -21056,7 +21056,7 @@
   definition:
   - a program that is broadcast again
   example:
-  - she likes to watch `I love Lucy´ reruns
+  - she likes to watch ‘I love Lucy’ reruns
   hypernym:
   - 06631935-n
   ili: i71259
@@ -22112,7 +22112,7 @@
   definition:
   - a compilation of the known facts regarding something or someone
   example:
-  - Al Smith used to say, `Let's look at the record´
+  - Al Smith used to say, ‘Let's look at the record’
   - his name is in all the record books
   hypernym:
   - 06648784-n
@@ -23797,7 +23797,7 @@
   wikidata: Q42283
 06678357-n:
   definition:
-  - a common way to make software available; users are allowed to log in as `guest´
+  - a common way to make software available; users are allowed to log in as ‘guest’
     without a password and copy whatever has been made available
   hypernym:
   - 06678115-n
@@ -26378,8 +26378,8 @@
   partOfSpeech: n
 06720117-n:
   definition:
-  - the highest U.S. military decoration awarded for bravery and valor in action `above
-    and beyond the call of duty´
+  - the highest U.S. military decoration awarded for bravery and valor in action ‘above
+    and beyond the call of duty’
   hypernym:
   - 06719615-n
   ili: i71750
@@ -26864,7 +26864,7 @@
   partOfSpeech: n
 06727491-n:
   definition:
-  - (often used with `pay´) a formal expression of esteem
+  - (often used with ‘pay’) a formal expression of esteem
   example:
   - he paid his respects to the mayor
   hypernym:
@@ -27192,7 +27192,7 @@
   definition:
   - an epithet that can be used to smear someone's reputation
   example:
-  - he used the smear word `communist´ for everyone who disagreed with him
+  - he used the smear word ‘communist’ for everyone who disagreed with him
   hypernym:
   - 06733713-n
   ili: i71825
@@ -27368,7 +27368,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - '`I always lie´ is a paradox because if it is true it must be false'
+  - '‘I always lie’ is a paradox because if it is true it must be false'
   hypernym:
   - 07221547-n
   ili: i71840
@@ -28485,9 +28485,9 @@
   - a definition in which the term is used by embedding it in a larger expression
     containing its explanation
   example:
-  - a contextual definition of `legal duty´ might be `X has a legal duty to do Y means
+  - a contextual definition of ‘legal duty’ might be ‘X has a legal duty to do Y means
     that X is required to do Y by a contract relationship that would be upheld in
-    a court of law´
+    a court of law’
   hypernym:
   - 06757091-n
   ili: i71938
@@ -28537,7 +28537,7 @@
   definition:
   - the act of giving a new definition
   example:
-  - words like `conservative´ require periodic redefinition
+  - words like ‘conservative’ require periodic redefinition
   - she provided a redefinition of his duties
   hypernym:
   - 06757091-n
@@ -29446,7 +29446,7 @@
   definition:
   - an intentionally noncommittal or ambiguous statement
   example:
-  - when you say `maybe´ you are just hedging
+  - when you say ‘maybe’ you are just hedging
   hypernym:
   - 06773810-n
   ili: i72025
@@ -29786,7 +29786,7 @@
   - an aggressive remark directed at a person like a missile and intended to have
     a telling effect
   example:
-  - his parting shot was `drop dead´
+  - his parting shot was ‘drop dead’
   - she threw shafts of sarcasm
   - she takes a dig at me every chance she gets
   hypernym:
@@ -31397,7 +31397,7 @@
   definition:
   - an individual instance of a type of symbol
   example:
-  - the word `error´ contains three tokens of `r´
+  - the word ‘error’ contains three tokens of ‘r’
   hypernym:
   - 06819327-n
   ili: i72197
@@ -31409,7 +31409,7 @@
   definition:
   - all of the tokens of the same symbol
   example:
-  - the word `element´ contains five different types of character
+  - the word ‘element’ contains five different types of character
   hypernym:
   - 06819327-n
   ili: i72198
@@ -32460,7 +32460,7 @@
 06825973-n:
   definition:
   - the positive fractional part of the representation of a logarithm; in the expression
-    `log 643 = 2.808´ the mantissa is .808
+    ‘log 643 = 2.808’ the mantissa is .808
   hypernym:
   - 13754218-n
   ili: i72299
@@ -32471,7 +32471,7 @@
 06826168-n:
   definition:
   - the integer part (positive or negative) of the representation of a logarithm;
-    in the expression `log 643 = 2.808´ the characteristic is 2
+    in the expression ‘log 643 = 2.808’ the characteristic is 2
   hypernym:
   - 13750609-n
   ili: i72300
@@ -32789,7 +32789,7 @@
   partOfSpeech: n
 06832423-n:
   definition:
-  - a variant form of a grapheme, as `m´ or `M´ or a handwritten version of that grapheme
+  - a variant form of a grapheme, as ‘m’ or ‘M’ or a handwritten version of that grapheme
   hypernym:
   - 06831828-n
   ili: i72329
@@ -32981,7 +32981,7 @@
   wikidata: Q216042
 06835587-n:
   definition:
-  - a mark (`) placed above a vowel to indicate pronunciation
+  - a mark (‘) placed above a vowel to indicate pronunciation
   hypernym:
   - 06835082-n
   ili: i72347
@@ -33321,7 +33321,7 @@
   partOfSpeech: n
 06841249-n:
   definition:
-  - a sign (`%´) used to indicate that the number preceding it should be understood
+  - a sign (‘%’) used to indicate that the number preceding it should be understood
     as a proportion multiplied by 100
   hypernym:
   - 06831828-n
@@ -33397,7 +33397,7 @@
 06843888-n:
   definition:
   - 'two successive letters (especially two letters used to represent a single sound:
-    `sh´ in `shoe´)'
+    ‘sh’ in ‘shoe’)'
   hypernym:
   - 06841868-n
   ili: i72384
@@ -34126,8 +34126,8 @@
   definition:
   - a letter that has two or more pronunciations
   example:
-  - '`c´ is a polyphone because it is pronounced like `k´ in `car´ but like `s´ in
-    `cell´'
+  - '‘c’ is a polyphone because it is pronounced like ‘k’ in ‘car’ but like ‘s’ in
+    ‘cell’'
   hypernym:
   - 06841868-n
   ili: i72460
@@ -34224,7 +34224,7 @@
   - a single written symbol that represents an entire word or phrase without indicating
     its pronunciation
   example:
-  - '`7´ is a logogram that is pronounced `seven´ in English and `nanatsu´ in Japanese'
+  - '‘7’ is a logogram that is pronounced ‘seven’ in English and ‘nanatsu’ in Japanese'
   hypernym:
   - 06853698-n
   ili: i72469
@@ -34263,7 +34263,7 @@
   partOfSpeech: n
 06854923-n:
   definition:
-  - a punctuation mark (`&´) used to represent conjunction (and)
+  - a punctuation mark (‘&’) used to represent conjunction (and)
   hypernym:
   - 06854415-n
   ili: i72473
@@ -34272,7 +34272,7 @@
   partOfSpeech: n
 06855037-n:
   definition:
-  - the mark (`'´) used to indicate the omission of one or more letters from a printed
+  - the mark (‘'’) used to indicate the omission of one or more letters from a printed
     word
   hypernym:
   - 06854415-n
@@ -34282,7 +34282,7 @@
   partOfSpeech: n
 06855215-n:
   definition:
-  - either of two punctuation marks (`{´ or `}´) used to enclose textual material
+  - either of two punctuation marks (‘{’ or ‘}’) used to enclose textual material
   hypernym:
   - 06854415-n
   ili: i72475
@@ -34291,7 +34291,7 @@
   partOfSpeech: n
 06855340-n:
   definition:
-  - either of two punctuation marks (`[´ or `]´) used to enclose textual material
+  - either of two punctuation marks (‘[’ or ‘]’) used to enclose textual material
   hypernym:
   - 06854415-n
   ili: i72476
@@ -34301,7 +34301,7 @@
   partOfSpeech: n
 06855502-n:
   definition:
-  - either of two punctuation marks (`<´ or `>´) used in computer programming and
+  - either of two punctuation marks (‘<’ or ‘>’) used in computer programming and
     sometimes used to enclose textual material
   hypernym:
   - 06854415-n
@@ -34312,7 +34312,7 @@
   partOfSpeech: n
 06855710-n:
   definition:
-  - a punctuation mark (`:´) used after a word introducing a series or an example
+  - a punctuation mark (‘:’) used after a word introducing a series or an example
     or an explanation (or after the salutation of a business letter)
   hypernym:
   - 06854415-n
@@ -34322,7 +34322,7 @@
   partOfSpeech: n
 06855902-n:
   definition:
-  - a punctuation mark (`,´) used to indicate the separation of elements within the
+  - a punctuation mark (‘,’) used to indicate the separation of elements within the
     grammatical structure of a sentence
   hypernym:
   - 06854415-n
@@ -34332,7 +34332,7 @@
   partOfSpeech: n
 06856067-n:
   definition:
-  - a punctuation mark (`!´) used after an exclamation
+  - a punctuation mark (‘!’) used after an exclamation
   hypernym:
   - 06854415-n
   ili: i72480
@@ -34342,7 +34342,7 @@
   partOfSpeech: n
 06856198-n:
   definition:
-  - a punctuation mark (`-´) used between parts of a compound word or between the
+  - a punctuation mark (‘-’) used between parts of a compound word or between the
     syllables of a word when the word is divided at the end of a line of text
   hypernym:
   - 06854415-n
@@ -34353,7 +34353,7 @@
   partOfSpeech: n
 06856443-n:
   definition:
-  - either of two punctuation marks `(´ or `)´ used to enclose textual material
+  - either of two punctuation marks ‘(’ or ‘)’ used to enclose textual material
   hypernym:
   - 06854415-n
   ili: i72482
@@ -34362,7 +34362,7 @@
   partOfSpeech: n
 06856570-n:
   definition:
-  - a punctuation mark (`.´) placed at the end of a declarative sentence to indicate
+  - a punctuation mark (‘.’) placed at the end of a declarative sentence to indicate
     a full stop or after abbreviations
   example:
   - in England they call a period a stop
@@ -34378,7 +34378,7 @@
   partOfSpeech: n
 06856888-n:
   definition:
-  - (usually plural) one of a series of points (`…´) indicating that something has
+  - (usually plural) one of a series of points (‘…’) indicating that something has
     been omitted or that the sentence is incomplete
   exemplifies:
   - 06306016-n
@@ -34390,7 +34390,7 @@
   partOfSpeech: n
 06857090-n:
   definition:
-  - a punctuation mark (`?´) placed at the end of a sentence to indicate a question
+  - a punctuation mark (‘?’) placed at the end of a sentence to indicate a question
   hypernym:
   - 06854415-n
   ili: i72485
@@ -34438,7 +34438,7 @@
   partOfSpeech: n
 06857789-n:
   definition:
-  - a punctuation mark (`;´) used to connect independent clauses; indicates a closer
+  - a punctuation mark (‘;’) used to connect independent clauses; indicates a closer
     relation than does a period
   hypernym:
   - 06854415-n
@@ -34448,7 +34448,7 @@
   partOfSpeech: n
 06857953-n:
   definition:
-  - a punctuation mark (`/´) used to separate related items of information
+  - a punctuation mark (‘/’) used to separate related items of information
   hypernym:
   - 06854415-n
   ili: i72491
@@ -34462,7 +34462,7 @@
   partOfSpeech: n
 06858126-n:
   definition:
-  - a punctuation mark (`⁓´) used in text to indicate the omission of a word
+  - a punctuation mark (‘⁓’) used in text to indicate the omission of a word
   hypernym:
   - 06854415-n
   ili: i72492
@@ -34521,7 +34521,7 @@
   partOfSpeech: n
 06864792-n:
   definition:
-  - a formally registered symbol (`™´) identifying the manufacturer or distributor
+  - a formally registered symbol (‘™’) identifying the manufacturer or distributor
     of a product
   exemplifies:
   - 92433720-n
@@ -45151,7 +45151,7 @@
   partOfSpeech: n
 07019828-n:
   definition:
-  - the theater as a profession (usually `the stage´)
+  - the theater as a profession (usually ‘the stage’)
   example:
   - an early movie simply showed a long kiss by two actors of the contemporary stage
   hypernym:
@@ -45519,7 +45519,7 @@
   definition:
   - persuasive but insincere talk that is usually intended to deceive or impress
   example:
-  - '`let me show you my etchings´ is a rather worn line'
+  - '‘let me show you my etchings’ is a rather worn line'
   - he has a smooth line but I didn't fall for it
   - that salesman must have practiced his fast line of talk
   hypernym:
@@ -46783,7 +46783,7 @@
 07050292-n:
   definition:
   - the first words of a medieval Latin hymn describing the Last Judgment (literally
-    `day of wrath´)
+    ‘day of wrath’)
   ili: i73634
   instance_hypernym:
   - 07049616-n
@@ -46825,8 +46825,8 @@
   partOfSpeech: n
 07050805-n:
   definition:
-  - (Luke) the canticle of the Virgin Mary (from Luke 1:46 beginning `Magnificat anima
-    mea Dominum´)
+  - (Luke) the canticle of the Virgin Mary (from Luke 1:46 beginning ‘Magnificat anima
+    mea Dominum’)
   domain_topic:
   - 06453643-n
   ili: i73638
@@ -48739,8 +48739,8 @@
   partOfSpeech: n
 07081916-n:
   definition:
-  - 'the use of closed-class words instead of inflections: e.g., `the father of the
-    bride´ instead of `the bride''s father´'
+  - 'the use of closed-class words instead of inflections: e.g., ‘the father of the
+    bride’ instead of ‘the bride''s father’'
   hypernym:
   - 07080699-n
   ili: i73822
@@ -49752,7 +49752,7 @@
   definition:
   - using more words than necessary
   example:
-  - plenoasms such as `a tiny little child´
+  - plenoasms such as ‘a tiny little child’
   hypernym:
   - 07103943-n
   ili: i73916
@@ -49763,7 +49763,7 @@
   definition:
   - useless and pointless repetition
   example:
-  - to say that something is `adequate enough´ is a tautology
+  - to say that something is ‘adequate enough’ is a tautology
   hypernym:
   - 07104913-n
   ili: i73917
@@ -49776,7 +49776,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - the statement `he is brave or he is not brave´ is a tautology
+  - the statement ‘he is brave or he is not brave’ is a tautology
   hypernym:
   - 06736815-n
   ili: i73918
@@ -49796,7 +49796,7 @@
   definition:
   - abbreviation of a word by omitting the final sound or sounds
   example:
-  - the British get `pud´ from `pudding´ by apocope
+  - the British get ‘pud’ from ‘pudding’ by apocope
   hypernym:
   - 07105779-n
   ili: i73920
@@ -49819,8 +49819,8 @@
   - a word formed from the initial letters of the several words in the name and pronounced
     as one word
   example:
-  - '`NATO´ is an initialism for North Atlantic Treaty Organization'
-  - the word `scuba´ is an acronym for s(elf)-c(ontained) u(nderwater) b(reathing)
+  - '‘NATO’ is an initialism for North Atlantic Treaty Organization'
+  - the word ‘scuba’ is an acronym for s(elf)-c(ontained) u(nderwater) b(reathing)
     a(pparatus)
   hypernym:
   - 06301417-n
@@ -50021,7 +50021,7 @@
   wikidata: Q465509
 07110182-n:
   definition:
-  - a metrical unit with unstressed-stressed-unstressed syllables (e.g., `remember´)
+  - a metrical unit with unstressed-stressed-unstressed syllables (e.g., ‘remember’)
   hypernym:
   - 07109509-n
   ili: i73940
@@ -50136,7 +50136,7 @@
   - use of the same consonant at the beginning of each stressed syllable in a line
     of verse
   example:
-  - initial rhyme such as `around the rock the ragged rascal ran´
+  - initial rhyme such as ‘around the rock the ragged rascal ran’
   hypernym:
   - 07111327-n
   ili: i73952
@@ -50172,7 +50172,7 @@
   definition:
   - a two-syllable rhyme
   example:
-  - '`ended´ and `blended´ form a double rhyme'
+  - '‘ended’ and ‘blended’ form a double rhyme'
   hypernym:
   - 07111327-n
   ili: i73955
@@ -50200,7 +50200,7 @@
   partOfSpeech: n
 07112759-n:
   definition:
-  - an imperfect rhyme (e.g., `love´ and `move´)
+  - an imperfect rhyme (e.g., ‘love’ and ‘move’)
   hypernym:
   - 07111327-n
   ili: i73958
@@ -50323,7 +50323,7 @@
   definition:
   - repetition of a word in a different case or inflection in the same sentence
   example:
-  - polyptoton such as `my own heart's heart´
+  - polyptoton such as ‘my own heart's heart’
   hypernym:
   - 07113937-n
   ili: i73970
@@ -50425,8 +50425,8 @@
   partOfSpeech: n
 07116700-n:
   definition:
-  - 'strained or paradoxical use of words either in error (as `blatant´ to mean `flagrant´)
-    or deliberately (as in a mixed metaphor: `blind mouths´)'
+  - 'strained or paradoxical use of words either in error (as ‘blatant’ to mean ‘flagrant’)
+    or deliberately (as in a mixed metaphor: ‘blind mouths’)'
   hypernym:
   - 07112859-n
   ili: i73981
@@ -50476,7 +50476,7 @@
   definition:
   - an exclamatory rhetorical device
   example:
-  - exclamation such as `O tempore! O mores´
+  - exclamation such as ‘O tempore! O mores’
   hypernym:
   - 07112859-n
   ili: i73986
@@ -50496,7 +50496,7 @@
 07117772-n:
   definition:
   - a substitution of part of speech or gender or number or tense etc. (e.g., editorial
-    `we´ for `I´)
+    ‘we’ for ‘I’)
   hypernym:
   - 07112859-n
   ili: i73988
@@ -50507,7 +50507,7 @@
   definition:
   - immediate rephrasing for intensification or justification
   example:
-  - epanorthosis such as `Seems, madam! Nay, it is´
+  - epanorthosis such as ‘Seems, madam! Nay, it is’
   hypernym:
   - 07112859-n
   ili: i73989
@@ -50535,7 +50535,7 @@
   partOfSpeech: n
 07118337-n:
   definition:
-  - reversal of the syntactic relation of two words (as in `her beauty's face´)
+  - reversal of the syntactic relation of two words (as in ‘her beauty's face’)
   hypernym:
   - 07112859-n
   ili: i73992
@@ -50544,7 +50544,7 @@
   partOfSpeech: n
 07118468-n:
   definition:
-  - reversal of normal word order (as in `cheese I love´)
+  - reversal of normal word order (as in ‘cheese I love’)
   hypernym:
   - 07112859-n
   ili: i73993
@@ -50562,7 +50562,7 @@
   partOfSpeech: n
 07118686-n:
   definition:
-  - use of a series of parallel clauses (as in `I came, I saw, I conquered´)
+  - use of a series of parallel clauses (as in ‘I came, I saw, I conquered’)
   hypernym:
   - 07112859-n
   ili: i73995
@@ -50571,7 +50571,7 @@
   partOfSpeech: n
 07118815-n:
   definition:
-  - reversal of normal order of two words or sentences etc. (as in `bred and born´)
+  - reversal of normal order of two words or sentences etc. (as in ‘bred and born’)
   hypernym:
   - 07112859-n
   ili: i73996
@@ -50583,7 +50583,7 @@
   - understatement for rhetorical effect (especially when expressing an affirmative
     by negating its contrary)
   example:
-  - saying `I was not a little upset´ when you mean `I was very upset´ is an example
+  - saying ‘I was not a little upset’ when you mean ‘I was very upset’ is an example
     of litotes
   hypernym:
   - 07112859-n
@@ -50616,7 +50616,7 @@
   partOfSpeech: n
 07119578-n:
   definition:
-  - juxtaposing words having a common derivation (as in `sense and sensibility´)
+  - juxtaposing words having a common derivation (as in ‘sense and sensibility’)
   hypernym:
   - 07112859-n
   ili: i74000
@@ -50626,7 +50626,7 @@
 07119711-n:
   definition:
   - using several conjunctions in close succession, especially where some might be
-    omitted (as in `he ran and jumped and laughed for joy´)
+    omitted (as in ‘he ran and jumped and laughed for joy’)
   hypernym:
   - 07112859-n
   ili: i74001
@@ -50717,8 +50717,8 @@
 07121768-n:
   definition:
   - a metaphor that has occurred so often that it has become a new meaning of the
-    expression (e.g., `he is a snake´ may once have been a metaphor but after years
-    of use it has died and become a new sense of the word `snake´)
+    expression (e.g., ‘he is a snake’ may once have been a metaphor but after years
+    of use it has died and become a new sense of the word ‘snake’)
   hypernym:
   - 07121485-n
   ili: i74010
@@ -50747,7 +50747,7 @@
 07122361-n:
   definition:
   - substituting the name of an attribute or feature for the name of the thing itself
-    (as in `they counted heads´)
+    (as in ‘they counted heads’)
   hypernym:
   - 07120141-n
   ili: i74013
@@ -50765,7 +50765,7 @@
   partOfSpeech: n
 07122695-n:
   definition:
-  - conjoining contradictory terms (as in `deafening silence´)
+  - conjoining contradictory terms (as in ‘deafening silence’)
   hypernym:
   - 07120141-n
   ili: i74015
@@ -50785,7 +50785,7 @@
 07122967-n:
   definition:
   - a figure of speech that expresses a resemblance between things of different kinds
-    (usually formed with `like´ or `as´)
+    (usually formed with ‘like’ or ‘as’)
   hypernym:
   - 07120141-n
   ili: i74017
@@ -50816,7 +50816,7 @@
   - use of a verb with two or more complements, playing on the verb's polysemy, for
     humorous effect
   example:
-  - '`Mr. Pickwick took his hat and his leave´ is an example of zeugma'
+  - '‘Mr. Pickwick took his hat and his leave’ is an example of zeugma'
   hypernym:
   - 07120141-n
   ili: i74020
@@ -51124,7 +51124,7 @@
 07129243-n:
   definition:
   - a semivowel produced with the tongue near the palate (like the initial sound in
-    the English word `yeast´)
+    the English word ‘yeast’)
   hypernym:
   - 07129117-n
   ili: i74048
@@ -51314,7 +51314,7 @@
   definition:
   - the insertion of a vowel or consonant into a word to make its pronunciation easier
   example:
-  - the insertion of a vowel in the plural of the word `bush´ is epenthesis
+  - the insertion of a vowel in the plural of the word ‘bush’ is epenthesis
   hypernym:
   - 07146562-n
   ili: i74066
@@ -51379,7 +51379,7 @@
 07133698-n:
   definition:
   - a composite speech sound consisting of a stop and a fricative articulated at the
-    same point (as `ch´ in `chair´ and `j´ in `joy´)
+    same point (as ‘ch’ in ‘chair’ and ‘j’ in ‘joy’)
   hypernym:
   - 07130392-n
   ili: i74072
@@ -51420,7 +51420,7 @@
   partOfSpeech: n
 07134351-n:
   definition:
-  - a frictionless continuant that is not a nasal consonant (especially `l´ and `r´)
+  - a frictionless continuant that is not a nasal consonant (especially ‘l’ and ‘r’)
   hypernym:
   - 07129729-n
   ili: i74076
@@ -51431,7 +51431,7 @@
   definition:
   - a doubled or long consonant
   example:
-  - the `n´ in `thinness´ is a geminate
+  - the ‘n’ in ‘thinness’ is a geminate
   hypernym:
   - 07129729-n
   ili: i74077
@@ -52199,7 +52199,7 @@
   partOfSpeech: n
 07147437-n:
   definition:
-  - (phonology) the loss of sounds from within a word (as in `fo'c'sle´ for `forecastle´)
+  - (phonology) the loss of sounds from within a word (as in ‘fo'c'sle’ for ‘forecastle’)
   domain_topic:
   - 06187166-n
   hypernym:
@@ -52234,7 +52234,7 @@
   definition:
   - an expression that is difficult to articulate clearly
   example:
-  - '`rubber baby buggy bumper´ is a tongue twister'
+  - '‘rubber baby buggy bumper’ is a tongue twister'
   hypernym:
   - 07166088-n
   ili: i74149
@@ -52243,7 +52243,7 @@
   partOfSpeech: n
 07148185-n:
   definition:
-  - the articulation of a consonant (especially the consonant `r´) with a rapid flutter
+  - the articulation of a consonant (especially the consonant ‘r’) with a rapid flutter
     of the tongue against the palate or uvula
   example:
   - he pronounced his R's with a distinct trill
@@ -52550,7 +52550,7 @@
 07153212-n:
   definition:
   - a report of a discourse in which deictic terms are modified appropriately (e.g.,
-    `he said "I am a fool"´ would be modified to `he said he is a fool´)
+    ‘he said "I am a fool"’ would be modified to ‘he said he is a fool’)
   hypernym:
   - 07232584-n
   ili: i74177
@@ -52590,7 +52590,7 @@
   partOfSpeech: n
 07154024-n:
   definition:
-  - discussion; (`talk about´ is a less formal alternative for `discussion of´)
+  - discussion; (‘talk about’ is a less formal alternative for ‘discussion of’)
   example:
   - his poetry contains much talk about love and anger
   hypernym:
@@ -53333,7 +53333,7 @@
   definition:
   - a commonly repeated word or phrase
   example:
-  - she repeated `So pleased with how it's going´ at intervals like a mantra
+  - she repeated ‘So pleased with how it's going’ at intervals like a mantra
   hypernym:
   - 07166967-n
   ili: i74250
@@ -53345,7 +53345,7 @@
   - a slogan used to rally support for a cause
   example:
   - a cry to arms
-  - our watchword will be `democracy´
+  - our watchword will be ‘democracy’
   hypernym:
   - 07166967-n
   ili: i74251
@@ -54766,7 +54766,7 @@
   - an accommodation in which both sides make concessions
   example:
   - the newly elected congressmen rejected a compromise because they considered it
-    `business as usual´
+    ‘business as usual’
   hypernym:
   - 07192097-n
   ili: i74381
@@ -56303,7 +56303,7 @@
   definition:
   - a grammatically substandard but emphatic negative
   example:
-  - double negative such as `I don't never go´
+  - double negative such as ‘I don't never go’
   hypernym:
   - 07219571-n
   ili: i74521
@@ -56314,7 +56314,7 @@
   definition:
   - an affirmative constructed from two negatives
   example:
-  - double negative such as `a not unwelcome outcome´
+  - double negative such as ‘a not unwelcome outcome’
   hypernym:
   - 07218356-n
   ili: i74522
@@ -56409,7 +56409,7 @@
   domain_topic:
   - 06173467-n
   example:
-  - the statement `he is brave and he is not brave´ is a contradiction
+  - the statement ‘he is brave and he is not brave’ is a contradiction
   hypernym:
   - 06769118-n
   ili: i74531
@@ -61098,7 +61098,7 @@
   partOfSpeech: n
 80475027-n:
   definition:
-  - English orthography used in Canada (characterized by `analyze´, `centre´, `useable´)
+  - English orthography used in Canada (characterized by ‘analyze’, ‘centre’, ‘useable’)
   hypernym:
   - 06364852-n
   members:
@@ -61157,7 +61157,7 @@
   partOfSpeech: n
 84746436-n:
   definition:
-  - English orthography used in Australia (characterized by `analyse´, `centre´, `usable´)
+  - English orthography used in Australia (characterized by ‘analyse’, ‘centre’, ‘usable’)
   hypernym:
   - 06364852-n
   members:
@@ -61177,7 +61177,7 @@
 86712636-n:
   definition:
   - English orthography used in the UK, Ireland and most of the Commonwealth (characterized
-    by `analyse´, `centre´ and `useable´)
+    by ‘analyse’, ‘centre’ and ‘useable’)
   hypernym:
   - 06364852-n
   members:
@@ -61196,8 +61196,8 @@
   partOfSpeech: n
 87027384-n:
   definition:
-  - English orthography used in the United States (characterized by `analyze´, `center´,
-    `usable´)
+  - English orthography used in the United States (characterized by ‘analyze’, ‘center’,
+    ‘usable’)
   hypernym:
   - 06364852-n
   members:
@@ -61400,7 +61400,7 @@
   source: Colloquial WordNet
 90011161-n:
   definition:
-  - An expression meaning `praise God´ in Arabic
+  - An expression meaning ‘praise God’ in Arabic
   hypernym:
   - 06642524-n
   members:
@@ -61485,7 +61485,7 @@
   definition:
   - A subgenre of alternative rock typified by significant use of guitar distortion,
     feedback, obscured vocals and the blurring of component musical parts into indistinguishable
-    `walls of sound´
+    ‘walls of sound’
   hypernym:
   - 07073295-n
   members:
@@ -61538,7 +61538,7 @@
   - a meter of poetry consisting of three iambic units per line.
   example:
   - In the dramatic forms of tragedy and comedy, iambic trimeter was used mainly for
-    the verses `spoken´ by a character, that is, the dialogue rather than the choral
+    the verses ‘spoken’ by a character, that is, the dialogue rather than the choral
     passages.
   hypernym:
   - 07109509-n
@@ -61635,7 +61635,7 @@
   - The characteristic quality of poetry that is marked by departure from the subject,
     course, or idea at hand; or by an exploration of a different or unrelated concern.
   example:
-  - Eighteenth-century writers, says Stabler, were never `lost´ in their digressiveness
+  - Eighteenth-century writers, says Stabler, were never ‘lost’ in their digressiveness
     and used it as a method of supporting their concepts.
   hypernym:
   - 07080699-n
@@ -62057,8 +62057,8 @@
   source: plWordNet 4.0
 92444678-n:
   definition:
-  - A direct mate with the stipulation `White to move and checkmate Black in no more
-    than n moves against any defence´ where n is greater than 3.
+  - A direct mate with the stipulation ‘White to move and checkmate Black in no more
+    than n moves against any defence’ where n is greater than 3.
   example:
   - This week's problem is a more-mover by a composer better known for his endgame
     study and theory work.
@@ -62070,8 +62070,8 @@
   source: plWordNet 4.0
 92444679-n:
   definition:
-  - A problem with the stipulation `White to move and checkmate Black in two moves
-    against any defence´.
+  - A problem with the stipulation ‘White to move and checkmate Black in two moves
+    against any defence’.
   example:
   - Although, if he was consistent, perhaps he should have said that a three-mover
     would be three times as difficult as a two-mover.
@@ -62083,8 +62083,8 @@
   source: plWordNet 4.0
 92444680-n:
   definition:
-  - A problem with the stipulation `White to move and checkmate Black in no more than
-    three moves against any defence´.
+  - A problem with the stipulation ‘White to move and checkmate Black in no more than
+    three moves against any defence’.
   example:
   - Accordingly, the solver usually takes it for granted that a three-mover has a
     threat, unless the setting definitely suggests a block position.
@@ -62169,8 +62169,8 @@
     features (it can modify verbs used with the noun, affect the noun's declension
     etc.).
   example:
-  - In other words, the inanimacy of a head noun like `evidence´ appeared not to penetrate
-    the syntactic analysis of the verb `examined´.
+  - In other words, the inanimacy of a head noun like ‘evidence’ appeared not to penetrate
+    the syntactic analysis of the verb ‘examined’.
   hypernym:
   - 06320373-n
   members:
@@ -62238,7 +62238,7 @@
   example:
   - source: https://en.wikipedia.org
     text: As an information management tool, a PIM tool's purpose is to facilitate
-      the recording, tracking, and management of certain types of `personal information´.
+      the recording, tracking, and management of certain types of ‘personal information’.
   hypernym:
   - 06581154-n
   members:
@@ -62573,7 +62573,7 @@
   definition:
   - a symbol that represents peace, in the form of three lines within a circle.
   example:
-  - In the 1950s the `peace sign´ as it is known today, was designed as the logo for
+  - In the 1950s the ‘peace sign’ as it is known today, was designed as the logo for
     the British Campaign for Nuclear Disarmament and adopted by anti-war and counterculture
     activists in the United States and elsewhere.
   hypernym:
@@ -62636,7 +62636,7 @@
   example:
   - The sotadic metre or sotadic verse, which has been classified by ancient and modern
     scholars as a form of ionic metre, is one that reads backwards and forwards the
-    same, as `llewd did I live, and evil I did dwell´.
+    same, as ‘llewd did I live, and evil I did dwell’.
   hypernym:
   - 06389065-n
   members:
@@ -62671,12 +62671,12 @@
 92460868-n:
   definition:
   - a large subgenre of trance music, named for the feeling which listeners claim
-    to get (often described as a `rush´).
+    to get (often described as a ‘rush’).
   example:
   - Instead of the darker tone of Goa, uplifting trance uses similar chord progressions
     as progressive trance, but tracks' chord progressions usually rest on a major
     chord, and the balance between major and minor chords in a progression will determine
-    how `happy´ or `sad´ the progression sounds.
+    how ‘happy’ or ‘sad’ the progression sounds.
   hypernym:
   - 92460865-n
   members:
@@ -62690,7 +62690,7 @@
   example:
   - The en dash is commonly used to indicate a closed range of values — a range with
     clearly defined and finite upper and lower boundaries — roughly signifying what
-    might otherwise be communicated by the word `through´.
+    might otherwise be communicated by the word ‘through’.
   hypernym:
   - 06856198-n
   members:
@@ -62729,7 +62729,7 @@
   - a poem whose meaning is conveyed through its graphic shape or pattern on the printed
     page.
   example:
-  - '`The Mouse''s Tale´ is a concrete poem by Lewis Carroll which appears in his
+  - '‘The Mouse''s Tale’ is a concrete poem by Lewis Carroll which appears in his
     novel Alice''s Adventures in Wonderland.'
   hypernym:
   - 06389065-n
@@ -62743,7 +62743,7 @@
     and using electronic instruments such as guitars and synthesizers.
   example:
   - Jazz Fusion incorporates elements of different genres while maintaining an element
-    that is distinctly `jazz´.
+    that is distinctly ‘jazz’.
   hypernym:
   - 07076737-n
   members:
@@ -62766,7 +62766,7 @@
 92460923-n:
   definition:
   - a type of operatic soprano voice that has the limpidity and easy high notes of
-    a lyric soprano, yet can be `pushed´ on to achieve dramatic climaxes without strain.
+    a lyric soprano, yet can be ‘pushed’ on to achieve dramatic climaxes without strain.
   example:
   - The more dramatic sister of the lyric soprano is the spinto soprano, not quite
     a full-on dramatic soprano, but possessing a combination of qualities of both
@@ -62785,7 +62785,7 @@
   - Most languages can adopt theme-rheme structure idiosyncratically — as for English,
     we often use as for theme constructions — but topic-prominent languages use systematic
     changes in syntax or even dedicated morpological elements such as the Japanese
-    clitic particle `-wa´ to mark themes and to set them apart from rhemes.
+    clitic particle ‘-wa’ to mark themes and to set them apart from rhemes.
   hypernym:
   - 06317223-n
   members:
@@ -62812,7 +62812,7 @@
   - a piece of music composed for the Hungarian Csárdás dance.
   example:
   - 'The Csárdás is characterized by a variation in tempo: it starts out slowly (lassú)
-    and ends in a very fast tempo (friss, literally `fresh´).'
+    and ends in a very fast tempo (friss, literally ‘fresh’).'
   hypernym:
   - 07068473-n
   members:
@@ -62909,8 +62909,8 @@
   - In their present form in the Roman Rite, the Improperia are a series of three
     couplets, sung antiphonally by cantors and followed by alternate Greek and Latin
     responses from the two halves of the choir; and nine other lines sung by the cantors,
-    with the full choir responding after each with the refrain `Popule meus, quid
-    feci tibi? …´
+    with the full choir responding after each with the refrain ‘Popule meus, quid
+    feci tibi? …’
   hypernym:
   - 07046732-n
   members:
@@ -62947,12 +62947,12 @@
   definition:
   - a meaningless chant or expression used in conjuring or incantation.
   example:
-  - This claim is substantiated by the fact that in the Netherlands, the words `Hocus
-    pocus´ are usually accompanied by the additional words `pilatus pas´, and this
+  - This claim is substantiated by the fact that in the Netherlands, the words ‘Hocus
+    pocus’ are usually accompanied by the additional words ‘pilatus pas’, and this
     is said to be based on a post-Reformation parody of the traditional Catholic ritual
     of transubstantiation during mass, being a Dutch corruption of the Latin words
-    `Hoc est corpus´, meaning `this is (my) body´, and the credo `sub Pontio Pilato
-    passus et sepultus est´, meaning `under Pontius Pilate he suffered and was buried´.
+    ‘Hoc est corpus’, meaning ‘this is (my) body’, and the credo ‘sub Pontio Pilato
+    passus et sepultus est’, meaning ‘under Pontius Pilate he suffered and was buried’.
   hypernym:
   - 07174442-n
   members:
@@ -62988,7 +62988,7 @@
   definition:
   - Etiquette practiced or advocated in electronic communication over a computer network.
   example:
-  - I know there is a UK political blog war going on at the moment about `netiquette´
+  - I know there is a UK political blog war going on at the moment about ‘netiquette’
     and lies and spin and deceit, and I have not wanted to join in.
   hypernym:
   - 06677590-n
@@ -63150,8 +63150,8 @@
     the alveolar ridge.
   example:
   - The sibilant postalveolars (i.e. fricatives and affricates) are sometimes called
-    `hush consonants´ because they include the sound /ʃ/ of English `Shhh!´ (as distinguished
-    from the `hiss´ consonant /s/, as in `Ssss!´).
+    ‘hush consonants’ because they include the sound /ʃ/ of English ‘Shhh!’ (as distinguished
+    from the ‘hiss’ consonant /s/, as in ‘Ssss!’).
   hypernym:
   - 07129729-n
   members:
@@ -63179,8 +63179,8 @@
   - the tense that is used to refer to events, actions, and conditions that are happening
     all the time, or exist now.
   example:
-  - The sentences `I live in Madrid´, `She doesn't like cheese´, and `I think you're
-    wrong´ are all in the present simple.
+  - The sentences ‘I live in Madrid’, ‘She doesn't like cheese’, and ‘I think you're
+    wrong’ are all in the present simple.
   hypernym:
   - 06340727-n
   members:
@@ -63190,7 +63190,7 @@
   source: plWordNet 4.0
 92462177-n:
   definition:
-  - an aorist formed by adding sigma or `-s´ to the stem.
+  - an aorist formed by adding sigma or ‘-s’ to the stem.
   example:
   - The sigmatic aorist has disappeared in Baltic, so our information on this category
     is limited to the Slavic data.
@@ -63202,7 +63202,7 @@
   source: plWordNet 4.0
 92462178-n:
   definition:
-  - an aorist that lacks the sigma or `-s´ phoneme.
+  - an aorist that lacks the sigma or ‘-s’ phoneme.
   example:
   - Over time, the asigmatic aorist became increasingly marked as an archaic language
     feature and was eventually replaced by the other two aorist formations.
@@ -63217,7 +63217,7 @@
   - the form of a verb used to describe an action that happened before the present
     time and is no longer happening.
   example:
-  - Regular verbs form the simple past in `-ed´; however there are a few hundred irregular
+  - Regular verbs form the simple past in ‘-ed’; however there are a few hundred irregular
     verbs with different forms.
   hypernym:
   - 06341255-n
@@ -63231,7 +63231,7 @@
   - a verb form expressing action as single in its occurrence without repetition or
     continuation.
   example:
-  - Semelfactive verbs include `blink´, `sneeze´, and `knock´.
+  - Semelfactive verbs include ‘blink’, ‘sneeze’, and ‘knock’.
   hypernym:
   - 92462256-n
   members:
@@ -63269,7 +63269,7 @@
   definition:
   - the name of an object which may be perceived by one or more of the five senses.
   example:
-  - '`Kitten´ is an example of a concrete noun. A kitten registers with the five senses:
+  - '‘Kitten’ is an example of a concrete noun. A kitten registers with the five senses:
     you can see a kitten, pet its fur, smell its breath, hear it purr and taste its
     kisses.'
   hypernym:
@@ -63318,8 +63318,8 @@
   - That state of an adverb indicating simple quality, without comparison or relation
     to increase or diminution.
   example:
-  - An example using a positive-degree adverb that doesn't end in `-ly´ would be the
-    adverb `fast´ in the sentence, `She drove fast´.
+  - An example using a positive-degree adverb that doesn't end in ‘-ly’ would be the
+    adverb ‘fast’ in the sentence, ‘She drove fast’.
   hypernym:
   - 06333461-n
   members:
@@ -63331,7 +63331,7 @@
   definition:
   - An adverb that describes how the action of a verb is carried out.
   example:
-  - Adverbs of manner (like `desperately´) can modify verbs directly.
+  - Adverbs of manner (like ‘desperately’) can modify verbs directly.
   hypernym:
   - 06334605-n
   members:
@@ -63436,7 +63436,7 @@
 92462515-n:
   definition:
   - The Cyrillic letter Ь/ь, which in Old Church Slavonic represented a short (or
-    `reduced´) front vowel, and in modern languages serves to denote a soft (palatalized)
+    ‘reduced’) front vowel, and in modern languages serves to denote a soft (palatalized)
     consonant.
   example:
   - The yers in weak position were lost, although not in some instances before palatalizing
@@ -63529,7 +63529,7 @@
   definition:
   - a morpheme that signifies the past tense of a verb.
   example:
-  - In English, The most popular past tense morpheme is indicated by the suffix `-ed´
+  - In English, The most popular past tense morpheme is indicated by the suffix ‘-ed’
     added to regular verbs.
   hypernym:
   - 06317596-n
@@ -63554,8 +63554,8 @@
   definition:
   - nasalization that consists of an oral vowel followed by a nasal semivowel.
   example:
-  - It is only before a fricative (and for `ą´ in word-final position) that `ę´ and
-    `ą´ are pronounced as asynchronous nasal vowels, that is, /eu/ and /ou/.
+  - It is only before a fricative (and for ‘ą’ in word-final position) that ‘ę’ and
+    ‘ą’ are pronounced as asynchronous nasal vowels, that is, /eu/ and /ou/.
   - Before a fricative and in word-final position (in the case of ą) they are transcribed
     as an oral vowel /ɔ, ɛ/ followed by a nasal consonant /ɲ, ŋ/ or /j̃, w̃/
   hypernym:
@@ -63568,7 +63568,7 @@
   definition:
   - a poetic phrase, utterance, etc.
   example:
-  - Just as `hath´ is a poeticism in Keats and an unmarked form for Shakespeare, `sogebided´
+  - Just as ‘hath’ is a poeticism in Keats and an unmarked form for Shakespeare, ‘sogebided’
     may have been a poeticism to Alfred and an unmarked form for Qedmon.
   hypernym:
   - 06297048-n
@@ -63580,7 +63580,7 @@
   definition:
   - an extreme form of tragicomedy.
   example:
-  - The Suicide of Solitude, a `tragifarce´ production, is currently being performed
+  - The Suicide of Solitude, a ‘tragifarce’ production, is currently being performed
     by the local theatre troupe at Rochford Winery in Healesville.
   hypernym:
   - 07029911-n
@@ -63713,7 +63713,7 @@
   source: plWordNet 4.0
 92463196-n:
   definition:
-  - a name of a `minor´ or small natural feature (e.g., a field, path, bridge, ditch,
+  - a name of a ‘minor’ or small natural feature (e.g., a field, path, bridge, ditch,
     etc.).
   example:
   - Larrain is the name of a farmhouse in Astigarraga (Gipuzkoa) and a microtoponym
@@ -63791,7 +63791,7 @@
   - a syllable ended by a vowel or diphthong.
   example:
   - An open syllable occurs when a vowel is at the end of the syllable, resulting
-    in the long vowel sound, e.g. `pa/per´, `e/ven´, `o/pen´, `go´ & `we´.
+    in the long vowel sound, e.g. ‘pa/per’, ‘e/ven’, ‘o/pen’, ‘go’ & ‘we’.
   hypernym:
   - 06315661-n
   members:
@@ -63876,7 +63876,7 @@
   definition:
   - (phonetics) Any vowel sound produced in the front of the mouth.
   example:
-  - Examples of front vowels include `a´ in `man´ and `e´ in `gel´.
+  - Examples of front vowels include ‘a’ in ‘man’ and ‘e’ in ‘gel’.
   hypernym:
   - 07127258-n
   members:
@@ -63887,7 +63887,7 @@
   definition:
   - (phonetics) Any vowel sound produced in the back of the mouth.
   example:
-  - Examples of back vowels include `u´ in `rule´ and `o´ in `pole´.
+  - Examples of back vowels include ‘u’ in ‘rule’ and ‘o’ in ‘pole’.
   hypernym:
   - 07127258-n
   members:
@@ -63950,7 +63950,7 @@
   - a speech sound having as an obvious concomitant an audible puff of breath, as
     initial stop consonants or initial /h/ sounds.
   example:
-  - The `p´ in English `pot´ is an aspirate, but the `p´ in `spot´ is not.
+  - The ‘p’ in English ‘pot’ is an aspirate, but the ‘p’ in ‘spot’ is not.
   hypernym:
   - 07125755-n
   members:
@@ -64079,7 +64079,7 @@
   - The name of a Saint taken as a proper name.
   example:
   - This Native place name was used for a while in parallel with the hagionym Saint-Francois-Xavier
-    (1850s) as well as another `official´ toponym, Grantown, named after Cuthbert
+    (1850s) as well as another ‘official’ toponym, Grantown, named after Cuthbert
     Grant.
   hypernym:
   - 06349648-n
@@ -64091,7 +64091,7 @@
   definition:
   - a clitic that is associated with a following word.
   example:
-  - The indefinite article `a´ is a proclitic, a word that wants to merge phonologically
+  - The indefinite article ‘a’ is a proclitic, a word that wants to merge phonologically
     with the word that follows it.
   hypernym:
   - 92460927-n
@@ -64131,7 +64131,7 @@
     is important to the text's interpretation.
   example:
   - What caught my eye about this is that it bears interesting relation to Bakhtin's
-    concept of the dialogism of the `living word´ — in fact, capitalize that `w´ and
+    concept of the dialogism of the ‘living word’ — in fact, capitalize that ‘w’ and
     it would be downright eerie.
   hypernym:
   - 07112859-n
@@ -64222,7 +64222,7 @@
   definition:
   - an adverbial that describes when the action of a verb is carried out.
   example:
-  - An adverb phrase that answers the question `when?´ is called a temporal adverbial.
+  - An adverb phrase that answers the question ‘when?’ is called a temporal adverbial.
   hypernym:
   - 06335348-n
   members:
@@ -64284,8 +64284,8 @@
   - (grammar) a pronoun having no specific referent, such as someone, anybody, or
     nothing.
   example:
-  - In `many disagree with his views´ the word `many´ functions as an indefinite pronoun,
-    while in `many people disagree with his views´ it functions as a quantifier.
+  - In ‘many disagree with his views’ the word ‘many’ functions as an indefinite pronoun,
+    while in ‘many people disagree with his views’ it functions as a quantifier.
   hypernym:
   - 06336363-n
   members:
@@ -64323,7 +64323,7 @@
     or on coins or medals.
   example:
   - One practice was rendering an over-used, formulaic phrase only as a siglum, e.g.
-    RIP for `requiescat in pace´ (`Rest in Peace´), because the long-form written
+    RIP for ‘requiescat in pace’ (‘Rest in Peace’), because the long-form written
     usage of the abbreviated phrase, itself, was rare.
   hypernym:
   - 06831828-n
@@ -64335,7 +64335,7 @@
   definition:
   - an act of describing oneself.
   example:
-  - His self-description as an `experimenter´ puts him shoulder-to-shoulder with William
+  - His self-description as an ‘experimenter’ puts him shoulder-to-shoulder with William
     James and John Dewey.
   hypernym:
   - 07216025-n
@@ -64434,9 +64434,9 @@
 92464557-n:
   definition:
   - The subject of a sentence that expresses the actual agent of an expressed or implied
-    action (as father in `it is your father speaking´) or that is the thing about
-    which something is otherwise predicated (as to do right in `it is sometimes hard
-    to do right´).
+    action (as father in ‘it is your father speaking’) or that is the thing about
+    which something is otherwise predicated (as to do right in ‘it is sometimes hard
+    to do right’).
   example:
   - The notion of a logical subject can be made more precise in terms of a definition
     of reference, for something is a logical subject only if it is a referent of a
@@ -64453,9 +64453,9 @@
     subject in normal English word order and anticipates a subsequent word or phrase
     that specifies the actual substantive content.
   example:
-  - In the sentence `the bear was killed by the hunter´, the topicalized goal of the
-    action (`the bear´) is the grammatical subject of the passive sentence and is
-    acted upon by the agent (`the hunter´), which is the logical, but not the grammatical,
+  - In the sentence ‘the bear was killed by the hunter’, the topicalized goal of the
+    action (‘the bear’) is the grammatical subject of the passive sentence and is
+    acted upon by the agent (‘the hunter’), which is the logical, but not the grammatical,
     subject of the passive sentence.
   hypernym:
   - 06320921-n
@@ -64514,7 +64514,7 @@
   - a word or line of verse of seven syllables.
   example:
   - On the other hand, this heptasyllable is not merely common in the Saturnian but
-    obviously the `regular´ or `normal´ form of the longer cola.
+    obviously the ‘regular’ or ‘normal’ form of the longer cola.
   hypernym:
   - 06396351-n
   members:
@@ -64565,7 +64565,7 @@
   - a constructed language designed for aesthetic pleasure.
   example:
   - By far the largest group of artistic languages are fictional languages (sometimes
-    also referred to as `professional artlangs´), intended to be the languages of
+    also referred to as ‘professional artlangs’), intended to be the languages of
     a fictional world, and often designed with the intent of giving more depth and
     an appearance of plausibility to the fictional worlds with which they are associated,
     and to have their characters communicate in a fashion which is both alien and
@@ -64593,13 +64593,13 @@
   definition:
   - 'A rhetorical figure resulting from a reverted arrangement in the last clause
     of a sentence of the two principal words of the clause preceding; inversion of
-    the members of an antithesis: as, `A poem is a speaking picture; a picture a mute
-    poem´.'
+    the members of an antithesis: as, ‘A poem is a speaking picture; a picture a mute
+    poem’.'
   example:
   - I am not of Paracelsus's mind, that boldly delivers a receipt to make a man without
     conjunction; yet cannot but wonder at the multitude of heads that do deny traduction,
     having no other arguments to confirm their belief than that rhetorical sentence
-    and antimetathesis of Augustine, `creando infunditur, infundendo creatur´.
+    and antimetathesis of Augustine, ‘creando infunditur, infundendo creatur’.
   hypernym:
   - 07112859-n
   members:
@@ -64624,7 +64624,7 @@
   definition:
   - an Indo-European language that shows distinctive preservation of the Proto-Indo-European
     labiovelars and that shows a historical development of velar articulations, as
-    the sounds /k/ or /kʰ/ (`kh´) from Proto-Indo-European palatal phonemes.
+    the sounds /k/ or /kʰ/ (‘kh’) from Proto-Indo-European palatal phonemes.
   example:
   - The Centum languages show characteristic plain velars and labiovelars articulated
     at the back of the mouth in inherited Indo-European lexical items.
@@ -64726,7 +64726,7 @@
   source: plWordNet 4.0
 92470531-n:
   definition:
-  - a song associated with the dance `The Twist´ and the associated cultural craze.
+  - a song associated with the dance ‘The Twist’ and the associated cultural craze.
   example:
   - There was Twist merchandise and memorabilia sold in those times, and many other
     music artists recorded twist songs.
@@ -64789,7 +64789,7 @@
   definition:
   - an indication of satisfaction or approval.
   example:
-  - The phrase `two thumbs up´ has come to be used as an indication of very high quality
+  - The phrase ‘two thumbs up’ has come to be used as an indication of very high quality
     or unanimity of praise.
   hypernym:
   - 06699481-n

--- a/src/yaml/noun.event.yaml
+++ b/src/yaml/noun.event.yaml
@@ -8611,7 +8611,7 @@
   definition:
   - activity that is a malfunction, intrusion, or interruption
   example:
-  - the term `distress' connotes some degree of perturbation and emotional upset
+  - the term `distress´ connotes some degree of perturbation and emotional upset
   - he looked around for the source of the disturbance
   - there was a disturbance of neural function
   hypernym:
@@ -11421,7 +11421,7 @@
 07489458-n:
   definition:
   - ultimate success achieved after a near failure (inspired by the saying `he laughs
-    best who laughs last')
+    best who laughs last´)
   example:
   - we had the last laugh after the votes were counted
   hypernym:
@@ -11856,7 +11856,7 @@
     individual conscience because it is neither forbidden nor enjoined by the scriptures.
   example:
   - For all of the wild-eyed (and completely sectarian) assertions floating around
-    the LCMS that ordination is a mere adiaphoron, that `laying on of hands' does
+    the LCMS that ordination is a mere adiaphoron, that `laying on of hands´ does
     not mean ritual ordination but rather a democratic election, that ordination confers
     nothing - I have yet to ever read about anyone actually graduating seminary and
     taking a call to a congregation and choosing to forgo the rite of ordination.

--- a/src/yaml/noun.event.yaml
+++ b/src/yaml/noun.event.yaml
@@ -8611,7 +8611,7 @@
   definition:
   - activity that is a malfunction, intrusion, or interruption
   example:
-  - the term `distress´ connotes some degree of perturbation and emotional upset
+  - the term ‘distress’ connotes some degree of perturbation and emotional upset
   - he looked around for the source of the disturbance
   - there was a disturbance of neural function
   hypernym:
@@ -11420,8 +11420,8 @@
   partOfSpeech: n
 07489458-n:
   definition:
-  - ultimate success achieved after a near failure (inspired by the saying `he laughs
-    best who laughs last´)
+  - ultimate success achieved after a near failure (inspired by the saying ‘he laughs
+    best who laughs last’)
   example:
   - we had the last laugh after the votes were counted
   hypernym:
@@ -11856,7 +11856,7 @@
     individual conscience because it is neither forbidden nor enjoined by the scriptures.
   example:
   - For all of the wild-eyed (and completely sectarian) assertions floating around
-    the LCMS that ordination is a mere adiaphoron, that `laying on of hands´ does
+    the LCMS that ordination is a mere adiaphoron, that ‘laying on of hands’ does
     not mean ritual ordination but rather a democratic election, that ordination confers
     nothing - I have yet to ever read about anyone actually graduating seminary and
     taking a call to a congregation and choosing to forgo the rite of ordination.

--- a/src/yaml/noun.feeling.yaml
+++ b/src/yaml/noun.feeling.yaml
@@ -2282,7 +2282,7 @@
   partOfSpeech: n
 07531995-n:
   definition:
-  - a feeling of intense indignation (now used only in the phrase `in high dudgeon')
+  - a feeling of intense indignation (now used only in the phrase `in high dudgeon´)
   hypernym:
   - 07532976-n
   ili: i76254

--- a/src/yaml/noun.feeling.yaml
+++ b/src/yaml/noun.feeling.yaml
@@ -2282,7 +2282,7 @@
   partOfSpeech: n
 07531995-n:
   definition:
-  - a feeling of intense indignation (now used only in the phrase `in high dudgeon´)
+  - a feeling of intense indignation (now used only in the phrase ‘in high dudgeon’)
   hypernym:
   - 07532976-n
   ili: i76254

--- a/src/yaml/noun.food.yaml
+++ b/src/yaml/noun.food.yaml
@@ -659,7 +659,7 @@
 07585209-n:
   definition:
   - flour made by grinding the entire wheat berry including the bran; (`whole meal
-    flour' is British usage)
+    flour´ is British usage)
   domain_region:
   - 08879115-n
   hypernym:
@@ -2369,7 +2369,7 @@
   definition:
   - prepared food that is intended to be eaten off of the premises
   example:
-  - in England they call takeout food `takeaway'
+  - in England they call takeout food `takeaway´
   hypernym:
   - 07609120-n
   ili: i76701
@@ -3620,7 +3620,7 @@
   partOfSpeech: n
 07628605-n:
   definition:
-  - (British) the dessert course of a meal (`pud' is used informally)
+  - (British) the dessert course of a meal (`pud´ is used informally)
   domain_region:
   - 08879115-n
   hypernym:
@@ -12304,8 +12304,8 @@
   partOfSpeech: n
 07753721-n:
   definition:
-  - pod of the peanut vine containing usually 2 nuts or seeds; `groundnut' and `monkey
-    nut' are British terms
+  - pod of the peanut vine containing usually 2 nuts or seeds; `groundnut´ and `monkey
+    nut´ are British terms
   hypernym:
   - 07753057-n
   ili: i77699
@@ -13919,7 +13919,7 @@
   partOfSpeech: n
 07778889-n:
   definition:
-  - huge fruit native to southeastern Asia `smelling like Hell and tasting like Heaven';
+  - huge fruit native to southeastern Asia `smelling like Hell and tasting like Heaven´;
     seeds are roasted and eaten like nuts
   hypernym:
   - 07721676-n
@@ -16541,7 +16541,7 @@
   partOfSpeech: n
 07820128-n:
   definition:
-  - seed of the annual grass Avena sativa (spoken of primarily in the plural as `oats')
+  - seed of the annual grass Avena sativa (spoken of primarily in the plural as `oats´)
   exemplifies:
   - 06306016-n
   hypernym:
@@ -18108,7 +18108,7 @@
   - white crystalline compound used as a food additive to enhance flavor; often used
     in Chinese cooking
   example:
-  - food manufacturers sometimes list MSG simply as `artificial flavors' in ingredient
+  - food manufacturers sometimes list MSG simply as `artificial flavors´ in ingredient
     lists
   hypernym:
   - 07825344-n
@@ -19408,7 +19408,7 @@
   definition:
   - cream that has at least 18% butterfat
   example:
-  - in England they call light cream `single cream'
+  - in England they call light cream `single cream´
   hypernym:
   - 07863174-n
   ili: i78411
@@ -22805,7 +22805,7 @@
   partOfSpeech: n
 07913175-n:
   definition:
-  - any of several white wines from the Rhine River valley in Germany (`hock' is British
+  - any of several white wines from the Rhine River valley in Germany (`hock´ is British
     usage)
   domain_region:
   - 08879115-n
@@ -23019,8 +23019,8 @@
   - wine that does not meet the minimum qualifications and standards for use of a
     designation by appellation of origin (where the grapes are grown) or by varietal
     content; may only be labeled by proprietary (made-up) name, by general color (such
-    as `vin rouge', `vino rosso', `rotwein', `red wine', etc.), or by general class
-    (as `vin ordinaire', `vin de table', `vino da tavola', `tafelwein', `table wine',
+    as `vin rouge´, `vino rosso´, `rotwein´, `red wine´, etc.), or by general class
+    (as `vin ordinaire´, `vin de table´, `vino da tavola´, `tafelwein´, `table wine´,
     etc.)
   hypernym:
   - 07907701-n
@@ -24571,7 +24571,7 @@
   partOfSpeech: n
 07937855-n:
   definition:
-  - alcoholic drink from fermented cider; `cider' and `cyder' are European (especially
+  - alcoholic drink from fermented cider; `cider´ and `cyder´ are European (especially
     British) usages for the fermented beverage
   hypernym:
   - 07937695-n
@@ -26338,7 +26338,7 @@
   - a simple type of soup where a basic roux is thinned with cream or milk and then
     mushrooms and/or mushroom broth are added.
   example:
-  - Canned cream of mushroom soup has been described as `America's béchamel'.
+  - Canned cream of mushroom soup has been described as `America's béchamel´.
   hypernym:
   - 07598762-n
   members:
@@ -26766,7 +26766,7 @@
   - The practice of eating mainly vegetarian food, but making occasional exceptions
     for social, pragmatic, cultural, or nutritional reasons.
   example:
-  - Flexitarianism will be the next `mega trend' leading to sales of vegetarian foods
+  - Flexitarianism will be the next `mega trend´ leading to sales of vegetarian foods
     in the UK to grow by 10% by 2016, according to food trends agency The Food People.
   hypernym:
   - 07576677-n

--- a/src/yaml/noun.food.yaml
+++ b/src/yaml/noun.food.yaml
@@ -658,8 +658,8 @@
   wikidata: Q2249305
 07585209-n:
   definition:
-  - flour made by grinding the entire wheat berry including the bran; (`whole meal
-    flour´ is British usage)
+  - flour made by grinding the entire wheat berry including the bran; (‘whole meal
+    flour’ is British usage)
   domain_region:
   - 08879115-n
   hypernym:
@@ -2369,7 +2369,7 @@
   definition:
   - prepared food that is intended to be eaten off of the premises
   example:
-  - in England they call takeout food `takeaway´
+  - in England they call takeout food ‘takeaway’
   hypernym:
   - 07609120-n
   ili: i76701
@@ -3620,7 +3620,7 @@
   partOfSpeech: n
 07628605-n:
   definition:
-  - (British) the dessert course of a meal (`pud´ is used informally)
+  - (British) the dessert course of a meal (‘pud’ is used informally)
   domain_region:
   - 08879115-n
   hypernym:
@@ -12304,8 +12304,8 @@
   partOfSpeech: n
 07753721-n:
   definition:
-  - pod of the peanut vine containing usually 2 nuts or seeds; `groundnut´ and `monkey
-    nut´ are British terms
+  - pod of the peanut vine containing usually 2 nuts or seeds; ‘groundnut’ and ‘monkey
+    nut’ are British terms
   hypernym:
   - 07753057-n
   ili: i77699
@@ -13919,7 +13919,7 @@
   partOfSpeech: n
 07778889-n:
   definition:
-  - huge fruit native to southeastern Asia `smelling like Hell and tasting like Heaven´;
+  - huge fruit native to southeastern Asia ‘smelling like Hell and tasting like Heaven’;
     seeds are roasted and eaten like nuts
   hypernym:
   - 07721676-n
@@ -16541,7 +16541,7 @@
   partOfSpeech: n
 07820128-n:
   definition:
-  - seed of the annual grass Avena sativa (spoken of primarily in the plural as `oats´)
+  - seed of the annual grass Avena sativa (spoken of primarily in the plural as ‘oats’)
   exemplifies:
   - 06306016-n
   hypernym:
@@ -18108,7 +18108,7 @@
   - white crystalline compound used as a food additive to enhance flavor; often used
     in Chinese cooking
   example:
-  - food manufacturers sometimes list MSG simply as `artificial flavors´ in ingredient
+  - food manufacturers sometimes list MSG simply as ‘artificial flavors’ in ingredient
     lists
   hypernym:
   - 07825344-n
@@ -19408,7 +19408,7 @@
   definition:
   - cream that has at least 18% butterfat
   example:
-  - in England they call light cream `single cream´
+  - in England they call light cream ‘single cream’
   hypernym:
   - 07863174-n
   ili: i78411
@@ -22805,7 +22805,7 @@
   partOfSpeech: n
 07913175-n:
   definition:
-  - any of several white wines from the Rhine River valley in Germany (`hock´ is British
+  - any of several white wines from the Rhine River valley in Germany (‘hock’ is British
     usage)
   domain_region:
   - 08879115-n
@@ -23019,8 +23019,8 @@
   - wine that does not meet the minimum qualifications and standards for use of a
     designation by appellation of origin (where the grapes are grown) or by varietal
     content; may only be labeled by proprietary (made-up) name, by general color (such
-    as `vin rouge´, `vino rosso´, `rotwein´, `red wine´, etc.), or by general class
-    (as `vin ordinaire´, `vin de table´, `vino da tavola´, `tafelwein´, `table wine´,
+    as ‘vin rouge’, ‘vino rosso’, ‘rotwein’, ‘red wine’, etc.), or by general class
+    (as ‘vin ordinaire’, ‘vin de table’, ‘vino da tavola’, ‘tafelwein’, ‘table wine’,
     etc.)
   hypernym:
   - 07907701-n
@@ -24571,7 +24571,7 @@
   partOfSpeech: n
 07937855-n:
   definition:
-  - alcoholic drink from fermented cider; `cider´ and `cyder´ are European (especially
+  - alcoholic drink from fermented cider; ‘cider’ and ‘cyder’ are European (especially
     British) usages for the fermented beverage
   hypernym:
   - 07937695-n
@@ -26338,7 +26338,7 @@
   - a simple type of soup where a basic roux is thinned with cream or milk and then
     mushrooms and/or mushroom broth are added.
   example:
-  - Canned cream of mushroom soup has been described as `America's béchamel´.
+  - Canned cream of mushroom soup has been described as ‘America's béchamel’.
   hypernym:
   - 07598762-n
   members:
@@ -26766,7 +26766,7 @@
   - The practice of eating mainly vegetarian food, but making occasional exceptions
     for social, pragmatic, cultural, or nutritional reasons.
   example:
-  - Flexitarianism will be the next `mega trend´ leading to sales of vegetarian foods
+  - Flexitarianism will be the next ‘mega trend’ leading to sales of vegetarian foods
     in the UK to grow by 10% by 2016, according to food trends agency The Food People.
   hypernym:
   - 07576677-n

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -3391,7 +3391,7 @@
 08018826-n:
   definition:
   - a company that operates its business primarily on the internet using a URL that
-    ends in `.com´
+    ends in ‘.com’
   hypernym:
   - 08074934-n
   ili: i79343
@@ -4578,7 +4578,7 @@
 08040596-n:
   definition:
   - the most popular and feared Islamic extremist group in central Asia; advocates
-    `pure´ Islam and the creation of a worldwide Islamic state
+    ‘pure’ Islam and the creation of a worldwide Islamic state
   domain_region:
   - 09230176-n
   domain_topic:
@@ -8728,7 +8728,7 @@
 08114732-n:
   definition:
   - a religious sect founded in the United States in 1966; based on Vedic scriptures;
-    groups engage in joyful chanting of `Hare Krishna´ and other mantras based on
+    groups engage in joyful chanting of ‘Hare Krishna’ and other mantras based on
     the name of the Hindu god Krishna; devotees usually wear saffron robes and practice
     vegetarianism and celibacy
   hypernym:
@@ -11436,7 +11436,7 @@
 08168750-n:
   definition:
   - (Melanesia) the followers of one of several millenarian cults that believe salvation
-    will come in the form of wealth (`cargo´) brought by westerners; some ascribe
+    will come in the form of wealth (‘cargo’) brought by westerners; some ascribe
     divine attributes to westerners on first contact (especially to missionaries)
   domain_topic:
   - 08855622-n
@@ -18361,7 +18361,7 @@
   domain_topic:
   - 06104629-n
   example:
-  - '`extragalactic nebula´ is a former name for `galaxy´'
+  - '‘extragalactic nebula’ is a former name for ‘galaxy’'
   hypernym:
   - 07968050-n
   ili: i80600
@@ -19366,7 +19366,7 @@
   partOfSpeech: n
 08304103-n:
   definition:
-  - a British abbreviation of `university´; usually refers to Oxford University or
+  - a British abbreviation of ‘university’; usually refers to Oxford University or
     Cambridge University
   hypernym:
   - 08303084-n
@@ -20905,7 +20905,7 @@
   definition:
   - the first council of the Western Church held in the Lateran Palace in 1123; focused
     on church discipline and made plans to recover the Holy Lands from the Muslim
-    `infidels´
+    ‘infidels’
   hypernym:
   - 08332124-n
   ili: i80831
@@ -21726,7 +21726,7 @@
 08347225-n:
   definition:
   - one of the twelve federal United States courts of appeals that cover a group of
-    states known as a `circuit´
+    states known as a ‘circuit’
   domain_topic:
   - 08458195-n
   hypernym:
@@ -27897,7 +27897,7 @@
   partOfSpeech: n
 08453462-n:
   definition:
-  - an entire system; used in the phrase `the whole shebang´
+  - an entire system; used in the phrase ‘the whole shebang’
   hypernym:
   - 08452398-n
   ili: i81455
@@ -28286,7 +28286,7 @@
   domain_topic:
   - 08458195-n
   example:
-  - the United States Constitution declares itself to be `the supreme law of the land´
+  - the United States Constitution declares itself to be ‘the supreme law of the land’
   hypernym:
   - 08458195-n
   ili: i81488
@@ -30907,7 +30907,7 @@
   source: plWordNet 4.0
 92428451-n:
   definition:
-  - fictional people in the `Fortess´, a series of fantasy novels by science fiction
+  - fictional people in the ‘Fortess’, a series of fantasy novels by science fiction
     and fantasy author C. J. Cherryh.
   domain_topic:
   - 06380048-n
@@ -30982,8 +30982,8 @@
     by a tendency to use free verse, complicated metrical innovations, and daring
     imagery and symbolism instead of traditional form and content.
   example:
-  - Jorge Luis Borges declared that the `newest aesthetic,´ Ultraism, is the poetic
-    alternative to `the prevailing Rubenism and Anecdotalism.´
+  - Jorge Luis Borges declared that the ‘newest aesthetic,’ Ultraism, is the poetic
+    alternative to ‘the prevailing Rubenism and Anecdotalism.’
   hypernym:
   - 08483654-n
   members:
@@ -31010,7 +31010,7 @@
     nearby Slavic states in the Balkans as well as Russia.
   example:
   - The Neo-Slavism of 1908-1910 and its effects up to the First World. War were to
-    a large extent a creation of Czech `foreign policy´.
+    a large extent a creation of Czech ‘foreign policy’.
   hypernym:
   - 08481612-n
   members:
@@ -31025,7 +31025,7 @@
   example:
   - This ephemeral appearance of Karaism on Spanish soil was fruitful for Jewish historical
     literature, for it induced the philosophically trained Abraham ibn Daud of Toledo
-    to write his `Sefer ha-Ḳabbalah´ (1161), which is invaluable for the history of
+    to write his ‘Sefer ha-Ḳabbalah’ (1161), which is invaluable for the history of
     the Jews in Spain.
   hypernym:
   - 08110979-n
@@ -31105,8 +31105,8 @@
   definition:
   - The quality of being Japanese.
   example:
-  - Japan's continuous obsession with the idea of the `Japaneseness´ in craft products
-    was complicated by its effort to redeﬁne itself in terms of its `Orientalness´.
+  - Japan's continuous obsession with the idea of the ‘Japaneseness’ in craft products
+    was complicated by its effort to redeﬁne itself in terms of its ‘Orientalness’.
   hypernym:
   - 08304765-n
   members:
@@ -31312,7 +31312,7 @@
   source: plWordNet 4.0
 92447043-n:
   definition:
-  - any form of drama which is not naturalistic, traditional, conventional or `legit´;
+  - any form of drama which is not naturalistic, traditional, conventional or ‘legit’;
     thus, theatre which disobeys or actively goes against accepted laws and rules
     of dramaturgy.
   example:
@@ -31341,7 +31341,7 @@
   definition:
   - Advocacy of rural life instead of urbanism or city living.
   example:
-  - By `ruralism´ I mean the glorification of country life, and a dissatisfaction
+  - By ‘ruralism’ I mean the glorification of country life, and a dissatisfaction
     with urbanism.
   hypernym:
   - 08481612-n

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -31025,8 +31025,8 @@
   example:
   - This ephemeral appearance of Karaism on Spanish soil was fruitful for Jewish historical
     literature, for it induced the philosophically trained Abraham ibn Daud of Toledo
-    to write his `Sefer ha-Ḳabbalah' (1161), which is invaluable for the history
-    of the Jews in Spain.
+    to write his `Sefer ha-Ḳabbalah' (1161), which is invaluable for the history of
+    the Jews in Spain.
   hypernym:
   - 08110979-n
   members:

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -3391,7 +3391,7 @@
 08018826-n:
   definition:
   - a company that operates its business primarily on the internet using a URL that
-    ends in `.com'
+    ends in `.com´
   hypernym:
   - 08074934-n
   ili: i79343
@@ -4578,7 +4578,7 @@
 08040596-n:
   definition:
   - the most popular and feared Islamic extremist group in central Asia; advocates
-    `pure' Islam and the creation of a worldwide Islamic state
+    `pure´ Islam and the creation of a worldwide Islamic state
   domain_region:
   - 09230176-n
   domain_topic:
@@ -8728,7 +8728,7 @@
 08114732-n:
   definition:
   - a religious sect founded in the United States in 1966; based on Vedic scriptures;
-    groups engage in joyful chanting of `Hare Krishna' and other mantras based on
+    groups engage in joyful chanting of `Hare Krishna´ and other mantras based on
     the name of the Hindu god Krishna; devotees usually wear saffron robes and practice
     vegetarianism and celibacy
   hypernym:
@@ -11436,7 +11436,7 @@
 08168750-n:
   definition:
   - (Melanesia) the followers of one of several millenarian cults that believe salvation
-    will come in the form of wealth (`cargo') brought by westerners; some ascribe
+    will come in the form of wealth (`cargo´) brought by westerners; some ascribe
     divine attributes to westerners on first contact (especially to missionaries)
   domain_topic:
   - 08855622-n
@@ -18361,7 +18361,7 @@
   domain_topic:
   - 06104629-n
   example:
-  - '`extragalactic nebula'' is a former name for `galaxy'''
+  - '`extragalactic nebula´ is a former name for `galaxy´'
   hypernym:
   - 07968050-n
   ili: i80600
@@ -19366,7 +19366,7 @@
   partOfSpeech: n
 08304103-n:
   definition:
-  - a British abbreviation of `university'; usually refers to Oxford University or
+  - a British abbreviation of `university´; usually refers to Oxford University or
     Cambridge University
   hypernym:
   - 08303084-n
@@ -20905,7 +20905,7 @@
   definition:
   - the first council of the Western Church held in the Lateran Palace in 1123; focused
     on church discipline and made plans to recover the Holy Lands from the Muslim
-    `infidels'
+    `infidels´
   hypernym:
   - 08332124-n
   ili: i80831
@@ -21726,7 +21726,7 @@
 08347225-n:
   definition:
   - one of the twelve federal United States courts of appeals that cover a group of
-    states known as a `circuit'
+    states known as a `circuit´
   domain_topic:
   - 08458195-n
   hypernym:
@@ -27897,7 +27897,7 @@
   partOfSpeech: n
 08453462-n:
   definition:
-  - an entire system; used in the phrase `the whole shebang'
+  - an entire system; used in the phrase `the whole shebang´
   hypernym:
   - 08452398-n
   ili: i81455
@@ -28286,7 +28286,7 @@
   domain_topic:
   - 08458195-n
   example:
-  - the United States Constitution declares itself to be `the supreme law of the land'
+  - the United States Constitution declares itself to be `the supreme law of the land´
   hypernym:
   - 08458195-n
   ili: i81488
@@ -30811,7 +30811,7 @@
   definition:
   - The quality or characteristic of being Czech.
   example:
-  - There's more Czechness in Brno than in Prague, says American academic now living
+  - There´s more Czechness in Brno than in Prague, says American academic now living
     in the Czech Republic.
   hypernym:
   - 08304765-n
@@ -30907,7 +30907,7 @@
   source: plWordNet 4.0
 92428451-n:
   definition:
-  - fictional people in the `Fortess', a series of fantasy novels by science fiction
+  - fictional people in the `Fortess´, a series of fantasy novels by science fiction
     and fantasy author C. J. Cherryh.
   domain_topic:
   - 06380048-n
@@ -30982,8 +30982,8 @@
     by a tendency to use free verse, complicated metrical innovations, and daring
     imagery and symbolism instead of traditional form and content.
   example:
-  - Jorge Luis Borges declared that the `newest aesthetic,' Ultraism, is the poetic
-    alternative to `the prevailing Rubenism and Anecdotalism.'
+  - Jorge Luis Borges declared that the `newest aesthetic,´ Ultraism, is the poetic
+    alternative to `the prevailing Rubenism and Anecdotalism.´
   hypernym:
   - 08483654-n
   members:
@@ -31010,7 +31010,7 @@
     nearby Slavic states in the Balkans as well as Russia.
   example:
   - The Neo-Slavism of 1908-1910 and its effects up to the First World. War were to
-    a large extent a creation of Czech `foreign policy'.
+    a large extent a creation of Czech `foreign policy´.
   hypernym:
   - 08481612-n
   members:
@@ -31025,7 +31025,7 @@
   example:
   - This ephemeral appearance of Karaism on Spanish soil was fruitful for Jewish historical
     literature, for it induced the philosophically trained Abraham ibn Daud of Toledo
-    to write his `Sefer ha-Ḳabbalah' (1161), which is invaluable for the history of
+    to write his `Sefer ha-Ḳabbalah´ (1161), which is invaluable for the history of
     the Jews in Spain.
   hypernym:
   - 08110979-n
@@ -31105,8 +31105,8 @@
   definition:
   - The quality of being Japanese.
   example:
-  - Japan's continuous obsession with the idea of the `Japaneseness' in craft products
-    was complicated by its effort to redeﬁne itself in terms of its `Orientalness'.
+  - Japan's continuous obsession with the idea of the `Japaneseness´ in craft products
+    was complicated by its effort to redeﬁne itself in terms of its `Orientalness´.
   hypernym:
   - 08304765-n
   members:
@@ -31312,7 +31312,7 @@
   source: plWordNet 4.0
 92447043-n:
   definition:
-  - any form of drama which is not naturalistic, traditional, conventional or `legit';
+  - any form of drama which is not naturalistic, traditional, conventional or `legit´;
     thus, theatre which disobeys or actively goes against accepted laws and rules
     of dramaturgy.
   example:
@@ -31341,7 +31341,7 @@
   definition:
   - Advocacy of rural life instead of urbanism or city living.
   example:
-  - By `ruralism' I mean the glorification of country life, and a dissatisfaction
+  - By `ruralism´ I mean the glorification of country life, and a dissatisfaction
     with urbanism.
   hypernym:
   - 08481612-n

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -18361,7 +18361,7 @@
   domain_topic:
   - 06104629-n
   example:
-  - '‘extragalactic nebula’ is a former name for ‘galaxy’'
+  - ‘extragalactic nebula’ is a former name for ‘galaxy’
   hypernym:
   - 07968050-n
   ili: i80600

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -30811,7 +30811,7 @@
   definition:
   - The quality or characteristic of being Czech.
   example:
-  - There´s more Czechness in Brno than in Prague, says American academic now living
+  - There's more Czechness in Brno than in Prague, says American academic now living
     in the Czech Republic.
   hypernym:
   - 08304765-n

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -1232,7 +1232,8 @@
   domain_topic:
   - 00315295-n
   example:
-  - "`on her beam-ends' means heeled over on the side so that the deck is almost vertical"
+  - '`on her beam-ends'' means heeled over on the side so that the deck is almost
+    vertical'
   hypernym:
   - 08527687-n
   ili: i81775
@@ -38023,8 +38024,8 @@
   partOfSpeech: n
 89497668-n:
   definition:
-  - kingdom and sovereign state consisting of the Netherlands, Aruba, Curacao and Sint
-    Maarten
+  - kingdom and sovereign state consisting of the Netherlands, Aruba, Curacao and
+    Sint Maarten
   hypernym:
   - 08608825-n
   members:

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -1232,8 +1232,7 @@
   domain_topic:
   - 00315295-n
   example:
-  - '`on her beam-ends'' means heeled over on the side so that the deck is almost
-    vertical'
+  - '`on her beam-ends´ means heeled over on the side so that the deck is almost vertical'
   hypernym:
   - 08527687-n
   ili: i81775
@@ -1684,7 +1683,7 @@
   definition:
   - a place where taxis park while awaiting customers
   example:
-  - in England the place where taxis wait to be hired is called a `taxi rank'
+  - in England the place where taxis wait to be hired is called a `taxi rank´
   hypernym:
   - 08671281-n
   ili: i81816
@@ -3784,7 +3783,7 @@
   definition:
   - the surface at either extremity of a three-dimensional object
   example:
-  - one end of the box was marked `This side up'
+  - one end of the box was marked `This side up´
   hypernym:
   - 08677970-n
   ili: i82002
@@ -16108,7 +16107,7 @@
     it was built a temple and later the name extended to the whole hill; finally it
     became a synonym for the city of Jerusalem
   example:
-  - the inhabitants of Jerusalem are personified as `the daughter of Zion'
+  - the inhabitants of Jerusalem are personified as `the daughter of Zion´
   ili: i83084
   instance_hypernym:
   - 09325914-n
@@ -16497,7 +16496,7 @@
   wikidata: Q3476
 08822339-n:
   definition:
-  - a region of southern Italy (forming the instep of the Italian `boot')
+  - a region of southern Italy (forming the instep of the Italian `boot´)
   domain_region:
   - 08819530-n
   ili: i83113
@@ -16528,7 +16527,7 @@
   partOfSpeech: n
 08822814-n:
   definition:
-  - a region of southern Italy (forming the toe of the Italian `boot')
+  - a region of southern Italy (forming the toe of the Italian `boot´)
   domain_region:
   - 08819530-n
   ili: i83116
@@ -19679,7 +19678,7 @@
 08879115-n:
   definition:
   - a monarchy in northwestern Europe occupying most of the British Isles; divided
-    into England and Scotland and Wales and Northern Ireland; `Great Britain' is often
+    into England and Scotland and Wales and Northern Ireland; `Great Britain´ is often
     used loosely to refer to the United Kingdom
   ili: i83373
   instance_hypernym:
@@ -20168,7 +20167,7 @@
 08899615-n:
   definition:
   - a port city in northeastern England on the River Tyne; a center for coal exports
-    (giving rise to the expression `carry coals to Newcastle' meaning to do something
+    (giving rise to the expression `carry coals to Newcastle´ meaning to do something
     unnecessary)
   ili: i83408
   instance_hypernym:
@@ -34471,7 +34470,7 @@
   partOfSpeech: n
 09145635-n:
   definition:
-  - a mainly residential district of Manhattan; `the Village' became a home for many
+  - a mainly residential district of Manhattan; `the Village´ became a home for many
     writers and artists in the 20th century
   ili: i84571
   instance_hypernym:
@@ -38319,7 +38318,7 @@
     to receive a promotion.
   example:
   - In traditional Western chess the pawns promote/enrobe on the 8th rank (the `promotion
-    zone').
+    zone´).
   hypernym:
   - 08526463-n
   members:

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -1232,7 +1232,7 @@
   domain_topic:
   - 00315295-n
   example:
-  - '‘on her beam-ends’ means heeled over on the side so that the deck is almost vertical'
+  - ‘on her beam-ends’ means heeled over on the side so that the deck is almost vertical
   hypernym:
   - 08527687-n
   ili: i81775

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -1232,7 +1232,7 @@
   domain_topic:
   - 00315295-n
   example:
-  - '`on her beam-ends´ means heeled over on the side so that the deck is almost vertical'
+  - '‘on her beam-ends’ means heeled over on the side so that the deck is almost vertical'
   hypernym:
   - 08527687-n
   ili: i81775
@@ -1683,7 +1683,7 @@
   definition:
   - a place where taxis park while awaiting customers
   example:
-  - in England the place where taxis wait to be hired is called a `taxi rank´
+  - in England the place where taxis wait to be hired is called a ‘taxi rank’
   hypernym:
   - 08671281-n
   ili: i81816
@@ -3783,7 +3783,7 @@
   definition:
   - the surface at either extremity of a three-dimensional object
   example:
-  - one end of the box was marked `This side up´
+  - one end of the box was marked ‘This side up’
   hypernym:
   - 08677970-n
   ili: i82002
@@ -16107,7 +16107,7 @@
     it was built a temple and later the name extended to the whole hill; finally it
     became a synonym for the city of Jerusalem
   example:
-  - the inhabitants of Jerusalem are personified as `the daughter of Zion´
+  - the inhabitants of Jerusalem are personified as ‘the daughter of Zion’
   ili: i83084
   instance_hypernym:
   - 09325914-n
@@ -16496,7 +16496,7 @@
   wikidata: Q3476
 08822339-n:
   definition:
-  - a region of southern Italy (forming the instep of the Italian `boot´)
+  - a region of southern Italy (forming the instep of the Italian ‘boot’)
   domain_region:
   - 08819530-n
   ili: i83113
@@ -16527,7 +16527,7 @@
   partOfSpeech: n
 08822814-n:
   definition:
-  - a region of southern Italy (forming the toe of the Italian `boot´)
+  - a region of southern Italy (forming the toe of the Italian ‘boot’)
   domain_region:
   - 08819530-n
   ili: i83116
@@ -19678,7 +19678,7 @@
 08879115-n:
   definition:
   - a monarchy in northwestern Europe occupying most of the British Isles; divided
-    into England and Scotland and Wales and Northern Ireland; `Great Britain´ is often
+    into England and Scotland and Wales and Northern Ireland; ‘Great Britain’ is often
     used loosely to refer to the United Kingdom
   ili: i83373
   instance_hypernym:
@@ -20167,7 +20167,7 @@
 08899615-n:
   definition:
   - a port city in northeastern England on the River Tyne; a center for coal exports
-    (giving rise to the expression `carry coals to Newcastle´ meaning to do something
+    (giving rise to the expression ‘carry coals to Newcastle’ meaning to do something
     unnecessary)
   ili: i83408
   instance_hypernym:
@@ -34470,7 +34470,7 @@
   partOfSpeech: n
 09145635-n:
   definition:
-  - a mainly residential district of Manhattan; `the Village´ became a home for many
+  - a mainly residential district of Manhattan; ‘the Village’ became a home for many
     writers and artists in the 20th century
   ili: i84571
   instance_hypernym:
@@ -38317,8 +38317,8 @@
   - A predesignated portion of a chess board that a starting piece must reach in order
     to receive a promotion.
   example:
-  - In traditional Western chess the pawns promote/enrobe on the 8th rank (the `promotion
-    zone´).
+  - In traditional Western chess the pawns promote/enrobe on the 8th rank (the ‘promotion
+    zone’).
   hypernym:
   - 08526463-n
   members:

--- a/src/yaml/noun.motive.yaml
+++ b/src/yaml/noun.motive.yaml
@@ -49,7 +49,7 @@
 09202503-n:
   definition:
   - the cause or intention underlying an action or situation, especially in the phrase
-    `the whys and wherefores'
+    `the whys and wherefores´
   hypernym:
   - 09201896-n
   ili: i84881

--- a/src/yaml/noun.motive.yaml
+++ b/src/yaml/noun.motive.yaml
@@ -49,7 +49,7 @@
 09202503-n:
   definition:
   - the cause or intention underlying an action or situation, especially in the phrase
-    `the whys and wherefores´
+    ‘the whys and wherefores’
   hypernym:
   - 09201896-n
   ili: i84881

--- a/src/yaml/noun.object.yaml
+++ b/src/yaml/noun.object.yaml
@@ -5120,7 +5120,7 @@
 09298379-n:
   definition:
   - the 2nd smallest continent (actually a vast peninsula of Eurasia); the British
-    use `Europe´ to refer to all of the continent except the British Isles
+    use ‘Europe’ to refer to all of the continent except the British Isles
   ili: i85374
   instance_hypernym:
   - 09277520-n
@@ -16085,7 +16085,7 @@
   definition:
   - a constellation in the Southern Hemisphere between Carina and Pyxis
   example:
-  - because of its configuration Vela is sometimes called `the Sails´
+  - because of its configuration Vela is sometimes called ‘the Sails’
   ili: i86387
   instance_hypernym:
   - 09275876-n
@@ -16107,7 +16107,7 @@
   definition:
   - the second nearest planet to the sun; it is peculiar in that its rotation is slow
     and retrograde (in the opposite sense of the Earth and all other planets except
-    Uranus); it is visible from Earth as an early `morning star´ or an `evening star´
+    Uranus); it is visible from Earth as an early ‘morning star’ or an ‘evening star’
   example:
   - before it was known that they were the same object the evening star was called
     Venus and the morning star was called Lucifer

--- a/src/yaml/noun.object.yaml
+++ b/src/yaml/noun.object.yaml
@@ -5120,7 +5120,7 @@
 09298379-n:
   definition:
   - the 2nd smallest continent (actually a vast peninsula of Eurasia); the British
-    use `Europe' to refer to all of the continent except the British Isles
+    use `Europe´ to refer to all of the continent except the British Isles
   ili: i85374
   instance_hypernym:
   - 09277520-n
@@ -16085,7 +16085,7 @@
   definition:
   - a constellation in the Southern Hemisphere between Carina and Pyxis
   example:
-  - because of its configuration Vela is sometimes called `the Sails'
+  - because of its configuration Vela is sometimes called `the Sails´
   ili: i86387
   instance_hypernym:
   - 09275876-n
@@ -16107,7 +16107,7 @@
   definition:
   - the second nearest planet to the sun; it is peculiar in that its rotation is slow
     and retrograde (in the opposite sense of the Earth and all other planets except
-    Uranus); it is visible from Earth as an early `morning star' or an `evening star'
+    Uranus); it is visible from Earth as an early `morning star´ or an `evening star´
   example:
   - before it was known that they were the same object the evening star was called
     Venus and the morning star was called Lucifer

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -6993,7 +6993,8 @@
   definition:
   - a mythical Greek hero of the Iliad; a foremost Greek warrior at the siege of Troy;
     when he was a baby his mother tried to make him immortal by bathing him in a magical
-    river but the heel by which she held him remained vulnerable — his `Achilles' heel'
+    river but the heel by which she held him remained vulnerable — his `Achilles'
+    heel'
   ili: i87084
   instance_hypernym:
   - 09507794-n
@@ -51533,8 +51534,8 @@
   partOfSpeech: n
 10342840-n:
   definition:
-  - someone sent on a mission — especially a religious or charitable mission to a foreign
-    country
+  - someone sent on a mission — especially a religious or charitable mission to a
+    foreign country
   hypernym:
   - 09651570-n
   ili: i91402

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -1828,7 +1828,7 @@
 09538404-n:
   definition:
   - the Babylonian father of the gods; identified with Assyrian Ashur; in Sumerian
-    the name signifies `the totality of the upper world´
+    the name signifies ‘the totality of the upper world’
   domain_region:
   - 08936605-n
   ili: i86625
@@ -2109,8 +2109,8 @@
   partOfSpeech: n
 09542043-n:
   definition:
-  - Babylonian consort of Anshar; in Sumerian the name signifies `the totality of
-    the lower world´
+  - Babylonian consort of Anshar; in Sumerian the name signifies ‘the totality of
+    the lower world’
   domain_region:
   - 08936605-n
   ili: i86649
@@ -2130,7 +2130,7 @@
   partOfSpeech: n
 09542327-n:
   definition:
-  - a name under which Ninkhursag was worshipped, meaning `Mother´
+  - a name under which Ninkhursag was worshipped, meaning ‘Mother’
   ili: i86651
   instance_hypernym:
   - 09537037-n
@@ -2269,7 +2269,7 @@
   wikidata: Q836170
 09544186-n:
   definition:
-  - a name under which Ninkhursag was worshipped, meaning `Lady of Birth´
+  - a name under which Ninkhursag was worshipped, meaning ‘Lady of Birth’
   ili: i86664
   instance_hypernym:
   - 09537037-n
@@ -2488,7 +2488,7 @@
   partOfSpeech: n
 09547806-n:
   definition:
-  - (literally `possessing horses´ in Sanskrit) in Hinduism the twin chariot warriors
+  - (literally ‘possessing horses’ in Sanskrit) in Hinduism the twin chariot warriors
     conveying Surya
   domain_topic:
   - 06981803-n
@@ -2608,7 +2608,7 @@
 09549355-n:
   definition:
   - in Hinduism, goddess of purity and posterity and a benevolent aspect of Devi;
-    the `brilliant´
+    the ‘brilliant’
   ili: i86696
   instance_hypernym:
   - 09546113-n
@@ -2861,7 +2861,7 @@
   partOfSpeech: n
 09552486-n:
   definition:
-  - a benevolent aspect of Devi; `splendor´
+  - a benevolent aspect of Devi; ‘splendor’
   ili: i86723
   instance_hypernym:
   - 09546113-n
@@ -6993,8 +6993,8 @@
   definition:
   - a mythical Greek hero of the Iliad; a foremost Greek warrior at the siege of Troy;
     when he was a baby his mother tried to make him immortal by bathing him in a magical
-    river but the heel by which she held him remained vulnerable — his `Achilles'
-    heel´
+    river but the heel by which she held him remained vulnerable — his ‘Achilles'
+    heel’
   ili: i87084
   instance_hypernym:
   - 09507794-n
@@ -7194,7 +7194,7 @@
 09620972-n:
   definition:
   - (Greek mythology) a tragic king of Thebes who unknowingly killed his father Laius
-    and married his mother Jocasta; the subject of the drama `Oedipus Rex´ by Sophocles
+    and married his mother Jocasta; the subject of the drama ‘Oedipus Rex’ by Sophocles
   domain_topic:
   - 07995848-n
   ili: i87101
@@ -7704,7 +7704,7 @@
   partOfSpeech: n
 09628284-n:
   definition:
-  - a reference to yourself or myself etc.; `take care of number one´ means to put
+  - a reference to yourself or myself etc.; ‘take care of number one’ means to put
     your own interests first
   exemplifies:
   - 07089193-n
@@ -8856,7 +8856,7 @@
   wikidata: Q2072081
 09659490-n:
   definition:
-  - a person with African ancestry, `Negro´ and `Negroid´ are archaic and pejorative
+  - a person with African ancestry, ‘Negro’ and ‘Negroid’ are archaic and pejorative
     today
   hypernym:
   - 09786620-n
@@ -10379,7 +10379,7 @@
   partOfSpeech: n
 09686327-n:
   definition:
-  - a member of any of about two dozen Native American peoples called `Pueblos´ by
+  - a member of any of about two dozen Native American peoples called ‘Pueblos’ by
     the Spanish because they live in pueblos (villages built of adobe and rock)
   hypernym:
   - 09664887-n
@@ -12437,8 +12437,8 @@
 09721530-n:
   definition:
   - a person of Anglo-Saxon (especially British) descent whose native tongue is English
-    and whose culture is strongly influenced by English culture as in WASP for `White
-    Anglo-Saxon Protestant´
+    and whose culture is strongly influenced by English culture as in WASP for ‘White
+    Anglo-Saxon Protestant’
   domain_region:
   - 08879115-n
   example:
@@ -17488,7 +17488,7 @@
   partOfSpeech: n
 09802387-n:
   definition:
-  - the fictional woodcutter who discovered that `open sesame´ opened a cave in the
+  - the fictional woodcutter who discovered that ‘open sesame’ opened a cave in the
     Arabian Nights' Entertainment
   ili: i88147
   instance_hypernym:
@@ -19909,7 +19909,7 @@
   partOfSpeech: n
 09846568-n:
   definition:
-  - South African term for `boss´
+  - South African term for ‘boss’
   hypernym:
   - 10123978-n
   ili: i88378
@@ -19918,7 +19918,7 @@
   partOfSpeech: n
 09846648-n:
   definition:
-  - used as a Hindi courtesy title; equivalent to English `Mr´
+  - used as a Hindi courtesy title; equivalent to English ‘Mr’
   hypernym:
   - 10306910-n
   ili: i88379
@@ -26025,7 +26025,7 @@
   example:
   - she writes books for children
   - they're just kids
-  - '`tiddler´ is a British term for youngster'
+  - '‘tiddler’ is a British term for youngster'
   hypernym:
   - 09645219-n
   ili: i88964
@@ -28204,7 +28204,7 @@
   partOfSpeech: n
 09975423-n:
   definition:
-  - informal abbreviation of `representative´
+  - informal abbreviation of ‘representative’
   hypernym:
   - 09975260-n
   ili: i89171
@@ -29353,8 +29353,8 @@
   partOfSpeech: n
 09992739-n:
   definition:
-  - local names for a cowboy (`vaquero´ is used especially in southwestern and central
-    Texas and `buckaroo´ is used especially in California)
+  - local names for a cowboy (‘vaquero’ is used especially in southwestern and central
+    Texas and ‘buckaroo’ is used especially in California)
   hypernym:
   - 09992191-n
   ili: i89283
@@ -32616,7 +32616,7 @@
   partOfSpeech: n
 10046092-n:
   definition:
-  - a person who responds `I don't know´ in a public opinion poll
+  - a person who responds ‘I don't know’ in a public opinion poll
   example:
   - 70% in favor, 13% opposed and 17% don't-knows
   exemplifies:
@@ -34800,8 +34800,8 @@
 10083442-n:
   definition:
   - a member of a people inhabiting the Arctic (northern Canada or Greenland or Alaska
-    or eastern Siberia); the Algonquians called them Eskimo (`eaters of raw flesh´)
-    but they call themselves the Inuit (`the people´)
+    or eastern Siberia); the Algonquians called them Eskimo (‘eaters of raw flesh’)
+    but they call themselves the Inuit (‘the people’)
   hypernym:
   - 09664887-n
   ili: i89798
@@ -35130,7 +35130,7 @@
 10088735-n:
   definition:
   - a title used to address dignitaries (such as ambassadors or governors); usually
-    preceded by `Your´ or `His´ or `Her´
+    preceded by ‘Your’ or ‘His’ or ‘Her’
   example:
   - Your Excellency
   hypernym:
@@ -35883,8 +35883,8 @@
   partOfSpeech: n
 10100973-n:
   definition:
-  - '`Father´ is a term of address for priests in some churches (especially the Roman
-    Catholic Church or the Orthodox Catholic Church); `Padre´ is frequently used in
+  - '‘Father’ is a term of address for priests in some churches (especially the Roman
+    Catholic Church or the Orthodox Catholic Church); ‘Padre’ is frequently used in
     the military'
   hypernym:
   - 10490364-n
@@ -38840,7 +38840,7 @@
   partOfSpeech: n
 10146723-n:
   definition:
-  - informal abbreviation of `gentleman´
+  - informal abbreviation of ‘gentleman’
   hypernym:
   - 10146810-n
   ili: i90188
@@ -40474,7 +40474,7 @@
   partOfSpeech: n
 10169935-n:
   definition:
-  - a soldier who is a member of a unit called `the guard´ or `guards´
+  - a soldier who is a member of a unit called ‘the guard’ or ‘guards’
   hypernym:
   - 10641415-n
   ili: i90347
@@ -42478,7 +42478,7 @@
   - the person who is in possession of a check or note or bond or document of title
     that is endorsed to him or to whoever holds it
   example:
-  - the bond was marked `payable to bearer´
+  - the bond was marked ‘payable to bearer’
   hypernym:
   - 09632262-n
   ili: i90534
@@ -44896,7 +44896,7 @@
   definition:
   - (Old Testament) son of Isaac; brother of Esau; father of the twelve patriarchs
     of Israel; Jacob wrestled with God and forced God to bless him, so God gave Jacob
-    the new name of Israel (meaning `one who has been strong against God´)
+    the new name of Israel (meaning ‘one who has been strong against God’)
   domain_topic:
   - 06461405-n
   hypernym:
@@ -51962,7 +51962,7 @@
   partOfSpeech: n
 10349388-n:
   definition:
-  - used as a French courtesy title; equivalent to English `Mr´
+  - used as a French courtesy title; equivalent to English ‘Mr’
   hypernym:
   - 10306910-n
   ili: i91444
@@ -61144,7 +61144,7 @@
 10509149-n:
   definition:
   - someone with a sociopathic personality; a person with an antisocial personality
-    disorder (`psychopath´ was once widely used but has now been superseded by `sociopath´)
+    disorder (‘psychopath’ was once widely used but has now been superseded by ‘sociopath’)
   hypernym:
   - 10374597-n
   ili: i92328
@@ -62389,7 +62389,7 @@
   partOfSpeech: n
 10527376-n:
   definition:
-  - a fictional character in Dostoevsky's novel `Crime and Punishment´; he kills old
+  - a fictional character in Dostoevsky's novel ‘Crime and Punishment’; he kills old
     women because he believes he is beyond the bounds of good or evil
   ili: i92450
   instance_hypernym:
@@ -64382,7 +64382,7 @@
   - kill the rat
   - throw the bum out
   - you cowardly little pukes!
-  - the British call a contemptible person a `git´
+  - the British call a contemptible person a ‘git’
   exemplifies:
   - 06730109-n
   hypernym:
@@ -65007,8 +65007,8 @@
   partOfSpeech: n
 10569647-n:
   definition:
-  - a young peddler of sand; used now only to express great happiness in `happy as
-    a sandboy´
+  - a young peddler of sand; used now only to express great happiness in ‘happy as
+    a sandboy’
   domain_region:
   - 08879115-n
   hypernym:
@@ -66223,7 +66223,7 @@
   partOfSpeech: n
 10588198-n:
   definition:
-  - an intermediate person; used in the phrase `at second hand´
+  - an intermediate person; used in the phrase ‘at second hand’
   example:
   - he could learn at second hand from books
   hypernym:
@@ -66810,7 +66810,7 @@
   partOfSpeech: n
 10598404-n:
   definition:
-  - a Portuguese title of respect; equivalent to English `Mr´
+  - a Portuguese title of respect; equivalent to English ‘Mr’
   hypernym:
   - 10306910-n
   ili: i92871
@@ -68107,7 +68107,7 @@
   partOfSpeech: n
 10617421-n:
   definition:
-  - an Italian title of respect for a man; equivalent to the English `sir´; used separately
+  - an Italian title of respect for a man; equivalent to the English ‘sir’; used separately
     (not prefixed to his name)
   hypernym:
   - 10306910-n
@@ -68117,7 +68117,7 @@
   partOfSpeech: n
 10617589-n:
   definition:
-  - an Italian courtesy title for an unmarried woman; equivalent to `Miss´, it is
+  - an Italian courtesy title for an unmarried woman; equivalent to ‘Miss’, it is
     either used alone or before a name
   hypernym:
   - 10759169-n
@@ -69923,8 +69923,8 @@
   partOfSpeech: n
 10647730-n:
   definition:
-  - '`Johnny´ was applied as a nickname for Confederate soldiers by the Federal soldiers
-    in the American Civil War; `greyback´ derived from their grey Confederate uniforms'
+  - '‘Johnny’ was applied as a nickname for Confederate soldiers by the Federal soldiers
+    in the American Civil War; ‘greyback’ derived from their grey Confederate uniforms'
   exemplifies:
   - 07089193-n
   hypernym:
@@ -75669,7 +75669,7 @@
 10739916-n:
   definition:
   - a follower of Tractarianism and supporter of the Oxford movement (which was expounded
-    in pamphlets called `Tracts for the Times´)
+    in pamphlets called ‘Tracts for the Times’)
   hypernym:
   - 09697405-n
   ili: i93719
@@ -85803,7 +85803,7 @@
   partOfSpeech: n
 10901368-n:
   definition:
-  - Czech writer who introduced the word `robot´ into the English language (1890-1938)
+  - Czech writer who introduced the word ‘robot’ into the English language (1890-1938)
   ili: i94639
   instance_hypernym:
   - 10813654-n
@@ -86283,7 +86283,7 @@
   partOfSpeech: n
 10908784-n:
   definition:
-  - Spanish writer best remembered for `Don Quixote´ which satirizes chivalry and
+  - Spanish writer best remembered for ‘Don Quixote’ which satirizes chivalry and
     influenced the development of the novel form (1547-1616)
   ili: i94681
   instance_hypernym:
@@ -87122,7 +87122,7 @@
 10922924-n:
   definition:
   - king of the Franks who unified Gaul and established his capital at Paris and founded
-    the Frankish monarchy; his name was rendered as Gallic `Louis´ (466-511)
+    the Frankish monarchy; his name was rendered as Gallic ‘Louis’ (466-511)
   ili: i94751
   instance_hypernym:
   - 10251212-n
@@ -88085,7 +88085,7 @@
 10938110-n:
   definition:
   - United States lithographer who (with his partner James Ives) produced thousands
-    of prints signed `Currier & Ives´ (1813-1888)
+    of prints signed ‘Currier & Ives’ (1813-1888)
   ili: i94833
   instance_hypernym:
   - 10286183-n
@@ -90253,7 +90253,7 @@
   partOfSpeech: n
 10973597-n:
   definition:
-  - German bacteriologist who found a `magic bullet´ to cure syphilis and was a pioneer
+  - German bacteriologist who found a ‘magic bullet’ to cure syphilis and was a pioneer
     in the study of immunology (1854-1915)
   ili: i95017
   instance_hypernym:
@@ -92214,7 +92214,7 @@
 11006018-n:
   definition:
   - United States biochemist (born in Poland) who showed that several diseases were
-    caused by dietary deficiencies and who coined the term `vitamin´ for the chemicals
+    caused by dietary deficiencies and who coined the term ‘vitamin’ for the chemicals
     involved (1884-1967)
   ili: i95187
   instance_hypernym:
@@ -92965,7 +92965,7 @@
   partOfSpeech: n
 11018470-n:
   definition:
-  - United States illustrator remembered for his creation of the `Gibson girl´ (1867-1944)
+  - United States illustrator remembered for his creation of the ‘Gibson girl’ (1867-1944)
   ili: i95253
   instance_hypernym:
   - 09831473-n
@@ -94568,8 +94568,8 @@
 11043619-n:
   definition:
   - a soldier of the American Revolution who was hanged as a spy by the British; his
-    last words were supposed to have been `I only regret that I have but one life
-    to give for my country´ (1755-1776)
+    last words were supposed to have been ‘I only regret that I have but one life
+    to give for my country’ (1755-1776)
   ili: i95388
   instance_hypernym:
   - 09759416-n
@@ -96710,7 +96710,7 @@
   - English scientist who formulated the law of elasticity and proposed a wave theory
     of light and formulated a theory of planetary motion and proposed the inverse
     square law of gravitational attraction and discovered the cellular structure of
-    cork and introduced the term `cell´ into biology and invented a balance spring
+    cork and introduced the term ‘cell’ into biology and invented a balance spring
     for watches (1635-1703)
   ili: i95574
   instance_hypernym:
@@ -97216,7 +97216,7 @@
   partOfSpeech: n
 11085713-n:
   definition:
-  - United States naval officer who commanded the `Constitution´ during the War of
+  - United States naval officer who commanded the ‘Constitution’ during the War of
     1812 and won a series of brilliant victories against the British (1773-1843)
   ili: i95619
   instance_hypernym:
@@ -97835,7 +97835,7 @@
 11095442-n:
   definition:
   - United States lithographer who (with his partner Nathaniel Currier) produced thousands
-    of prints signed `Currier & Ives´ (1824-1895)
+    of prints signed ‘Currier & Ives’ (1824-1895)
   ili: i95672
   instance_hypernym:
   - 10286183-n
@@ -99543,7 +99543,7 @@
   definition:
   - United States lawyer and poet who wrote a poem after witnessing the British attack
     on Baltimore during the War of 1812; the poem was later set to music and entitled
-    `The Star-Spangled Banner´ (1779-1843)
+    ‘The Star-Spangled Banner’ (1779-1843)
   ili: i95814
   instance_hypernym:
   - 10269647-n
@@ -106854,7 +106854,7 @@
 11233313-n:
   definition:
   - German naturalist whose speculations that plants and animals are made up of tiny
-    living `infusoria´ led to the cell theory (1779-1851)
+    living ‘infusoria’ led to the cell theory (1779-1851)
   ili: i96446
   instance_hypernym:
   - 10366245-n
@@ -110420,7 +110420,7 @@
   - 26th President of the United States; hero of the Spanish-American War; Panama
     Canal was built during his administration
   example:
-  - Theodore Roosevelt said `Speak softly but carry a big stick´
+  - Theodore Roosevelt said ‘Speak softly but carry a big stick’
   ili: i96751
   instance_hypernym:
   - 10486961-n
@@ -110936,7 +110936,7 @@
 11298110-n:
   definition:
   - French soldier and writer whose descriptions of sexual perversion gave rise to
-    the term `sadism´ (1740-1814)
+    the term ‘sadism’ (1740-1814)
   ili: i96795
   instance_hypernym:
   - 10813654-n
@@ -113775,7 +113775,7 @@
 11341423-n:
   definition:
   - Austrian composer and son of Strauss the Elder; composed many famous waltzes and
-    became known as the `waltz king´ (1825-1899)
+    became known as the ‘waltz king’ (1825-1899)
   ili: i97041
   instance_hypernym:
   - 09966711-n
@@ -114007,7 +114007,7 @@
 11344897-n:
   definition:
   - United States architect known for his steel framed skyscrapers and for coining
-    the phrase `form follows function´ (1856-1924)
+    the phrase ‘form follows function’ (1856-1924)
   ili: i97062
   instance_hypernym:
   - 09824898-n
@@ -116818,7 +116818,7 @@
   partOfSpeech: n
 11387431-n:
   definition:
-  - a Roman poet; author of the epic poem `Aeneid´ (70-19 BC)
+  - a Roman poet; author of the epic poem ‘Aeneid’ (70-19 BC)
   ili: i97307
   instance_hypernym:
   - 10463768-n

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -26025,7 +26025,7 @@
   example:
   - she writes books for children
   - they're just kids
-  - '‘tiddler’ is a British term for youngster'
+  - ‘tiddler’ is a British term for youngster
   hypernym:
   - 09645219-n
   ili: i88964
@@ -35883,9 +35883,9 @@
   partOfSpeech: n
 10100973-n:
   definition:
-  - '‘Father’ is a term of address for priests in some churches (especially the Roman
+  - ‘Father’ is a term of address for priests in some churches (especially the Roman
     Catholic Church or the Orthodox Catholic Church); ‘Padre’ is frequently used in
-    the military'
+    the military
   hypernym:
   - 10490364-n
   - 06350786-n
@@ -69923,8 +69923,8 @@
   partOfSpeech: n
 10647730-n:
   definition:
-  - '‘Johnny’ was applied as a nickname for Confederate soldiers by the Federal soldiers
-    in the American Civil War; ‘greyback’ derived from their grey Confederate uniforms'
+  - ‘Johnny’ was applied as a nickname for Confederate soldiers by the Federal soldiers
+    in the American Civil War; ‘greyback’ derived from their grey Confederate uniforms
   exemplifies:
   - 07089193-n
   hypernym:

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -1828,7 +1828,7 @@
 09538404-n:
   definition:
   - the Babylonian father of the gods; identified with Assyrian Ashur; in Sumerian
-    the name signifies `the totality of the upper world'
+    the name signifies `the totality of the upper world´
   domain_region:
   - 08936605-n
   ili: i86625
@@ -2110,7 +2110,7 @@
 09542043-n:
   definition:
   - Babylonian consort of Anshar; in Sumerian the name signifies `the totality of
-    the lower world'
+    the lower world´
   domain_region:
   - 08936605-n
   ili: i86649
@@ -2130,7 +2130,7 @@
   partOfSpeech: n
 09542327-n:
   definition:
-  - a name under which Ninkhursag was worshipped, meaning `Mother'
+  - a name under which Ninkhursag was worshipped, meaning `Mother´
   ili: i86651
   instance_hypernym:
   - 09537037-n
@@ -2269,7 +2269,7 @@
   wikidata: Q836170
 09544186-n:
   definition:
-  - a name under which Ninkhursag was worshipped, meaning `Lady of Birth'
+  - a name under which Ninkhursag was worshipped, meaning `Lady of Birth´
   ili: i86664
   instance_hypernym:
   - 09537037-n
@@ -2488,7 +2488,7 @@
   partOfSpeech: n
 09547806-n:
   definition:
-  - (literally `possessing horses' in Sanskrit) in Hinduism the twin chariot warriors
+  - (literally `possessing horses´ in Sanskrit) in Hinduism the twin chariot warriors
     conveying Surya
   domain_topic:
   - 06981803-n
@@ -2608,7 +2608,7 @@
 09549355-n:
   definition:
   - in Hinduism, goddess of purity and posterity and a benevolent aspect of Devi;
-    the `brilliant'
+    the `brilliant´
   ili: i86696
   instance_hypernym:
   - 09546113-n
@@ -2861,7 +2861,7 @@
   partOfSpeech: n
 09552486-n:
   definition:
-  - a benevolent aspect of Devi; `splendor'
+  - a benevolent aspect of Devi; `splendor´
   ili: i86723
   instance_hypernym:
   - 09546113-n
@@ -6994,7 +6994,7 @@
   - a mythical Greek hero of the Iliad; a foremost Greek warrior at the siege of Troy;
     when he was a baby his mother tried to make him immortal by bathing him in a magical
     river but the heel by which she held him remained vulnerable — his `Achilles'
-    heel'
+    heel´
   ili: i87084
   instance_hypernym:
   - 09507794-n
@@ -7194,7 +7194,7 @@
 09620972-n:
   definition:
   - (Greek mythology) a tragic king of Thebes who unknowingly killed his father Laius
-    and married his mother Jocasta; the subject of the drama `Oedipus Rex' by Sophocles
+    and married his mother Jocasta; the subject of the drama `Oedipus Rex´ by Sophocles
   domain_topic:
   - 07995848-n
   ili: i87101
@@ -7704,7 +7704,7 @@
   partOfSpeech: n
 09628284-n:
   definition:
-  - a reference to yourself or myself etc.; `take care of number one' means to put
+  - a reference to yourself or myself etc.; `take care of number one´ means to put
     your own interests first
   exemplifies:
   - 07089193-n
@@ -8856,7 +8856,7 @@
   wikidata: Q2072081
 09659490-n:
   definition:
-  - a person with African ancestry, `Negro' and `Negroid' are archaic and pejorative
+  - a person with African ancestry, `Negro´ and `Negroid´ are archaic and pejorative
     today
   hypernym:
   - 09786620-n
@@ -10379,7 +10379,7 @@
   partOfSpeech: n
 09686327-n:
   definition:
-  - a member of any of about two dozen Native American peoples called `Pueblos' by
+  - a member of any of about two dozen Native American peoples called `Pueblos´ by
     the Spanish because they live in pueblos (villages built of adobe and rock)
   hypernym:
   - 09664887-n
@@ -12438,7 +12438,7 @@
   definition:
   - a person of Anglo-Saxon (especially British) descent whose native tongue is English
     and whose culture is strongly influenced by English culture as in WASP for `White
-    Anglo-Saxon Protestant'
+    Anglo-Saxon Protestant´
   domain_region:
   - 08879115-n
   example:
@@ -17488,7 +17488,7 @@
   partOfSpeech: n
 09802387-n:
   definition:
-  - the fictional woodcutter who discovered that `open sesame' opened a cave in the
+  - the fictional woodcutter who discovered that `open sesame´ opened a cave in the
     Arabian Nights' Entertainment
   ili: i88147
   instance_hypernym:
@@ -19909,7 +19909,7 @@
   partOfSpeech: n
 09846568-n:
   definition:
-  - South African term for `boss'
+  - South African term for `boss´
   hypernym:
   - 10123978-n
   ili: i88378
@@ -19918,7 +19918,7 @@
   partOfSpeech: n
 09846648-n:
   definition:
-  - used as a Hindi courtesy title; equivalent to English `Mr'
+  - used as a Hindi courtesy title; equivalent to English `Mr´
   hypernym:
   - 10306910-n
   ili: i88379
@@ -26025,7 +26025,7 @@
   example:
   - she writes books for children
   - they're just kids
-  - '`tiddler'' is a British term for youngster'
+  - '`tiddler´ is a British term for youngster'
   hypernym:
   - 09645219-n
   ili: i88964
@@ -28204,7 +28204,7 @@
   partOfSpeech: n
 09975423-n:
   definition:
-  - informal abbreviation of `representative'
+  - informal abbreviation of `representative´
   hypernym:
   - 09975260-n
   ili: i89171
@@ -29353,8 +29353,8 @@
   partOfSpeech: n
 09992739-n:
   definition:
-  - local names for a cowboy (`vaquero' is used especially in southwestern and central
-    Texas and `buckaroo' is used especially in California)
+  - local names for a cowboy (`vaquero´ is used especially in southwestern and central
+    Texas and `buckaroo´ is used especially in California)
   hypernym:
   - 09992191-n
   ili: i89283
@@ -32616,7 +32616,7 @@
   partOfSpeech: n
 10046092-n:
   definition:
-  - a person who responds `I don't know' in a public opinion poll
+  - a person who responds `I don't know´ in a public opinion poll
   example:
   - 70% in favor, 13% opposed and 17% don't-knows
   exemplifies:
@@ -34800,8 +34800,8 @@
 10083442-n:
   definition:
   - a member of a people inhabiting the Arctic (northern Canada or Greenland or Alaska
-    or eastern Siberia); the Algonquians called them Eskimo (`eaters of raw flesh')
-    but they call themselves the Inuit (`the people')
+    or eastern Siberia); the Algonquians called them Eskimo (`eaters of raw flesh´)
+    but they call themselves the Inuit (`the people´)
   hypernym:
   - 09664887-n
   ili: i89798
@@ -35130,7 +35130,7 @@
 10088735-n:
   definition:
   - a title used to address dignitaries (such as ambassadors or governors); usually
-    preceded by `Your' or `His' or `Her'
+    preceded by `Your´ or `His´ or `Her´
   example:
   - Your Excellency
   hypernym:
@@ -35883,9 +35883,9 @@
   partOfSpeech: n
 10100973-n:
   definition:
-  - '`Father'' is a term of address for priests in some churches (especially the Roman
-    Catholic Church or the Orthodox Catholic Church); `Padre'' is frequently used
-    in the military'
+  - '`Father´ is a term of address for priests in some churches (especially the Roman
+    Catholic Church or the Orthodox Catholic Church); `Padre´ is frequently used in
+    the military'
   hypernym:
   - 10490364-n
   - 06350786-n
@@ -38840,7 +38840,7 @@
   partOfSpeech: n
 10146723-n:
   definition:
-  - informal abbreviation of `gentleman'
+  - informal abbreviation of `gentleman´
   hypernym:
   - 10146810-n
   ili: i90188
@@ -40474,7 +40474,7 @@
   partOfSpeech: n
 10169935-n:
   definition:
-  - a soldier who is a member of a unit called `the guard' or `guards'
+  - a soldier who is a member of a unit called `the guard´ or `guards´
   hypernym:
   - 10641415-n
   ili: i90347
@@ -42478,7 +42478,7 @@
   - the person who is in possession of a check or note or bond or document of title
     that is endorsed to him or to whoever holds it
   example:
-  - the bond was marked `payable to bearer'
+  - the bond was marked `payable to bearer´
   hypernym:
   - 09632262-n
   ili: i90534
@@ -44896,7 +44896,7 @@
   definition:
   - (Old Testament) son of Isaac; brother of Esau; father of the twelve patriarchs
     of Israel; Jacob wrestled with God and forced God to bless him, so God gave Jacob
-    the new name of Israel (meaning `one who has been strong against God')
+    the new name of Israel (meaning `one who has been strong against God´)
   domain_topic:
   - 06461405-n
   hypernym:
@@ -51962,7 +51962,7 @@
   partOfSpeech: n
 10349388-n:
   definition:
-  - used as a French courtesy title; equivalent to English `Mr'
+  - used as a French courtesy title; equivalent to English `Mr´
   hypernym:
   - 10306910-n
   ili: i91444
@@ -61144,7 +61144,7 @@
 10509149-n:
   definition:
   - someone with a sociopathic personality; a person with an antisocial personality
-    disorder (`psychopath' was once widely used but has now been superseded by `sociopath')
+    disorder (`psychopath´ was once widely used but has now been superseded by `sociopath´)
   hypernym:
   - 10374597-n
   ili: i92328
@@ -62389,7 +62389,7 @@
   partOfSpeech: n
 10527376-n:
   definition:
-  - a fictional character in Dostoevsky's novel `Crime and Punishment'; he kills old
+  - a fictional character in Dostoevsky's novel `Crime and Punishment´; he kills old
     women because he believes he is beyond the bounds of good or evil
   ili: i92450
   instance_hypernym:
@@ -64382,7 +64382,7 @@
   - kill the rat
   - throw the bum out
   - you cowardly little pukes!
-  - the British call a contemptible person a `git'
+  - the British call a contemptible person a `git´
   exemplifies:
   - 06730109-n
   hypernym:
@@ -65008,7 +65008,7 @@
 10569647-n:
   definition:
   - a young peddler of sand; used now only to express great happiness in `happy as
-    a sandboy'
+    a sandboy´
   domain_region:
   - 08879115-n
   hypernym:
@@ -66223,7 +66223,7 @@
   partOfSpeech: n
 10588198-n:
   definition:
-  - an intermediate person; used in the phrase `at second hand'
+  - an intermediate person; used in the phrase `at second hand´
   example:
   - he could learn at second hand from books
   hypernym:
@@ -66810,7 +66810,7 @@
   partOfSpeech: n
 10598404-n:
   definition:
-  - a Portuguese title of respect; equivalent to English `Mr'
+  - a Portuguese title of respect; equivalent to English `Mr´
   hypernym:
   - 10306910-n
   ili: i92871
@@ -68107,7 +68107,7 @@
   partOfSpeech: n
 10617421-n:
   definition:
-  - an Italian title of respect for a man; equivalent to the English `sir'; used separately
+  - an Italian title of respect for a man; equivalent to the English `sir´; used separately
     (not prefixed to his name)
   hypernym:
   - 10306910-n
@@ -68117,7 +68117,7 @@
   partOfSpeech: n
 10617589-n:
   definition:
-  - an Italian courtesy title for an unmarried woman; equivalent to `Miss', it is
+  - an Italian courtesy title for an unmarried woman; equivalent to `Miss´, it is
     either used alone or before a name
   hypernym:
   - 10759169-n
@@ -69923,8 +69923,8 @@
   partOfSpeech: n
 10647730-n:
   definition:
-  - '`Johnny'' was applied as a nickname for Confederate soldiers by the Federal soldiers
-    in the American Civil War; `greyback'' derived from their grey Confederate uniforms'
+  - '`Johnny´ was applied as a nickname for Confederate soldiers by the Federal soldiers
+    in the American Civil War; `greyback´ derived from their grey Confederate uniforms'
   exemplifies:
   - 07089193-n
   hypernym:
@@ -75669,7 +75669,7 @@
 10739916-n:
   definition:
   - a follower of Tractarianism and supporter of the Oxford movement (which was expounded
-    in pamphlets called `Tracts for the Times')
+    in pamphlets called `Tracts for the Times´)
   hypernym:
   - 09697405-n
   ili: i93719
@@ -85803,7 +85803,7 @@
   partOfSpeech: n
 10901368-n:
   definition:
-  - Czech writer who introduced the word `robot' into the English language (1890-1938)
+  - Czech writer who introduced the word `robot´ into the English language (1890-1938)
   ili: i94639
   instance_hypernym:
   - 10813654-n
@@ -86283,7 +86283,7 @@
   partOfSpeech: n
 10908784-n:
   definition:
-  - Spanish writer best remembered for `Don Quixote' which satirizes chivalry and
+  - Spanish writer best remembered for `Don Quixote´ which satirizes chivalry and
     influenced the development of the novel form (1547-1616)
   ili: i94681
   instance_hypernym:
@@ -87122,7 +87122,7 @@
 10922924-n:
   definition:
   - king of the Franks who unified Gaul and established his capital at Paris and founded
-    the Frankish monarchy; his name was rendered as Gallic `Louis' (466-511)
+    the Frankish monarchy; his name was rendered as Gallic `Louis´ (466-511)
   ili: i94751
   instance_hypernym:
   - 10251212-n
@@ -88085,7 +88085,7 @@
 10938110-n:
   definition:
   - United States lithographer who (with his partner James Ives) produced thousands
-    of prints signed `Currier & Ives' (1813-1888)
+    of prints signed `Currier & Ives´ (1813-1888)
   ili: i94833
   instance_hypernym:
   - 10286183-n
@@ -90253,7 +90253,7 @@
   partOfSpeech: n
 10973597-n:
   definition:
-  - German bacteriologist who found a `magic bullet' to cure syphilis and was a pioneer
+  - German bacteriologist who found a `magic bullet´ to cure syphilis and was a pioneer
     in the study of immunology (1854-1915)
   ili: i95017
   instance_hypernym:
@@ -92214,7 +92214,7 @@
 11006018-n:
   definition:
   - United States biochemist (born in Poland) who showed that several diseases were
-    caused by dietary deficiencies and who coined the term `vitamin' for the chemicals
+    caused by dietary deficiencies and who coined the term `vitamin´ for the chemicals
     involved (1884-1967)
   ili: i95187
   instance_hypernym:
@@ -92965,7 +92965,7 @@
   partOfSpeech: n
 11018470-n:
   definition:
-  - United States illustrator remembered for his creation of the `Gibson girl' (1867-1944)
+  - United States illustrator remembered for his creation of the `Gibson girl´ (1867-1944)
   ili: i95253
   instance_hypernym:
   - 09831473-n
@@ -94569,7 +94569,7 @@
   definition:
   - a soldier of the American Revolution who was hanged as a spy by the British; his
     last words were supposed to have been `I only regret that I have but one life
-    to give for my country' (1755-1776)
+    to give for my country´ (1755-1776)
   ili: i95388
   instance_hypernym:
   - 09759416-n
@@ -96710,7 +96710,7 @@
   - English scientist who formulated the law of elasticity and proposed a wave theory
     of light and formulated a theory of planetary motion and proposed the inverse
     square law of gravitational attraction and discovered the cellular structure of
-    cork and introduced the term `cell' into biology and invented a balance spring
+    cork and introduced the term `cell´ into biology and invented a balance spring
     for watches (1635-1703)
   ili: i95574
   instance_hypernym:
@@ -97216,7 +97216,7 @@
   partOfSpeech: n
 11085713-n:
   definition:
-  - United States naval officer who commanded the `Constitution' during the War of
+  - United States naval officer who commanded the `Constitution´ during the War of
     1812 and won a series of brilliant victories against the British (1773-1843)
   ili: i95619
   instance_hypernym:
@@ -97835,7 +97835,7 @@
 11095442-n:
   definition:
   - United States lithographer who (with his partner Nathaniel Currier) produced thousands
-    of prints signed `Currier & Ives' (1824-1895)
+    of prints signed `Currier & Ives´ (1824-1895)
   ili: i95672
   instance_hypernym:
   - 10286183-n
@@ -99543,7 +99543,7 @@
   definition:
   - United States lawyer and poet who wrote a poem after witnessing the British attack
     on Baltimore during the War of 1812; the poem was later set to music and entitled
-    `The Star-Spangled Banner' (1779-1843)
+    `The Star-Spangled Banner´ (1779-1843)
   ili: i95814
   instance_hypernym:
   - 10269647-n
@@ -106854,7 +106854,7 @@
 11233313-n:
   definition:
   - German naturalist whose speculations that plants and animals are made up of tiny
-    living `infusoria' led to the cell theory (1779-1851)
+    living `infusoria´ led to the cell theory (1779-1851)
   ili: i96446
   instance_hypernym:
   - 10366245-n
@@ -110420,7 +110420,7 @@
   - 26th President of the United States; hero of the Spanish-American War; Panama
     Canal was built during his administration
   example:
-  - Theodore Roosevelt said `Speak softly but carry a big stick'
+  - Theodore Roosevelt said `Speak softly but carry a big stick´
   ili: i96751
   instance_hypernym:
   - 10486961-n
@@ -110936,7 +110936,7 @@
 11298110-n:
   definition:
   - French soldier and writer whose descriptions of sexual perversion gave rise to
-    the term `sadism' (1740-1814)
+    the term `sadism´ (1740-1814)
   ili: i96795
   instance_hypernym:
   - 10813654-n
@@ -113775,7 +113775,7 @@
 11341423-n:
   definition:
   - Austrian composer and son of Strauss the Elder; composed many famous waltzes and
-    became known as the `waltz king' (1825-1899)
+    became known as the `waltz king´ (1825-1899)
   ili: i97041
   instance_hypernym:
   - 09966711-n
@@ -114007,7 +114007,7 @@
 11344897-n:
   definition:
   - United States architect known for his steel framed skyscrapers and for coining
-    the phrase `form follows function' (1856-1924)
+    the phrase `form follows function´ (1856-1924)
   ili: i97062
   instance_hypernym:
   - 09824898-n
@@ -116818,7 +116818,7 @@
   partOfSpeech: n
 11387431-n:
   definition:
-  - a Roman poet; author of the epic poem `Aeneid' (70-19 BC)
+  - a Roman poet; author of the epic poem `Aeneid´ (70-19 BC)
   ili: i97307
   instance_hypernym:
   - 10463768-n

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -15363,7 +15363,7 @@
 11854046-n:
   definition:
   - a caryophyllaceous genus of the family Chenopodiaceae, its name is derived from
-    the Greek words `salt' and `neighbour' (Halogeton)
+    the Greek words `salt´ and `neighbour´ (Halogeton)
   hypernym:
   - 11594111-n
   ili: i99470
@@ -31206,7 +31206,7 @@
 12127057-n:
   definition:
   - 'annual or perennial grasses cosmopolitan in Northern Hemisphere: bent grass (so
-    named from `bent'' meaning an area of unfenced grassland)'
+    named from `bent´ meaning an area of unfenced grassland)'
   hypernym:
   - 11765328-n
   ili: i100768
@@ -31409,7 +31409,7 @@
 12130344-n:
   definition:
   - 'annual grass of Europe and North Africa; grains used as food and fodder (referred
-    to primarily in the plural: `oats'')'
+    to primarily in the plural: `oats´)'
   hypernym:
   - 12162012-n
   ili: i100785
@@ -37433,7 +37433,7 @@
   partOfSpeech: n
 12234762-n:
   definition:
-  - a living fossil or so-called `green dinosaur'; genus or subfamily of primitive
+  - a living fossil or so-called `green dinosaur´; genus or subfamily of primitive
     nut-bearing trees thought to have died out 50 million years ago; a single specimen
     found in 1994 on Mount Bartle Frere in eastern Australia; not yet officially named
   hypernym:
@@ -58803,7 +58803,6 @@
 12599160-n:
   definition:
   - seed of the mung bean plant; used for food
-  - seed of the mung bean plant
   hypernym:
   - 13157075-n
   members:
@@ -85119,7 +85118,7 @@
 13033733-n:
   definition:
   - a poisonous agaric with a fibrillose cap and brown scales on a white ground color;
-    cap can reach a diameter of 30 cm; often forms `fairy rings'
+    cap can reach a diameter of 30 cm; often forms `fairy rings´
   hypernym:
   - 13019575-n
   ili: i105125
@@ -89241,7 +89240,7 @@
   partOfSpeech: n
 13106507-n:
   definition:
-  - 'usually used in combination: `liverwort'', `milkwort'', `whorlywort'''
+  - 'usually used in combination: `liverwort´, `milkwort´, `whorlywort´'
   hypernym:
   - 12226211-n
   ili: i105477

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -15363,7 +15363,7 @@
 11854046-n:
   definition:
   - a caryophyllaceous genus of the family Chenopodiaceae, its name is derived from
-    the Greek words `salt´ and `neighbour´ (Halogeton)
+    the Greek words ‘salt’ and ‘neighbour’ (Halogeton)
   hypernym:
   - 11594111-n
   ili: i99470
@@ -31206,7 +31206,7 @@
 12127057-n:
   definition:
   - 'annual or perennial grasses cosmopolitan in Northern Hemisphere: bent grass (so
-    named from `bent´ meaning an area of unfenced grassland)'
+    named from ‘bent’ meaning an area of unfenced grassland)'
   hypernym:
   - 11765328-n
   ili: i100768
@@ -31409,7 +31409,7 @@
 12130344-n:
   definition:
   - 'annual grass of Europe and North Africa; grains used as food and fodder (referred
-    to primarily in the plural: `oats´)'
+    to primarily in the plural: ‘oats’)'
   hypernym:
   - 12162012-n
   ili: i100785
@@ -37433,7 +37433,7 @@
   partOfSpeech: n
 12234762-n:
   definition:
-  - a living fossil or so-called `green dinosaur´; genus or subfamily of primitive
+  - a living fossil or so-called ‘green dinosaur’; genus or subfamily of primitive
     nut-bearing trees thought to have died out 50 million years ago; a single specimen
     found in 1994 on Mount Bartle Frere in eastern Australia; not yet officially named
   hypernym:
@@ -85118,7 +85118,7 @@
 13033733-n:
   definition:
   - a poisonous agaric with a fibrillose cap and brown scales on a white ground color;
-    cap can reach a diameter of 30 cm; often forms `fairy rings´
+    cap can reach a diameter of 30 cm; often forms ‘fairy rings’
   hypernym:
   - 13019575-n
   ili: i105125
@@ -89240,7 +89240,7 @@
   partOfSpeech: n
 13106507-n:
   definition:
-  - 'usually used in combination: `liverwort´, `milkwort´, `whorlywort´'
+  - 'usually used in combination: ‘liverwort’, ‘milkwort’, ‘whorlywort’'
   hypernym:
   - 12226211-n
   ili: i105477

--- a/src/yaml/noun.possession.yaml
+++ b/src/yaml/noun.possession.yaml
@@ -10716,7 +10716,7 @@
   partOfSpeech: n
 13436341-n:
   definition:
-  - an informal debt instrument; representing `I owe you´
+  - an informal debt instrument; representing ‘I owe you’
   hypernym:
   - 13419642-n
   ili: i107238
@@ -11253,8 +11253,8 @@
     banks against an approved collateral.
   example:
   - source: https://en.wikipedia.org
-    text: Lending is via central banks, in particular the securities `eligible for
-      collateral´ which are registered on lists; as a general rule, the Lombard rate
+    text: Lending is via central banks, in particular the securities ‘eligible for
+      collateral’ which are registered on lists; as a general rule, the Lombard rate
       (interest rate) is more or less one per cent above discount rate.
   hypernym:
   - 13340054-n
@@ -11583,7 +11583,7 @@
   - a fixed rate paid according to the quantity produced.
   example:
   - source: https://en.wikipedia.org
-    text: Factories today may receive the label `sweatshop´ more because they have
+    text: Factories today may receive the label ‘sweatshop’ more because they have
       the long hours and poor working conditions, even if they pay an hourly or daily
       wage instead of a piece rate.
   hypernym:

--- a/src/yaml/noun.possession.yaml
+++ b/src/yaml/noun.possession.yaml
@@ -10716,7 +10716,7 @@
   partOfSpeech: n
 13436341-n:
   definition:
-  - an informal debt instrument; representing `I owe you'
+  - an informal debt instrument; representing `I owe you´
   hypernym:
   - 13419642-n
   ili: i107238
@@ -11254,7 +11254,7 @@
   example:
   - source: https://en.wikipedia.org
     text: Lending is via central banks, in particular the securities `eligible for
-      collateral' which are registered on lists; as a general rule, the Lombard rate
+      collateral´ which are registered on lists; as a general rule, the Lombard rate
       (interest rate) is more or less one per cent above discount rate.
   hypernym:
   - 13340054-n
@@ -11583,7 +11583,7 @@
   - a fixed rate paid according to the quantity produced.
   example:
   - source: https://en.wikipedia.org
-    text: Factories today may receive the label `sweatshop' more because they have
+    text: Factories today may receive the label `sweatshop´ more because they have
       the long hours and poor working conditions, even if they pay an hourly or daily
       wage instead of a piece rate.
   hypernym:

--- a/src/yaml/noun.process.yaml
+++ b/src/yaml/noun.process.yaml
@@ -571,8 +571,8 @@
   partOfSpeech: n
 13454234-n:
   definition:
-  - (linguistics) omission at the beginning of a word as in `coon´ for `raccoon´ or
-    `till´ for `until´
+  - (linguistics) omission at the beginning of a word as in ‘coon’ for ‘raccoon’ or
+    ‘till’ for ‘until’
   domain_topic:
   - 06182505-n
   hypernym:
@@ -585,7 +585,7 @@
 13454456-n:
   definition:
   - the gradual disappearance of an initial (usually unstressed) vowel or syllable
-    as in `squire´ for `esquire´
+    as in ‘squire’ for ‘esquire’
   hypernym:
   - 13545602-n
   ili: i107338
@@ -2150,7 +2150,7 @@
   domain_topic:
   - 06191300-n
   example:
-  - '`singer´ from `sing´ or `undo´ from `do´ are examples of derivations'
+  - '‘singer’ from ‘sing’ or ‘undo’ from ‘do’ are examples of derivations'
   hypernym:
   - 13529536-n
   ili: i107484

--- a/src/yaml/noun.process.yaml
+++ b/src/yaml/noun.process.yaml
@@ -2150,7 +2150,7 @@
   domain_topic:
   - 06191300-n
   example:
-  - '‘singer’ from ‘sing’ or ‘undo’ from ‘do’ are examples of derivations'
+  - ‘singer’ from ‘sing’ or ‘undo’ from ‘do’ are examples of derivations
   hypernym:
   - 13529536-n
   ili: i107484

--- a/src/yaml/noun.process.yaml
+++ b/src/yaml/noun.process.yaml
@@ -571,8 +571,8 @@
   partOfSpeech: n
 13454234-n:
   definition:
-  - (linguistics) omission at the beginning of a word as in `coon' for `raccoon' or
-    `till' for `until'
+  - (linguistics) omission at the beginning of a word as in `coon´ for `raccoon´ or
+    `till´ for `until´
   domain_topic:
   - 06182505-n
   hypernym:
@@ -585,7 +585,7 @@
 13454456-n:
   definition:
   - the gradual disappearance of an initial (usually unstressed) vowel or syllable
-    as in `squire' for `esquire'
+    as in `squire´ for `esquire´
   hypernym:
   - 13545602-n
   ili: i107338
@@ -2150,7 +2150,7 @@
   domain_topic:
   - 06191300-n
   example:
-  - '`singer'' from `sing'' or `undo'' from `do'' are examples of derivations'
+  - '`singer´ from `sing´ or `undo´ from `do´ are examples of derivations'
   hypernym:
   - 13529536-n
   ili: i107484

--- a/src/yaml/noun.quantity.yaml
+++ b/src/yaml/noun.quantity.yaml
@@ -1124,7 +1124,7 @@
   definition:
   - a quantity expressed in two different units
   example:
-  - compound number such as `one hour and ten minutes´
+  - compound number such as ‘one hour and ten minutes’
   hypernym:
   - 13603216-n
   ili: i108152
@@ -1918,7 +1918,7 @@
   partOfSpeech: n
 13635266-n:
   definition:
-  - (abbreviated `ha´) a unit of surface area equal to 100 ares (or 10,000 square
+  - (abbreviated ‘ha’) a unit of surface area equal to 100 ares (or 10,000 square
     meters)
   hypernym:
   - 13621647-n
@@ -2743,7 +2743,7 @@
   domain_topic:
   - 06138021-n
   example:
-  - since blocks are often defined as a single sector, the terms `block´ and `sector´
+  - since blocks are often defined as a single sector, the terms ‘block’ and ‘sector’
     are sometimes used interchangeably
   hypernym:
   - 13622839-n
@@ -9154,8 +9154,8 @@
   definition:
   - a quad with a square body
   example:
-  - since `em quad´ is hard to distinguish from `en quad´, printers sometimes called
-    it a `mutton quad´
+  - since ‘em quad’ is hard to distinguish from ‘en quad’, printers sometimes called
+    it a ‘mutton quad’
   hypernym:
   - 13621647-n
   ili: i108906
@@ -11522,7 +11522,7 @@
   partOfSpeech: n
 13769254-n:
   definition:
-  - all the numbers that end in `-teen´
+  - all the numbers that end in ‘-teen’
   hypernym:
   - 13767560-n
   ili: i109114
@@ -12327,8 +12327,8 @@
   partOfSpeech: n
 13781286-n:
   definition:
-  - the approximate amount of something (usually used prepositionally as in `in the
-    region of´)
+  - the approximate amount of something (usually used prepositionally as in ‘in the
+    region of’)
   example:
   - it was going to take in the region of two or three months to finish the job
   - the price is in the neighborhood of $100
@@ -13557,7 +13557,7 @@
   partOfSpeech: n
 13796604-n:
   definition:
-  - (often followed by `of´) a large number or amount or extent
+  - (often followed by ‘of’) a large number or amount or extent
   example:
   - a batch of letters
   - a deal of trouble
@@ -13620,8 +13620,8 @@
   definition:
   - an unimaginably large amount
   example:
-  - British say `it rained like billyo´ where Americans say `it rained like all get
-    out´
+  - British say ‘it rained like billyo’ where Americans say ‘it rained like all get
+    out’
   hypernym:
   - 13779864-n
   ili: i109296
@@ -14085,7 +14085,7 @@
   definition:
   - a type of measure of a country's money supply.
   example:
-  - There is no single `correct´ measure of the money supply; instead, there are several
+  - There is no single ‘correct’ measure of the money supply; instead, there are several
     measures, classified along a spectrum or continuum between narrow and broad monetary
     aggregates.
   hypernym:

--- a/src/yaml/noun.quantity.yaml
+++ b/src/yaml/noun.quantity.yaml
@@ -1124,7 +1124,7 @@
   definition:
   - a quantity expressed in two different units
   example:
-  - compound number such as `one hour and ten minutes'
+  - compound number such as `one hour and ten minutes´
   hypernym:
   - 13603216-n
   ili: i108152
@@ -1918,7 +1918,7 @@
   partOfSpeech: n
 13635266-n:
   definition:
-  - (abbreviated `ha') a unit of surface area equal to 100 ares (or 10,000 square
+  - (abbreviated `ha´) a unit of surface area equal to 100 ares (or 10,000 square
     meters)
   hypernym:
   - 13621647-n
@@ -2743,7 +2743,7 @@
   domain_topic:
   - 06138021-n
   example:
-  - since blocks are often defined as a single sector, the terms `block' and `sector'
+  - since blocks are often defined as a single sector, the terms `block´ and `sector´
     are sometimes used interchangeably
   hypernym:
   - 13622839-n
@@ -9154,8 +9154,8 @@
   definition:
   - a quad with a square body
   example:
-  - since `em quad' is hard to distinguish from `en quad', printers sometimes called
-    it a `mutton quad'
+  - since `em quad´ is hard to distinguish from `en quad´, printers sometimes called
+    it a `mutton quad´
   hypernym:
   - 13621647-n
   ili: i108906
@@ -12328,7 +12328,7 @@
 13781286-n:
   definition:
   - the approximate amount of something (usually used prepositionally as in `in the
-    region of')
+    region of´)
   example:
   - it was going to take in the region of two or three months to finish the job
   - the price is in the neighborhood of $100
@@ -13557,7 +13557,7 @@
   partOfSpeech: n
 13796604-n:
   definition:
-  - (often followed by `of') a large number or amount or extent
+  - (often followed by `of´) a large number or amount or extent
   example:
   - a batch of letters
   - a deal of trouble
@@ -13620,8 +13620,8 @@
   definition:
   - an unimaginably large amount
   example:
-  - British say `it rained like billyo' where Americans say `it rained like all get
-    out'
+  - British say `it rained like billyo´ where Americans say `it rained like all get
+    out´
   hypernym:
   - 13779864-n
   ili: i109296
@@ -14085,7 +14085,7 @@
   definition:
   - a type of measure of a country's money supply.
   example:
-  - There is no single `correct' measure of the money supply; instead, there are several
+  - There is no single `correct´ measure of the money supply; instead, there are several
     measures, classified along a spectrum or continuum between narrow and broad monetary
     aggregates.
   hypernym:

--- a/src/yaml/noun.quantity.yaml
+++ b/src/yaml/noun.quantity.yaml
@@ -11522,7 +11522,7 @@
   partOfSpeech: n
 13769254-n:
   definition:
-  - all the numbers that end in -teen
+  - all the numbers that end in `-teen´
   hypernym:
   - 13767560-n
   ili: i109114

--- a/src/yaml/noun.quantity.yaml
+++ b/src/yaml/noun.quantity.yaml
@@ -12105,7 +12105,8 @@
   partOfSpeech: n
 13776305-n:
   definition:
-  - the base of the natural system of logarithms; approximately equal to 2.718282 …
+  - the base of the natural system of logarithms; approximately equal to 2.718282
+    …
   hypernym:
   - 13752866-n
   ili: i109164

--- a/src/yaml/noun.relation.yaml
+++ b/src/yaml/noun.relation.yaml
@@ -4923,8 +4923,8 @@
   - the inflection of nouns, pronouns, adjectives, and articles to indicate masculine
     grammatical gender.
   example:
-  - Feminine declension treats `k', `g', `ch' as softenable, whereas masculine and neuter
-    declension does not (hence they take the `other' ending, `-u').
+  - Feminine declension treats `k', `g', `ch' as softenable, whereas masculine and
+    neuter declension does not (hence they take the `other' ending, `-u').
   hypernym:
   - 13826415-n
   members:

--- a/src/yaml/noun.relation.yaml
+++ b/src/yaml/noun.relation.yaml
@@ -19,9 +19,9 @@
   partOfSpeech: n
 13802931-n:
   definition:
-  - a relation between people; (`relationship´ is often used where `relation´ would
-    serve, as in `the relationship between inflation and unemployment´, but the preferred
-    usage of `relationship´ is for human relations or states of relatedness)
+  - a relation between people; (‘relationship’ is often used where ‘relation’ would
+    serve, as in ‘the relationship between inflation and unemployment’, but the preferred
+    usage of ‘relationship’ is for human relations or states of relatedness)
   example:
   - the relationship between mothers and their children
   hypernym:
@@ -1138,8 +1138,8 @@
   partOfSpeech: n
 13823252-n:
   definition:
-  - a grammatical qualification that makes the meaning more specific (`red hat´ has
-    a more specific meaning than `hat´)
+  - a grammatical qualification that makes the meaning more specific (‘red hat’ has
+    a more specific meaning than ‘hat’)
   hypernym:
   - 13823013-n
   ili: i109432
@@ -1150,7 +1150,7 @@
   definition:
   - a grammatical relation between a word and a noun phrase that follows
   example:
-  - '`Rudolph the red-nosed reindeer´ is an example of apposition'
+  - '‘Rudolph the red-nosed reindeer’ is an example of apposition'
   hypernym:
   - 13823013-n
   ili: i109433
@@ -1268,7 +1268,7 @@
   - the voice used to indicate that the grammatical subject of the verb is performing
     the action or causing the happening denoted by the verb
   example:
-  - '`The boy threw the ball´ uses the active voice'
+  - '‘The boy threw the ball’ uses the active voice'
   hypernym:
   - 13825132-n
   ili: i109443
@@ -1282,8 +1282,8 @@
   - the voice used to indicate that the grammatical subject of the verb is the recipient
     (not the source) of the action denoted by the verb
   example:
-  - '`The ball was thrown by the boy´ uses the passive voice'
-  - '`The ball was thrown´ is an abbreviated passive'
+  - '‘The ball was thrown by the boy’ uses the passive voice'
+  - '‘The ball was thrown’ is an abbreviated passive'
   hypernym:
   - 13825132-n
   ili: i109444
@@ -1451,7 +1451,7 @@
   definition:
   - a perfective tense used to express action completed in the present
   example:
-  - '`I have finished´ is an example of the present perfect'
+  - '‘I have finished’ is an example of the present perfect'
   hypernym:
   - 13828352-n
   ili: i109460
@@ -1473,7 +1473,7 @@
   definition:
   - a perfective tense used to express action completed in the past
   example:
-  - '`I had finished´ is an example of the past perfect'
+  - '‘I had finished’ is an example of the past perfect'
   hypernym:
   - 13828352-n
   ili: i109462
@@ -1487,7 +1487,7 @@
   definition:
   - a progressive tense used to describe on-going action in the past
   example:
-  - '`I had been running´ is an example of the past progressive'
+  - '‘I had been running’ is an example of the past progressive'
   hypernym:
   - 13827946-n
   ili: i109463
@@ -1499,7 +1499,7 @@
   definition:
   - a perfective tense used to describe action that will be completed in the future
   example:
-  - '`I will have finished´ is an example of the future perfect'
+  - '‘I will have finished’ is an example of the future perfect'
   hypernym:
   - 13828352-n
   ili: i109464
@@ -1511,7 +1511,7 @@
   definition:
   - a progressive tense used to express action that will be on-going in the future
   example:
-  - '`I will be running´ is an example of the future progressive'
+  - '‘I will be running’ is an example of the future progressive'
   hypernym:
   - 13827946-n
   ili: i109465
@@ -4703,7 +4703,7 @@
   partOfSpeech: n
 13882478-n:
   definition:
-  - a logical relation between propositions p and q of the form `if p then q´; if
+  - a logical relation between propositions p and q of the form ‘if p then q’; if
     p is true then q cannot be false
   hypernym:
   - 13805250-n
@@ -4923,8 +4923,8 @@
   - the inflection of nouns, pronouns, adjectives, and articles to indicate masculine
     grammatical gender.
   example:
-  - Feminine declension treats `k´, `g´, `ch´ as softenable, whereas masculine and
-    neuter declension does not (hence they take the `other´ ending, `-u´).
+  - Feminine declension treats ‘k’, ‘g’, ‘ch’ as softenable, whereas masculine and
+    neuter declension does not (hence they take the ‘other’ ending, ‘-u’).
   hypernym:
   - 13826415-n
   members:
@@ -4935,7 +4935,7 @@
   definition:
   - a conjunction that expresses something inferred from another statement or fact.
   example:
-  - One could argue grammatically in favour of `accordingly´ being an illative conjunction.
+  - One could argue grammatically in favour of ‘accordingly’ being an illative conjunction.
   hypernym:
   - 13821604-n
   members:

--- a/src/yaml/noun.relation.yaml
+++ b/src/yaml/noun.relation.yaml
@@ -19,9 +19,9 @@
   partOfSpeech: n
 13802931-n:
   definition:
-  - a relation between people; (`relationship' is often used where `relation' would
-    serve, as in `the relationship between inflation and unemployment', but the preferred
-    usage of `relationship' is for human relations or states of relatedness)
+  - a relation between people; (`relationship´ is often used where `relation´ would
+    serve, as in `the relationship between inflation and unemployment´, but the preferred
+    usage of `relationship´ is for human relations or states of relatedness)
   example:
   - the relationship between mothers and their children
   hypernym:
@@ -1138,8 +1138,8 @@
   partOfSpeech: n
 13823252-n:
   definition:
-  - a grammatical qualification that makes the meaning more specific (`red hat' has
-    a more specific meaning than `hat')
+  - a grammatical qualification that makes the meaning more specific (`red hat´ has
+    a more specific meaning than `hat´)
   hypernym:
   - 13823013-n
   ili: i109432
@@ -1150,7 +1150,7 @@
   definition:
   - a grammatical relation between a word and a noun phrase that follows
   example:
-  - '`Rudolph the red-nosed reindeer'' is an example of apposition'
+  - '`Rudolph the red-nosed reindeer´ is an example of apposition'
   hypernym:
   - 13823013-n
   ili: i109433
@@ -1268,7 +1268,7 @@
   - the voice used to indicate that the grammatical subject of the verb is performing
     the action or causing the happening denoted by the verb
   example:
-  - '`The boy threw the ball'' uses the active voice'
+  - '`The boy threw the ball´ uses the active voice'
   hypernym:
   - 13825132-n
   ili: i109443
@@ -1282,8 +1282,8 @@
   - the voice used to indicate that the grammatical subject of the verb is the recipient
     (not the source) of the action denoted by the verb
   example:
-  - '`The ball was thrown by the boy'' uses the passive voice'
-  - '`The ball was thrown'' is an abbreviated passive'
+  - '`The ball was thrown by the boy´ uses the passive voice'
+  - '`The ball was thrown´ is an abbreviated passive'
   hypernym:
   - 13825132-n
   ili: i109444
@@ -1451,7 +1451,7 @@
   definition:
   - a perfective tense used to express action completed in the present
   example:
-  - '`I have finished'' is an example of the present perfect'
+  - '`I have finished´ is an example of the present perfect'
   hypernym:
   - 13828352-n
   ili: i109460
@@ -1473,7 +1473,7 @@
   definition:
   - a perfective tense used to express action completed in the past
   example:
-  - '`I had finished'' is an example of the past perfect'
+  - '`I had finished´ is an example of the past perfect'
   hypernym:
   - 13828352-n
   ili: i109462
@@ -1487,7 +1487,7 @@
   definition:
   - a progressive tense used to describe on-going action in the past
   example:
-  - '`I had been running'' is an example of the past progressive'
+  - '`I had been running´ is an example of the past progressive'
   hypernym:
   - 13827946-n
   ili: i109463
@@ -1499,7 +1499,7 @@
   definition:
   - a perfective tense used to describe action that will be completed in the future
   example:
-  - '`I will have finished'' is an example of the future perfect'
+  - '`I will have finished´ is an example of the future perfect'
   hypernym:
   - 13828352-n
   ili: i109464
@@ -1511,7 +1511,7 @@
   definition:
   - a progressive tense used to express action that will be on-going in the future
   example:
-  - '`I will be running'' is an example of the future progressive'
+  - '`I will be running´ is an example of the future progressive'
   hypernym:
   - 13827946-n
   ili: i109465
@@ -4703,7 +4703,7 @@
   partOfSpeech: n
 13882478-n:
   definition:
-  - a logical relation between propositions p and q of the form `if p then q'; if
+  - a logical relation between propositions p and q of the form `if p then q´; if
     p is true then q cannot be false
   hypernym:
   - 13805250-n
@@ -4923,8 +4923,8 @@
   - the inflection of nouns, pronouns, adjectives, and articles to indicate masculine
     grammatical gender.
   example:
-  - Feminine declension treats `k', `g', `ch' as softenable, whereas masculine and
-    neuter declension does not (hence they take the `other' ending, `-u').
+  - Feminine declension treats `k´, `g´, `ch´ as softenable, whereas masculine and
+    neuter declension does not (hence they take the `other´ ending, `-u´).
   hypernym:
   - 13826415-n
   members:
@@ -4935,7 +4935,7 @@
   definition:
   - a conjunction that expresses something inferred from another statement or fact.
   example:
-  - One could argue grammatically in favour of `accordingly' being an illative conjunction.
+  - One could argue grammatically in favour of `accordingly´ being an illative conjunction.
   hypernym:
   - 13821604-n
   members:

--- a/src/yaml/noun.relation.yaml
+++ b/src/yaml/noun.relation.yaml
@@ -1150,7 +1150,7 @@
   definition:
   - a grammatical relation between a word and a noun phrase that follows
   example:
-  - '‘Rudolph the red-nosed reindeer’ is an example of apposition'
+  - ‘Rudolph the red-nosed reindeer’ is an example of apposition
   hypernym:
   - 13823013-n
   ili: i109433
@@ -1268,7 +1268,7 @@
   - the voice used to indicate that the grammatical subject of the verb is performing
     the action or causing the happening denoted by the verb
   example:
-  - '‘The boy threw the ball’ uses the active voice'
+  - ‘The boy threw the ball’ uses the active voice
   hypernym:
   - 13825132-n
   ili: i109443
@@ -1282,8 +1282,8 @@
   - the voice used to indicate that the grammatical subject of the verb is the recipient
     (not the source) of the action denoted by the verb
   example:
-  - '‘The ball was thrown by the boy’ uses the passive voice'
-  - '‘The ball was thrown’ is an abbreviated passive'
+  - ‘The ball was thrown by the boy’ uses the passive voice
+  - ‘The ball was thrown’ is an abbreviated passive
   hypernym:
   - 13825132-n
   ili: i109444
@@ -1451,7 +1451,7 @@
   definition:
   - a perfective tense used to express action completed in the present
   example:
-  - '‘I have finished’ is an example of the present perfect'
+  - ‘I have finished’ is an example of the present perfect
   hypernym:
   - 13828352-n
   ili: i109460
@@ -1473,7 +1473,7 @@
   definition:
   - a perfective tense used to express action completed in the past
   example:
-  - '‘I had finished’ is an example of the past perfect'
+  - ‘I had finished’ is an example of the past perfect
   hypernym:
   - 13828352-n
   ili: i109462
@@ -1487,7 +1487,7 @@
   definition:
   - a progressive tense used to describe on-going action in the past
   example:
-  - '‘I had been running’ is an example of the past progressive'
+  - ‘I had been running’ is an example of the past progressive
   hypernym:
   - 13827946-n
   ili: i109463
@@ -1499,7 +1499,7 @@
   definition:
   - a perfective tense used to describe action that will be completed in the future
   example:
-  - '‘I will have finished’ is an example of the future perfect'
+  - ‘I will have finished’ is an example of the future perfect
   hypernym:
   - 13828352-n
   ili: i109464
@@ -1511,7 +1511,7 @@
   definition:
   - a progressive tense used to express action that will be on-going in the future
   example:
-  - '‘I will be running’ is an example of the future progressive'
+  - ‘I will be running’ is an example of the future progressive
   hypernym:
   - 13827946-n
   ili: i109465

--- a/src/yaml/noun.shape.yaml
+++ b/src/yaml/noun.shape.yaml
@@ -3849,7 +3849,7 @@
   - a curve whose equation in Cartesian coordinates is of the form y = a cos x.
   example:
   - The shape of the cosine curve is the same for each full rotation of the angle
-    and so the function is called `periodic'.
+    and so the function is called `periodic´.
   hypernym:
   - 13890262-n
   members:
@@ -3872,7 +3872,7 @@
   - a plane curve that is the graph of the equation y = tan x, where x is an angle.
   example:
   - The shape of the tangent curve is the same for each full rotation of the angle
-    and so the function is called `periodic'.
+    and so the function is called `periodic´.
   hypernym:
   - 13890262-n
   members:

--- a/src/yaml/noun.shape.yaml
+++ b/src/yaml/noun.shape.yaml
@@ -3849,7 +3849,7 @@
   - a curve whose equation in Cartesian coordinates is of the form y = a cos x.
   example:
   - The shape of the cosine curve is the same for each full rotation of the angle
-    and so the function is called `periodic´.
+    and so the function is called ‘periodic’.
   hypernym:
   - 13890262-n
   members:
@@ -3872,7 +3872,7 @@
   - a plane curve that is the graph of the equation y = tan x, where x is an angle.
   example:
   - The shape of the tangent curve is the same for each full rotation of the angle
-    and so the function is called `periodic´.
+    and so the function is called ‘periodic’.
   hypernym:
   - 13890262-n
   members:

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -1672,7 +1672,7 @@
   - (usually plural) the status or rank or office of a Christian clergyman in an ecclesiastical
     hierarchy
   example:
-  - theologians still disagree over whether `bishop' should or should not be a separate
+  - theologians still disagree over whether `bishop´ should or should not be a separate
     Order
   hypernym:
   - 13968971-n
@@ -11236,7 +11236,7 @@
   - diabetes caused by a relative or absolute deficiency of insulin and characterized
     by polyuria
   example:
-  - when doctors say `diabetes' they usually mean `diabetes mellitus'
+  - when doctors say `diabetes´ they usually mean `diabetes mellitus´
   hypernym:
   - 14141287-n
   ili: i111129
@@ -23848,7 +23848,7 @@
 14365537-n:
   definition:
   - inflammation of the brain usually caused by a virus; symptoms include headache
-    and neck pain and drowsiness and nausea and fever (`phrenitis' is no longer in
+    and neck pain and drowsiness and nausea and fever (`phrenitis´ is no longer in
     scientific use)
   hypernym:
   - 14359944-n
@@ -25169,7 +25169,7 @@
   partOfSpeech: n
 14384587-n:
   definition:
-  - a painful muscle spasm especially in the neck or back (`rick' and `wrick' are
+  - a painful muscle spasm especially in the neck or back (`rick´ and `wrick´ are
     British)
   domain_region:
   - 08879115-n
@@ -26820,9 +26820,9 @@
 14411544-n:
   definition:
   - a personality disorder characterized by amorality and lack of affect; capable
-    of violent acts without guilt feelings (`psychopathic personality' was once widely
-    used but was superseded by `sociopathic personality' to indicate the social aspects
-    of the disorder, but now `antisocial personality disorder' is the preferred term)
+    of violent acts without guilt feelings (`psychopathic personality´ was once widely
+    used but was superseded by `sociopathic personality´ to indicate the social aspects
+    of the disorder, but now `antisocial personality disorder´ is the preferred term)
   hypernym:
   - 14411212-n
   ili: i112626
@@ -27552,8 +27552,8 @@
   wikidata: Q836379
 14425892-n:
   definition:
-  - defective articulation of the `l' phoneme or the phoneme `r' is pronounced as
-    `l'
+  - defective articulation of the `l´ phoneme or the phoneme `r´ is pronounced as
+    `l´
   hypernym:
   - 14424081-n
   ili: i112691
@@ -27563,7 +27563,7 @@
 14426029-n:
   definition:
   - speech defect involving excessive use or unusual pronunciation of the phoneme
-    `l'
+    `l´
   hypernym:
   - 14424081-n
   ili: i112692
@@ -27572,8 +27572,8 @@
   partOfSpeech: n
 14426167-n:
   definition:
-  - a speech defect that involves pronouncing `s' like voiceless `th' and `z' like
-    voiced `th'
+  - a speech defect that involves pronouncing `s´ like voiceless `th´ and `z´ like
+    voiced `th´
   hypernym:
   - 14424081-n
   ili: i112693
@@ -30762,7 +30762,7 @@
   partOfSpeech: n
 14479883-n:
   definition:
-  - without clothing (especially in the phrase `in the nude')
+  - without clothing (especially in the phrase `in the nude´)
   domain_topic:
   - 00845915-n
   example:
@@ -30874,7 +30874,7 @@
   definition:
   - not wearing a jacket
   example:
-  - '`in your shirtsleeves'' means you are not wearing anything over your shirt'
+  - '`in your shirtsleeves´ means you are not wearing anything over your shirt'
   - in hot weather they dined in their shirtsleeves
   hypernym:
   - 14481286-n
@@ -31095,7 +31095,7 @@
   partOfSpeech: n
 14485263-n:
   definition:
-  - everything available; usually preceded by `the'
+  - everything available; usually preceded by `the´
   example:
   - we saw the whole shebang
   - a hotdog with the works
@@ -35629,7 +35629,7 @@
   definition:
   - a standard for judging when freedom of speech can be abridged
   example:
-  - no one has a right to shout `fire' in a crowded theater when there is no fire
+  - no one has a right to shout `fire´ in a crowded theater when there is no fire
     because such an action would pose a clear and present danger to public safety
   hypernym:
   - 14564367-n
@@ -35904,8 +35904,8 @@
   partOfSpeech: n
 14569829-n:
   definition:
-  - the state of (good) health (especially in the phrases `in condition' or `in shape'
-    or `out of condition' or `out of shape')
+  - the state of (good) health (especially in the phrases `in condition´ or `in shape´
+    or `out of condition´ or `out of shape´)
   hypernym:
   - 14073193-n
   ili: i113444
@@ -38196,8 +38196,8 @@
   - The property of being of dubious veracity; of questionable accuracy or truthfulness.
   example:
   - Not sure of the relative apocryphalness of this story, but I've always heard that
-    the Chevrolet Nova didn't sell too well in Latin America because `no va' in Spanish
-    means `it does not go'.
+    the Chevrolet Nova didn't sell too well in Latin America because `no va´ in Spanish
+    means `it does not go´.
   hypernym:
   - 13983750-n
   members:
@@ -38359,7 +38359,7 @@
   definition:
   - The state or condition of being fundamental; essential importance.
   example:
-  - At a similar level of fundamentalness or `broadness' is the question of whether
+  - At a similar level of fundamentalness or `broadness´ is the question of whether
     to adopt strategies that are overt versus covert.
   hypernym:
   - 14458819-n
@@ -38614,7 +38614,7 @@
   example:
   - In Treatise on Money (1930, chapter 29), economist John Maynard Keynes argued
     that in commodity markets, backwardation is not an abnormal market situation,
-    but rather arises naturally as `normal backwardation' from the fact that producers
+    but rather arises naturally as `normal backwardation´ from the fact that producers
     of commodities are more prone to hedge their price risk than consumers.
   hypernym:
   - 14512178-n

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -1672,7 +1672,7 @@
   - (usually plural) the status or rank or office of a Christian clergyman in an ecclesiastical
     hierarchy
   example:
-  - theologians still disagree over whether `bishop´ should or should not be a separate
+  - theologians still disagree over whether ‘bishop’ should or should not be a separate
     Order
   hypernym:
   - 13968971-n
@@ -11236,7 +11236,7 @@
   - diabetes caused by a relative or absolute deficiency of insulin and characterized
     by polyuria
   example:
-  - when doctors say `diabetes´ they usually mean `diabetes mellitus´
+  - when doctors say ‘diabetes’ they usually mean ‘diabetes mellitus’
   hypernym:
   - 14141287-n
   ili: i111129
@@ -23848,7 +23848,7 @@
 14365537-n:
   definition:
   - inflammation of the brain usually caused by a virus; symptoms include headache
-    and neck pain and drowsiness and nausea and fever (`phrenitis´ is no longer in
+    and neck pain and drowsiness and nausea and fever (‘phrenitis’ is no longer in
     scientific use)
   hypernym:
   - 14359944-n
@@ -25169,7 +25169,7 @@
   partOfSpeech: n
 14384587-n:
   definition:
-  - a painful muscle spasm especially in the neck or back (`rick´ and `wrick´ are
+  - a painful muscle spasm especially in the neck or back (‘rick’ and ‘wrick’ are
     British)
   domain_region:
   - 08879115-n
@@ -26820,9 +26820,9 @@
 14411544-n:
   definition:
   - a personality disorder characterized by amorality and lack of affect; capable
-    of violent acts without guilt feelings (`psychopathic personality´ was once widely
-    used but was superseded by `sociopathic personality´ to indicate the social aspects
-    of the disorder, but now `antisocial personality disorder´ is the preferred term)
+    of violent acts without guilt feelings (‘psychopathic personality’ was once widely
+    used but was superseded by ‘sociopathic personality’ to indicate the social aspects
+    of the disorder, but now ‘antisocial personality disorder’ is the preferred term)
   hypernym:
   - 14411212-n
   ili: i112626
@@ -27572,8 +27572,8 @@
   partOfSpeech: n
 14426167-n:
   definition:
-  - a speech defect that involves pronouncing /s/ like voiceless `th´, /θ/ and /z/
-    like voiced `th´, /ð/
+  - a speech defect that involves pronouncing /s/ like voiceless ‘th’, /θ/ and /z/
+    like voiced ‘th’, /ð/
   hypernym:
   - 14424081-n
   ili: i112693
@@ -30762,7 +30762,7 @@
   partOfSpeech: n
 14479883-n:
   definition:
-  - without clothing (especially in the phrase `in the nude´)
+  - without clothing (especially in the phrase ‘in the nude’)
   domain_topic:
   - 00845915-n
   example:
@@ -30874,7 +30874,7 @@
   definition:
   - not wearing a jacket
   example:
-  - '`in your shirtsleeves´ means you are not wearing anything over your shirt'
+  - '‘in your shirtsleeves’ means you are not wearing anything over your shirt'
   - in hot weather they dined in their shirtsleeves
   hypernym:
   - 14481286-n
@@ -31095,7 +31095,7 @@
   partOfSpeech: n
 14485263-n:
   definition:
-  - everything available; usually preceded by `the´
+  - everything available; usually preceded by ‘the’
   example:
   - we saw the whole shebang
   - a hotdog with the works
@@ -35629,7 +35629,7 @@
   definition:
   - a standard for judging when freedom of speech can be abridged
   example:
-  - no one has a right to shout `fire´ in a crowded theater when there is no fire
+  - no one has a right to shout ‘fire’ in a crowded theater when there is no fire
     because such an action would pose a clear and present danger to public safety
   hypernym:
   - 14564367-n
@@ -35904,8 +35904,8 @@
   partOfSpeech: n
 14569829-n:
   definition:
-  - the state of (good) health (especially in the phrases `in condition´ or `in shape´
-    or `out of condition´ or `out of shape´)
+  - the state of (good) health (especially in the phrases ‘in condition’ or ‘in shape’
+    or ‘out of condition’ or ‘out of shape’)
   hypernym:
   - 14073193-n
   ili: i113444
@@ -38196,8 +38196,8 @@
   - The property of being of dubious veracity; of questionable accuracy or truthfulness.
   example:
   - Not sure of the relative apocryphalness of this story, but I've always heard that
-    the Chevrolet Nova didn't sell too well in Latin America because `no va´ in Spanish
-    means `it does not go´.
+    the Chevrolet Nova didn't sell too well in Latin America because ‘no va’ in Spanish
+    means ‘it does not go’.
   hypernym:
   - 13983750-n
   members:
@@ -38359,7 +38359,7 @@
   definition:
   - The state or condition of being fundamental; essential importance.
   example:
-  - At a similar level of fundamentalness or `broadness´ is the question of whether
+  - At a similar level of fundamentalness or ‘broadness’ is the question of whether
     to adopt strategies that are overt versus covert.
   hypernym:
   - 14458819-n
@@ -38614,7 +38614,7 @@
   example:
   - In Treatise on Money (1930, chapter 29), economist John Maynard Keynes argued
     that in commodity markets, backwardation is not an abnormal market situation,
-    but rather arises naturally as `normal backwardation´ from the fact that producers
+    but rather arises naturally as ‘normal backwardation’ from the fact that producers
     of commodities are more prone to hedge their price risk than consumers.
   hypernym:
   - 14512178-n

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -30874,7 +30874,7 @@
   definition:
   - not wearing a jacket
   example:
-  - '‘in your shirtsleeves’ means you are not wearing anything over your shirt'
+  - ‘in your shirtsleeves’ means you are not wearing anything over your shirt
   - in hot weather they dined in their shirtsleeves
   hypernym:
   - 14481286-n

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -38395,8 +38395,8 @@
   definition:
   - The property of relating to, or having the nature of a serious criminal offense.
   example:
-  - Big John might give you a smack, but that required an extraordinary circumstance
-    , feloniousness of a type that was beyond Joey and Linwood.
+  - Big John might give you a smack, but that required an extraordinary circumstance,
+    feloniousness of a type that was beyond Joey and Linwood.
   hypernym:
   - 14014831-n
   members:

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -29024,8 +29024,8 @@
   definition:
   - the state of being banished or ostracized (excluded from society by general consent)
   example:
-  - the association should get rid of its elderly members — not by euthanasia, of course,
-    but by Coventry
+  - the association should get rid of its elderly members — not by euthanasia, of
+    course, but by Coventry
   hypernym:
   - 13958260-n
   ili: i112823
@@ -30874,7 +30874,7 @@
   definition:
   - not wearing a jacket
   example:
-  - "`in your shirtsleeves' means you are not wearing anything over your shirt"
+  - '`in your shirtsleeves'' means you are not wearing anything over your shirt'
   - in hot weather they dined in their shirtsleeves
   hypernym:
   - 14481286-n

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -27552,8 +27552,8 @@
   wikidata: Q836379
 14425892-n:
   definition:
-  - defective articulation of the `l´ phoneme or the phoneme `r´ is pronounced as
-    `l´
+  - defective articulation of the /l/ phoneme or the phoneme /r/ is pronounced as
+    /l/
   hypernym:
   - 14424081-n
   ili: i112691
@@ -27563,7 +27563,7 @@
 14426029-n:
   definition:
   - speech defect involving excessive use or unusual pronunciation of the phoneme
-    `l´
+    /l/
   hypernym:
   - 14424081-n
   ili: i112692
@@ -27572,8 +27572,8 @@
   partOfSpeech: n
 14426167-n:
   definition:
-  - a speech defect that involves pronouncing `s´ like voiceless `th´ and `z´ like
-    voiced `th´
+  - a speech defect that involves pronouncing /s/ like voiceless `th´, /θ/ and /z/
+    like voiced `th´, /ð/
   hypernym:
   - 14424081-n
   ili: i112693

--- a/src/yaml/noun.substance.yaml
+++ b/src/yaml/noun.substance.yaml
@@ -25842,7 +25842,8 @@
   partOfSpeech: n
 15045756-n:
   definition:
-  - pad for preliminary or hasty writing or notes or sketches etc; `scribbling block' is a British term
+  - pad for preliminary or hasty writing or notes or sketches etc; `scribbling block'
+    is a British term
   hypernym:
   - 15045652-n
   ili: i116098
@@ -31846,8 +31847,8 @@
   source: plWordNet 4.0
 92424810-n:
   definition:
-  - "The name `ecdysteroid' refers to the insect moulting and sex hormones
-    which include ecdysone and its homologues such as 20-hydroxyecdysone."
+  - The name `ecdysteroid' refers to the insect moulting and sex hormones which include
+    ecdysone and its homologues such as 20-hydroxyecdysone.
   example:
   - source: https://en.wikipedia.org
     text: Ecdysteroids also occur in other invertebrates where they can play a different
@@ -32083,9 +32084,9 @@
   - an aqueous suspension of calcium hydroxide, used in tanning as a basic agent.
   example:
   - source: https://en.wikipedia.org
-    text: "After soaking, the hides and skins are taken for liming: treatment with
-      milk of lime (a basic agent) that may involve the addition of `sharpening agents'
-      (disulfide reducing agents) like sodium sulfide, cyanides, amines etc."
+    text: 'After soaking, the hides and skins are taken for liming: treatment with
+      milk of lime (a basic agent) that may involve the addition of `sharpening agents''
+      (disulfide reducing agents) like sodium sulfide, cyanides, amines etc.'
   - source: https://en.wikipedia.org
     text: When excess calcium hydroxide is added to limewater, a suspension of calcium
       hydroxide particles results, giving it a milky aspect, in which case it has
@@ -33108,8 +33109,8 @@
   source: plWordNet 4.0
 92464700-n:
   definition:
-  - an isometric hydrocarbon isolated from cardamon and marjoram oils, as well as other
-    natural sources.
+  - an isometric hydrocarbon isolated from cardamon and marjoram oils, as well as
+    other natural sources.
   example:
   - source: https://en.wikipedia.org
     text: α-Terpinene is a perfume and flavoring chemical used in the cosmetics and

--- a/src/yaml/noun.substance.yaml
+++ b/src/yaml/noun.substance.yaml
@@ -25842,7 +25842,7 @@
   partOfSpeech: n
 15045756-n:
   definition:
-  - pad for preliminary or hasty writing or notes or sketches etc; `scribbling block'
+  - pad for preliminary or hasty writing or notes or sketches etc.; `scribbling block'
     is a British term
   hypernym:
   - 15045652-n

--- a/src/yaml/noun.substance.yaml
+++ b/src/yaml/noun.substance.yaml
@@ -306,7 +306,7 @@
   partOfSpeech: n
 14610299-n:
   definition:
-  - an abbreviation for `hazardous material´ used on warning signs
+  - an abbreviation for ‘hazardous material’ used on warning signs
   example:
   - NO HAZMATS IN TUNNEL
   hypernym:
@@ -25842,7 +25842,7 @@
   partOfSpeech: n
 15045756-n:
   definition:
-  - pad for preliminary or hasty writing or notes or sketches etc.; `scribbling block´
+  - pad for preliminary or hasty writing or notes or sketches etc.; ‘scribbling block’
     is a British term
   hypernym:
   - 15045652-n
@@ -28065,7 +28065,7 @@
   partOfSpeech: n
 15083322-n:
   definition:
-  - the cholesterol in high-density lipoproteins; the `good´ cholesterol; a high level
+  - the cholesterol in high-density lipoproteins; the ‘good’ cholesterol; a high level
     in the blood is thought to lower the risk of coronary artery disease
   hypernym:
   - 15083111-n
@@ -28075,7 +28075,7 @@
   partOfSpeech: n
 15083554-n:
   definition:
-  - the cholesterol in low-density lipoproteins; the `bad´ cholesterol; a high level
+  - the cholesterol in low-density lipoproteins; the ‘bad’ cholesterol; a high level
     in the blood is thought to be related to various pathogenic conditions
   hypernym:
   - 15083111-n
@@ -31847,7 +31847,7 @@
   source: plWordNet 4.0
 92424810-n:
   definition:
-  - The name `ecdysteroid´ refers to the insect moulting and sex hormones which include
+  - The name ‘ecdysteroid’ refers to the insect moulting and sex hormones which include
     ecdysone and its homologues such as 20-hydroxyecdysone.
   example:
   - source: https://en.wikipedia.org
@@ -31862,7 +31862,7 @@
   wikidata: Q138983
 92424812-n:
   definition:
-  - The term `zooecdysone´ refers to the molting hormones of insects.
+  - The term ‘zooecdysone’ refers to the molting hormones of insects.
   hypernym:
   - 92424810-n
   members:
@@ -32085,7 +32085,7 @@
   example:
   - source: https://en.wikipedia.org
     text: 'After soaking, the hides and skins are taken for liming: treatment with
-      milk of lime (a basic agent) that may involve the addition of `sharpening agents´
+      milk of lime (a basic agent) that may involve the addition of ‘sharpening agents’
       (disulfide reducing agents) like sodium sulfide, cyanides, amines etc.'
   - source: https://en.wikipedia.org
     text: When excess calcium hydroxide is added to limewater, a suspension of calcium

--- a/src/yaml/noun.substance.yaml
+++ b/src/yaml/noun.substance.yaml
@@ -306,7 +306,7 @@
   partOfSpeech: n
 14610299-n:
   definition:
-  - an abbreviation for `hazardous material' used on warning signs
+  - an abbreviation for `hazardous material´ used on warning signs
   example:
   - NO HAZMATS IN TUNNEL
   hypernym:
@@ -25842,7 +25842,7 @@
   partOfSpeech: n
 15045756-n:
   definition:
-  - pad for preliminary or hasty writing or notes or sketches etc.; `scribbling block'
+  - pad for preliminary or hasty writing or notes or sketches etc.; `scribbling block´
     is a British term
   hypernym:
   - 15045652-n
@@ -28065,7 +28065,7 @@
   partOfSpeech: n
 15083322-n:
   definition:
-  - the cholesterol in high-density lipoproteins; the `good' cholesterol; a high level
+  - the cholesterol in high-density lipoproteins; the `good´ cholesterol; a high level
     in the blood is thought to lower the risk of coronary artery disease
   hypernym:
   - 15083111-n
@@ -28075,7 +28075,7 @@
   partOfSpeech: n
 15083554-n:
   definition:
-  - the cholesterol in low-density lipoproteins; the `bad' cholesterol; a high level
+  - the cholesterol in low-density lipoproteins; the `bad´ cholesterol; a high level
     in the blood is thought to be related to various pathogenic conditions
   hypernym:
   - 15083111-n
@@ -31847,7 +31847,7 @@
   source: plWordNet 4.0
 92424810-n:
   definition:
-  - The name `ecdysteroid' refers to the insect moulting and sex hormones which include
+  - The name `ecdysteroid´ refers to the insect moulting and sex hormones which include
     ecdysone and its homologues such as 20-hydroxyecdysone.
   example:
   - source: https://en.wikipedia.org
@@ -31862,7 +31862,7 @@
   wikidata: Q138983
 92424812-n:
   definition:
-  - The term `zooecdysone' refers to the molting hormones of insects.
+  - The term `zooecdysone´ refers to the molting hormones of insects.
   hypernym:
   - 92424810-n
   members:
@@ -32085,7 +32085,7 @@
   example:
   - source: https://en.wikipedia.org
     text: 'After soaking, the hides and skins are taken for liming: treatment with
-      milk of lime (a basic agent) that may involve the addition of `sharpening agents''
+      milk of lime (a basic agent) that may involve the addition of `sharpening agents´
       (disulfide reducing agents) like sodium sulfide, cyanides, amines etc.'
   - source: https://en.wikipedia.org
     text: When excess calcium hydroxide is added to limewater, a suspension of calcium

--- a/src/yaml/noun.time.yaml
+++ b/src/yaml/noun.time.yaml
@@ -3035,7 +3035,7 @@
   - a weekday on which no festival or holiday is celebrated
   example:
   - in the middle ages feria was used with a prefixed ordinal number to designate
-    the day of the week, so `secunda feria´ meant Monday, but Sunday and Saturday
+    the day of the week, so ‘secunda feria’ meant Monday, but Sunday and Saturday
     were always called by their names, Dominicus and Sabbatum, and so feria came to
     mean an ordinary weekday
   hypernym:
@@ -5069,7 +5069,7 @@
 15220457-n:
   definition:
   - the 7th Wednesday before Easter; the first day of Lent; the day following Mardi
-    Gras (`Fat Tuesday´); a day of fasting and repentance
+    Gras (‘Fat Tuesday’); a day of fasting and repentance
   hypernym:
   - 15209005-n
   ili: i117076
@@ -9644,7 +9644,7 @@
   partOfSpeech: n
 15293068-n:
   definition:
-  - (`cease´ is a noun only in the phrase `without cease´) end
+  - (‘cease’ is a noun only in the phrase ‘without cease’) end
   hypernym:
   - 15291722-n
   ili: i117482
@@ -11725,7 +11725,7 @@
   - a reckoning of the passage of time based on the Sun's position in the sky.
   example:
   - In September the Sun takes less time (as measured by an accurate clock) to make
-    an apparent revolution than it does in December; 24 `hours´ of solar time can
+    an apparent revolution than it does in December; 24 ‘hours’ of solar time can
     be 21 seconds less or 29 seconds more than 24 hours of clock time.
   hypernym:
   - 00028468-n
@@ -11806,7 +11806,7 @@
     for the child's welfare.
   example:
   - source: https://en.wikipedia.org
-    text: The terms `parental leave´ and `family leave´ include maternity, paternity,
+    text: The terms ‘parental leave’ and ‘family leave’ include maternity, paternity,
       and adoption leave.
   hypernym:
   - 15164090-n

--- a/src/yaml/noun.time.yaml
+++ b/src/yaml/noun.time.yaml
@@ -3035,7 +3035,7 @@
   - a weekday on which no festival or holiday is celebrated
   example:
   - in the middle ages feria was used with a prefixed ordinal number to designate
-    the day of the week, so `secunda feria' meant Monday, but Sunday and Saturday
+    the day of the week, so `secunda feria´ meant Monday, but Sunday and Saturday
     were always called by their names, Dominicus and Sabbatum, and so feria came to
     mean an ordinary weekday
   hypernym:
@@ -5069,7 +5069,7 @@
 15220457-n:
   definition:
   - the 7th Wednesday before Easter; the first day of Lent; the day following Mardi
-    Gras (`Fat Tuesday'); a day of fasting and repentance
+    Gras (`Fat Tuesday´); a day of fasting and repentance
   hypernym:
   - 15209005-n
   ili: i117076
@@ -9644,7 +9644,7 @@
   partOfSpeech: n
 15293068-n:
   definition:
-  - (`cease' is a noun only in the phrase `without cease') end
+  - (`cease´ is a noun only in the phrase `without cease´) end
   hypernym:
   - 15291722-n
   ili: i117482
@@ -11725,7 +11725,7 @@
   - a reckoning of the passage of time based on the Sun's position in the sky.
   example:
   - In September the Sun takes less time (as measured by an accurate clock) to make
-    an apparent revolution than it does in December; 24 `hours' of solar time can
+    an apparent revolution than it does in December; 24 `hours´ of solar time can
     be 21 seconds less or 29 seconds more than 24 hours of clock time.
   hypernym:
   - 00028468-n
@@ -11806,7 +11806,7 @@
     for the child's welfare.
   example:
   - source: https://en.wikipedia.org
-    text: The terms `parental leave' and `family leave' include maternity, paternity,
+    text: The terms `parental leave´ and `family leave´ include maternity, paternity,
       and adoption leave.
   hypernym:
   - 15164090-n

--- a/src/yaml/verb.change.yaml
+++ b/src/yaml/verb.change.yaml
@@ -7255,7 +7255,7 @@
   definition:
   - shorten
   example:
-  - Abbreviate `New York´ and write `NY´
+  - Abbreviate ‘New York’ and write ‘NY’
   hypernym:
   - 00243282-v
   ili: i22936
@@ -16417,7 +16417,7 @@
   partOfSpeech: v
 00391412-v:
   definition:
-  - silence (someone) by uttering `shush!´
+  - silence (someone) by uttering ‘shush!’
   hypernym:
   - 00462448-v
   ili: i23684
@@ -18160,7 +18160,7 @@
   definition:
   - make transitive
   example:
-  - adding `out´ to many verbs transitivizes them
+  - adding ‘out’ to many verbs transitivizes them
   hypernym:
   - 00126072-v
   ili: i23828
@@ -21185,7 +21185,7 @@
   - wipe out the effect of something
   example:
   - The new tax effectively cancels out my raise
-  - The `A´ will cancel out the `C´ on your record
+  - The ‘A’ will cancel out the ‘C’ on your record
   hypernym:
   - 00472642-v
   ili: i24071
@@ -26458,7 +26458,7 @@
   definition:
   - make into a verb
   example:
-  - '`mouse´ has been verbified by computer users'
+  - '‘mouse’ has been verbified by computer users'
   hypernym:
   - 00126072-v
   ili: i24517

--- a/src/yaml/verb.change.yaml
+++ b/src/yaml/verb.change.yaml
@@ -26458,7 +26458,7 @@
   definition:
   - make into a verb
   example:
-  - '‘mouse’ has been verbified by computer users'
+  - ‘mouse’ has been verbified by computer users
   hypernym:
   - 00126072-v
   ili: i24517

--- a/src/yaml/verb.change.yaml
+++ b/src/yaml/verb.change.yaml
@@ -7255,7 +7255,7 @@
   definition:
   - shorten
   example:
-  - Abbreviate `New York' and write `NY'
+  - Abbreviate `New York´ and write `NY´
   hypernym:
   - 00243282-v
   ili: i22936
@@ -16417,7 +16417,7 @@
   partOfSpeech: v
 00391412-v:
   definition:
-  - silence (someone) by uttering `shush!'
+  - silence (someone) by uttering `shush!´
   hypernym:
   - 00462448-v
   ili: i23684
@@ -18160,7 +18160,7 @@
   definition:
   - make transitive
   example:
-  - adding `out' to many verbs transitivizes them
+  - adding `out´ to many verbs transitivizes them
   hypernym:
   - 00126072-v
   ili: i23828
@@ -21185,7 +21185,7 @@
   - wipe out the effect of something
   example:
   - The new tax effectively cancels out my raise
-  - The `A' will cancel out the `C' on your record
+  - The `A´ will cancel out the `C´ on your record
   hypernym:
   - 00472642-v
   ili: i24071
@@ -26458,7 +26458,7 @@
   definition:
   - make into a verb
   example:
-  - '`mouse'' has been verbified by computer users'
+  - '`mouse´ has been verbified by computer users'
   hypernym:
   - 00126072-v
   ili: i24517

--- a/src/yaml/verb.cognition.yaml
+++ b/src/yaml/verb.cognition.yaml
@@ -1734,7 +1734,7 @@
   definition:
   - recognize as being; establish the identity of someone or something
   example:
-  - She identified the man on the `wanted´ poster
+  - She identified the man on the ‘wanted’ poster
   hypernym:
   - 00701581-v
   ili: i24849

--- a/src/yaml/verb.cognition.yaml
+++ b/src/yaml/verb.cognition.yaml
@@ -1734,7 +1734,7 @@
   definition:
   - recognize as being; establish the identity of someone or something
   example:
-  - She identified the man on the `wanted' poster
+  - She identified the man on the `wanted´ poster
   hypernym:
   - 00701581-v
   ili: i24849

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -375,7 +375,7 @@
   definition:
   - begin to speak or say
   example:
-  - '`Now listen, friends'', he began'
+  - '`Now listen, friends´, he began'
   hypernym:
   - 00944022-v
   ili: i25435
@@ -2206,7 +2206,7 @@
   definition:
   - continue talking
   example:
-  - '`I know it''s hard'', he continued, `but there is no choice'''
+  - '`I know it''s hard´, he continued, `but there is no choice´'
   - carry on — pretend we are not in the room
   hypernym:
   - 00964479-v
@@ -5295,7 +5295,7 @@
   definition:
   - to enlarge beyond bounds or the truth
   example:
-  - tended to romanticize and exaggerate this `gracious Old South' imagery
+  - tended to romanticize and exaggerate this `gracious Old South´ imagery
   hypernym:
   - 00835688-v
   ili: i25843
@@ -6385,7 +6385,7 @@
   partOfSpeech: v
 00862146-v:
   definition:
-  - applaud with shouts of `bravo' or `brava'
+  - applaud with shouts of `bravo´ or `brava´
   hypernym:
   - 00863593-v
   ili: i25931
@@ -6682,7 +6682,7 @@
   partOfSpeech: v
 00867440-v:
   definition:
-  - express admiration and pleasure by uttering `ooh' or `aah'
+  - express admiration and pleasure by uttering `ooh´ or `aah´
   example:
   - They oohed and aahed when they unwrapped the presents
   hypernym:
@@ -9297,9 +9297,9 @@
   definition:
   - utter aloud; often with surprise, horror, or joy
   example:
-  - '`I won!'' he exclaimed'
-  - '`Help!'' she cried'
-  - '`I''m here,'' the mother shouted when she saw her child looking lost'
+  - '`I won!´ he exclaimed'
+  - '`Help!´ she cried'
+  - '`I''m here,´ the mother shouted when she saw her child looking lost'
   hypernym:
   - 00942415-v
   ili: i26175
@@ -9363,7 +9363,7 @@
   - 00914001-v
 00915748-v:
   definition:
-  - cry `hollo'
+  - cry `hollo´
   hypernym:
   - 00915018-v
   ili: i26179
@@ -9372,7 +9372,7 @@
   partOfSpeech: v
 00915838-v:
   definition:
-  - encourage somebody by crying `hollo'
+  - encourage somebody by crying `hollo´
   hypernym:
   - 01822202-v
   ili: i26180
@@ -9381,7 +9381,7 @@
   partOfSpeech: v
 00915935-v:
   definition:
-  - shout `hurrah!'
+  - shout `hurrah!´
   hypernym:
   - 00915018-v
   ili: i26181
@@ -9390,7 +9390,7 @@
   partOfSpeech: v
 00916014-v:
   definition:
-  - shout `halloo', as when greeting someone or attracting attention
+  - shout `halloo´, as when greeting someone or attracting attention
   hypernym:
   - 00915018-v
   ili: i26182
@@ -9486,7 +9486,7 @@
   definition:
   - utter words loudly and forcefully
   example:
-  - '`Get out of here,'' he roared'
+  - '`Get out of here,´ he roared'
   hypernym:
   - 00914426-v
   ili: i26190
@@ -9890,7 +9890,7 @@
   - indicate a certain reading; of gauges and instruments
   example:
   - The thermometer showed thirteen degrees below zero
-  - The gauge read `empty'
+  - The gauge read `empty´
   hypernym:
   - 00929986-v
   ili: i26225
@@ -10284,7 +10284,7 @@
   - give sudden release to an expression
   example:
   - We burst out laughing
-  - '`I hate you,'' she burst out'
+  - '`I hate you,´ she burst out'
   hypernym:
   - 00945869-v
   ili: i26260
@@ -10364,7 +10364,7 @@
   definition:
   - have as a meaning
   example:
-  - '`multi-'' denotes `many'''
+  - '`multi-´ denotes `many´'
   hypernym:
   - 00933814-v
   ili: i26267
@@ -10378,7 +10378,7 @@
   definition:
   - denote or connote
   example:
-  - '`maison'' means `house'' in French'
+  - '`maison´ means `house´ in French'
   - An example sentence would show what this word means
   ili: i26268
   members:
@@ -11118,7 +11118,7 @@
   - recite or repeat a fixed text
   example:
   - Say grace
-  - She said her `Hail Mary'
+  - She said her `Hail Mary´
   hypernym:
   - 00947287-v
   ili: i26329
@@ -11396,7 +11396,7 @@
   definition:
   - pronounce (vowels) by bringing the tongue closer to the roof of the mouth
   example:
-  - raise your `o'
+  - raise your `o´
   hypernym:
   - 00980581-v
   ili: i26352
@@ -11475,7 +11475,7 @@
   partOfSpeech: v
 00953943-v:
   definition:
-  - utter `tsk,' `tut,' or `tut-tut,' as in disapproval
+  - utter `tsk,´ `tut,´ or `tut-tut,´ as in disapproval
   hypernym:
   - 00985856-v
   ili: i26359
@@ -11750,7 +11750,7 @@
   definition:
   - give a definition for the meaning of a word
   example:
-  - Define `sadness'
+  - Define `sadness´
   hypernym:
   - 00949109-v
   ili: i26382
@@ -12035,7 +12035,7 @@
   definition:
   - make or coin into a word or accept a new word into the lexicon of a language
   example:
-  - The concept expressed by German `Gemuetlichkeit' is not lexicalized in English
+  - The concept expressed by German `Gemuetlichkeit´ is not lexicalized in English
   hypernym:
   - 00982485-v
   ili: i26407
@@ -12864,7 +12864,7 @@
   definition:
   - state or announce
   example:
-  - '`I am not a Communist,'' he exclaimed'
+  - '`I am not a Communist,´ he exclaimed'
   - The King will proclaim an amnesty
   hypernym:
   - 01012145-v
@@ -12935,7 +12935,7 @@
   - 00944022-v
   example:
   - She pronounces French words in a funny way
-  - I cannot say `zip wire'
+  - I cannot say `zip wire´
   - Can the child sound out this complicated word?
   ili: i26483
   members:
@@ -12974,7 +12974,7 @@
   definition:
   - utter aloud
   example:
-  - She said `Hello' to everyone in the office
+  - She said `Hello´ to everyone in the office
   hypernym:
   - 00942415-v
   ili: i26486
@@ -13221,7 +13221,7 @@
   definition:
   - utter with a gurgling sound
   example:
-  - '`Help,'' the stabbing victim gurgled'
+  - '`Help,´ the stabbing victim gurgled'
   hypernym:
   - 00985856-v
   ili: i26507
@@ -13243,7 +13243,7 @@
   definition:
   - speak in a nasal voice
   example:
-  - '`Come here,'' he nasaled'
+  - '`Come here,´ he nasaled'
   hypernym:
   - 00985856-v
   ili: i26509
@@ -13339,7 +13339,7 @@
   definition:
   - utter in unison
   example:
-  - '`yes,'' the children chorused'
+  - '`yes,´ the children chorused'
   hypernym:
   - 00985856-v
   ili: i26518
@@ -14847,7 +14847,7 @@
   - 06182505-n
   example:
   - Speakers topicalize more often than they realize
-  - The object of the sentence is topicalized in what linguists call `Yiddish Movement'
+  - The object of the sentence is topicalized in what linguists call `Yiddish Movement´
   hypernym:
   - 01015376-v
   ili: i26650
@@ -15024,8 +15024,8 @@
   definition:
   - make the (grammatical) predicate in a proposition
   example:
-  - The predicate `dog' is predicated of the subject `Fido' in the sentence `Fido
-    is a dog'
+  - The predicate `dog´ is predicated of the subject `Fido´ in the sentence `Fido
+    is a dog´
   hypernym:
   - 02730292-v
   ili: i26664
@@ -15587,7 +15587,7 @@
   definition:
   - state or say further
   example:
-  - '`It doesn''t matter,'' he supplied'
+  - '`It doesn''t matter,´ he supplied'
   hypernym:
   - 01011267-v
   ili: i26710
@@ -15600,7 +15600,7 @@
   definition:
   - add casually to a conversation
   example:
-  - '`I don''t agree with this,'' she tossed in'
+  - '`I don''t agree with this,´ she tossed in'
   hypernym:
   - 01029183-v
   ili: i26711
@@ -15671,7 +15671,7 @@
   definition:
   - designate by an identifying term
   example:
-  - They styled their nation `The Confederate States'
+  - They styled their nation `The Confederate States´
   hypernym:
   - 01030757-v
   ili: i26717
@@ -15760,7 +15760,7 @@
   definition:
   - assign a label to; designate with a label
   example:
-  - These students were labelled `learning disabled'
+  - These students were labelled `learning disabled´
   hypernym:
   - 01032165-v
   ili: i26725
@@ -15993,7 +15993,7 @@
   - to consider or examine in speech or writing
   example:
   - The author talks about the different aspects of this question
-  - The class discussed Dante's `Inferno'
+  - The class discussed Dante's `Inferno´
   hypernym:
   - 01035399-v
   ili: i26745
@@ -17245,7 +17245,7 @@
   partOfSpeech: v
 01057138-v:
   definition:
-  - pronounce with a trill, of the phoneme `r'
+  - pronounce with a trill, of the phoneme `r´
   example:
   - Some speakers trill their r's
   hypernym:
@@ -17665,7 +17665,7 @@
   partOfSpeech: v
 01063726-v:
   definition:
-  - utter `haw'
+  - utter `haw´
   example:
   - he hemmed and hawed
   hypernym:
@@ -17676,7 +17676,7 @@
   partOfSpeech: v
 01063821-v:
   definition:
-  - utter `hem' or `ahem'
+  - utter `hem´ or `ahem´
   hypernym:
   - 00985856-v
   ili: i26893
@@ -17685,7 +17685,7 @@
   partOfSpeech: v
 01063903-v:
   definition:
-  - utter `hems' and `haws'; indicated hesitation
+  - utter `hems´ and `haws´; indicated hesitation
   example:
   - He hemmed and hawed when asked to address the crowd
   hypernym:

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -375,7 +375,7 @@
   definition:
   - begin to speak or say
   example:
-  - '`Now listen, friends´, he began'
+  - '‘Now listen, friends’, he began'
   hypernym:
   - 00944022-v
   ili: i25435
@@ -2206,7 +2206,7 @@
   definition:
   - continue talking
   example:
-  - '`I know it''s hard,´ he continued, `but there is no choice´'
+  - '‘I know it''s hard,’ he continued, ‘but there is no choice’'
   - carry on — pretend we are not in the room
   hypernym:
   - 00964479-v
@@ -5295,7 +5295,7 @@
   definition:
   - to enlarge beyond bounds or the truth
   example:
-  - tended to romanticize and exaggerate this `gracious Old South´ imagery
+  - tended to romanticize and exaggerate this ‘gracious Old South’ imagery
   hypernym:
   - 00835688-v
   ili: i25843
@@ -6385,7 +6385,7 @@
   partOfSpeech: v
 00862146-v:
   definition:
-  - applaud with shouts of `bravo´ or `brava´
+  - applaud with shouts of ‘bravo’ or ‘brava’
   hypernym:
   - 00863593-v
   ili: i25931
@@ -6682,7 +6682,7 @@
   partOfSpeech: v
 00867440-v:
   definition:
-  - express admiration and pleasure by uttering `ooh´ or `aah´
+  - express admiration and pleasure by uttering ‘ooh’ or ‘aah’
   example:
   - They oohed and aahed when they unwrapped the presents
   hypernym:
@@ -9297,9 +9297,9 @@
   definition:
   - utter aloud; often with surprise, horror, or joy
   example:
-  - '`I won!´ he exclaimed'
-  - '`Help!´ she cried'
-  - '`I''m here,´ the mother shouted when she saw her child looking lost'
+  - '‘I won!’ he exclaimed'
+  - '‘Help!’ she cried'
+  - '‘I''m here,’ the mother shouted when she saw her child looking lost'
   hypernym:
   - 00942415-v
   ili: i26175
@@ -9363,7 +9363,7 @@
   - 00914001-v
 00915748-v:
   definition:
-  - cry `hollo´
+  - cry ‘hollo’
   hypernym:
   - 00915018-v
   ili: i26179
@@ -9372,7 +9372,7 @@
   partOfSpeech: v
 00915838-v:
   definition:
-  - encourage somebody by crying `hollo´
+  - encourage somebody by crying ‘hollo’
   hypernym:
   - 01822202-v
   ili: i26180
@@ -9381,7 +9381,7 @@
   partOfSpeech: v
 00915935-v:
   definition:
-  - shout `hurrah!´
+  - shout ‘hurrah!’
   hypernym:
   - 00915018-v
   ili: i26181
@@ -9390,7 +9390,7 @@
   partOfSpeech: v
 00916014-v:
   definition:
-  - shout `halloo´, as when greeting someone or attracting attention
+  - shout ‘halloo’, as when greeting someone or attracting attention
   hypernym:
   - 00915018-v
   ili: i26182
@@ -9486,7 +9486,7 @@
   definition:
   - utter words loudly and forcefully
   example:
-  - '`Get out of here,´ he roared'
+  - '‘Get out of here,’ he roared'
   hypernym:
   - 00914426-v
   ili: i26190
@@ -9890,7 +9890,7 @@
   - indicate a certain reading; of gauges and instruments
   example:
   - The thermometer showed thirteen degrees below zero
-  - The gauge read `empty´
+  - The gauge read ‘empty’
   hypernym:
   - 00929986-v
   ili: i26225
@@ -10284,7 +10284,7 @@
   - give sudden release to an expression
   example:
   - We burst out laughing
-  - '`I hate you,´ she burst out'
+  - '‘I hate you,’ she burst out'
   hypernym:
   - 00945869-v
   ili: i26260
@@ -10364,7 +10364,7 @@
   definition:
   - have as a meaning
   example:
-  - '`multi-´ denotes `many´'
+  - '‘multi-’ denotes ‘many’'
   hypernym:
   - 00933814-v
   ili: i26267
@@ -10378,7 +10378,7 @@
   definition:
   - denote or connote
   example:
-  - '`maison´ means `house´ in French'
+  - '‘maison’ means ‘house’ in French'
   - An example sentence would show what this word means
   ili: i26268
   members:
@@ -11118,7 +11118,7 @@
   - recite or repeat a fixed text
   example:
   - Say grace
-  - She said her `Hail Mary´
+  - She said her ‘Hail Mary’
   hypernym:
   - 00947287-v
   ili: i26329
@@ -11396,7 +11396,7 @@
   definition:
   - pronounce (vowels) by bringing the tongue closer to the roof of the mouth
   example:
-  - raise your `o´
+  - raise your ‘o’
   hypernym:
   - 00980581-v
   ili: i26352
@@ -11475,7 +11475,7 @@
   partOfSpeech: v
 00953943-v:
   definition:
-  - utter `tsk,´ `tut,´ or `tut-tut,´ as in disapproval
+  - utter ‘tsk,’ ‘tut,’ or ‘tut-tut,’ as in disapproval
   hypernym:
   - 00985856-v
   ili: i26359
@@ -11750,7 +11750,7 @@
   definition:
   - give a definition for the meaning of a word
   example:
-  - Define `sadness´
+  - Define ‘sadness’
   hypernym:
   - 00949109-v
   ili: i26382
@@ -12035,7 +12035,7 @@
   definition:
   - make or coin into a word or accept a new word into the lexicon of a language
   example:
-  - The concept expressed by German `Gemuetlichkeit´ is not lexicalized in English
+  - The concept expressed by German ‘Gemuetlichkeit’ is not lexicalized in English
   hypernym:
   - 00982485-v
   ili: i26407
@@ -12864,7 +12864,7 @@
   definition:
   - state or announce
   example:
-  - '`I am not a Communist,´ he exclaimed'
+  - '‘I am not a Communist,’ he exclaimed'
   - The King will proclaim an amnesty
   hypernym:
   - 01012145-v
@@ -12935,7 +12935,7 @@
   - 00944022-v
   example:
   - She pronounces French words in a funny way
-  - I cannot say `zip wire´
+  - I cannot say ‘zip wire’
   - Can the child sound out this complicated word?
   ili: i26483
   members:
@@ -12974,7 +12974,7 @@
   definition:
   - utter aloud
   example:
-  - She said `Hello´ to everyone in the office
+  - She said ‘Hello’ to everyone in the office
   hypernym:
   - 00942415-v
   ili: i26486
@@ -13221,7 +13221,7 @@
   definition:
   - utter with a gurgling sound
   example:
-  - '`Help,´ the stabbing victim gurgled'
+  - '‘Help,’ the stabbing victim gurgled'
   hypernym:
   - 00985856-v
   ili: i26507
@@ -13243,7 +13243,7 @@
   definition:
   - speak in a nasal voice
   example:
-  - '`Come here,´ he nasaled'
+  - '‘Come here,’ he nasaled'
   hypernym:
   - 00985856-v
   ili: i26509
@@ -13339,7 +13339,7 @@
   definition:
   - utter in unison
   example:
-  - '`yes,´ the children chorused'
+  - '‘yes,’ the children chorused'
   hypernym:
   - 00985856-v
   ili: i26518
@@ -14847,7 +14847,7 @@
   - 06182505-n
   example:
   - Speakers topicalize more often than they realize
-  - The object of the sentence is topicalized in what linguists call `Yiddish Movement´
+  - The object of the sentence is topicalized in what linguists call ‘Yiddish Movement’
   hypernym:
   - 01015376-v
   ili: i26650
@@ -15024,8 +15024,8 @@
   definition:
   - make the (grammatical) predicate in a proposition
   example:
-  - The predicate `dog´ is predicated of the subject `Fido´ in the sentence `Fido
-    is a dog´
+  - The predicate ‘dog’ is predicated of the subject ‘Fido’ in the sentence ‘Fido
+    is a dog’
   hypernym:
   - 02730292-v
   ili: i26664
@@ -15587,7 +15587,7 @@
   definition:
   - state or say further
   example:
-  - '`It doesn''t matter,´ he supplied'
+  - '‘It doesn''t matter,’ he supplied'
   hypernym:
   - 01011267-v
   ili: i26710
@@ -15600,7 +15600,7 @@
   definition:
   - add casually to a conversation
   example:
-  - '`I don''t agree with this,´ she tossed in'
+  - '‘I don''t agree with this,’ she tossed in'
   hypernym:
   - 01029183-v
   ili: i26711
@@ -15671,7 +15671,7 @@
   definition:
   - designate by an identifying term
   example:
-  - They styled their nation `The Confederate States´
+  - They styled their nation ‘The Confederate States’
   hypernym:
   - 01030757-v
   ili: i26717
@@ -15760,7 +15760,7 @@
   definition:
   - assign a label to; designate with a label
   example:
-  - These students were labelled `learning disabled´
+  - These students were labelled ‘learning disabled’
   hypernym:
   - 01032165-v
   ili: i26725
@@ -15993,7 +15993,7 @@
   - to consider or examine in speech or writing
   example:
   - The author talks about the different aspects of this question
-  - The class discussed Dante's `Inferno´
+  - The class discussed Dante's ‘Inferno’
   hypernym:
   - 01035399-v
   ili: i26745
@@ -17665,7 +17665,7 @@
   partOfSpeech: v
 01063726-v:
   definition:
-  - utter `haw´
+  - utter ‘haw’
   example:
   - he hemmed and hawed
   hypernym:
@@ -17676,7 +17676,7 @@
   partOfSpeech: v
 01063821-v:
   definition:
-  - utter `hem´ or `ahem´
+  - utter ‘hem’ or ‘ahem’
   hypernym:
   - 00985856-v
   ili: i26893
@@ -17685,7 +17685,7 @@
   partOfSpeech: v
 01063903-v:
   definition:
-  - utter `hems´ and `haws´; indicated hesitation
+  - utter ‘hems’ and ‘haws’; indicated hesitation
   example:
   - He hemmed and hawed when asked to address the crowd
   hypernym:

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -2206,7 +2206,7 @@
   definition:
   - continue talking
   example:
-  - '`I know it''s hard´, he continued, `but there is no choice´'
+  - '`I know it''s hard,´ he continued, `but there is no choice´'
   - carry on — pretend we are not in the room
   hypernym:
   - 00964479-v

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -10364,7 +10364,7 @@
   definition:
   - have as a meaning
   example:
-  - '`multi-'' denotes `many'' '
+  - '`multi-'' denotes `many'''
   hypernym:
   - 00933814-v
   ili: i26267

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -17245,7 +17245,7 @@
   partOfSpeech: v
 01057138-v:
   definition:
-  - pronounce with a trill, of the phoneme `r´
+  - pronounce with a trill, of the phoneme /r/
   example:
   - Some speakers trill their r's
   hypernym:

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -375,7 +375,7 @@
   definition:
   - begin to speak or say
   example:
-  - '‘Now listen, friends’, he began'
+  - ‘Now listen, friends’, he began
   hypernym:
   - 00944022-v
   ili: i25435
@@ -2206,7 +2206,7 @@
   definition:
   - continue talking
   example:
-  - '‘I know it''s hard,’ he continued, ‘but there is no choice’'
+  - ‘I know it's hard,’ he continued, ‘but there is no choice’
   - carry on — pretend we are not in the room
   hypernym:
   - 00964479-v
@@ -9297,9 +9297,9 @@
   definition:
   - utter aloud; often with surprise, horror, or joy
   example:
-  - '‘I won!’ he exclaimed'
-  - '‘Help!’ she cried'
-  - '‘I''m here,’ the mother shouted when she saw her child looking lost'
+  - ‘I won!’ he exclaimed
+  - ‘Help!’ she cried
+  - ‘I'm here,’ the mother shouted when she saw her child looking lost
   hypernym:
   - 00942415-v
   ili: i26175
@@ -9486,7 +9486,7 @@
   definition:
   - utter words loudly and forcefully
   example:
-  - '‘Get out of here,’ he roared'
+  - ‘Get out of here,’ he roared
   hypernym:
   - 00914426-v
   ili: i26190
@@ -10284,7 +10284,7 @@
   - give sudden release to an expression
   example:
   - We burst out laughing
-  - '‘I hate you,’ she burst out'
+  - ‘I hate you,’ she burst out
   hypernym:
   - 00945869-v
   ili: i26260
@@ -10364,7 +10364,7 @@
   definition:
   - have as a meaning
   example:
-  - '‘multi-’ denotes ‘many’'
+  - ‘multi-’ denotes ‘many’
   hypernym:
   - 00933814-v
   ili: i26267
@@ -10378,7 +10378,7 @@
   definition:
   - denote or connote
   example:
-  - '‘maison’ means ‘house’ in French'
+  - ‘maison’ means ‘house’ in French
   - An example sentence would show what this word means
   ili: i26268
   members:
@@ -12864,7 +12864,7 @@
   definition:
   - state or announce
   example:
-  - '‘I am not a Communist,’ he exclaimed'
+  - ‘I am not a Communist,’ he exclaimed
   - The King will proclaim an amnesty
   hypernym:
   - 01012145-v
@@ -13221,7 +13221,7 @@
   definition:
   - utter with a gurgling sound
   example:
-  - '‘Help,’ the stabbing victim gurgled'
+  - ‘Help,’ the stabbing victim gurgled
   hypernym:
   - 00985856-v
   ili: i26507
@@ -13243,7 +13243,7 @@
   definition:
   - speak in a nasal voice
   example:
-  - '‘Come here,’ he nasaled'
+  - ‘Come here,’ he nasaled
   hypernym:
   - 00985856-v
   ili: i26509
@@ -13339,7 +13339,7 @@
   definition:
   - utter in unison
   example:
-  - '‘yes,’ the children chorused'
+  - ‘yes,’ the children chorused
   hypernym:
   - 00985856-v
   ili: i26518
@@ -15587,7 +15587,7 @@
   definition:
   - state or say further
   example:
-  - '‘It doesn''t matter,’ he supplied'
+  - ‘It doesn't matter,’ he supplied
   hypernym:
   - 01011267-v
   ili: i26710
@@ -15600,7 +15600,7 @@
   definition:
   - add casually to a conversation
   example:
-  - '‘I don''t agree with this,’ she tossed in'
+  - ‘I don't agree with this,’ she tossed in
   hypernym:
   - 01029183-v
   ili: i26711

--- a/src/yaml/verb.contact.yaml
+++ b/src/yaml/verb.contact.yaml
@@ -183,7 +183,7 @@
   - produce by manipulating keys or strings of musical instruments
   example:
   - The pianist strikes a middle C
-  - strike `z´ on the keyboard
+  - strike ‘z’ on the keyboard
   hypernym:
   - 01208838-v
   ili: i27669
@@ -4593,7 +4593,7 @@
 01280991-v:
   definition:
   - make wrinkles or creases on a smooth surface; make a pressed, folded or wrinkled
-    line in; `crisp´ is archaic
+    line in; ‘crisp’ is archaic
   example:
   - The dress got wrinkled
   - crease the paper like this to make a crane
@@ -10808,7 +10808,7 @@
   partOfSpeech: v
 01380788-v:
   definition:
-  - spread by scattering (`straw´ is archaic)
+  - spread by scattering (‘straw’ is archaic)
   example:
   - strew toys all over the carpet
   hypernym:
@@ -15122,7 +15122,7 @@
   definition:
   - make strenuous pushing movements during birth to expel the baby
   example:
-  - '`Now push hard,´ said the doctor to the woman'
+  - '‘Now push hard,’ said the doctor to the woman'
   hypernym:
   - 01875972-v
   ili: i28965

--- a/src/yaml/verb.contact.yaml
+++ b/src/yaml/verb.contact.yaml
@@ -183,7 +183,7 @@
   - produce by manipulating keys or strings of musical instruments
   example:
   - The pianist strikes a middle C
-  - strike `z' on the keyboard
+  - strike `z´ on the keyboard
   hypernym:
   - 01208838-v
   ili: i27669
@@ -4593,7 +4593,7 @@
 01280991-v:
   definition:
   - make wrinkles or creases on a smooth surface; make a pressed, folded or wrinkled
-    line in; `crisp' is archaic
+    line in; `crisp´ is archaic
   example:
   - The dress got wrinkled
   - crease the paper like this to make a crane
@@ -10808,7 +10808,7 @@
   partOfSpeech: v
 01380788-v:
   definition:
-  - spread by scattering (`straw' is archaic)
+  - spread by scattering (`straw´ is archaic)
   example:
   - strew toys all over the carpet
   hypernym:
@@ -15122,7 +15122,7 @@
   definition:
   - make strenuous pushing movements during birth to expel the baby
   example:
-  - '`Now push hard,'' said the doctor to the woman'
+  - '`Now push hard,´ said the doctor to the woman'
   hypernym:
   - 01875972-v
   ili: i28965

--- a/src/yaml/verb.contact.yaml
+++ b/src/yaml/verb.contact.yaml
@@ -15122,7 +15122,7 @@
   definition:
   - make strenuous pushing movements during birth to expel the baby
   example:
-  - '‘Now push hard,’ said the doctor to the woman'
+  - ‘Now push hard,’ said the doctor to the woman
   hypernym:
   - 01875972-v
   ili: i28965

--- a/src/yaml/verb.creation.yaml
+++ b/src/yaml/verb.creation.yaml
@@ -4295,7 +4295,7 @@
   definition:
   - trace a line through or across
   example:
-  - cross your `t´
+  - cross your ‘t’
   - dot your i's and cross your t's!
   hypernym:
   - 01694952-v
@@ -5510,7 +5510,7 @@
   domain_topic:
   - 06167042-n
   example:
-  - we are going to stage `Othello´
+  - we are going to stage ‘Othello’
   hypernym:
   - 01622373-v
   ili: i30302
@@ -5836,7 +5836,7 @@
   - 06167042-n
   example:
   - What's playing in the local movie theater?
-  - '`Cats´ has been playing on Broadway for many years'
+  - '‘Cats’ has been playing on Broadway for many years'
   ili: i30328
   members:
   - play
@@ -5956,7 +5956,7 @@
   domain_topic:
   - 06167042-n
   example:
-  - He is auditioning for `Julius Caesar´ at Stratford this year
+  - He is auditioning for ‘Julius Caesar’ at Stratford this year
   hypernym:
   - 01722394-v
   ili: i30337
@@ -6008,8 +6008,8 @@
   - 07019235-n
   example:
   - She acts in this play
-  - He acted in `Julius Caesar´
-  - I played in `A Christmas Carol´
+  - He acted in ‘Julius Caesar’
+  - I played in ‘A Christmas Carol’
   hypernym:
   - 01718067-v
   ili: i30340
@@ -6079,7 +6079,7 @@
   - 07019235-n
   example:
   - Gielgud appears briefly in this movie
-  - She appeared in `Hamlet´ on the London stage
+  - She appeared in ‘Hamlet’ on the London stage
   hypernym:
   - 01716563-v
   ili: i30345
@@ -6533,7 +6533,7 @@
   domain_topic:
   - 00544270-n
   example:
-  - They banged out `The star-spangled banner´
+  - They banged out ‘The star-spangled banner’
   hypernym:
   - 01728336-v
   ili: i30382
@@ -6559,7 +6559,7 @@
   definition:
   - sing with a choir or an orchestra
   example:
-  - Every year the local orchestra and choir perform the `Messiah´ and the audience
+  - Every year the local orchestra and choir perform the ‘Messiah’ and the audience
     is invited to sing along
   hypernym:
   - 01733312-v
@@ -6646,7 +6646,7 @@
   partOfSpeech: v
 01734265-v:
   definition:
-  - sing using syllables like `do´, `re´ and `mi´ to represent the tones of the scale
+  - sing using syllables like ‘do’, ‘re’ and ‘mi’ to represent the tones of the scale
   domain_topic:
   - 00544270-n
   example:

--- a/src/yaml/verb.creation.yaml
+++ b/src/yaml/verb.creation.yaml
@@ -5836,7 +5836,7 @@
   - 06167042-n
   example:
   - What's playing in the local movie theater?
-  - '‘Cats’ has been playing on Broadway for many years'
+  - ‘Cats’ has been playing on Broadway for many years
   ili: i30328
   members:
   - play

--- a/src/yaml/verb.creation.yaml
+++ b/src/yaml/verb.creation.yaml
@@ -4295,7 +4295,7 @@
   definition:
   - trace a line through or across
   example:
-  - cross your `t'
+  - cross your `t´
   - dot your i's and cross your t's!
   hypernym:
   - 01694952-v
@@ -5510,7 +5510,7 @@
   domain_topic:
   - 06167042-n
   example:
-  - we are going to stage `Othello'
+  - we are going to stage `Othello´
   hypernym:
   - 01622373-v
   ili: i30302
@@ -5836,7 +5836,7 @@
   - 06167042-n
   example:
   - What's playing in the local movie theater?
-  - '`Cats'' has been playing on Broadway for many years'
+  - '`Cats´ has been playing on Broadway for many years'
   ili: i30328
   members:
   - play
@@ -5956,7 +5956,7 @@
   domain_topic:
   - 06167042-n
   example:
-  - He is auditioning for `Julius Caesar' at Stratford this year
+  - He is auditioning for `Julius Caesar´ at Stratford this year
   hypernym:
   - 01722394-v
   ili: i30337
@@ -6008,8 +6008,8 @@
   - 07019235-n
   example:
   - She acts in this play
-  - He acted in `Julius Caesar'
-  - I played in `A Christmas Carol'
+  - He acted in `Julius Caesar´
+  - I played in `A Christmas Carol´
   hypernym:
   - 01718067-v
   ili: i30340
@@ -6079,7 +6079,7 @@
   - 07019235-n
   example:
   - Gielgud appears briefly in this movie
-  - She appeared in `Hamlet' on the London stage
+  - She appeared in `Hamlet´ on the London stage
   hypernym:
   - 01716563-v
   ili: i30345
@@ -6533,7 +6533,7 @@
   domain_topic:
   - 00544270-n
   example:
-  - They banged out `The star-spangled banner'
+  - They banged out `The star-spangled banner´
   hypernym:
   - 01728336-v
   ili: i30382
@@ -6559,7 +6559,7 @@
   definition:
   - sing with a choir or an orchestra
   example:
-  - Every year the local orchestra and choir perform the `Messiah' and the audience
+  - Every year the local orchestra and choir perform the `Messiah´ and the audience
     is invited to sing along
   hypernym:
   - 01733312-v
@@ -6646,7 +6646,7 @@
   partOfSpeech: v
 01734265-v:
   definition:
-  - sing using syllables like `do', `re' and `mi' to represent the tones of the scale
+  - sing using syllables like `do´, `re´ and `mi´ to represent the tones of the scale
   domain_topic:
   - 00544270-n
   example:

--- a/src/yaml/verb.emotion.yaml
+++ b/src/yaml/verb.emotion.yaml
@@ -641,7 +641,7 @@
   definition:
   - evoke an emotional response
   example:
-  - Brahms's `Requiem' gets me every time
+  - Brahms's `Requiem´ gets me every time
   hypernym:
   - 01774723-v
   ili: i30592

--- a/src/yaml/verb.emotion.yaml
+++ b/src/yaml/verb.emotion.yaml
@@ -641,7 +641,7 @@
   definition:
   - evoke an emotional response
   example:
-  - Brahms's `Requiem´ gets me every time
+  - Brahms's ‘Requiem’ gets me every time
   hypernym:
   - 01774723-v
   ili: i30592

--- a/src/yaml/verb.motion.yaml
+++ b/src/yaml/verb.motion.yaml
@@ -782,7 +782,7 @@
   - move in order to make room for someone for something
   example:
   - The park gave way to a supermarket
-  - '`Move over,'' he told the crowd'
+  - '`Move over,´ he told the crowd'
   hypernym:
   - 01835473-v
   ili: i30953
@@ -1385,7 +1385,7 @@
   definition:
   - move quickly to another scene or focus when filming
   example:
-  - '`cut away now!'' the director shouted'
+  - '`cut away now!´ the director shouted'
   hypernym:
   - 01864093-v
   ili: i31003
@@ -10290,7 +10290,7 @@
   partOfSpeech: v
 02007494-v:
   definition:
-  - drive away by crying `shoo!'
+  - drive away by crying `shoo!´
   hypernym:
   - 02006752-v
   ili: i31753

--- a/src/yaml/verb.motion.yaml
+++ b/src/yaml/verb.motion.yaml
@@ -782,7 +782,7 @@
   - move in order to make room for someone for something
   example:
   - The park gave way to a supermarket
-  - '`Move over,´ he told the crowd'
+  - '‘Move over,’ he told the crowd'
   hypernym:
   - 01835473-v
   ili: i30953
@@ -1385,7 +1385,7 @@
   definition:
   - move quickly to another scene or focus when filming
   example:
-  - '`cut away now!´ the director shouted'
+  - '‘cut away now!’ the director shouted'
   hypernym:
   - 01864093-v
   ili: i31003
@@ -10290,7 +10290,7 @@
   partOfSpeech: v
 02007494-v:
   definition:
-  - drive away by crying `shoo!´
+  - drive away by crying ‘shoo!’
   hypernym:
   - 02006752-v
   ili: i31753

--- a/src/yaml/verb.motion.yaml
+++ b/src/yaml/verb.motion.yaml
@@ -782,7 +782,7 @@
   - move in order to make room for someone for something
   example:
   - The park gave way to a supermarket
-  - '‘Move over,’ he told the crowd'
+  - ‘Move over,’ he told the crowd
   hypernym:
   - 01835473-v
   ili: i30953
@@ -1385,7 +1385,7 @@
   definition:
   - move quickly to another scene or focus when filming
   example:
-  - '‘cut away now!’ the director shouted'
+  - ‘cut away now!’ the director shouted
   hypernym:
   - 01864093-v
   ili: i31003

--- a/src/yaml/verb.perception.yaml
+++ b/src/yaml/verb.perception.yaml
@@ -1697,7 +1697,7 @@
   - 02140192-v
 02140484-v:
   definition:
-  - make a light, metallic sound; go `ting´
+  - make a light, metallic sound; go ‘ting’
   hypernym:
   - 02180712-v
   ili: i32433
@@ -2936,7 +2936,7 @@
   definition:
   - produce or introduce on the stage
   example:
-  - The Shakespeare Company is offering `King Lear´ this month
+  - The Shakespeare Company is offering ‘King Lear’ this month
   hypernym:
   - 02161530-v
   ili: i32537
@@ -4060,8 +4060,8 @@
   definition:
   - make a certain noise or sound
   example:
-  - She went `Mmmmm´
-  - The gun went `bang´
+  - She went ‘Mmmmm’
+  - The gun went ‘bang’
   hypernym:
   - 02128368-v
   ili: i32635
@@ -4304,7 +4304,7 @@
   partOfSpeech: v
 02185620-v:
   definition:
-  - go `ding dong´, like a bell
+  - go ‘ding dong’, like a bell
   hypernym:
   - 02185344-v
   ili: i32657

--- a/src/yaml/verb.perception.yaml
+++ b/src/yaml/verb.perception.yaml
@@ -1697,7 +1697,7 @@
   - 02140192-v
 02140484-v:
   definition:
-  - make a light, metallic sound; go `ting'
+  - make a light, metallic sound; go `ting´
   hypernym:
   - 02180712-v
   ili: i32433
@@ -2936,7 +2936,7 @@
   definition:
   - produce or introduce on the stage
   example:
-  - The Shakespeare Company is offering `King Lear' this month
+  - The Shakespeare Company is offering `King Lear´ this month
   hypernym:
   - 02161530-v
   ili: i32537
@@ -4060,8 +4060,8 @@
   definition:
   - make a certain noise or sound
   example:
-  - She went `Mmmmm'
-  - The gun went `bang'
+  - She went `Mmmmm´
+  - The gun went `bang´
   hypernym:
   - 02128368-v
   ili: i32635
@@ -4304,7 +4304,7 @@
   partOfSpeech: v
 02185620-v:
   definition:
-  - go `ding dong', like a bell
+  - go `ding dong´, like a bell
   hypernym:
   - 02185344-v
   ili: i32657

--- a/src/yaml/verb.possession.yaml
+++ b/src/yaml/verb.possession.yaml
@@ -5107,7 +5107,7 @@
   definition:
   - acquire or deserve by one's efforts or actions
   example:
-  - its beauty won Paris the name `City of Lights´
+  - its beauty won Paris the name ‘City of Lights’
   hypernym:
   - 02215637-v
   ili: i33181

--- a/src/yaml/verb.possession.yaml
+++ b/src/yaml/verb.possession.yaml
@@ -5107,7 +5107,7 @@
   definition:
   - acquire or deserve by one's efforts or actions
   example:
-  - its beauty won Paris the name `City of Lights'
+  - its beauty won Paris the name `City of Lights´
   hypernym:
   - 02215637-v
   ili: i33181

--- a/src/yaml/verb.social.yaml
+++ b/src/yaml/verb.social.yaml
@@ -3317,7 +3317,7 @@
   definition:
   - call a meeting; invite or command to meet
   example:
-  - The Wannsee Conference was called to discuss the `Final Solution´
+  - The Wannsee Conference was called to discuss the ‘Final Solution’
   - The new dean calls meetings every week
   hypernym:
   - 00754770-v
@@ -12965,7 +12965,7 @@
   definition:
   - greet, as with a prescribed form, title, or name
   example:
-  - He always addresses me with `Sir´
+  - He always addresses me with ‘Sir’
   - Call me Mister
   - She calls him by first name
   hypernym:

--- a/src/yaml/verb.social.yaml
+++ b/src/yaml/verb.social.yaml
@@ -3317,7 +3317,7 @@
   definition:
   - call a meeting; invite or command to meet
   example:
-  - The Wannsee Conference was called to discuss the `Final Solution'
+  - The Wannsee Conference was called to discuss the `Final Solution´
   - The new dean calls meetings every week
   hypernym:
   - 00754770-v
@@ -12965,7 +12965,7 @@
   definition:
   - greet, as with a prescribed form, title, or name
   example:
-  - He always addresses me with `Sir'
+  - He always addresses me with `Sir´
   - Call me Mister
   - She calls him by first name
   hypernym:

--- a/src/yaml/verb.social.yaml
+++ b/src/yaml/verb.social.yaml
@@ -6897,8 +6897,8 @@
   - spend time at a lower socio-economic level than one's own, motivated by curiosity
     or desire for adventure; usage considered condescending and insensitive
   example:
-  - attending a motion picture show by the upper class was considered slumming in the
-    early 20th century
+  - attending a motion picture show by the upper class was considered slumming in
+    the early 20th century
   hypernym:
   - 02714280-v
   ili: i34185

--- a/src/yaml/verb.stative.yaml
+++ b/src/yaml/verb.stative.yaml
@@ -338,7 +338,7 @@
   definition:
   - have a strong tendency to occur side by side
   example:
-  - The words `new' and `world' collocate
+  - The words `new´ and `world´ collocate
   hypernym:
   - 02618403-v
   ili: i34735
@@ -3157,7 +3157,7 @@
   definition:
   - go or occur together
   example:
-  - The word `hot' tends to cooccur with `cold'
+  - The word `hot´ tends to cooccur with `cold´
   hypernym:
   - 02722040-v
   ili: i34970
@@ -3656,7 +3656,7 @@
   - A few words would answer
   - This car suits my purpose well
   - Will $100 do?
-  - A `B' grade doesn't suffice to get me into medical school
+  - A `B´ grade doesn't suffice to get me into medical school
   - Nothing else will serve
   hypernym:
   - 02677669-v
@@ -4194,7 +4194,7 @@
   - be the first item or point, constitute the beginning or start, come first in a
     series
   example:
-  - The number `one' begins the sequence
+  - The number `one´ begins the sequence
   - A terrible murder begins the novel
   - The convocation ceremony officially begins the semester
   ili: i35056
@@ -5377,8 +5377,8 @@
   definition:
   - take the place of or be parallel or equivalent to
   example:
-  - Because of the sound changes in the course of history, an `h' in Greek stands
-    for an `s' in Latin
+  - Because of the sound changes in the course of history, an `h´ in Greek stands
+    for an `s´ in Latin
   hypernym:
   - 02670846-v
   ili: i35152
@@ -5803,7 +5803,7 @@
   definition:
   - be included in or classified as
   example:
-  - This falls under the rubric `various'
+  - This falls under the rubric `various´
   hypernym:
   - 02626667-v
   ili: i35187

--- a/src/yaml/verb.stative.yaml
+++ b/src/yaml/verb.stative.yaml
@@ -338,7 +338,7 @@
   definition:
   - have a strong tendency to occur side by side
   example:
-  - The words `new´ and `world´ collocate
+  - The words ‘new’ and ‘world’ collocate
   hypernym:
   - 02618403-v
   ili: i34735
@@ -3157,7 +3157,7 @@
   definition:
   - go or occur together
   example:
-  - The word `hot´ tends to cooccur with `cold´
+  - The word ‘hot’ tends to cooccur with ‘cold’
   hypernym:
   - 02722040-v
   ili: i34970
@@ -3656,7 +3656,7 @@
   - A few words would answer
   - This car suits my purpose well
   - Will $100 do?
-  - A `B´ grade doesn't suffice to get me into medical school
+  - A ‘B’ grade doesn't suffice to get me into medical school
   - Nothing else will serve
   hypernym:
   - 02677669-v
@@ -4194,7 +4194,7 @@
   - be the first item or point, constitute the beginning or start, come first in a
     series
   example:
-  - The number `one´ begins the sequence
+  - The number ‘one’ begins the sequence
   - A terrible murder begins the novel
   - The convocation ceremony officially begins the semester
   ili: i35056
@@ -5377,8 +5377,8 @@
   definition:
   - take the place of or be parallel or equivalent to
   example:
-  - Because of the sound changes in the course of history, an `h´ in Greek stands
-    for an `s´ in Latin
+  - Because of the sound changes in the course of history, an ‘h’ in Greek stands
+    for an ‘s’ in Latin
   hypernym:
   - 02670846-v
   ili: i35152
@@ -5803,7 +5803,7 @@
   definition:
   - be included in or classified as
   example:
-  - This falls under the rubric `various´
+  - This falls under the rubric ‘various’
   hypernym:
   - 02626667-v
   ili: i35187


### PR DESCRIPTION
Same as [PR1026](https://github.com/globalwordnet/english-wordnet/pull/1026) with a different choice of quoting characters: single quotes with
```
‘ , u2018, single quotation, left/opening
’ , u2019, single quotation, right/closing
```
yielding:

`‘quoted’`

The exact rendering depends on the font but here is an enlarged screenshot:

![single quotes](https://github.com/globalwordnet/english-wordnet/assets/16848556/e7df624e-cd64-4f3a-8868-80b6ec497a5d)

