### PR TITLE
Quote to focus on word form

### DIFF
--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -19623,7 +19623,7 @@
   definition:
   - malicious burning to destroy property
   example:
-  - the British term for arson is fire-raising
+  - the British term for arson is `fire-raising´
   hypernym:
   - 00378877-n
   ili: i37396

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -373,7 +373,7 @@
   definition:
   - a short road giving access to an expressway
   example:
-  - in Britain they call an access road a slip road
+  - in Britain they call an access road a `slip road´
   hypernym:
   - 04103160-n
   ili: i49790
@@ -12220,7 +12220,7 @@
   - a flat wire hairpin whose prongs press tightly together; used to hold bobbed hair
     in place
   example:
-  - in Britain they call a bobby pin a grip
+  - in Britain they call a bobby pin a `grip´
   hypernym:
   - 03481436-n
   ili: i50897
@@ -23278,7 +23278,7 @@
   definition:
   - a light concrete building block made with cinder aggregate
   example:
-  - cinder blocks are called breeze blocks in Britain
+  - cinder blocks are called `breeze blocks´ in Britain
   hypernym:
   - 02918159-n
   ili: i51938
@@ -34549,7 +34549,7 @@
   - a highway divided down the middle by a barrier that separates traffic going in
     different directions
   example:
-  - in Britain they call a divided highway a dual carriageway
+  - in Britain they call a divided highway a `dual carriageway´
   hypernym:
   - 03525144-n
   ili: i53010
@@ -40218,7 +40218,7 @@
   - a small vessel with a rim curved to fit the orbit of the eye; use to apply medicated
     or cleansing solution to the eyeball
   example:
-  - an eyecup is called an eyebath in Britain
+  - an eyecup is called `an eyebath´ in Britain
   hypernym:
   - 04538393-n
   ili: i53540
@@ -41212,7 +41212,7 @@
   definition:
   - a barrier that surrounds the wheels of a vehicle to block splashing water or mud
   example:
-  - in Britain they call a fender a wing
+  - in Britain they call a fender a `wing´
   hypernym:
   - 02799782-n
   ili: i53635
@@ -46899,7 +46899,7 @@
   definition:
   - a truck for collecting domestic refuse
   example:
-  - in Britain a garbage truck is called a dustcart
+  - in Britain a garbage truck is called a `dustcart´
   hypernym:
   - 04497386-n
   ili: i54176
@@ -47820,7 +47820,7 @@
   definition:
   - a mechanical device for engaging and disengaging gears
   example:
-  - in Britain they call a gearshift a gear lever
+  - in Britain they call a gearshift a `gear lever´
   hypernym:
   - 03742461-n
   ili: i54262
@@ -51919,7 +51919,7 @@
   definition:
   - a store selling hardware
   example:
-  - in Great Britain they used to call a hardware store an ironmonger's shop
+  - in Great Britain they used to call a hardware store an `ironmonger's shop´
   hypernym:
   - 04209460-n
   ili: i54653
@@ -65441,7 +65441,7 @@
   definition:
   - letter carrier's shoulder bag
   example:
-  - in Britain they call a mailbag a postbag
+  - in Britain they call a mailbag a `postbag´
   hypernym:
   - 02776042-n
   ili: i55938
@@ -79893,7 +79893,7 @@
   definition:
   - game equipment on which pinball is played
   example:
-  - in Britain they call a pinball machine a pin table
+  - in Britain they call a pinball machine a `pin table´
   hypernym:
   - 03419072-n
   ili: i57305
@@ -95718,7 +95718,7 @@
   definition:
   - a blouse with buttons down the front
   example:
-  - in Britain they call a shirtwaist a shirtwaister
+  - in Britain they call a shirtwaist a `shirtwaister´
   hypernym:
   - 02858206-n
   ili: i58814
@@ -96405,7 +96405,7 @@
   domain_topic:
   - 02961779-n
   example:
-  - in Britain a showroom is called a salesroom
+  - in Britain a showroom is called a `salesroom´
   hypernym:
   - 03889641-n
   ili: i58878
@@ -108996,7 +108996,7 @@
   domain_topic:
   - 06287933-n
   example:
