### PR TITLE
Master is only male in some senses

### DIFF
--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -49905,7 +49905,6 @@
   - directs the work of others
   hypernym:
   - 10074465-n
-  - 10306910-n
   ili: i91249
   members:
   - master


### PR DESCRIPTION
Fixes #1076

This removes the male assertion from `master' in the sense of `directs the work of others', while keeping it for `schoolmaster'