### PR TITLE
Lemmas with '%'

### DIFF
--- a/scripts/from_yaml.py
+++ b/scripts/from_yaml.py
@@ -22,10 +22,20 @@ def map_sense_key(sk):
     """
     if "%" in sk:
         e = sk.split("%")
-        return ("oewn-" + e[0].replace("'","-ap-").replace("/","-sl-").replace("!","-ex-").replace(",","-cm-").replace(":","-cn-").replace("+","-pl-") +
-            "__" + e[1].replace("_","-sp-").replace(":","."))
+        if len(e) > 2:
+            lemma = "%".join(e[:-1])
+            info = e[-1]
+        else:
+            lemma = e[0]
+            info = e[1]
+        return ("oewn-" + lemma.replace("'","-ap-").replace("/","-sl-").
+                replace("!","-ex-").replace(",","-cm-")
+                .replace(":","-cn-").replace("+","-pl-") +
+            "__" + info.replace("_","-sp-").replace(":","."))
     else:
-        return "oewn-" + sk.replace("%", "__").replace("'","-ap-").replace("/","-sl-").replace("!","-ex-").replace(",","-cm-").replace(":","-cn-").replace("+","-pl-")
+        return ("oewn-" + sk.replace("%", "__").replace("'","-ap-").
+            replace("/","-sl-").replace("!","-ex-").
+            replace(",","-cm-").replace(":","-cn-").replace("+","-pl-"))
 
 def unmap_sense_key(sk):
     """
@@ -51,15 +61,6 @@ def make_pos(y, pos):
         return pos[:1]
     else:
         return pos
-
-
-def make_sense_id(y, lemma, pos):
-    """
-    Create a sense ID from a YAML entry
-    """
-    return "oewn-%s-%s-%s" % (
-        escape_lemma(lemma), make_pos(y, pos), y["synset"][:-2])
-
 
 def sense_from_yaml(y, lemma, pos, n):
     """

--- a/scripts/wordnet.py
+++ b/scripts/wordnet.py
@@ -820,6 +820,8 @@ def escape_lemma(lemma):
             return '-ex-'
         elif c == '+':
             return '-pl-'
+        elif c == '%':
+            return '-pc-'
         elif xml_id_char_re.match(c):
             return c
         raise ValueError(f'Illegal character {c}')


### PR DESCRIPTION
Lemmas with '%' are potentially ambiguous as discussed in #1123 as this leads to two percentage (`%`) occurring in the sense key.

This PR fixes our tools to work with them as follows.

The `lemma` and the `lex_sense` are split by the **last** percentage sign to occur. In this way ambiguity is avoided.

This even works with the Princeton WordNet tools:

```shell
-> % wordnet "100% correct" -over

Overview of adj 100%_correct

The adj 100% correct has 1 sense (no senses from tagged texts)
                                   
1. accurate, 100% correct -- (conforming exactly or almost exactly to fact or to a standard or performing with total accuracy; "an accurate reproduction"; "the accounting was accurate"; "accurate measurements"; "an accurate scale")
```