### PR TITLE
Update incorrect hypernyms of male words

### DIFF
--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -119599,7 +119599,7 @@
   definition:
   - a male person who is not a serf or a slave
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 10130792-n
   members:
   - freeman
@@ -119625,7 +119625,7 @@
   - a male person who has received a degree from a school (high school or college
     or university)
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 09805779-n
   members:
   - alumnus
@@ -119741,7 +119741,7 @@
   definition:
   - a male member of a clan
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 10327942-n
   members:
   - clansman
@@ -119842,7 +119842,7 @@
   - an adulterous man; a man who has an ongoing extramarital sexual relationship with
     a woman
   hypernym:
-  - 10807146-n
+  - 10306910-n
   members:
   - kept man
   partOfSpeech: n
@@ -119850,7 +119850,7 @@
   definition:
   - a man who can be a successful husband and care for his children
   hypernym:
-  - 10807146-n
+  - 10306910-n
   members:
   - wonder man
   partOfSpeech: n
@@ -119885,7 +119885,7 @@
   definition:
   - a male member of the United States House of Representatives
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 09975260-n
   members:
   - congressman
@@ -119894,7 +119894,7 @@
   definition:
   - the male officer who presides at the meetings of an organization
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 10488547-n
   members:
   - chairman
@@ -119928,7 +119928,7 @@
   definition:
   - a male who serves (or waits to be called to serve) on a jury
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 10247948-n
   members:
   - juryman
@@ -119937,7 +119937,7 @@
   definition:
   - a male stand-in for movie stars to perform dangerous stunts
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 10686285-n
   members:
   - stunt man
@@ -119976,7 +119976,7 @@
   - a male human being whose body has been taken over in whole or in part by electromechanical
     devices
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 10005508-n
   members:
   - bionic man
@@ -120076,7 +120076,7 @@
   definition:
   - a male who signs a bond as surety for someone else
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 09884685-n
   members:
   - bondsman
@@ -120115,7 +120115,7 @@
   definition:
   - the father of at least one of your children
   hypernym:
-  - 10807146-n
+  - 10306910-n
   members:
   - baby papa
   partOfSpeech: n
@@ -120172,7 +120172,7 @@
   definition:
   - a male person of French nationality
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 09727801-n
   members:
   - Frenchman
@@ -120212,7 +120212,7 @@
   definition:
   - a male person who has been freed from slavery
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 10129754-n
   members:
   - freedman
@@ -120250,7 +120250,7 @@
   definition:
   - a male person with fair skin and hair
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 09879912-n
   members:
   - blond
@@ -120297,7 +120297,7 @@
   - a male journalist employed to provide news stories for newspapers or broadcast
     media
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 09986240-n
   members:
   - newspaperman
@@ -120333,7 +120333,7 @@
   definition:
   - a male person who owns or sails a yacht
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 10821647-n
   members:
   - yachtsman
@@ -120372,7 +120372,7 @@
   definition:
   - a male competitor who holds a preeminent position
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 10254721-n
   members:
   - king
@@ -120438,7 +120438,7 @@
   definition:
   - a male who engages in sports
   hypernym:
-  - 10807146-n
+  - 10306910-n
   - 10658320-n
   members:
   - sportsman


### PR DESCRIPTION
Fixes #1057

A thorough check shows that this affects the following words: alumnus, clansman, kept man, wonder man, congressman, chairman, juryman, stunt man, bionic man, bondsman, baby papa, Frenchman, freedman, blond, pressman, yachtsman, king, sportsman