### PR TITLE
Unnatural semicolon

### DIFF
--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -2380,7 +2380,7 @@
   definition:
   - devoid of activity
   example:
-  - this is a dead town; nothing ever happens here
+  - 'this is a dead town: nothing ever happens here'
   ili: i184
   members:
   - dead
@@ -12809,7 +12809,7 @@
   - sleeping deeply
   example:
   - lying fast asleep on the sofa
-  - it would be cruel to wake him; he's sound asleep
+  - 'it would be cruel to wake him: he''s sound asleep'
   ili: i1019
   members:
   - fast asleep
@@ -18597,7 +18597,7 @@
   - marked by courage and determination in the face of difficulties or danger; robust
     and uninhibited
   example:
-  - you have to admire her; it was a gutsy thing to do
+  - 'you have to admire her: it was a gutsy thing to do'
   - source: Judith Crist
     text: the gutsy … intensity of her musical involvement
   - a gutsy red wine
@@ -33866,7 +33866,7 @@
   definition:
   - causing physical discomfort
   example:
-  - bites of black flies are more than irritating; they can be very painful
+  - 'bites of black flies are more than irritating: they can be very painful'
   ili: i2701
   members:
   - irritating
@@ -38529,7 +38529,7 @@
   example:
   - a crisp retort
   - a response so curt as to be almost rude
-  - the laconic reply; ‘yes’
+  - 'the laconic reply: ‘yes’'
   - short and terse and easy to understand
   ili: i3062
   members:
@@ -39709,7 +39709,7 @@
   definition:
   - having a common boundary or edge; abutting; touching
   example:
-  - Rhode Island has two bordering states; Massachusetts and Connecticut
+  - 'Rhode Island has two bordering states: Massachusetts and Connecticut'
   - the side of Germany conterminous with France
   - Utah and the contiguous state of Idaho
   - neighboring cities
@@ -44795,8 +44795,8 @@
   definition:
   - without care or thought for others
   example:
-  - the thoughtless saying of a great princess on being informed that the people had
-    no bread; ‘Let them eat cake’
+  - 'the thoughtless saying of a great princess on being informed that the people
+    had no bread: ‘Let them eat cake’'
   ili: i3558
   members:
   - thoughtless
@@ -46205,7 +46205,7 @@
   - having dimension — the quality or character or stature proper to a person
   example:
   - source: Norman Cousins
-    text: never matures as a dimensional character; he is pasty, bland, faceless
+    text: 'never matures as a dimensional character: he is pasty, bland, faceless'
   ili: i3671
   members:
   - dimensional
@@ -47128,7 +47128,7 @@
   definition:
   - produced by a manufacturing process
   example:
-  - bought some made goods at the local store; rope and nails
+  - 'bought some made goods at the local store: rope and nails'
   ili: i3742
   members:
   - made
@@ -48973,7 +48973,7 @@
   definition:
   - not derived or copied or translated from something else
   example:
-  - the play is original; not an adaptation
+  - the play is original, not an adaptation
   - he kept the original copy and gave her only a xerox
   - the translation misses much of the subtlety of the original French
   ili: i3890
@@ -50632,7 +50632,7 @@
   - likely to perform unpredictably
   example:
   - erratic winds are the bane of a sailor
-  - a temperamental motor; sometimes it would start and sometimes it wouldn't
+  - 'a temperamental motor: sometimes it would start and sometimes it wouldn''t'
   - source: Osbert Lancaster
     text: that beautiful but temperamental instrument the flute
   ili: i4014
@@ -54006,7 +54006,7 @@
   definition:
   - not selective or discriminating
   example:
-  - unselective in her reading habits; her choices seemed completely random
+  - 'unselective in her reading habits: her choices seemed completely random'
   ili: i4278
   members:
   - unselective
@@ -55574,7 +55574,7 @@
   - practicing complete abstinence from alcoholic beverages
   example:
   - he's been dry for ten years
-  - no thank you; I happen to be teetotal
+  - no thank you, I happen to be teetotal
   ili: i4403
   members:
   - dry
@@ -56184,7 +56184,7 @@
   definition:
   - tediously repetitious or lacking in variety
   example:
-  - a humdrum existence; all work and no play
+  - 'a humdrum existence: all work and no play'
   - nothing is so monotonous as the sea
   ili: i4450
   members:
@@ -71163,7 +71163,7 @@
   example:
   - he is adamant in his refusal to change his mind
   - source: W.Churchill
-    text: Cynthia was inexorable; she would have none of him
+    text: 'Cynthia was inexorable: she would have none of him'
   - an intransigent conservative opposed to every liberal tendency
   ili: i5606
   members:
@@ -75900,7 +75900,7 @@
   definition:
   - not drained
   example:
-  - preserve wetlands; keep them undrained
+  - 'preserve wetlands: keep them undrained'
   ili: i5982
   members:
   - undrained
@@ -76012,7 +76012,7 @@
   definition:
   - affecting or involved in structure or construction
   example:
-  - the structural details of a house such as beams and joists and rafters; not ornamental
+  - the structural details of a house such as beams and joists and rafters, not ornamental
     elements
   - structural damage
   ili: i5991
@@ -82029,7 +82029,7 @@
   - without a mucous or watery discharge
   example:
   - a dry cough
-  - that rare thing in the wintertime; a small child with a dry nose
+  - 'that rare thing in the wintertime: a small child with a dry nose'
   ili: i6446
   members:
   - dry
@@ -82516,7 +82516,7 @@
   - having the consistency of dough because of insufficient leavening or improper
     cooking
   example:
-  - the cake fell; it's a doughy mess
+  - 'the cake fell: it''s a doughy mess'
   ili: i6485
   members:
   - doughy
@@ -82760,7 +82760,7 @@
   - not easily borne; wearing
   example:
   - the burdensome task of preparing the income tax return
-  - my duties weren't onerous; I only had to greet the guests
+  - 'my duties weren''t onerous: I only had to greet the guests'
   - a taxing schedule
   ili: i6505
   members:
@@ -90450,7 +90450,7 @@
   - easily spread
   example:
   - source: Bertrand Russell
-    text: fear is exceedingly infectious; children catch it from their elders
+    text: 'fear is exceedingly infectious: children catch it from their elders'
   ili: i7098
   members:
   - infectious
@@ -102253,7 +102253,7 @@
   - relating to small (not capitalized) letters that were kept in the lower half of
     a compositor's type case
   example:
-  - lowercase letters; a and b and c etc
+  - 'lowercase letters: a and b and c etc.'
   ili: i8032
   members:
   - lowercase
@@ -102282,7 +102282,7 @@
   - relating to capital letters which were kept in the top half of a compositor's
     type case
   example:
-  - uppercase letters; X and Y and Z etc
+  - 'uppercase letters: X and Y and Z etc.'
   ili: i8034
   members:
   - uppercase
@@ -104618,7 +104618,7 @@
   definition:
   - like or containing meat
   example:
-  - enough of vegetarianism; let's have a meaty meal
+  - 'enough of vegetarianism: let''s have a meaty meal!'
   ili: i8225
   members:
   - meaty
@@ -115078,7 +115078,7 @@
   definition:
   - (of clothing) made in or consisting of three parts or pieces
   example:
-  - the standard three-piece business suit; jacket and trousers and vest
+  - 'the standard three-piece business suit: jacket and trousers and vest'
   ili: i9039
   members:
   - three-piece
@@ -130027,7 +130027,7 @@
   - suggestive of the isolated life of an island
   example:
   - source: Leonard Michaels
-    text: an exceedingly insular man; so deeply private as to seem inaccessible to
+    text: an exceedingly insular man, so deeply private as to seem inaccessible to
       the scrutiny of a novelist
   ili: i10212
   members:
@@ -156261,7 +156261,7 @@
   definition:
   - not fashioned to sizes
   example:
-  - unsized gloves; one size fits all
+  - 'unsized gloves: one size fits all'
   ili: i12301
   members:
   - unsized

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -135072,7 +135072,7 @@
   - being or occurring in fact or actuality; having verified existence; not illusory
   example:
   - real objects
-  - real people; not ghosts
+  - real people, not ghosts
   - a film based on real life
   - a real illness
   - real humility
@@ -158746,7 +158746,7 @@
   - shunning contact with others
   example:
   - standoffish and antisocial
-  - he's not antisocial; just shy
+  - he's not antisocial, just shy
   ili: i12501
   members:
   - antisocial

--- a/src/yaml/adj.pert.yaml
+++ b/src/yaml/adj.pert.yaml
@@ -21578,7 +21578,7 @@
   definition:
   - relating to or based on function especially as opposed to structure
   example:
-  - the problem now is not a constitutional one; it is a functional one
+  - 'the problem now is not a constitutional one: it is a functional one'
   - delegates elected on a functional rather than a geographical basis
   ili: i16982
   members:

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -20541,8 +20541,8 @@
   definition:
   - without finality; inconclusively
   example:
-  - the battle ended indecisively; neither side had clearly won but neither side admitted
-    defeat
+  - 'the battle ended indecisively: neither side had clearly won but neither side
+    admitted defeat'
   ili: i20220
   members:
   - indecisively

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -33728,8 +33728,8 @@
   definition:
   - the weight per unit volume of a material.
   example:
-  - Unlike density, specific weight is not absolute; it depends upon the gravitational
-    acceleration, the temperature of the material and even pressure.
+  - 'Unlike density, specific weight is not absolute: it depends upon the gravitational
+    acceleration, the temperature of the material and even pressure.'
   hypernym:
   - 05034009-n
   members:
@@ -35594,8 +35594,8 @@
   definition:
   - The quality of being curious and interested.
   example:
-  - The penetration and the inquisitiveness of his glance troubled me; I felt embarrassed
-    and guilty in his presence.
+  - 'The penetration and the inquisitiveness of his glance troubled me: I felt embarrassed
+    and guilty in his presence.'
   hypernym:
   - 04899279-n
   members:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -2108,7 +2108,7 @@
   definition:
   - an inability to write
   example:
-  - he had writer's block; the words wouldn't come
+  - 'he had writer''s block: the words wouldn''t come'
   hypernym:
   - 05653044-n
   ili: i66586

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -34128,7 +34128,7 @@
   definition:
   - beyond human control or responsibility
   example:
-  - there is nothing more I can do; it's in the lap of the gods now
+  - 'there is nothing more I can do: it''s in the lap of the gods now'
   hypernym:
   - 14538643-n
   ili: i113281
@@ -37705,7 +37705,7 @@
   definition:
   - the condition of being varied
   example:
-  - that restaurant's menu lacks diversification; every day it is the same
+  - 'that restaurant''s menu lacks diversification: every day it is the same'
   hypernym:
   - 13943868-n
   ili: i113618

--- a/src/yaml/verb.change.yaml
+++ b/src/yaml/verb.change.yaml
@@ -11635,7 +11635,7 @@
   definition:
   - put (an image) into focus
   example:
-  - Please focus the image; we cannot enjoy the movie
+  - 'Please focus the image: we cannot enjoy the movie'
   hypernym:
   - 00296959-v
   ili: i23301

--- a/src/yaml/verb.cognition.yaml
+++ b/src/yaml/verb.cognition.yaml
@@ -1087,7 +1087,7 @@
   - 00626756-v
   example:
   - He is studying geology in his room
-  - I have an exam next week; I must hit the books now
+  - 'I have an exam next week: I must hit the books now'
   hypernym:
   - 00599310-v
   ili: i24796

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -16071,7 +16071,7 @@
   definition:
   - make a compromise; arrive at a compromise
   example:
-  - nobody will get everything he wants; we all must compromise
+  - 'nobody will get everything he wants: we all must compromise'
   hypernym:
   - 01037402-v
   ili: i26752

--- a/src/yaml/verb.possession.yaml
+++ b/src/yaml/verb.possession.yaml
@@ -3675,7 +3675,7 @@
   domain_topic:
   - 01092370-n
   example:
-  - don't trust my ex-wife; I won't pay her debts anymore
+  - 'don''t trust my ex-wife: I won''t pay her debts anymore'
   exemplifies:
   - 07087487-n
   hypernym:

--- a/src/yaml/verb.social.yaml
+++ b/src/yaml/verb.social.yaml
@@ -4776,7 +4776,7 @@
   definition:
   - work or act as a baby-sitter
   example:
-  - I cannot baby-sit tonight; I have too much homework to do
+  - 'I cannot baby-sit tonight: I have too much homework to do'
   hypernym:
   - 02461453-v
   ili: i34002
@@ -7061,8 +7061,8 @@
   definition:
   - confine as if in a prison
   example:
-  - His daughters are virtually imprisoned in their own house; he does not let them
-    go out without a chaperone
+  - 'His daughters are virtually imprisoned in their own house: he does not let them
+    go out without a chaperone'
   hypernym:
   - 02500687-v
   ili: i34198


### PR DESCRIPTION
These instances of semicolon appear unnatural to me.

Wikipedia has it that 

> The most common use of the semicolon is to join two **independent clauses** without using a conjunction like "and".
> 
> [It is used] between closely related independent clauses not conjoined with a coordinating conjunction, when the two clauses are **balanced, opposed or contradictory**.
> 
As opposed to the semicolon, the colon

> often precedes an **explanation, a list, or a quoted sentence**. It is used
> 

- >  before list
- >  before a description
- >  before definition
- >  before explanation
 

Sometimes a simple comma will do here. Please also note that an emdash can replace the colon in these cases, as seems to be usual practice in OEWN examples.