-  - the British call a tv set a telly
+  - the British call a tv set a `telly´
   hypernym:
   - 04067759-n
   ili: i60090

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -27441,7 +27441,8 @@
   definition:
   - vastness of size or extent
   example:
-  - in careful usage the noun `enormity´ is not used to express the idea of great size
+  - in careful usage the noun `enormity´ is not used to express the idea of great
+    size
   - universities recognized the enormity of their task
   exemplifies:
   - 07089193-n

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -27441,7 +27441,7 @@
   definition:
   - vastness of size or extent
   example:
-  - in careful usage the noun enormity is not used to express the idea of great size
+  - in careful usage the noun `enormity´ is not used to express the idea of great size
   - universities recognized the enormity of their task
   exemplifies:
   - 07089193-n

--- a/src/yaml/noun.body.yaml
+++ b/src/yaml/noun.body.yaml
@@ -1175,7 +1175,7 @@
   definition:
   - bare skin
   example:
-  - `swimming in the buff´ means to swim naked
+  - '`swimming in the buff´ means to swim naked'
   hypernym:
   - 05245612-n
   ili: i64486

--- a/src/yaml/noun.body.yaml
+++ b/src/yaml/noun.body.yaml
@@ -1175,7 +1175,7 @@
   definition:
   - bare skin
   example:
-  - swimming in the buff means to swim naked
+  - `swimming in the buff´ means to swim naked
   hypernym:
   - 05245612-n
   ili: i64486

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -63256,8 +63256,8 @@
   definition:
   - A verb that explicitly conveys the kind of speech act being performed.
   example:
-  - It is for this reason that `apologize´ is called a performative verb, defined as
-    a verb denoting linguistic action that can both describe a speech act and express
+  - It is for this reason that `apologize´ is called a performative verb, defined
+    as a verb denoting linguistic action that can both describe a speech act and express
     it.
   hypernym:
   - 06331562-n
@@ -63282,8 +63282,8 @@
   definition:
   - A noun identifying a person.
   example:
-  - The fact that `baroque flautist´ is the personal noun form can be deduced from the
-    fact that `flautist´ is the personal noun form of the head noun `flute´.
+  - The fact that `baroque flautist´ is the personal noun form can be deduced from
+    the fact that `flautist´ is the personal noun form of the head noun `flute´.
   hypernym:
   - 06330286-n
   members:
@@ -63494,7 +63494,7 @@
   - A linguistic feature of Yiddish, especially a Yiddish idiom or phrasing that appears
     in another language.
   example:
-  - `schmooze´ is an example of a Yiddishism.
+  - '`schmooze´ is an example of a Yiddishism.'
   hypernym:
   - 06304241-n
   members:
@@ -63518,7 +63518,7 @@
   definition:
   - having the same syntactic function in the sentence as one of its immediate constituents.
   example:
-  - `greenhouse´ is an endocentric compound, since it is a noun as is its head house.
+  - '`greenhouse´ is an endocentric compound, since it is a noun as is its head house.'
   hypernym:
   - 92460746-n
   members:
@@ -64359,7 +64359,7 @@
   definition:
   - a numeral that does not specify an exact number.
   example:
-  - `most´ is an indefinite numeral adjective denoting part of a whole.
+  - '`most´ is an indefinite numeral adjective denoting part of a whole.'
   hypernym:
   - 92464376-n
   members:
@@ -64370,8 +64370,8 @@
   definition:
   - a word expressing a number.
   example:
-  - Numerals may be attributive, as in `two dogs´, or pronominal, as in `I saw two (of
-    them)´.
+  - Numerals may be attributive, as in `two dogs´, or pronominal, as in `I saw two
+    (of them)´.
   hypernym:
   - 06300030-n
   members:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -21068,7 +21068,7 @@
   - a program during which well-known people discuss a topic or answer questions telephoned
     in by the audience
   example:
-  - in England they call a talk show a chat show
+  - in England they call a talk show a `chat show´
   hypernym:
   - 06631935-n
   ili: i71260
@@ -34365,7 +34365,7 @@
   - a punctuation mark (‘.’) placed at the end of a declarative sentence to indicate
     a full stop or after abbreviations
   example:
-  - in England they call a period a stop
+  - in England they call a period a `stop´
   hypernym:
   - 06854415-n
   ili: i72483
