### PR TITLE
Reverse hypernym link 'beat' => 'surpass'

### DIFF
--- a/src/yaml/verb.competition.yaml
+++ b/src/yaml/verb.competition.yaml
@@ -1753,7 +1753,7 @@
   - We beat the competition
   - Harvard defeated Yale in the last football game
   hypernym:
-  - 01110559-v
+  - 01108050-v
   ili: i27103
   members:
   - beat
@@ -2005,7 +2005,7 @@
   - This exceeds all my expectations
   - This car outperforms all others in its class
   hypernym:
-  - 01104324-v
+  - 01110559-v
   ili: i27124
   members:
   - surpass


### PR DESCRIPTION
Fixes #1042 