@@ -63256,7 +63256,7 @@
   definition:
   - A verb that explicitly conveys the kind of speech act being performed.
   example:
-  - It is for this reason that apologize is called a performative verb, defined as
+  - It is for this reason that `apologize´ is called a performative verb, defined as
     a verb denoting linguistic action that can both describe a speech act and express
     it.
   hypernym:
@@ -63282,8 +63282,8 @@
   definition:
   - A noun identifying a person.
   example:
-  - The fact that baroque flautist is the personal noun form can be deduced from the
-    fact that flautist is the personal noun form of the head noun flute.
+  - The fact that `baroque flautist´ is the personal noun form can be deduced from the
+    fact that `flautist´ is the personal noun form of the head noun `flute´.
   hypernym:
   - 06330286-n
   members:
@@ -63305,8 +63305,8 @@
   definition:
   - a preposition that consists of a group of words that act as one unit.
   example:
-  - Examples of complex prepositions in English include in spite of, with respect
-    to, except for, by dint of, and next to.
+  - Examples of complex prepositions in English include in `spite of´, `with respect
+    to´, `except for´, `by dint of´, and `next to´.
   hypernym:
   - 06336138-n
   members:
@@ -63494,7 +63494,7 @@
   - A linguistic feature of Yiddish, especially a Yiddish idiom or phrasing that appears
     in another language.
   example:
-  - Schmooze is an example of a Yiddishism.
+  - `schmooze´ is an example of a Yiddishism.
   hypernym:
   - 06304241-n
   members:
@@ -63506,7 +63506,7 @@
   - a grammatical compound not having the same syntactic function in the sentence
     as any one of its immediate constituents.
   example:
-  - The noun bittersweet is an exocentric compound, since it is a noun but its elements
+  - The noun `bittersweet´ is an exocentric compound, since it is a noun but its elements
     are both adjectives.
   hypernym:
   - 92460746-n
@@ -63518,7 +63518,7 @@
   definition:
   - having the same syntactic function in the sentence as one of its immediate constituents.
   example:
-  - Greenhouse is an endocentric compound, since it is a noun as is its head house.
+  - `greenhouse´ is an endocentric compound, since it is a noun as is its head house.
   hypernym:
   - 92460746-n
   members:
@@ -64260,7 +64260,7 @@
   definition:
   - an adverbial that describes how the action of a verb is carried out.
   example:
-  - Manner adverbials (peacefully) come before place adverbials (in our beds).
+  - Manner adverbials (`peacefully´) come before place adverbials (`in our beds´).
   hypernym:
   - 06335348-n
   members:
@@ -64323,7 +64323,7 @@
     or on coins or medals.
   example:
   - One practice was rendering an over-used, formulaic phrase only as a siglum, e.g.
-    RIP for ‘requiescat in pace’ (‘Rest in Peace’), because the long-form written
+    `RIP´ for `requiescat in pace´ (`Rest in Peace´), because the long-form written
     usage of the abbreviated phrase, itself, was rare.
   hypernym:
   - 06831828-n
@@ -64359,7 +64359,7 @@
   definition:
   - a numeral that does not specify an exact number.
   example:
-  - Most is an indefinite numeral adjective denoting part of a whole.
+  - `most´ is an indefinite numeral adjective denoting part of a whole.
   hypernym:
   - 92464376-n
   members:
@@ -64370,8 +64370,8 @@
   definition:
   - a word expressing a number.
   example:
-  - Numerals may be attributive, as in two dogs, or pronominal, as in I saw two (of
-    them).
+  - Numerals may be attributive, as in `two dogs´, or pronominal, as in `I saw two (of
+    them)´.
   hypernym:
   - 06300030-n
   members:

--- a/src/yaml/noun.food.yaml
+++ b/src/yaml/noun.food.yaml
@@ -3822,7 +3822,7 @@
   definition:
   - ice cream or water ice on a small wooden stick
   example:
-  - in England a popsicle is called an ice lolly
+  - in England a popsicle is called an `ice lolly´
   hypernym:
   - 07626967-n
   ili: i76849
@@ -25013,7 +25013,7 @@
   definition:
   - a sweet drink containing carbonated water and flavoring
   example:
-  - in New England they call sodas tonics
+  - in New England they call sodas `tonics´
   hypernym:
   - 07943437-n
   ili: i78966

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -36915,7 +36915,7 @@
   ili: i90000
   members:
   - floor leader
-  partOfSpeech: n`´
+  partOfSpeech: n
 10117031-n:
   definition:
   - an employee of a retail store who supervises sales personnel and helps with customer

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -33978,7 +33978,7 @@
   definition:
   - a man employed to operate an elevator
   example:
-  - in England they call an elevator man a liftman
+  - in England they call an elevator man a `liftman´
   hypernym:
   - 10070240-n
   ili: i89718
@@ -36915,13 +36915,13 @@
   ili: i90000
   members:
   - floor leader
-  partOfSpeech: n
+  partOfSpeech: n`´
 10117031-n:
   definition:
   - an employee of a retail store who supervises sales personnel and helps with customer
     problems
   example:
-  - a floorwalker is called a shopwalker in Britain
+  - a floorwalker is called a `shopwalker´ in Britain
   hypernym:
   - 10073616-n
   ili: i90001
@@ -40398,7 +40398,7 @@
   definition:
   - an unskilled or low-ranking soldier or other worker
   example:
-  - infantrymen in Vietnam were called grunts
+  - infantrymen in Vietnam were called `grunts´
   - he went from grunt to chairman in six years
   hypernym:
   - 09655462-n
@@ -43171,7 +43171,7 @@
   definition:
   - a wrecker of houses
   example:
-  - in England a housewrecker is called a housebreaker
+  - in England a housewrecker is called a `housebreaker´
   hypernym:
   - 10812496-n
   ili: i90600
@@ -44769,7 +44769,7 @@
   definition:
   - someone who sells hardware
   example:
-  - in England they call a hardwareman an ironmonger
+  - in England they call a hardwareman an `ironmonger´
   hypernym:
   - 10740102-n
   ili: i90750
@@ -58554,7 +58554,7 @@
   definition:
   - someone who moves slowly
   example:
-  - in England they call a slowpoke a slowcoach
+  - in England they call a slowpoke a `slowcoach´
   hypernym:
   - 10012790-n
   ili: i92083
@@ -62510,7 +62510,7 @@
   definition:
   - a person who is authorized to act as an agent for the sale of land
   example:
-  - in England they call a real estate agent a land agent
+  - in England they call a real estate agent a `land agent´
   hypernym:
   - 09796453-n
   ili: i92462

--- a/src/yaml/noun.possession.yaml
+++ b/src/yaml/noun.possession.yaml
@@ -6546,7 +6546,7 @@
   definition:
   - insurance paid to named beneficiaries when the insured person dies
   example:
-  - in England they call life insurance life assurance
+  - in England they call life insurance `life assurance´
   hypernym:
   - 13365819-n
   ili: i106846

--- a/src/yaml/noun.quantity.yaml
+++ b/src/yaml/noun.quantity.yaml
@@ -11956,7 +11956,7 @@
   domain_region:
   - 08879115-n
   example:
-  - in England they call one thousand million a milliard
+  - in England they call one thousand million a `milliard´
   hypernym:
   - 13773969-n
   ili: i109152
@@ -12000,7 +12000,7 @@
   - 08879115-n
   - 08784821-n
   example:
-  - in England they call a quintillion a trillion
+  - in England they call a quintillion a `trillion´
   hypernym:
   - 13767560-n
   ili: i109155
@@ -12027,7 +12027,7 @@
   - 08879115-n
   - 08784821-n
   example:
-  - in England they call a septillion a quadrillion
+  - in England they call a septillion a `quadrillion´
   hypernym:
   - 13767560-n
   ili: i109157


### PR DESCRIPTION
These examples seem to focus attention on the word or word form (signifier) and not really its meaning or reference. Hence the use of quotes around the word.

For instance

> He called me a moron.


involves the meaning, and is not really a verbatim report, but

> He called me \`a moron´, not \`an idiot´


reports the very words (the meaning being just about the same). Likewise,

> in Britain they call a divided highway a \`dual carriageway´