### PR TITLE
Fix some capitalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ add_qids.py
 changes.yaml
 protonyms.py
 protonyms.txt
+tmp.py

--- a/src/yaml/entries-a.yaml
+++ b/src/yaml/entries-a.yaml
@@ -2685,11 +2685,6 @@ Admiralty Islands:
     sense:
     - id: 'admiralty_islands%1:15:00::'
       synset: 08862077-n
-Admiralty Metal:
-  n:
-    sense:
-    - id: 'admiralty_metal%1:27:00::'
-      synset: 14984400-n
 Admiralty Mountains:
   n:
     sense:
@@ -2704,6 +2699,11 @@ Admiralty brass:
   n:
     sense:
     - id: 'admiralty_brass%1:27:00::'
+      synset: 14984400-n
+Admiralty metal:
+  n:
+    sense:
+    - id: 'admiralty_metal%1:27:00::'
       synset: 14984400-n
 Admiralty mile:
   n:
@@ -4129,13 +4129,6 @@ Agriculture Department:
     sense:
     - id: 'agriculture_department%1:14:00::'
       synset: 08145946-n
-Agriculture Secretary:
-  n:
-    sense:
-    - id: 'agriculture_secretary%1:18:00::'
-      synset: 10590148-n
-    - id: 'agriculture_secretary%1:04:00::'
-      synset: 00601315-n
 Agrigento:
   n:
     sense:
@@ -5777,8 +5770,6 @@ Alexander:
     - value: ˌæ.lɨɡˈzɑːn.də
       variety: GB
     sense:
-    - id: 'alexander%1:20:00::'
-      synset: 12966588-n
     - derivation:
       - 'alexandrian%3:01:00::'
       id: 'alexander%1:18:00::'
@@ -5933,16 +5924,6 @@ Alexander the Liberator:
     sense:
     - id: 'alexander_the_liberator%1:18:00::'
       synset: 10832404-n
-Alexanders:
-  n:
-    pronunciation:
-    - value: ˌælɨɡˈzændɚz
-      variety: US
-    - value: ˌælɨɡˈzɑːndəz
-      variety: GB
-    sense:
-    - id: 'alexanders%1:20:00::'
-      synset: 12966588-n
 Alexandre Dumas:
   n:
     sense:
@@ -7152,11 +7133,6 @@ Alpinia:
     sense:
     - id: 'alpinia%1:20:00::'
       synset: 12377185-n
-Alpinia Zerumbet:
-  n:
-    sense:
-    - id: 'alpinia_zerumbet%1:20:00::'
-      synset: 12378002-n
 Alpinia galanga:
   n:
     sense:
@@ -7181,6 +7157,11 @@ Alpinia speciosa:
   n:
     sense:
     - id: 'alpinia_speciosa%1:20:00::'
+      synset: 12378002-n
+Alpinia zerumbet:
+  n:
+    sense:
+    - id: 'alpinia_zerumbet%1:20:00::'
       synset: 12378002-n
 Alpinism:
   n:
@@ -7725,7 +7706,7 @@ Ameiurus:
     sense:
     - id: 'ameiurus%1:05:00::'
       synset: 02521621-n
-Ameiurus Melas:
+Ameiurus melas:
   n:
     sense:
     - id: 'ameiurus_melas%1:05:00::'
@@ -8948,11 +8929,6 @@ Ammodytidae:
     sense:
     - id: 'ammodytidae%1:05:00::'
       synset: 02620874-n
-Ammonium Nitrate/Fuel Oil:
-  n:
-    sense:
-    - id: 'ammonium_nitrate/fuel_oil%1:06:01::'
-      synset: 91000711-n
 Ammotragus:
   n:
     sense:
@@ -10125,7 +10101,7 @@ Anemia adiantifolia:
     sense:
     - id: 'anemia_adiantifolia%1:20:00::'
       synset: 12976600-n
-Anemone Canadensis:
+Anemone canadensis:
   n:
     sense:
     - id: 'anemone_canadensis%1:20:00::'
@@ -10242,7 +10218,7 @@ Angel Falls:
     sense:
     - id: 'angel_falls%1:17:00::'
       synset: 09220538-n
-Angelica Archangelica:
+Angelica archangelica:
   n:
     sense:
     - id: 'angelica_archangelica%1:20:00::'
@@ -13779,6 +13755,11 @@ Arenaria interpres:
     sense:
     - id: 'arenaria_interpres%1:05:00::'
       synset: 02027893-n
+Arenaria melanocephala:
+  n:
+    sense:
+    - id: 'arenaria_melanocephala%1:05:00::'
+      synset: 02028043-n
 Arenaria peploides:
   n:
     sense:
@@ -13794,11 +13775,6 @@ Arenaria stricta:
     sense:
     - id: 'arenaria_stricta%1:20:00::'
       synset: 11827148-n
-Arenaria-Melanocephala:
-  n:
-    sense:
-    - id: 'arenaria-melanocephala%1:05:00::'
-      synset: 02028043-n
 Arenaviridae:
   n:
     sense:
@@ -13983,8 +13959,6 @@ Argonaut:
     sense:
     - id: 'argonaut%1:18:01::'
       synset: 09612759-n
-    - id: 'argonaut%1:05:00::'
-      synset: 01973308-n
 Argonauta:
   n:
     sense:
@@ -14539,8 +14513,6 @@ Armageddon:
     sense:
     - id: 'armageddon%1:15:00::'
       synset: 08523953-n
-    - id: 'armageddon%1:04:00::'
-      synset: 00958451-n
 Armagnac:
   n:
     sense:
@@ -17464,18 +17436,6 @@ Attlee:
     sense:
     - id: 'attlee%1:18:00::'
       synset: 10847477-n
-Attorney General:
-  n:
-    sense:
-    - id: 'attorney_general%1:18:01::'
-      synset: 10589873-n
-    - id: 'attorney_general%1:04:00::'
-      synset: 00601032-n
-Attorney General of the United States:
-  n:
-    sense:
-    - id: 'attorney_general_of_the_united_states%1:04:00::'
-      synset: 00601032-n
 Au:
   n:
     sense:
@@ -18304,11 +18264,6 @@ Automeris io:
     sense:
     - id: 'automeris_io%1:05:00::'
       synset: 02306688-n
-Autonomous Sensory Meridian Response:
-  n:
-    sense:
-    - id: 'autonomous_sensory_meridian_response%1:04:01::'
-      synset: 91000431-n
 Auvergne:
   n:
     sense:
@@ -40167,6 +40122,13 @@ agriculture:
       synset: 00918295-n
     - id: 'agriculture%1:14:00::'
       synset: 08092123-n
+agriculture secretary:
+  n:
+    sense:
+    - id: 'agriculture_secretary%1:18:01::'
+      synset: 10590148-n
+    - id: 'agriculture_secretary%1:04:02::'
+      synset: 00601315-n
 agriculturist:
   n:
     sense:
@@ -43367,6 +43329,16 @@ alewife:
       synset: 07801607-n
     - id: 'alewife%1:05:00::'
       synset: 02533745-n
+alexander:
+  n:
+    sense:
+    - id: 'alexander%1:20:01::'
+      synset: 12966588-n
+alexanders:
+  n:
+    sense:
+    - id: 'alexanders%1:20:00::'
+      synset: 12966588-n
 alexandrite:
   n:
     pronunciation:
@@ -50525,6 +50497,11 @@ ammonium nitrate:
     sense:
     - id: 'ammonium_nitrate%1:27:00::'
       synset: 15038579-n
+ammonium nitrate/fuel oil:
+  n:
+    sense:
+    - id: 'ammonium_nitrate/fuel_oil%1:06:00::'
+      synset: 91000711-n
 ammonium salt:
   n:
     sense:
@@ -68941,6 +68918,8 @@ argonaut:
     sense:
     - id: 'argonaut%1:18:00::'
       synset: 09630812-n
+    - id: 'argonaut%1:05:02::'
+      synset: 01973308-n
 argonon:
   n:
     sense:
@@ -69574,6 +69553,11 @@ armadillo:
     sense:
     - id: 'armadillo%1:05:00::'
       synset: 02457010-n
+armageddon:
+  n:
+    sense:
+    - id: 'armageddon%1:04:01::'
+      synset: 00958451-n
 armament:
   n:
     pronunciation:
@@ -80990,6 +80974,15 @@ attorney general:
     sense:
     - id: 'attorney_general%1:18:00::'
       synset: 09842232-n
+    - id: 'attorney_general%1:18:01::'
+      synset: 10589873-n
+    - id: 'attorney_general%1:04:02::'
+      synset: 00601032-n
+attorney general of the United States:
+  n:
+    sense:
+    - id: 'attorney_general_of_the_united_states%1:04:00::'
+      synset: 00601032-n
 attorney-client privilege:
   n:
     sense:
@@ -84323,6 +84316,11 @@ autonomous:
       - 'autonomy%1:26:02::'
       id: autonomous%5:00:01:independent:00
       synset: 00731669-s
+autonomous sensory meridian response:
+  n:
+    sense:
+    - id: 'autonomous_sensory_meridian_response%1:04:00::'
+      synset: 91000431-n
 autonomy:
   n:
     pronunciation:

--- a/src/yaml/entries-b.yaml
+++ b/src/yaml/entries-b.yaml
@@ -498,7 +498,7 @@ Babyrousa:
     sense:
     - id: 'babyrousa%1:05:00::'
       synset: 02399319-n
-Babyrousa Babyrussa:
+Babyrousa babyrussa:
   n:
     sense:
     - id: 'babyrousa_babyrussa%1:05:00::'
@@ -1356,8 +1356,6 @@ Baltic:
     - derivation:
       - 'baltic%1:10:00::'
       id: 'baltic%3:01:01::'
-      pertainym:
-      - 'baltic_state%1:15:00::'
       synset: 02974204-a
     - id: 'baltic%3:01:00::'
       pertainym:
@@ -1371,26 +1369,26 @@ Baltic:
       - 'baltic%3:01:01::'
       id: 'baltic%1:10:00::'
       synset: 06958441-n
-Baltic Republic:
-  n:
-    sense:
-    - id: 'baltic_republic%1:15:00::'
-      synset: 09034471-n
 Baltic Sea:
   n:
     sense:
     - id: 'baltic_sea%1:17:00::'
       synset: 09236161-n
-Baltic State:
-  n:
-    sense:
-    - id: 'baltic_state%1:15:00::'
-      synset: 09034471-n
 Baltic language:
   n:
     sense:
     - id: 'baltic_language%1:10:00::'
       synset: 06958441-n
+Baltic republic:
+  n:
+    sense:
+    - id: 'baltic_republic%1:15:00::'
+      synset: 09034471-n
+Baltic state:
+  n:
+    sense:
+    - id: 'baltic_state%1:15:00::'
+      synset: 09034471-n
 Baltic-Finnic:
   n:
     sense:
@@ -2337,7 +2335,7 @@ Bartolommeo Eustachio:
     sense:
     - id: 'bartolommeo_eustachio%1:18:00::'
       synset: 10983042-n
-Bartram Juneberry:
+Bartram juneberry:
   n:
     sense:
     - id: 'bartram_juneberry%1:20:00::'
@@ -3959,11 +3957,6 @@ Benadryl:
     sense:
     - id: 'benadryl%1:06:00::'
       synset: 03207909-n
-Bench:
-  n:
-    sense:
-    - id: 'bench%1:14:01::'
-      synset: 08345627-n
 Benchley:
   n:
     sense:
@@ -5276,10 +5269,10 @@ Bible Belt:
     sense:
     - id: 'bible_belt%1:15:00::'
       synset: 08527051-n
-Bible-worship:
+Bible worship:
   n:
     sense:
-    - id: 'bible-worship%1:04:00::'
+    - id: 'bible_worship%1:04:00::'
       synset: 01046791-n
 Biblical Aramaic:
   n:
@@ -8237,7 +8230,7 @@ Brachycome:
     sense:
     - id: 'brachycome%1:20:00::'
       synset: 11962188-n
-Brachycome Iberidifolia:
+Brachycome iberidifolia:
   n:
     sense:
     - id: 'brachycome_iberidifolia%1:20:00::'
@@ -9252,6 +9245,11 @@ British capital:
     sense:
     - id: 'british_capital%1:15:00::'
       synset: 08893849-n
+British colony in the Americas:
+  n:
+    sense:
+    - id: 'british_colony_in_the_americas%1:15:00::'
+      synset: 09070916-n
 British empiricism:
   n:
     sense:
@@ -30479,6 +30477,8 @@ bench:
       synset: 08226440-n
     - id: 'bench%1:06:03::'
       synset: 02832300-n
+    - id: 'bench%1:14:04::'
+      synset: 08345627-n
   v:
     sense:
     - derivation:

--- a/src/yaml/entries-c.yaml
+++ b/src/yaml/entries-c.yaml
@@ -1229,16 +1229,16 @@ Calidris:
     sense:
     - id: 'calidris%1:05:00::'
       synset: 02031210-n
-Calidris Ferruginea:
-  n:
-    sense:
-    - id: 'calidris_ferruginea%1:05:00::'
-      synset: 02031741-n
 Calidris canutus:
   n:
     sense:
     - id: 'calidris_canutus%1:05:00::'
       synset: 02031554-n
+Calidris ferruginea:
+  n:
+    sense:
+    - id: 'calidris_ferruginea%1:05:00::'
+      synset: 02031741-n
 Calidris melanotos:
   n:
     sense:
@@ -1516,18 +1516,6 @@ Calixtus III:
     sense:
     - id: 'calixtus_iii%1:18:00::'
       synset: 10899776-n
-Call:
-  n:
-    pronunciation:
-    - value: kɔːl
-      variety: GB
-    - value: kɔl
-      variety: US
-    sense:
-    - derivation:
-      - 'call%2:32:14::'
-      id: 'call%1:09:00::'
-      synset: 06208240-n
 Calla:
   n:
     sense:
@@ -1860,15 +1848,6 @@ Calopogon tuberosum:
     sense:
     - id: 'calopogon_tuberosum%1:20:00::'
       synset: 12069751-n
-Calorie:
-  n:
-    pronunciation:
-    - value: ˈkæləɹi
-    sense:
-    - derivation:
-      - 'caloric%3:01:02::'
-      id: 'calorie%1:23:02::'
-      synset: 13748672-n
 Caloscypha fulgens:
   n:
     sense:
@@ -2897,15 +2876,15 @@ Candlemas Day:
     sense:
     - id: 'candlemas_day%1:28:00::'
       synset: 15211516-n
+Canella alba:
+  n:
+    sense:
+    - id: 'canella_alba%1:20:00::'
+      synset: 12392750-n
 Canella winterana:
   n:
     sense:
     - id: 'canella_winterana%1:20:00::'
-      synset: 12392750-n
-Canella-alba:
-  n:
-    sense:
-    - id: 'canella-alba%1:20:00::'
       synset: 12392750-n
 Canellaceae:
   n:
@@ -4215,16 +4194,16 @@ Caribbean:
       synset: 09258801-n
     - id: 'caribbean%1:15:00::'
       synset: 08726871-n
-Caribbean Island:
-  n:
-    sense:
-    - id: 'caribbean_island%1:15:00::'
-      synset: 08764775-n
 Caribbean Sea:
   n:
     sense:
     - id: 'caribbean_sea%1:17:00::'
       synset: 09258801-n
+Caribbean island:
+  n:
+    sense:
+    - id: 'caribbean_island%1:15:00::'
+      synset: 08764775-n
 Caribbean language:
   n:
     sense:
@@ -7979,21 +7958,6 @@ Champs Elysees:
     sense:
     - id: 'champs_elysees%1:15:00::'
       synset: 08953947-n
-Chancellor:
-  n:
-    pronunciation:
-    - value: ˈtʃɑːnsələ
-      variety: GB
-    - value: ˈtʃænsələ
-      variety: US
-    sense:
-    - id: 'chancellor%1:18:02::'
-      synset: 09926866-n
-Chancellor of the Exchequer:
-  n:
-    sense:
-    - id: 'chancellor_of_the_exchequer%1:18:00::'
-      synset: 09926866-n
 Chancellorsville:
   n:
     sense:
@@ -9665,16 +9629,9 @@ Chico Marx:
     sense:
     - id: 'chico_marx%1:18:01::'
       synset: 11180851-n
-Chief Constable:
-  n:
-    sense:
-    - id: 'chief_constable%1:18:00::'
-      synset: 09935667-n
 Chief Executive:
   n:
     sense:
-    - id: 'chief_executive%1:18:00::'
-      synset: 10486961-n
     - id: 'chief_executive%1:04:00::'
       synset: 00598380-n
 Chief Joseph:
@@ -9682,11 +9639,6 @@ Chief Joseph:
     sense:
     - id: 'chief_joseph%1:18:00::'
       synset: 11112116-n
-Chief Secretary:
-  n:
-    sense:
-    - id: 'chief_secretary%1:18:00::'
-      synset: 09936939-n
 Chihuahua:
   n:
     pronunciation:
@@ -12163,7 +12115,7 @@ Circus:
     sense:
     - id: 'circus%1:05:00::'
       synset: 01612190-n
-Circus Aeruginosus:
+Circus aeruginosus:
   n:
     sense:
     - id: 'circus_aeruginosus%1:05:00::'
@@ -13784,11 +13736,6 @@ Cohn:
     sense:
     - id: 'cohn%1:18:00::'
       synset: 10924391-n
-Coigue:
-  n:
-    sense:
-    - id: 'coigue%1:20:00::'
-      synset: 12287161-n
 Coke:
   n:
     pronunciation:
@@ -14115,18 +14062,6 @@ Colonel Blimp:
       synset: 09956947-n
     - id: 'colonel_blimp%1:18:01::'
       synset: 09615321-n
-Colony:
-  n:
-    pronunciation:
-    - value: ˈkɒ.lə.ni
-      variety: GB
-    - value: ˈkɔ.lə.ni
-      variety: US
-    sense:
-    - derivation:
-      - 'colonist%1:18:00::'
-      id: 'colony%1:15:00::'
-      synset: 09070916-n
 Coloradan:
   n:
     sense:
@@ -14472,13 +14407,6 @@ Commerce Department:
     sense:
     - id: 'commerce_department%1:14:00::'
       synset: 08146250-n
-Commerce Secretary:
-  n:
-    sense:
-    - id: 'commerce_secretary%1:18:00::'
-      synset: 10590405-n
-    - id: 'commerce_secretary%1:04:00::'
-      synset: 00601550-n
 Commiphora:
   n:
     sense:
@@ -14711,11 +14639,6 @@ Comptonia peregrina:
     sense:
     - id: 'comptonia_peregrina%1:20:00::'
       synset: 11762779-n
-Comptroller General:
-  n:
-    sense:
-    - id: 'comptroller_general%1:18:00::'
-      synset: 09969629-n
 Comptroller of the Currency:
   n:
     sense:
@@ -17925,7 +17848,7 @@ Crown:
       - 'coronate%2:41:00::'
       id: 'crown%1:10:01::'
       synset: 06897147-n
-Crown Colony:
+Crown colony:
   n:
     sense:
     - id: 'crown_colony%1:15:00::'
@@ -22866,6 +22789,8 @@ call:
       - 'call%2:32:12::'
       id: 'call%1:04:04::'
       synset: 00081563-n
+    - id: 'call%1:09:16::'
+      synset: 06208240-n
   v:
     pronunciation:
     - value: kɔːl
@@ -23053,7 +22978,6 @@ call:
       - vtii
       synset: 00756201-v
     - derivation:
-      - 'call%1:09:00::'
       - 'calling%1:04:00::'
       id: 'call%2:32:14::'
       subcat:
@@ -23987,9 +23911,7 @@ caloric:
       pertainym:
       - 'heat%1:19:00::'
       synset: 02825392-a
-    - derivation:
-      - 'calorie%1:23:02::'
-      id: 'caloric%3:01:02::'
+    - id: 'caloric%3:01:02::'
       pertainym:
       - 'nutritionist''s_calorie%1:23:00::'
       synset: 02686183-a
@@ -24002,6 +23924,8 @@ calorie:
       - 'caloric%3:01:00::'
       id: 'calorie%1:23:01::'
       synset: 13748406-n
+    - id: 'calorie%1:23:02::'
+      synset: 13748672-n
 calorie chart:
   n:
     sense:
@@ -46105,6 +46029,13 @@ chancellor:
       - 'chancellorship%1:04:00::'
       id: 'chancellor%1:18:01::'
       synset: 09926301-n
+    - id: 'chancellor%1:18:02::'
+      synset: 09926866-n
+chancellor of the exchequer:
+  n:
+    sense:
+    - id: 'chancellor_of_the_exchequer%1:18:00::'
+      synset: 09926866-n
 chancellorship:
   n:
     sense:
@@ -52664,6 +52595,16 @@ chief assistant:
     sense:
     - id: 'chief_assistant%1:18:00::'
       synset: 10550684-n
+chief constable:
+  n:
+    sense:
+    - id: 'chief_constable%1:18:00::'
+      synset: 09935667-n
+chief executive:
+  n:
+    sense:
+    - id: 'chief_executive%1:18:01::'
+      synset: 10486961-n
 chief executive officer:
   n:
     sense:
@@ -52699,6 +52640,16 @@ chief petty officer:
     sense:
     - id: 'chief_petty_officer%1:18:00::'
       synset: 09936803-n
+chief secretary:
+  n:
+    sense:
+    - id: 'chief_secretary%1:18:00::'
+      synset: 09936939-n
+chief secretary to the Treasury:
+  n:
+    sense:
+    - id: 'chief_secretary_to_the_treasury%1:18:00::'
+      synset: 09936939-n
 chiefly:
   r:
     pronunciation:
@@ -74071,6 +74022,11 @@ coigne:
       synset: 04042480-n
     - id: 'coigne%1:06:01::'
       synset: 04042388-n
+coigue:
+  n:
+    sense:
+    - id: 'coigue%1:20:00::'
+      synset: 12287161-n
 coil:
   n:
     sense:
@@ -76457,7 +76413,6 @@ colonist:
       variety: US
     sense:
     - derivation:
-      - 'colony%1:15:00::'
       - 'colony%1:15:01::'
       - 'colony%1:14:00::'
       id: 'colonist%1:18:00::'
@@ -76576,6 +76531,8 @@ colony:
       synset: 08516868-n
     - id: 'colony%1:14:02::'
       synset: 08012452-n
+    - id: 'colony%1:15:03::'
+      synset: 09070916-n
 colophon:
   n:
     pronunciation:
@@ -80741,6 +80698,13 @@ commerce:
       synset: 01092370-n
     - id: 'commerce%1:10:00::'
       synset: 07152330-n
+commerce secretary:
+  n:
+    sense:
+    - id: 'commerce_secretary%1:18:01::'
+      synset: 10590405-n
+    - id: 'commerce_secretary%1:04:02::'
+      synset: 00601550-n
 commercial:
   a:
     pronunciation:
@@ -86671,6 +86635,11 @@ comptroller:
       - 'comptrollership%1:04:00::'
       id: 'comptroller%1:18:00::'
       synset: 09780826-n
+comptroller general:
+  n:
+    sense:
+    - id: 'comptroller_general%1:18:00::'
+      synset: 09969629-n
 comptrollership:
   n:
     sense:
@@ -97916,8 +97885,6 @@ continental:
       variety: GB
     sense:
     - id: 'continental%3:01:02::'
-      pertainym:
-      - 'colony%1:15:00::'
       synset: 02897710-a
     - derivation:
       - 'continent%1:17:00::'

--- a/src/yaml/entries-d.yaml
+++ b/src/yaml/entries-d.yaml
@@ -1764,16 +1764,16 @@ Davalia bullata mariesii:
     sense:
     - id: 'davalia_bullata_mariesii%1:20:00::'
       synset: 13209665-n
-Davallia Mariesii:
-  n:
-    sense:
-    - id: 'davallia_mariesii%1:20:00::'
-      synset: 13209665-n
 Davallia canariensis:
   n:
     sense:
     - id: 'davallia_canariensis%1:20:00::'
       synset: 13209360-n
+Davallia mariesii:
+  n:
+    sense:
+    - id: 'davallia_mariesii%1:20:00::'
+      synset: 13209665-n
 Davallia pyxidata:
   n:
     sense:
@@ -2414,13 +2414,6 @@ Defense Reutilization and Marketing Service:
     sense:
     - id: 'defense_reutilization_and_marketing_service%1:14:00::'
       synset: 08358478-n
-Defense Secretary:
-  n:
-    sense:
-    - id: 'defense_secretary%1:18:00::'
-      synset: 10590646-n
-    - id: 'defense_secretary%1:04:00::'
-      synset: 00601770-n
 Defense Technical Information Center:
   n:
     sense:
@@ -6670,13 +6663,6 @@ Dumetella carolinensis:
     sense:
     - id: 'dumetella_carolinensis%1:05:00::'
       synset: 01590167-n
-Dumpster:
-  n:
-    pronunciation:
-    - value: ˈdʌmpstɚ
-    sense:
-    - id: 'dumpster%1:06:00::'
-      synset: 03260735-n
 Dumpy level:
   n:
     sense:
@@ -18814,6 +18800,13 @@ defense reaction:
     sense:
     - id: 'defense_reaction%1:22:00::'
       synset: 13480525-n
+defense secretary:
+  n:
+    sense:
+    - id: 'defense_secretary%1:18:01::'
+      synset: 10590646-n
+    - id: 'defense_secretary%1:04:02::'
+      synset: 00601770-n
 defense system:
   n:
     sense:
@@ -68185,6 +68178,11 @@ dumpsite:
     sense:
     - id: 'dumpsite%1:15:00::'
       synset: 08577564-n
+dumpster:
+  n:
+    sense:
+    - id: 'dumpster%1:06:00::'
+      synset: 03260735-n
 dumpy:
   a:
     form:

--- a/src/yaml/entries-e.yaml
+++ b/src/yaml/entries-e.yaml
@@ -473,11 +473,6 @@ Earhart:
     sense:
     - id: 'earhart%1:18:00::'
       synset: 10967395-n
-Earl Marshal:
-  n:
-    sense:
-    - id: 'earl_marshal%1:18:00::'
-      synset: 10061347-n
 Earl Russell:
   n:
     sense:
@@ -1593,13 +1588,6 @@ Education Department:
     sense:
     - id: 'education_department%1:14:00::'
       synset: 08149619-n
-Education Secretary:
-  n:
-    sense:
-    - id: 'education_secretary%1:18:00::'
-      synset: 10590879-n
-    - id: 'education_secretary%1:04:00::'
-      synset: 00601986-n
 Edvard Grieg:
   n:
     sense:
@@ -2771,16 +2759,6 @@ Eleaticism:
     sense:
     - id: 'eleaticism%1:09:01::'
       synset: 92439204-n
-Elector:
-  n:
-    pronunciation:
-    - value: ɪˈlɛktə
-      variety: GB
-    - value: əˈlɛktɚ
-      variety: US
-    sense:
-    - id: 'elector%1:18:01::'
-      synset: 10492858-n
 Electra:
   n:
     sense:
@@ -3681,11 +3659,6 @@ Emperor Napoleon III:
     sense:
     - id: 'emperor_napoleon_iii%1:18:00::'
       synset: 11220482-n
-Emperor of Rome:
-  n:
-    sense:
-    - id: 'emperor_of_rome%1:18:00::'
-      synset: 10556797-n
 Empetraceae:
   n:
     sense:
@@ -3866,13 +3839,6 @@ Energy Department:
     sense:
     - id: 'energy_department%1:14:00::'
       synset: 08149937-n
-Energy Secretary:
-  n:
-    sense:
-    - id: 'energy_secretary%1:18:00::'
-      synset: 10591114-n
-    - id: 'energy_secretary%1:04:00::'
-      synset: 00602203-n
 Enesco:
   n:
     sense:
@@ -4793,13 +4759,6 @@ Episcopalianism:
     sense:
     - id: 'episcopalianism%1:09:00::'
       synset: 06198338-n
-Epistle:
-  n:
-    pronunciation:
-    - value: ɪˈpɪs.l
-    sense:
-    - id: 'epistle%1:10:00::'
-      synset: 06454286-n
 Epistle of James:
   n:
     sense:
@@ -5004,11 +4963,6 @@ Equisetum:
     sense:
     - id: 'equisetum%1:20:00::'
       synset: 13240156-n
-Equisetum Sylvaticum:
-  n:
-    sense:
-    - id: 'equisetum_sylvaticum%1:20:00::'
-      synset: 13241423-n
 Equisetum arvense:
   n:
     sense:
@@ -5039,6 +4993,11 @@ Equisetum robustum:
     sense:
     - id: 'equisetum_robustum%1:20:00::'
       synset: 13241020-n
+Equisetum sylvaticum:
+  n:
+    sense:
+    - id: 'equisetum_sylvaticum%1:20:00::'
+      synset: 13241423-n
 Equisetum variegatum:
   n:
     sense:
@@ -5049,11 +5008,6 @@ Equus:
     sense:
     - id: 'equus%1:05:00::'
       synset: 02376495-n
-Equus Burchelli:
-  n:
-    sense:
-    - id: 'equus_burchelli%1:05:00::'
-      synset: 02393886-n
 Equus africanus:
   n:
     sense:
@@ -5064,6 +5018,11 @@ Equus asinus:
     sense:
     - id: 'equus_asinus%1:05:01::'
       synset: 02392211-n
+Equus burchelli:
+  n:
+    sense:
+    - id: 'equus_burchelli%1:05:00::'
+      synset: 02393886-n
 Equus caballus:
   n:
     sense:
@@ -5920,11 +5879,6 @@ Erysiphe:
     sense:
     - id: 'erysiphe%1:20:00::'
       synset: 12984254-n
-Erythrina Indica:
-  n:
-    sense:
-    - id: 'erythrina_indica%1:20:00::'
-      synset: 12549479-n
 Erythrina caffra:
   n:
     sense:
@@ -5940,6 +5894,11 @@ Erythrina crista-galli:
     sense:
     - id: 'erythrina_crista-galli%1:20:00::'
       synset: 12549054-n
+Erythrina indica:
+  n:
+    sense:
+    - id: 'erythrina_indica%1:20:00::'
+      synset: 12549479-n
 Erythrina lysistemon:
   n:
     sense:
@@ -8849,6 +8808,11 @@ earl:
       - 'earldom%1:15:00::'
       id: 'earl%1:18:00::'
       synset: 10061181-n
+earl marshal:
+  n:
+    sense:
+    - id: 'earl_marshal%1:18:00::'
+      synset: 10061347-n
 earlap:
   n:
     sense:
@@ -12853,6 +12817,13 @@ education:
       - 'educate%2:41:01::'
       id: 'education%1:07:01::'
       synset: 04929077-n
+education secretary:
+  n:
+    sense:
+    - id: 'education_secretary%1:18:01::'
+      synset: 10590879-n
+    - id: 'education_secretary%1:04:02::'
+      synset: 00601986-n
 educational:
   a:
     pronunciation:
@@ -15644,6 +15615,8 @@ elector:
       - 'elect%2:41:00::'
       id: 'elector%1:18:00::'
       synset: 10780008-n
+    - id: 'elector%1:18:01::'
+      synset: 10492858-n
 electoral:
   a:
     sense:
@@ -20721,6 +20694,11 @@ emperor moth:
     sense:
     - id: 'emperor_moth%1:05:00::'
       synset: 02304587-n
+emperor of Rome:
+  n:
+    sense:
+    - id: 'emperor_of_rome%1:18:00::'
+      synset: 10556797-n
 emperor penguin:
   n:
     sense:
@@ -24624,6 +24602,13 @@ energy of activation:
     sense:
     - id: 'energy_of_activation%1:19:00::'
       synset: 11441936-n
+energy secretary:
+  n:
+    sense:
+    - id: 'energy_secretary%1:18:01::'
+      synset: 10591114-n
+    - id: 'energy_secretary%1:04:02::'
+      synset: 00602203-n
 energy state:
   n:
     sense:
@@ -29953,6 +29938,8 @@ epistle:
       - epistolary%5:00:00:informal:02
       id: 'epistle%1:10:01::'
       synset: 06638690-n
+    - id: 'epistle%1:10:02::'
+      synset: 06454286-n
 epistolary:
   a:
     pronunciation:
@@ -40088,6 +40075,11 @@ executive:
       synset: 08182354-n
     - id: 'executive%1:18:01::'
       synset: 09789895-n
+executive action:
+  n:
+    sense:
+    - id: 'executive_action%1:10:00::'
+      synset: 07184933-n
 executive agency:
   n:
     sense:

--- a/src/yaml/entries-f.yaml
+++ b/src/yaml/entries-f.yaml
@@ -2356,11 +2356,6 @@ First Lateran Council:
     sense:
     - id: 'first_lateran_council%1:14:00::'
       synset: 08332372-n
-First Lord of the Treasury:
-  n:
-    sense:
-    - id: 'first_lord_of_the_treasury%1:18:00::'
-      synset: 10747110-n
 First Marquess Cornwallis:
   n:
     sense:
@@ -4186,7 +4181,7 @@ Fraxinus:
     sense:
     - id: 'fraxinus%1:20:00::'
       synset: 12323866-n
-Fraxinus Americana:
+Fraxinus americana:
   n:
     sense:
     - id: 'fraxinus_americana%1:20:00::'
@@ -5189,11 +5184,6 @@ Frigga:
     sense:
     - id: 'frigga%1:18:00::'
       synset: 09603695-n
-Frigid Zone:
-  n:
-    sense:
-    - id: 'frigid_zone%1:15:00::'
-      synset: 08590805-n
 Frimaire:
   n:
     sense:
@@ -31457,6 +31447,11 @@ first light:
     sense:
     - id: 'first_light%1:28:00::'
       synset: 15193837-n
+first lord of the Treasury:
+  n:
+    sense:
+    - id: 'first_lord_of_the_treasury%1:18:00::'
+      synset: 10747110-n
 first mate:
   n:
     sense:
@@ -53924,6 +53919,11 @@ frigid:
       - 'frigidity%1:07:00::'
       id: frigid%5:00:00:cold:02
       synset: 01261336-s
+frigid zone:
+  n:
+    sense:
+    - id: 'frigid_zone%1:15:00::'
+      synset: 08590805-n
 frigidity:
   n:
     sense:

--- a/src/yaml/entries-g.yaml
+++ b/src/yaml/entries-g.yaml
@@ -2207,7 +2207,7 @@ Genghis Khan:
     sense:
     - id: 'genghis_khan%1:18:00::'
       synset: 11014304-n
-Genipa Americana:
+Genipa americana:
   n:
     sense:
     - id: 'genipa_americana%1:20:00::'
@@ -5060,11 +5060,6 @@ Goat:
       synset: 09772829-n
     - id: 'goat%1:15:00::'
       synset: 08705447-n
-Goat Eye:
-  n:
-    sense:
-    - id: 'goat_eye%1:06:01::'
-      synset: 92450758-n
 Gobi:
   n:
     sense:
@@ -5139,11 +5134,6 @@ God tree:
     sense:
     - id: 'god_tree%1:20:00::'
       synset: 12210927-n
-God's Will:
-  n:
-    sense:
-    - id: 'god''s_will%1:26:00::'
-      synset: 14482780-n
 God's Wisdom:
   n:
     sense:
@@ -5154,6 +5144,11 @@ God's acre:
     sense:
     - id: 'god''s_acre%1:15:00::'
       synset: 08664929-n
+God's will:
+  n:
+    sense:
+    - id: 'god''s_will%1:26:00::'
+      synset: 14482780-n
 Godard:
   n:
     sense:
@@ -6069,11 +6064,6 @@ Government Printing Office:
     sense:
     - id: 'government_printing_office%1:14:00::'
       synset: 08373500-n
-Governorate-General:
-  n:
-    sense:
-    - id: 'governorate-general%1:15:01::'
-      synset: 92406097-n
 Goya:
   n:
     sense:
@@ -6978,10 +6968,6 @@ Green:
     sense:
     - id: 'green%1:18:01::'
       synset: 11033320-n
-    - derivation:
-      - 'green%3:01:00::'
-      id: 'green%1:18:00::'
-      synset: 10080712-n
     - id: 'green%1:17:00::'
       synset: 09316972-n
 Green Bay:
@@ -8590,14 +8576,6 @@ Gymnadeniopsis:
     sense:
     - id: 'gymnadeniopsis%1:20:00::'
       synset: 12085315-n
-Gymnasium:
-  n:
-    pronunciation:
-    - value: dʒɪmˈneɪ.zi.əm
-      variety: US
-    sense:
-    - id: 'gymnasium%1:14:00::'
-      synset: 08301402-n
 Gymnelus:
   n:
     sense:
@@ -45182,6 +45160,11 @@ goat cheese:
     sense:
     - id: 'goat_cheese%1:13:00::'
       synset: 07869536-n
+goat eye:
+  n:
+    sense:
+    - id: 'goat_eye%1:06:00::'
+      synset: 92450758-n
 goat god:
   n:
     sense:
@@ -48877,6 +48860,11 @@ governor's race:
     sense:
     - id: 'governor''s_race%1:11:00::'
       synset: 07488347-n
+governorate-general:
+  n:
+    sense:
+    - id: 'governorate-general%1:15:00::'
+      synset: 92406097-n
 governorship:
   n:
     sense:
@@ -53770,9 +53758,7 @@ green:
       - 'greenness%1:07:00::'
       id: green%5:00:00:chromatic:00
       synset: 00377031-s
-    - derivation:
-      - 'green%1:18:00::'
-      id: 'green%3:01:00::'
+    - id: 'green%3:01:00::'
       pertainym:
       - 'green_party%1:14:00::'
       synset: 03081365-a
@@ -53803,6 +53789,8 @@ green:
       synset: 07725078-n
     - id: 'green%1:06:00::'
       synset: 03611785-n
+    - id: 'green%1:18:03::'
+      synset: 10080712-n
   s:
     sense:
     - id: green%5:00:02:good:01
@@ -61197,6 +61185,8 @@ gymnasium:
     sense:
     - id: 'gymnasium%1:06:00::'
       synset: 03477235-n
+    - id: 'gymnasium%1:14:01::'
+      synset: 08301402-n
 gymnast:
   n:
     pronunciation:

--- a/src/yaml/entries-h.yaml
+++ b/src/yaml/entries-h.yaml
@@ -6683,11 +6683,6 @@ Home Office:
     sense:
     - id: 'home_office%1:14:00::'
       synset: 08131262-n
-Home Secretary:
-  n:
-    sense:
-    - id: 'home_secretary%1:18:00::'
-      synset: 10202259-n
 Homel:
   n:
     sense:
@@ -8439,7 +8434,7 @@ Hydrastis:
     sense:
     - id: 'hydrastis%1:20:00::'
       synset: 11755794-n
-Hydrastis Canadensis:
+Hydrastis canadensis:
   n:
     sense:
     - id: 'hydrastis_canadensis%1:20:00::'
@@ -33517,6 +33512,11 @@ home run:
       synset: 00133175-n
     - id: 'home_run%1:04:01::'
       synset: 00065609-n
+home secretary:
+  n:
+    sense:
+    - id: 'home_secretary%1:18:00::'
+      synset: 10202259-n
 home stand:
   n:
     sense:

--- a/src/yaml/entries-i.yaml
+++ b/src/yaml/entries-i.yaml
@@ -564,11 +564,6 @@ Iberis:
     sense:
     - id: 'iberis%1:20:00::'
       synset: 11909942-n
-Ibero-mesornis:
-  n:
-    sense:
-    - id: 'ibero-mesornis%1:05:00::'
-      synset: 01519677-n
 Ibert:
   n:
     sense:
@@ -579,17 +574,17 @@ Ibis ibis:
     sense:
     - id: 'ibis_ibis%1:05:00::'
       synset: 02008717-n
-Ibizan Podenco:
-  n:
-    sense:
-    - id: 'ibizan_podenco%1:05:00::'
-      synset: 02093896-n
 Ibizan hound:
   n:
     pronunciation:
     - value: iˈbizn̩ˌhæʊ̯nd
     sense:
     - id: 'ibizan_hound%1:05:00::'
+      synset: 02093896-n
+Ibizan podenco:
+  n:
+    sense:
+    - id: 'ibizan_podenco%1:05:00::'
       synset: 02093896-n
 Ibn al-Haytham:
   n:
@@ -2416,13 +2411,6 @@ Interior Department:
     sense:
     - id: 'interior_department%1:14:00::'
       synset: 08156000-n
-Interior Secretary:
-  n:
-    sense:
-    - id: 'interior_secretary%1:18:00::'
-      synset: 10592333-n
-    - id: 'interior_secretary%1:04:00::'
-      synset: 00603335-n
 Interlaken:
   n:
     sense:
@@ -4676,6 +4664,16 @@ ib.:
     sense:
     - id: 'ib.%4:02:00::'
       synset: 00257456-r
+ibero-mesornis:
+  n:
+    sense:
+    - id: 'ibero-mesornis%1:05:00::'
+      synset: 01519677-n
+iberomesornis:
+  n:
+    sense:
+    - id: 'iberomesornis%1:05:00::'
+      synset: 01519677-n
 ibex:
   n:
     form:
@@ -33702,6 +33700,13 @@ interior monologue:
     sense:
     - id: 'interior_monologue%1:10:00::'
       synset: 06385864-n
+interior secretary:
+  n:
+    sense:
+    - id: 'interior_secretary%1:18:01::'
+      synset: 10592333-n
+    - id: 'interior_secretary%1:04:02::'
+      synset: 00603335-n
 interiorise:
   v:
     sense:

--- a/src/yaml/entries-j.yaml
+++ b/src/yaml/entries-j.yaml
@@ -5998,11 +5998,6 @@ Juneau:
     sense:
     - id: 'juneau%1:15:00::'
       synset: 09078249-n
-Juneberry:
-  n:
-    sense:
-    - id: 'juneberry%1:20:00::'
-      synset: 12644285-n
 Jung:
   n:
     sense:
@@ -13024,6 +13019,8 @@ juneberry:
     sense:
     - id: 'juneberry%1:13:00::'
       synset: 07761637-n
+    - id: 'juneberry%1:20:01::'
+      synset: 12644285-n
 juneberry holly:
   n:
     sense:

--- a/src/yaml/entries-k.yaml
+++ b/src/yaml/entries-k.yaml
@@ -320,16 +320,6 @@ Kakatoe leadbeateri:
     sense:
     - id: 'kakatoe_leadbeateri%1:05:00::'
       synset: 01822106-n
-Kakemono:
-  n:
-    pronunciation:
-    - value: ˌkɑkeɪˈmoʊnoʊ
-      variety: US
-    - value: ˌkækeɪˈməʊnəʊ
-      variety: GB
-    sense:
-    - id: 'kakemono%1:06:00::'
-      synset: 03612571-n
 Kalaallit Nunaat:
   n:
     sense:
@@ -4714,6 +4704,11 @@ kaiser roll:
     sense:
     - id: 'kaiser_roll%1:13:00::'
       synset: 07707699-n
+kakemono:
+  n:
+    sense:
+    - id: 'kakemono%1:06:00::'
+      synset: 03612571-n
 kaki:
   n:
     sense:

--- a/src/yaml/entries-l.yaml
+++ b/src/yaml/entries-l.yaml
@@ -409,13 +409,6 @@ Labor Department:
     sense:
     - id: 'labor_department%1:14:00::'
       synset: 08154495-n
-Labor Secretary:
-  n:
-    sense:
-    - id: 'labor_secretary%1:18:00::'
-      synset: 10591913-n
-    - id: 'labor_secretary%1:04:00::'
-      synset: 00602937-n
 Labour:
   n:
     pronunciation:
@@ -693,15 +686,6 @@ Ladrone Islands:
     sense:
     - id: 'ladrone_islands%1:15:00::'
       synset: 08856544-n
-Lady:
-  n:
-    pronunciation:
-    - value: ˈleɪdi
-    sense:
-    - antonym:
-      - 'lord%1:18:00::'
-      id: 'lady%1:18:00::'
-      synset: 10262488-n
 Lady Day:
   n:
     sense:
@@ -7038,7 +7022,7 @@ Lophius:
     sense:
     - id: 'lophius%1:05:00::'
       synset: 02550759-n
-Lophius Americanus:
+Lophius americanus:
   n:
     sense:
     - id: 'lophius_americanus%1:05:00::'
@@ -7135,14 +7119,6 @@ Lord:
     sense:
     - id: 'lord%1:18:02::'
       synset: 09559474-n
-    - antonym:
-      - 'lady%1:18:00::'
-      derivation:
-      - lordly%5:00:00:noble:02
-      - 'lordship%1:10:00::'
-      - 'lord%2:41:00::'
-      id: 'lord%1:18:00::'
-      synset: 10291374-n
 Lord Britten of Aldeburgh:
   n:
     sense:
@@ -7153,21 +7129,11 @@ Lord Byron:
     sense:
     - id: 'lord_byron%1:18:01::'
       synset: 10897005-n
-Lord Chancellor:
-  n:
-    sense:
-    - id: 'lord_chancellor%1:18:00::'
-      synset: 10291868-n
 Lord George Gordon Byron:
   n:
     sense:
     - id: 'lord_george_gordon_byron%1:18:00::'
       synset: 10897005-n
-Lord High Chancellor:
-  n:
-    sense:
-    - id: 'lord_high_chancellor%1:18:00::'
-      synset: 10291868-n
 Lord Macaulay:
   n:
     sense:
@@ -7243,9 +7209,7 @@ Lordship:
     - value: ˈlɔɹd.ʃɪp
       variety: US
     sense:
-    - derivation:
-      - 'lord%1:18:00::'
-      id: 'lordship%1:10:00::'
+    - id: 'lordship%1:10:00::'
       synset: 06354151-n
 Lorelei:
   n:
@@ -10050,6 +10014,13 @@ labor resources:
     sense:
     - id: 'labor_resources%1:21:00::'
       synset: 13353212-n
+labor secretary:
+  n:
+    sense:
+    - id: 'labor_secretary%1:18:01::'
+      synset: 10591913-n
+    - id: 'labor_secretary%1:04:02::'
+      synset: 00602937-n
 labor union:
   n:
     sense:
@@ -11386,6 +11357,8 @@ lady:
       synset: 10262834-n
     - id: 'lady%1:18:01::'
       synset: 10008828-n
+    - id: 'lady%1:18:03::'
+      synset: 10262488-n
 lady beetle:
   n:
     sense:
@@ -39859,6 +39832,8 @@ lord:
       - 'lordship%1:07:00::'
       id: 'lord%1:18:01::'
       synset: 10408139-n
+    - id: 'lord%1:18:03::'
+      synset: 10291374-n
   v:
     pronunciation:
     - value: lɔːd
@@ -39866,12 +39841,20 @@ lord:
     - value: lɔɹd
       variety: US
     sense:
-    - derivation:
-      - 'lord%1:18:00::'
-      id: 'lord%2:41:00::'
+    - id: 'lord%2:41:00::'
       subcat:
       - vtaa
       synset: 02403996-v
+lord chancellor:
+  n:
+    sense:
+    - id: 'lord_chancellor%1:18:00::'
+      synset: 10291868-n
+lord high chancellor:
+  n:
+    sense:
+    - id: 'lord_high_chancellor%1:18:00::'
+      synset: 10291868-n
 lord it over:
   v:
     sense:
@@ -39906,7 +39889,6 @@ lordly:
     - value: ˈlɔː(ɹ)dli
     sense:
     - derivation:
-      - 'lord%1:18:00::'
       - 'lordliness%1:07:01::'
       id: lordly%5:00:00:noble:02
       synset: 01595457-s

--- a/src/yaml/entries-m.yaml
+++ b/src/yaml/entries-m.yaml
@@ -1846,10 +1846,10 @@ Malaxis ophioglossoides:
     sense:
     - id: 'malaxis_ophioglossoides%1:20:00::'
       synset: 12092711-n
-Malaxis-unifolia:
+Malaxis unifolia:
   n:
     sense:
-    - id: 'malaxis-unifolia%1:20:00::'
+    - id: 'malaxis_unifolia%1:20:00::'
       synset: 12092711-n
 Malay:
   a:
@@ -3988,13 +3988,6 @@ Marilyn Monroe:
     sense:
     - id: 'marilyn_monroe%1:18:00::'
       synset: 11206197-n
-Marine:
-  n:
-    pronunciation:
-    - value: məˈɹiːn
-    sense:
-    - id: 'marine%1:18:00::'
-      synset: 10313800-n
 Marine Corps:
   n:
     sense:
@@ -4020,8 +4013,6 @@ Marines:
     sense:
     - id: 'marines%1:14:02::'
       synset: 08209900-n
-    - id: 'marines%1:14:01::'
-      synset: 08209747-n
 Marini:
   n:
     sense:
@@ -6073,13 +6064,6 @@ Mayan language:
     sense:
     - id: 'mayan_language%1:10:00::'
       synset: 06931991-n
-Mayday:
-  n:
-    pronunciation:
-    - value: ˈmeɪ.deɪ
-    sense:
-    - id: 'mayday%1:10:00::'
-      synset: 06816812-n
 Mayenne:
   n:
     sense:
@@ -6975,7 +6959,7 @@ Melia:
     sense:
     - id: 'melia%1:20:00::'
       synset: 12716521-n
-Melia Azadirachta:
+Melia azadirachta:
   n:
     sense:
     - id: 'melia_azadirachta%1:20:00::'
@@ -7128,7 +7112,7 @@ Melophagus:
     sense:
     - id: 'melophagus%1:05:00::'
       synset: 02201648-n
-Melophagus Ovinus:
+Melophagus ovinus:
   n:
     sense:
     - id: 'melophagus_ovinus%1:05:00::'
@@ -7213,11 +7197,6 @@ Melvin Calvin:
     sense:
     - id: 'melvin_calvin%1:18:00::'
       synset: 10900421-n
-Member of Parliament:
-  n:
-    sense:
-    - id: 'member_of_parliament%1:18:00::'
-      synset: 10420136-n
 Membracidae:
   n:
     sense:
@@ -7438,13 +7417,6 @@ Menopon palladum:
     sense:
     - id: 'menopon_palladum%1:05:00::'
       synset: 02188466-n
-Menorah:
-  n:
-    pronunciation:
-    - value: mɪˈnɔːɹə
-    sense:
-    - id: 'menorah%1:06:01::'
-      synset: 03751646-n
 Menotti:
   n:
     sense:
@@ -8868,10 +8840,10 @@ Microgramma:
     sense:
     - id: 'microgramma%1:20:00::'
       synset: 13197099-n
-Microgramma-piloselloides:
+Microgramma piloselloides:
   n:
     sense:
-    - id: 'microgramma-piloselloides%1:20:00::'
+    - id: 'microgramma_piloselloides%1:20:00::'
       synset: 13197261-n
 Microhylidae:
   n:
@@ -13442,10 +13414,10 @@ Muscivora:
     sense:
     - id: 'muscivora%1:05:00::'
       synset: 01550784-n
-Muscivora-forficata:
+Muscivora forficata:
   n:
     sense:
-    - id: 'muscivora-forficata%1:05:00::'
+    - id: 'muscivora_forficata%1:05:00::'
       synset: 01557946-n
 Muscoidea:
   n:
@@ -24764,6 +24736,8 @@ marine:
     sense:
     - id: 'marine%1:18:01::'
       synset: 10313979-n
+    - id: 'marine%1:18:03::'
+      synset: 10313800-n
 marine animal:
   n:
     sense:
@@ -24842,6 +24816,11 @@ mariner's compass:
     sense:
     - id: 'mariner''s_compass%1:06:00::'
       synset: 03084735-n
+marines:
+  n:
+    sense:
+    - id: 'marines%1:14:03::'
+      synset: 08209747-n
 marionette:
   n:
     sense:
@@ -30409,6 +30388,11 @@ maybe:
     sense:
     - id: 'maybe%4:02:00::'
       synset: 00301501-r
+mayday:
+  n:
+    sense:
+    - id: 'mayday%1:10:00::'
+      synset: 06816812-n
 mayeng:
   n:
     sense:
@@ -32897,16 +32881,16 @@ medieval:
       - 'american_spelling%1:10:01::'
       id: medieval%5:00:00:past:00
       synset: 01733389-s
-medieval Schoolman:
-  n:
-    sense:
-    - id: 'medieval_schoolman%1:18:00::'
-      synset: 10579111-n
 medieval mode:
   n:
     sense:
     - id: 'medieval_mode%1:10:00::'
       synset: 06873531-n
+medieval schoolman:
+  n:
+    sense:
+    - id: 'medieval_schoolman%1:18:00::'
+      synset: 10579111-n
 medievality:
   n:
     sense:
@@ -34767,6 +34751,11 @@ member bank:
     sense:
     - id: 'member_bank%1:14:00::'
       synset: 08435990-n
+member of parliament:
+  n:
+    sense:
+    - id: 'member_of_parliament%1:18:00::'
+      synset: 10420136-n
 membered:
   a:
     sense:
@@ -35597,6 +35586,8 @@ menorah:
     sense:
     - id: 'menorah%1:06:00::'
       synset: 03751496-n
+    - id: 'menorah%1:06:01::'
+      synset: 03751646-n
 menorrhagia:
   n:
     sense:

--- a/src/yaml/entries-n.yaml
+++ b/src/yaml/entries-n.yaml
@@ -1596,7 +1596,7 @@ Navy SEAL:
     sense:
     - id: 'navy_seal%1:18:00::'
       synset: 10368257-n
-Navy Secretary:
+Navy secretary:
   n:
     sense:
     - id: 'navy_secretary%1:04:00::'
@@ -1952,11 +1952,6 @@ Negev Desert:
     sense:
     - id: 'negev_desert%1:15:00::'
       synset: 09194457-n
-Negress:
-  n:
-    sense:
-    - id: 'negress%1:18:00::'
-      synset: 82074520-n
 Negritude:
   n:
     pronunciation:
@@ -3310,11 +3305,6 @@ New Zealand:
       synset: 08994872-n
     - id: 'new_zealand%1:15:01::'
       synset: 08994265-n
-New Zealand Dacryberry:
-  n:
-    sense:
-    - id: 'new_zealand_dacryberry%1:20:00::'
-      synset: 11674355-n
 New Zealand English orthography:
   n:
     sense:
@@ -3340,6 +3330,11 @@ New Zealand cotton:
     sense:
     - id: 'new_zealand_cotton%1:20:00::'
       synset: 12206043-n
+New Zealand dacryberry:
+  n:
+    sense:
+    - id: 'new_zealand_dacryberry%1:20:00::'
+      synset: 11674355-n
 New Zealand daisybush:
   n:
     sense:
@@ -12408,6 +12403,11 @@ negotiatrix:
     sense:
     - id: 'negotiatrix%1:18:00::'
       synset: 10371939-n
+negress:
+  n:
+    sense:
+    - id: 'negress%1:18:00::'
+      synset: 82074520-n
 negro:
   a:
     pronunciation:

--- a/src/yaml/entries-o.yaml
+++ b/src/yaml/entries-o.yaml
@@ -640,11 +640,6 @@ Odocoileus:
     sense:
     - id: 'odocoileus%1:05:00::'
       synset: 02434785-n
-Odocoileus Virginianus:
-  n:
-    sense:
-    - id: 'odocoileus_virginianus%1:05:00::'
-      synset: 02434937-n
 Odocoileus hemionus:
   n:
     sense:
@@ -655,6 +650,11 @@ Odocoileus hemionus columbianus:
     sense:
     - id: 'odocoileus_hemionus_columbianus%1:05:00::'
       synset: 02435350-n
+Odocoileus virginianus:
+  n:
+    sense:
+    - id: 'odocoileus_virginianus%1:05:00::'
+      synset: 02434937-n
 Odonata:
   n:
     sense:
@@ -3628,7 +3628,7 @@ Otaria:
     sense:
     - id: 'otaria%1:05:00::'
       synset: 02080811-n
-Otaria Byronia:
+Otaria byronia:
   n:
     sense:
     - id: 'otaria_byronia%1:05:00::'

--- a/src/yaml/entries-p.yaml
+++ b/src/yaml/entries-p.yaml
@@ -2290,13 +2290,6 @@ Parks:
     sense:
     - id: 'parks%1:18:00::'
       synset: 11243386-n
-Parliamentarian:
-  n:
-    pronunciation:
-    - value: ˌpɑː(ɹ)ləmənˈtɛəɹiən
-    sense:
-    - id: 'parliamentarian%1:18:01::'
-      synset: 10420136-n
 Parmelia:
   n:
     sense:
@@ -5728,21 +5721,6 @@ Phanerozoic eon:
     sense:
     - id: 'phanerozoic_eon%1:28:00::'
       synset: 15149100-n
-Pharaoh:
-  n:
-    pronunciation:
-    - value: ˈfæɹoʊ
-      variety: US
-    sense:
-    - derivation:
-      - 'pharaonic%3:01:00::'
-      id: 'pharaoh%1:18:00::'
-      synset: 10440761-n
-Pharaoh of Egypt:
-  n:
-    sense:
-    - id: 'pharaoh_of_egypt%1:18:00::'
-      synset: 10440761-n
 Pharaoh's chicken:
   n:
     sense:
@@ -5751,11 +5729,7 @@ Pharaoh's chicken:
 Pharaonic:
   a:
     sense:
-    - derivation:
-      - 'pharaoh%1:18:00::'
-      id: 'pharaonic%3:01:00::'
-      pertainym:
-      - 'pharaoh%1:18:00::'
+    - id: 'pharaonic%3:01:00::'
       synset: 02787620-a
 Pharisee:
   n:
@@ -7511,11 +7485,6 @@ Pietism:
       - 'pietistic%3:01:00::'
       id: 'pietism%1:14:00::'
       synset: 08492733-n
-Pigmy:
-  n:
-    sense:
-    - id: 'pigmy%1:18:00::'
-      synset: 10516074-n
 Pike's Peak:
   n:
     sense:
@@ -8734,14 +8703,6 @@ Plantago virginica:
     sense:
     - id: 'plantago_virginica%1:20:00::'
       synset: 12621028-n
-Plantation:
-  n:
-    pronunciation:
-    - value: plænˈteɪʃən
-      variety: US
-    sense:
-    - id: 'plantation%1:14:00::'
-      synset: 08391700-n
 Plantation walking horse:
   n:
     sense:
@@ -9855,14 +9816,6 @@ Poitou-Charentes:
     sense:
     - id: 'poitou-charentes%1:15:00::'
       synset: 08963997-n
-Poivrade:
-  n:
-    pronunciation:
-    - value: pwavɹɑːd
-      variety: GB
-    sense:
-    - id: 'poivrade%1:13:00::'
-      synset: 07855288-n
 Pokomo:
   n:
     sense:
@@ -11842,14 +11795,6 @@ President:
     - value: ˈpɹɛzɨdənt
     sense:
     - derivation:
-      - 'presidential%3:01:00::'
-      - 'presidentship%1:04:00::'
-      - 'presidency%1:28:00::'
-      - 'presidency%1:04:00::'
-      - 'preside%2:41:00::'
-      id: 'president%1:18:04::'
-      synset: 10486961-n
-    - derivation:
       - 'presidentship%1:04:00::'
       - 'presidency%1:28:00::'
       - 'presidency%1:04:00::'
@@ -12104,15 +12049,8 @@ President Wilson:
 President of the United States:
   n:
     sense:
-    - id: 'president_of_the_united_states%1:18:00::'
-      synset: 10486961-n
     - id: 'president_of_the_united_states%1:04:00::'
       synset: 00598380-n
-Presidential Directive:
-  n:
-    sense:
-    - id: 'presidential_directive%1:10:00::'
-      synset: 07184933-n
 Presidents' Day:
   n:
     sense:
@@ -12128,13 +12066,6 @@ Pressburg:
     sense:
     - id: 'pressburg%1:15:00::'
       synset: 08777096-n
-Pretender:
-  n:
-    sense:
-    - derivation:
-      - 'pretend%2:40:03::'
-      id: 'pretender%1:18:02::'
-      synset: 10489564-n
 Pretoria:
   n:
     sense:
@@ -12237,13 +12168,6 @@ Primaxin:
     sense:
     - id: 'primaxin%1:06:00::'
       synset: 04008894-n
-Prime Minister:
-  n:
-    pronunciation:
-    - value: ˈpraɪmɪnɪstə(r)
-    sense:
-    - id: 'prime_minister%1:18:01::'
-      synset: 09926654-n
 Prime meridian:
   n:
     sense:
@@ -14683,11 +14607,6 @@ Puritanism:
     sense:
     - id: 'puritanism%1:09:00::'
       synset: 06242789-n
-    - derivation:
-      - puritanical%5:00:00:nonindulgent:00
-      - 'puritanical%3:01:00::'
-      id: 'puritanism%1:07:00::'
-      synset: 04646948-n
 Purkinje:
   n:
     sense:
@@ -14807,13 +14726,6 @@ Pygmalion:
     sense:
     - id: 'pygmalion%1:18:00::'
       synset: 09577830-n
-Pygmy:
-  n:
-    pronunciation:
-    - value: pɪɡmiː
-    sense:
-    - id: 'pygmy%1:18:00::'
-      synset: 10516074-n
 Pygopodidae:
   n:
     sense:
@@ -23817,6 +23729,8 @@ parliamentarian:
     sense:
     - id: 'parliamentarian%1:18:00::'
       synset: 10420008-n
+    - id: 'parliamentarian%1:18:01::'
+      synset: 10420136-n
 parliamentary:
   a:
     pronunciation:
@@ -41647,11 +41561,21 @@ phantom orchid:
     sense:
     - id: 'phantom_orchid%1:20:00::'
       synset: 12081047-n
+pharaoh:
+  n:
+    sense:
+    - id: 'pharaoh%1:18:00::'
+      synset: 10440761-n
 pharaoh ant:
   n:
     sense:
     - id: 'pharaoh_ant%1:05:00::'
       synset: 02222707-n
+pharaoh of Egypt:
+  n:
+    sense:
+    - id: 'pharaoh_of_egypt%1:18:00::'
+      synset: 10440761-n
 pharaoh's ant:
   n:
     sense:
@@ -47981,6 +47905,8 @@ pigmy:
     sense:
     - id: 'pigmy%1:18:01::'
       synset: 10516211-n
+    - id: 'pigmy%1:18:02::'
+      synset: 10516074-n
 pigmy talinum:
   n:
     sense:
@@ -54431,6 +54357,8 @@ plantation:
       synset: 13273412-n
     - id: 'plantation%1:06:00::'
       synset: 03468764-n
+    - id: 'plantation%1:14:01::'
+      synset: 08391700-n
 plantation owner:
   n:
     sense:
@@ -61562,6 +61490,11 @@ poitrine d'agneau:
     sense:
     - id: 'poitrine_d''agneau%1:13:00::'
       synset: 07683225-n
+poivrade:
+  n:
+    sense:
+    - id: 'poivrade%1:13:00::'
+      synset: 07855288-n
 poke:
   n:
     pronunciation:
@@ -77959,7 +77892,6 @@ preside:
   v:
     sense:
     - derivation:
-      - 'president%1:18:04::'
       - 'president%1:18:03::'
       - 'president%1:18:02::'
       - 'president%1:18:01::'
@@ -77976,7 +77908,6 @@ presidency:
     - value: ˈpɹɛzɪdənsi
     sense:
     - derivation:
-      - 'president%1:18:04::'
       - 'president%1:04:04::'
       - 'president%1:18:03::'
       - 'president%1:18:02::'
@@ -77986,7 +77917,6 @@ presidency:
       synset: 15291076-n
     - derivation:
       - 'presidential%3:01:00::'
-      - 'president%1:18:04::'
       - 'president%1:04:04::'
       - 'president%1:18:03::'
       - 'president%1:18:02::'
@@ -78030,13 +77960,19 @@ president:
       - 'preside%2:41:00::'
       id: 'president%1:18:02::'
       synset: 10488335-n
+    - id: 'president%1:18:05::'
+      synset: 10486961-n
+president of the United States:
+  n:
+    sense:
+    - id: 'president_of_the_united_states%1:18:01::'
+      synset: 10486961-n
 presidential:
   a:
     pronunciation:
     - value: pɹɛzɪˈdɛnʃ(ə)l
     sense:
     - derivation:
-      - 'president%1:18:04::'
       - 'presidency%1:04:00::'
       - 'president%1:18:02::'
       - 'president%1:18:01::'
@@ -78049,6 +77985,11 @@ presidential:
       - 'unpresidential%3:00:00::'
       id: 'presidential%3:00:00::'
       synset: 00757025-a
+presidential directive:
+  n:
+    sense:
+    - id: 'presidential_directive%1:10:00::'
+      synset: 07184933-n
 presidential term:
   n:
     sense:
@@ -78065,7 +78006,6 @@ presidentship:
   n:
     sense:
     - derivation:
-      - 'president%1:18:04::'
       - 'president%1:04:04::'
       - 'president%1:18:03::'
       - 'president%1:18:02::'
@@ -79020,10 +78960,7 @@ pretend:
       - via
       - vtai
       synset: 01725433-v
-    - agent:
-      - 'pretender%1:18:02::'
-      derivation:
-      - 'pretender%1:18:02::'
+    - derivation:
       - 'pretension%1:10:00::'
       - 'pretense%1:07:00::'
       event:
@@ -79067,6 +79004,8 @@ pretender:
       synset: 10221154-n
     - id: 'pretender%1:18:01::'
       synset: 10215212-n
+    - id: 'pretender%1:18:02::'
+      synset: 10489564-n
 pretending:
   n:
     sense:
@@ -80892,6 +80831,8 @@ prime minister:
     sense:
     - id: 'prime_minister%1:18:00::'
       synset: 09926439-n
+    - id: 'prime_minister%1:18:01::'
+      synset: 09926654-n
 prime mover:
   n:
     sense:
@@ -97823,9 +97764,7 @@ puritanical:
     - value: pjɚ.ɪˈtæn.ɪ.kl̩
       variety: US
     sense:
-    - derivation:
-      - 'puritanism%1:07:00::'
-      id: 'puritanical%3:01:00::'
+    - id: 'puritanical%3:01:00::'
       pertainym:
       - 'puritan%1:18:00::'
       - 'puritanism%1:09:00::'
@@ -97836,7 +97775,6 @@ puritanical:
       synset: 01886245-s
     - derivation:
       - 'puritan%1:18:00::'
-      - 'puritanism%1:07:00::'
       id: puritanical%5:00:00:nonindulgent:00
       synset: 01303318-s
 puritanically:
@@ -97846,6 +97784,11 @@ puritanically:
       pertainym:
       - puritanical%5:00:00:proper:00
       synset: 00436397-r
+puritanism:
+  n:
+    sense:
+    - id: 'puritanism%1:07:01::'
+      synset: 04646948-n
 purity:
   n:
     pronunciation:
@@ -100697,6 +100640,8 @@ pygmy:
     sense:
     - id: 'pygmy%1:18:01::'
       synset: 10516211-n
+    - id: 'pygmy%1:18:02::'
+      synset: 10516074-n
 pygmy chimpanzee:
   n:
     sense:

--- a/src/yaml/entries-r.yaml
+++ b/src/yaml/entries-r.yaml
@@ -720,11 +720,6 @@ Ramses the Great:
     sense:
     - id: 'ramses_the_great%1:18:00::'
       synset: 11273238-n
-Ramsons:
-  n:
-    sense:
-    - id: 'ramsons%1:20:00::'
-      synset: 12456154-n
 Rana:
   n:
     sense:
@@ -1367,14 +1362,6 @@ Real Irish Republican Army:
     sense:
     - id: 'real_irish_republican_army%1:14:00::'
       synset: 08057514-n
-Realtor:
-  n:
-    pronunciation:
-    - value: ˈɹi(ə)l.təɹ
-      variety: US
-    sense:
-    - id: 'realtor%1:18:00::'
-      synset: 10529671-n
 Reaper:
   n:
     sense:
@@ -3853,7 +3840,7 @@ Richmondena:
     sense:
     - id: 'richmondena%1:05:00::'
       synset: 01543902-n
-Richmondena Cardinalis:
+Richmondena cardinalis:
   n:
     sense:
     - id: 'richmondena_cardinalis%1:05:00::'
@@ -5408,11 +5395,6 @@ Roman Church:
     sense:
     - id: 'roman_church%1:14:00::'
       synset: 08100476-n
-Roman Emperor:
-  n:
-    sense:
-    - id: 'roman_emperor%1:18:00::'
-      synset: 10556797-n
 Roman Empire:
   n:
     sense:
@@ -5428,11 +5410,6 @@ Roman Jakobson:
     sense:
     - id: 'roman_jakobson%1:18:00::'
       synset: 11098764-n
-Roman Legion:
-  n:
-    sense:
-    - id: 'roman_legion%1:14:00::'
-      synset: 08200838-n
 Roman Osipovich Jakobson:
   n:
     sense:
@@ -5493,6 +5470,11 @@ Roman deity:
     sense:
     - id: 'roman_deity%1:18:00::'
       synset: 09575810-n
+Roman emperor:
+  n:
+    sense:
+    - id: 'roman_emperor%1:18:00::'
+      synset: 10556797-n
 Roman hyacinth:
   n:
     sense:
@@ -5503,6 +5485,11 @@ Roman law:
     sense:
     - id: 'roman_law%1:10:00::'
       synset: 06546650-n
+Roman legion:
+  n:
+    sense:
+    - id: 'roman_legion%1:14:00::'
+      synset: 08200838-n
 Roman mile:
   n:
     sense:
@@ -12045,6 +12032,11 @@ ramshackle:
     sense:
     - id: ramshackle%5:00:00:damaged:00
       synset: 00682984-s
+ramsons:
+  n:
+    sense:
+    - id: 'ramsons%1:20:00::'
+      synset: 12456154-n
 ramus:
   n:
     form:
@@ -17729,6 +17721,11 @@ realpolitik:
     sense:
     - id: 'realpolitik%1:09:00::'
       synset: 06158489-n
+realtor:
+  n:
+    sense:
+    - id: 'realtor%1:18:00::'
+      synset: 10529671-n
 realty:
   n:
     pronunciation:
@@ -57147,6 +57144,11 @@ royal charter:
     sense:
     - id: 'royal_charter%1:10:00::'
       synset: 06488880-n
+royal colony:
+  n:
+    sense:
+    - id: 'royal_colony%1:15:00::'
+      synset: 08517107-n
 royal court:
   n:
     sense:

--- a/src/yaml/entries-s.yaml
+++ b/src/yaml/entries-s.yaml
@@ -564,7 +564,7 @@ Sabbath school:
     sense:
     - id: 'sabbath_school%1:14:00::'
       synset: 08429449-n
-Sabbatia Angularis:
+Sabbatia angularis:
   n:
     sense:
     - id: 'sabbatia_angularis%1:20:00::'
@@ -2928,11 +2928,6 @@ Sanicula:
     sense:
     - id: 'sanicula%1:20:00::'
       synset: 12964062-n
-Sanicula Europaea:
-  n:
-    sense:
-    - id: 'sanicula_europaea%1:20:00::'
-      synset: 12964855-n
 Sanicula arctopoides:
   n:
     sense:
@@ -2943,6 +2938,11 @@ Sanicula bipinnatifida:
     sense:
     - id: 'sanicula_bipinnatifida%1:20:00::'
       synset: 12964672-n
+Sanicula europaea:
+  n:
+    sense:
+    - id: 'sanicula_europaea%1:20:00::'
+      synset: 12964855-n
 Sansevieria guineensis:
   n:
     sense:
@@ -5005,11 +5005,6 @@ Schoolcraft:
     sense:
     - id: 'schoolcraft%1:18:00::'
       synset: 11306107-n
-Schoolman:
-  n:
-    sense:
-    - id: 'schoolman%1:18:01::'
-      synset: 10579111-n
 Schopenhauer:
   n:
     sense:
@@ -5809,7 +5804,7 @@ Scott Joplin:
     sense:
     - id: 'scott_joplin%1:18:00::'
       synset: 11111364-n
-Scott's Spleenwort:
+Scott's spleenwort:
   n:
     sense:
     - id: 'scott''s_spleenwort%1:20:00::'
@@ -6435,51 +6430,11 @@ Secretariat:
     sense:
     - id: 'secretariat%1:05:00::'
       synset: 02387080-n
-Secretary General:
-  n:
-    sense:
-    - id: 'secretary_general%1:18:00::'
-      synset: 10593273-n
-Secretary of Agriculture:
-  n:
-    sense:
-    - id: 'secretary_of_agriculture%1:18:00::'
-      synset: 10590148-n
-    - id: 'secretary_of_agriculture%1:04:00::'
-      synset: 00601315-n
-Secretary of Commerce:
-  n:
-    sense:
-    - id: 'secretary_of_commerce%1:18:00::'
-      synset: 10590405-n
-    - id: 'secretary_of_commerce%1:04:00::'
-      synset: 00601550-n
 Secretary of Commerce and Labor:
   n:
     sense:
     - id: 'secretary_of_commerce_and_labor%1:04:00::'
       synset: 00604627-n
-Secretary of Defense:
-  n:
-    sense:
-    - id: 'secretary_of_defense%1:18:00::'
-      synset: 10590646-n
-    - id: 'secretary_of_defense%1:04:00::'
-      synset: 00601770-n
-Secretary of Education:
-  n:
-    sense:
-    - id: 'secretary_of_education%1:18:00::'
-      synset: 10590879-n
-    - id: 'secretary_of_education%1:04:00::'
-      synset: 00601986-n
-Secretary of Energy:
-  n:
-    sense:
-    - id: 'secretary_of_energy%1:18:00::'
-      synset: 10591114-n
-    - id: 'secretary_of_energy%1:04:00::'
-      synset: 00602203-n
 Secretary of Health Education and Welfare:
   n:
     sense:
@@ -6499,13 +6454,6 @@ Secretary of Housing and Urban Development:
       synset: 10591629-n
     - id: 'secretary_of_housing_and_urban_development%1:04:00::'
       synset: 00602672-n
-Secretary of Labor:
-  n:
-    sense:
-    - id: 'secretary_of_labor%1:18:00::'
-      synset: 10591913-n
-    - id: 'secretary_of_labor%1:04:00::'
-      synset: 00602937-n
 Secretary of State:
   n:
     sense:
@@ -6513,18 +6461,6 @@ Secretary of State:
       synset: 10592150-n
     - id: 'secretary_of_state%1:04:00::'
       synset: 00603141-n
-Secretary of State for the Home Department:
-  n:
-    sense:
-    - id: 'secretary_of_state_for_the_home_department%1:18:00::'
-      synset: 10202259-n
-Secretary of Transportation:
-  n:
-    sense:
-    - id: 'secretary_of_transportation%1:18:00::'
-      synset: 10592793-n
-    - id: 'secretary_of_transportation%1:04:00::'
-      synset: 00603784-n
 Secretary of Veterans Affairs:
   n:
     sense:
@@ -6532,30 +6468,6 @@ Secretary of Veterans Affairs:
       synset: 10593040-n
     - id: 'secretary_of_veterans_affairs%1:04:00::'
       synset: 00604024-n
-Secretary of War:
-  n:
-    sense:
-    - id: 'secretary_of_war%1:04:00::'
-      synset: 00604246-n
-Secretary of the Interior:
-  n:
-    sense:
-    - id: 'secretary_of_the_interior%1:04:00::'
-      synset: 00603335-n
-    - id: 'secretary_of_the_interior%1:18:00::'
-      synset: 10592333-n
-Secretary of the Navy:
-  n:
-    sense:
-    - id: 'secretary_of_the_navy%1:04:00::'
-      synset: 00604434-n
-Secretary of the Treasury:
-  n:
-    sense:
-    - id: 'secretary_of_the_treasury%1:18:00::'
-      synset: 10592573-n
-    - id: 'secretary_of_the_treasury%1:04:00::'
-      synset: 00603563-n
 Section Eight:
   n:
     sense:
@@ -7373,11 +7285,6 @@ Sequoia National Park:
     sense:
     - id: 'sequoia_national_park%1:15:00::'
       synset: 08626543-n
-Sequoia Wellingtonia:
-  n:
-    sense:
-    - id: 'sequoia_wellingtonia%1:20:00::'
-      synset: 11661945-n
 Sequoia gigantea:
   n:
     sense:
@@ -7388,6 +7295,11 @@ Sequoia sempervirens:
     sense:
     - id: 'sequoia_sempervirens%1:20:00::'
       synset: 11661485-n
+Sequoia wellingtonia:
+  n:
+    sense:
+    - id: 'sequoia_wellingtonia%1:20:00::'
+      synset: 11661945-n
 Sequoiadendron:
   n:
     sense:
@@ -8061,11 +7973,6 @@ Shabuoth:
     sense:
     - id: 'shabuoth%1:28:00::'
       synset: 15221877-n
-Shah:
-  n:
-    sense:
-    - id: 'shah%1:18:00::'
-      synset: 10604948-n
 Shah Jahan:
   n:
     sense:
@@ -8076,11 +7983,6 @@ Shah Pahlavi:
     sense:
     - id: 'shah_pahlavi%1:18:00::'
       synset: 11240451-n
-Shah of Iran:
-  n:
-    sense:
-    - id: 'shah_of_iran%1:18:00::'
-      synset: 10604948-n
 Shahaptian:
   n:
     sense:
@@ -13174,7 +13076,7 @@ South Sea:
     sense:
     - id: 'south_sea%1:17:00::'
       synset: 09464779-n
-South Sea Islands:
+South Sea islands:
   n:
     sense:
     - id: 'south_sea_islands%1:17:00::'
@@ -13779,18 +13681,6 @@ Spatula querquedula:
     sense:
     - id: 'spatula_querquedula%1:05:00::'
       synset: 01851196-n
-Speaker:
-  n:
-    pronunciation:
-    - value: ˈspikɚ
-      variety: US
-    - value: ˈspiːkə
-      variety: GB
-    sense:
-    - derivation:
-      - 'speakership%1:04:00::'
-      id: 'speaker%1:18:01::'
-      synset: 10650671-n
 Special Air Service:
   n:
     sense:
@@ -15475,11 +15365,6 @@ State of the Vatican City:
     sense:
     - id: 'state_of_the_vatican_city%1:15:00::'
       synset: 09183883-n
-Statehouse:
-  n:
-    sense:
-    - id: 'statehouse%1:06:00::'
-      synset: 04312348-n
 Staten Island:
   n:
     sense:
@@ -17500,13 +17385,6 @@ Sur:
     sense:
     - id: 'sur%1:15:00::'
       synset: 08978107-n
-Surgeon General:
-  n:
-    sense:
-    - id: 'surgeon_general%1:18:01::'
-      synset: 10699057-n
-    - id: 'surgeon_general%1:18:00::'
-      synset: 10698950-n
 Suricata:
   n:
     sense:
@@ -30838,6 +30716,8 @@ schoolman:
     sense:
     - id: 'schoolman%1:18:00::'
       synset: 86121051-n
+    - id: 'schoolman%1:18:01::'
+      synset: 10579111-n
 schoolmarm:
   n:
     pronunciation:
@@ -38757,11 +38637,97 @@ secretary bird:
     sense:
     - id: 'secretary_bird%1:05:00::'
       synset: 01621144-n
+secretary general:
+  n:
+    sense:
+    - id: 'secretary_general%1:18:00::'
+      synset: 10593273-n
+secretary of agriculture:
+  n:
+    sense:
+    - id: 'secretary_of_agriculture%1:18:01::'
+      synset: 10590148-n
+    - id: 'secretary_of_agriculture%1:04:02::'
+      synset: 00601315-n
+secretary of commerce:
+  n:
+    sense:
+    - id: 'secretary_of_commerce%1:18:01::'
+      synset: 10590405-n
+    - id: 'secretary_of_commerce%1:04:02::'
+      synset: 00601550-n
+secretary of defense:
+  n:
+    sense:
+    - id: 'secretary_of_defense%1:18:01::'
+      synset: 10590646-n
+    - id: 'secretary_of_defense%1:04:02::'
+      synset: 00601770-n
+secretary of education:
+  n:
+    sense:
+    - id: 'secretary_of_education%1:18:01::'
+      synset: 10590879-n
+    - id: 'secretary_of_education%1:04:02::'
+      synset: 00601986-n
+secretary of energy:
+  n:
+    sense:
+    - id: 'secretary_of_energy%1:18:01::'
+      synset: 10591114-n
+    - id: 'secretary_of_energy%1:04:02::'
+      synset: 00602203-n
+secretary of labor:
+  n:
+    sense:
+    - id: 'secretary_of_labor%1:18:01::'
+      synset: 10591913-n
+    - id: 'secretary_of_labor%1:04:02::'
+      synset: 00602937-n
 secretary of state:
   n:
     sense:
     - id: 'secretary_of_state%1:18:00::'
       synset: 10123563-n
+secretary of state for the Home Department:
+  n:
+    sense:
+    - id: 'secretary_of_state_for_the_home_department%1:18:00::'
+      synset: 10202259-n
+secretary of the Navy:
+  n:
+    sense:
+    - id: 'secretary_of_the_navy%1:04:00::'
+      synset: 00604434-n
+secretary of the Treasury:
+  n:
+    sense:
+    - id: 'secretary_of_the_treasury%1:04:02::'
+      synset: 00603563-n
+secretary of the interior:
+  n:
+    sense:
+    - id: 'secretary_of_the_interior%1:18:01::'
+      synset: 10592333-n
+    - id: 'secretary_of_the_interior%1:04:02::'
+      synset: 00603335-n
+secretary of the treasury:
+  n:
+    sense:
+    - id: 'secretary_of_the_treasury%1:18:01::'
+      synset: 10592573-n
+secretary of transportation:
+  n:
+    sense:
+    - id: 'secretary_of_transportation%1:18:01::'
+      synset: 10592793-n
+    - id: 'secretary_of_transportation%1:04:02::'
+      synset: 00603784-n
+secretary of war:
+  n:
+    sense:
+    - id: 'secretary_of_war%1:04:00::'
+      synset: 00604246-n
 secretaryship:
   n:
     sense:
@@ -51770,6 +51736,16 @@ shaggymane mushroom:
     sense:
     - id: 'shaggymane_mushroom%1:20:00::'
       synset: 13026931-n
+shah:
+  n:
+    sense:
+    - id: 'shah%1:18:00::'
+      synset: 10604948-n
+shah of Iran:
+  n:
+    sense:
+    - id: 'shah_of_iran%1:18:00::'
+      synset: 10604948-n
 shahadah:
   n:
     sense:
@@ -93403,6 +93379,8 @@ speaker:
       synset: 10649550-n
     - id: 'speaker%1:06:00::'
       synset: 03696785-n
+    - id: 'speaker%1:18:01::'
+      synset: 10650671-n
 speaker identification:
   n:
     sense:
@@ -93431,9 +93409,7 @@ speakerphone:
 speakership:
   n:
     sense:
-    - derivation:
-      - 'speaker%1:18:01::'
-      id: 'speakership%1:04:00::'
+    - id: 'speakership%1:04:00::'
       synset: 00605539-n
 speaking:
   a:
@@ -110722,6 +110698,11 @@ stated:
     sense:
     - id: stated%5:00:00:explicit:00
       synset: 00944139-s
+statehouse:
+  n:
+    sense:
+    - id: 'statehouse%1:06:00::'
+      synset: 04312348-n
 stateless:
   a:
     sense:
@@ -139033,6 +139014,18 @@ surgeon:
     sense:
     - id: 'surgeon%1:18:00::'
       synset: 10698621-n
+surgeon general:
+  n:
+    sense:
+    - id: 'surgeon_general%1:18:01::'
+      synset: 10699057-n
+    - id: 'surgeon_general%1:18:02::'
+      synset: 10698950-n
+surgeon general of the United States:
+  n:
+    sense:
+    - id: 'surgeon_general_of_the_united_states%1:18:00::'
+      synset: 10699057-n
 surgeon's knot:
   n:
     sense:

--- a/src/yaml/entries-t.yaml
+++ b/src/yaml/entries-t.yaml
@@ -2405,14 +2405,6 @@ Teleostei:
     sense:
     - id: 'teleostei%1:05:00::'
       synset: 02530444-n
-Teleprompter:
-  n:
-    pronunciation:
-    - value: ˈtɛləˌpɹɑmptəɹ
-      variety: US
-    sense:
-    - id: 'teleprompter%1:06:00::'
-      synset: 04410659-n
 Telescopium:
   n:
     sense:
@@ -2458,7 +2450,7 @@ Telopea:
     sense:
     - id: 'telopea%1:20:00::'
       synset: 12243922-n
-Telopea Oreades:
+Telopea oreades:
   n:
     sense:
     - id: 'telopea_oreades%1:20:00::'
@@ -6207,7 +6199,7 @@ Townsendia:
     sense:
     - id: 'townsendia%1:20:00::'
       synset: 12046775-n
-Townsendia Exscapa:
+Townsendia exscapa:
   n:
     sense:
     - id: 'townsendia_exscapa%1:20:00::'
@@ -6457,7 +6449,7 @@ Tragulus:
     sense:
     - id: 'tragulus%1:05:00::'
       synset: 02438698-n
-Tragulus Javanicus:
+Tragulus javanicus:
   n:
     sense:
     - id: 'tragulus_javanicus%1:05:00::'
@@ -6528,13 +6520,6 @@ Transportation:
     sense:
     - id: 'transportation%1:14:00::'
       synset: 08160653-n
-Transportation Secretary:
-  n:
-    sense:
-    - id: 'transportation_secretary%1:18:00::'
-      synset: 10592793-n
-    - id: 'transportation_secretary%1:04:00::'
-      synset: 00603784-n
 Transportation Security Administration:
   n:
     sense:
@@ -6639,8 +6624,6 @@ Treasury:
     sense:
     - id: 'treasury%1:21:01::'
       synset: 13415499-n
-    - id: 'treasury%1:18:00::'
-      synset: 10747110-n
     - id: 'treasury%1:14:01::'
       synset: 08156795-n
 Treasury Department:
@@ -6648,13 +6631,6 @@ Treasury Department:
     sense:
     - id: 'treasury_department%1:14:00::'
       synset: 08156795-n
-Treasury Secretary:
-  n:
-    sense:
-    - id: 'treasury_secretary%1:18:00::'
-      synset: 10592573-n
-    - id: 'treasury_secretary%1:04:00::'
-      synset: 00603563-n
 Treasury bill:
   n:
     sense:
@@ -6675,6 +6651,11 @@ Treasury obligations:
     sense:
     - id: 'treasury_obligations%1:21:00::'
       synset: 13415499-n
+Treasury secretary:
+  n:
+    sense:
+    - id: 'treasury_secretary%1:04:02::'
+      synset: 00603563-n
 Treaty of Versailles:
   n:
     sense:
@@ -20292,6 +20273,11 @@ teleprocessing:
     sense:
     - id: 'teleprocessing%1:22:00::'
       synset: 13489745-n
+teleprompter:
+  n:
+    sense:
+    - id: 'teleprompter%1:06:00::'
+      synset: 04410659-n
 telerobotics:
   n:
     sense:
@@ -49780,6 +49766,13 @@ transportation company:
     sense:
     - id: 'transportation_company%1:14:00::'
       synset: 08020531-n
+transportation secretary:
+  n:
+    sense:
+    - id: 'transportation_secretary%1:18:01::'
+      synset: 10592793-n
+    - id: 'transportation_secretary%1:04:02::'
+      synset: 00603784-n
 transportation system:
   n:
     sense:
@@ -51512,6 +51505,11 @@ treasury agent:
     sense:
     - id: 'treasury_agent%1:18:00::'
       synset: 10732903-n
+treasury secretary:
+  n:
+    sense:
+    - id: 'treasury_secretary%1:18:01::'
+      synset: 10592573-n
 treasury shares:
   n:
     sense:

--- a/src/yaml/entries-u.yaml
+++ b/src/yaml/entries-u.yaml
@@ -226,11 +226,6 @@ US Army Criminal Investigation Laboratory:
     sense:
     - id: 'us_army_criminal_investigation_laboratory%1:06:00::'
       synset: 04517385-n
-US Attorney General:
-  n:
-    sense:
-    - id: 'us_attorney_general%1:18:00::'
-      synset: 10589873-n
 US Border Patrol:
   n:
     sense:
@@ -351,6 +346,11 @@ US Trade Representative:
     sense:
     - id: 'us_trade_representative%1:14:00::'
       synset: 08145627-n
+US attorney general:
+  n:
+    sense:
+    - id: 'us_attorney_general%1:18:00::'
+      synset: 10589873-n
 US spelling:
   n:
     sense:
@@ -1328,11 +1328,6 @@ United States Army Special Forces:
     sense:
     - id: 'united_states_army_special_forces%1:14:00::'
       synset: 08230345-n
-United States Attorney General:
-  n:
-    sense:
-    - id: 'united_states_attorney_general%1:18:00::'
-      synset: 10589873-n
 United States Border Patrol:
   n:
     sense:
@@ -1478,11 +1473,6 @@ United States Postal Service:
     sense:
     - id: 'united_states_postal_service%1:14:00::'
       synset: 08144286-n
-United States President:
-  n:
-    sense:
-    - id: 'united_states_president%1:18:00::'
-      synset: 10486961-n
 United States Public Health Service:
   n:
     sense:
@@ -1518,6 +1508,11 @@ United States Virgin Islands:
     sense:
     - id: 'united_states_virgin_islands%1:15:00::'
       synset: 08772836-n
+United States attorney general:
+  n:
+    sense:
+    - id: 'united_states_attorney_general%1:18:00::'
+      synset: 10589873-n
 United States dollar:
   n:
     sense:
@@ -1548,6 +1543,11 @@ United States of America:
     sense:
     - id: 'united_states_of_america%1:15:00::'
       synset: 09067337-n
+United States president:
+  n:
+    sense:
+    - id: 'united_states_president%1:18:00::'
+      synset: 10486961-n
 United States waters:
   n:
     sense:
@@ -2058,11 +2058,6 @@ Ursus:
     sense:
     - id: 'ursus%1:05:00::'
       synset: 02134594-n
-Ursus Maritimus:
-  n:
-    sense:
-    - id: 'ursus_maritimus%1:05:00::'
-      synset: 02136736-n
 Ursus americanus:
   n:
     sense:
@@ -2093,6 +2088,11 @@ Ursus horribilis:
     sense:
     - id: 'ursus_horribilis%1:05:00::'
       synset: 02135232-n
+Ursus maritimus:
+  n:
+    sense:
+    - id: 'ursus_maritimus%1:05:00::'
+      synset: 02136736-n
 Ursus middendorffi:
   n:
     sense:
@@ -27091,6 +27091,10 @@ utopian:
       - 'utopia%1:26:00::'
       id: 'utopian%3:00:00::'
       synset: 02507751-a
+  n:
+    sense:
+    - id: 'utopian%1:18:02::'
+      synset: 10763013-n
 utopian socialism:
   n:
     sense:

--- a/src/yaml/entries-w.yaml
+++ b/src/yaml/entries-w.yaml
@@ -744,11 +744,6 @@ War Department:
     sense:
     - id: 'war_department%1:14:00::'
       synset: 08162100-n
-War Secretary:
-  n:
-    sense:
-    - id: 'war_secretary%1:04:00::'
-      synset: 00604246-n
 War between the States:
   n:
     sense:
@@ -7533,6 +7528,11 @@ war room:
     sense:
     - id: 'war_room%1:06:00::'
       synset: 04559837-n
+war secretary:
+  n:
+    sense:
+    - id: 'war_secretary%1:04:00::'
+      synset: 00604246-n
 war vessel:
   n:
     sense:

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -32093,8 +32093,8 @@
   - 00600587-n
   ili: i38571
   members:
-  - Attorney General
-  - Attorney General of the United States
+  - attorney general
+  - attorney general of the United States
   partOfSpeech: n
 00601315-n:
   definition:
@@ -32105,8 +32105,8 @@
   - 00600587-n
   ili: i38572
   members:
-  - Secretary of Agriculture
-  - Agriculture Secretary
+  - secretary of agriculture
+  - agriculture secretary
   partOfSpeech: n
 00601550-n:
   definition:
@@ -32117,8 +32117,8 @@
   - 00600587-n
   ili: i38573
   members:
-  - Secretary of Commerce
-  - Commerce Secretary
+  - secretary of commerce
+  - commerce secretary
   partOfSpeech: n
 00601770-n:
   definition:
@@ -32129,8 +32129,8 @@
   - 00600587-n
   ili: i38574
   members:
-  - Secretary of Defense
-  - Defense Secretary
+  - secretary of defense
+  - defense secretary
   partOfSpeech: n
 00601986-n:
   definition:
@@ -32141,8 +32141,8 @@
   - 00600587-n
   ili: i38575
   members:
-  - Secretary of Education
-  - Education Secretary
+  - secretary of education
+  - education secretary
   partOfSpeech: n
 00602203-n:
   definition:
@@ -32153,8 +32153,8 @@
   - 00600587-n
   ili: i38576
   members:
-  - Secretary of Energy
-  - Energy Secretary
+  - secretary of energy
+  - energy secretary
   partOfSpeech: n
 00602411-n:
   definition:
@@ -32188,8 +32188,8 @@
   - 00600587-n
   ili: i38579
   members:
-  - Secretary of Labor
-  - Labor Secretary
+  - secretary of labor
+  - labor secretary
   partOfSpeech: n
 00603141-n:
   definition:
@@ -32211,8 +32211,8 @@
   - 00600587-n
   ili: i38581
   members:
-  - Secretary of the Interior
-  - Interior Secretary
+  - secretary of the interior
+  - interior secretary
   partOfSpeech: n
 00603563-n:
   definition:
@@ -32223,8 +32223,8 @@
   - 00600587-n
   ili: i38582
   members:
-  - Secretary of the Treasury
-  - Treasury Secretary
+  - secretary of the Treasury
+  - Treasury secretary
   partOfSpeech: n
 00603784-n:
   definition:
@@ -32235,8 +32235,8 @@
   - 00600587-n
   ili: i38583
   members:
-  - Secretary of Transportation
-  - Transportation Secretary
+  - secretary of transportation
+  - transportation secretary
   partOfSpeech: n
 00604024-n:
   definition:
@@ -32257,8 +32257,8 @@
   - 00600587-n
   ili: i38585
   members:
-  - Secretary of War
-  - War Secretary
+  - secretary of war
+  - war secretary
   partOfSpeech: n
 00604434-n:
   definition:
@@ -32268,8 +32268,8 @@
   - 00600587-n
   ili: i38586
   members:
-  - Secretary of the Navy
-  - Navy Secretary
+  - secretary of the Navy
+  - Navy secretary
   partOfSpeech: n
 00604627-n:
   definition:
@@ -52032,7 +52032,7 @@
   - 00955670-n
   ili: i40425
   members:
-  - Armageddon
+  - armageddon
   partOfSpeech: n
 00958596-n:
   definition:
@@ -56866,7 +56866,7 @@
   ili: i40878
   members:
   - bibliolatry
-  - Bible-worship
+  - Bible worship
   partOfSpeech: n
 01046907-n:
   definition:
@@ -72948,7 +72948,7 @@
   hypernym:
   - 00860679-n
   members:
-  - Autonomous Sensory Meridian Response
+  - autonomous sensory meridian response
   - ASMR
   partOfSpeech: n
   source: Colloquial WordNet

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -11248,7 +11248,8 @@
   - 01505702-n
   ili: i43226
   members:
-  - Ibero-mesornis
+  - ibero-mesornis
+  - iberomesornis
   partOfSpeech: n
 01519906-n:
   definition:
@@ -12819,7 +12820,7 @@
   members:
   - cardinal
   - cardinal grosbeak
-  - Richmondena Cardinalis
+  - Richmondena cardinalis
   - Cardinalis cardinalis
   - redbird
   partOfSpeech: n
@@ -13792,7 +13793,7 @@
   members:
   - scissortail
   - scissortailed flycatcher
-  - Muscivora-forficata
+  - Muscivora forficata
   partOfSpeech: n
 01558227-n:
   definition:
@@ -17549,7 +17550,7 @@
   ili: i43766
   members:
   - marsh harrier
-  - Circus Aeruginosus
+  - Circus aeruginosus
   partOfSpeech: n
 01612741-n:
   definition:
@@ -40069,7 +40070,7 @@
   members:
   - paper nautilus
   - nautilus
-  - Argonaut
+  - argonaut
   - Argonauta argo
   partOfSpeech: n
 01973507-n:
@@ -43760,7 +43761,7 @@
   ili: i46017
   members:
   - black turnstone
-  - Arenaria-Melanocephala
+  - Arenaria melanocephala
   partOfSpeech: n
 02028184-n:
   definition:
@@ -44008,7 +44009,7 @@
   ili: i46037
   members:
   - curlew sandpiper
-  - Calidris Ferruginea
+  - Calidris ferruginea
   partOfSpeech: n
   wikidata: Q62345
 02031897-n:
@@ -47368,7 +47369,7 @@
   ili: i46326
   members:
   - South American sea lion
-  - Otaria Byronia
+  - Otaria byronia
   partOfSpeech: n
 02081088-n:
   definition:
@@ -48239,7 +48240,7 @@
   ili: i46406
   members:
   - Ibizan hound
-  - Ibizan Podenco
+  - Ibizan podenco
   partOfSpeech: n
   wikidata: Q37755
 02094119-n:
@@ -51056,7 +51057,7 @@
   members:
   - ice bear
   - polar bear
-  - Ursus Maritimus
+  - Ursus maritimus
   - Thalarctos maritimus
   partOfSpeech: n
 02136892-n:
@@ -55371,7 +55372,7 @@
   - sheep ked
   - sheep-tick
   - sheep tick
-  - Melophagus Ovinus
+  - Melophagus ovinus
   partOfSpeech: n
 02202004-n:
   definition:
@@ -68312,7 +68313,7 @@
   members:
   - common zebra
   - Burchell's zebra
-  - Equus Burchelli
+  - Equus burchelli
   partOfSpeech: n
 02394025-n:
   definition:
@@ -68688,7 +68689,7 @@
   - babirusa
   - babiroussa
   - babirussa
-  - Babyrousa Babyrussa
+  - Babyrousa babyrussa
   partOfSpeech: n
 02399622-n:
   definition:
@@ -71114,7 +71115,7 @@
   - whitetail
   - white-tailed deer
   - whitetail deer
-  - Odocoileus Virginianus
+  - Odocoileus virginianus
   partOfSpeech: n
 02435157-n:
   definition:
@@ -71407,7 +71408,7 @@
   ili: i48446
   members:
   - napu
-  - Tragulus Javanicus
+  - Tragulus javanicus
   partOfSpeech: n
 02439145-n:
   definition:
@@ -76820,7 +76821,7 @@
   - horned pout
   - hornpout
   - pout
-  - Ameiurus Melas
+  - Ameiurus melas
   partOfSpeech: n
 02522103-n:
   definition:
@@ -78828,7 +78829,7 @@
   - monkfish
   - lotte
   - allmouth
-  - Lophius Americanus
+  - Lophius americanus
   mero_part:
   - 07795723-n
   partOfSpeech: n

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -37214,7 +37214,7 @@
   - 03099154-n
   ili: i53252
   members:
-  - Dumpster
+  - dumpster
   partOfSpeech: n
   wikidata: Q8703132
 03260869-n:
@@ -59085,7 +59085,7 @@
   - 03496279-n
   ili: i55325
   members:
-  - Kakemono
+  - kakemono
   partOfSpeech: n
 03612740-n:
   definition:
@@ -67637,7 +67637,7 @@
   - 02951254-n
   ili: i56142
   members:
-  - Menorah
+  - menorah
   partOfSpeech: n
 03751821-n:
   definition:
@@ -102836,7 +102836,7 @@
   - 03454508-n
   ili: i59494
   members:
-  - Statehouse
+  - statehouse
   partOfSpeech: n
 04312461-n:
   definition:
@@ -108985,7 +108985,7 @@
   - 04017155-n
   ili: i60079
   members:
-  - Teleprompter
+  - teleprompter
   partOfSpeech: n
 04410773-n:
   definition:
@@ -122853,7 +122853,7 @@
   hypernym:
   - 03309675-n
   members:
-  - Ammonium Nitrate/Fuel Oil
+  - ammonium nitrate/fuel oil
   - ANFO
   partOfSpeech: n
   source: Colloquial WordNet
@@ -125000,7 +125000,7 @@
   hypernym:
   - 92450755-n
   members:
-  - Goat Eye
+  - goat eye
   partOfSpeech: n
   source: plWordNet 4.0
 92450760-n:

--- a/src/yaml/noun.attribute.yaml
+++ b/src/yaml/noun.attribute.yaml
@@ -1306,7 +1306,7 @@
   - 04646728-n
   ili: i61455
   members:
-  - Puritanism
+  - puritanism
   partOfSpeech: n
 04647089-n:
   definition:

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -29986,7 +29986,7 @@
   - 06206319-n
   ili: i69103
   members:
-  - Call
+  - call
   partOfSpeech: n
 06208443-n:
   definition:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -10704,7 +10704,7 @@
   - 06406508-n
   ili: i70340
   members:
-  - Epistle
+  - epistle
   partOfSpeech: n
 06454833-n:
   definition:
@@ -32036,7 +32036,7 @@
   - 06816494-n
   ili: i72244
   members:
-  - Mayday
+  - mayday
   partOfSpeech: n
 06816955-n:
   definition:
@@ -54403,7 +54403,8 @@
   - 07184731-n
   ili: i74334
   members:
-  - Presidential Directive
+  - presidential directive
+  - executive action
   partOfSpeech: n
 07185118-n:
   definition:

--- a/src/yaml/noun.food.yaml
+++ b/src/yaml/noun.food.yaml
@@ -18802,7 +18802,7 @@
   ili: i78350
   members:
   - pepper sauce
-  - Poivrade
+  - poivrade
   partOfSpeech: n
 07855454-n:
   definition:

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -13505,7 +13505,7 @@
   - 08200720-n
   ili: i80151
   members:
-  - Roman Legion
+  - Roman legion
   partOfSpeech: n
 08200970-n:
   definition:
@@ -14060,7 +14060,7 @@
   - 08215077-n
   ili: i80199
   members:
-  - Marines
+  - marines
   partOfSpeech: n
 08209900-n:
   definition:
@@ -19303,7 +19303,7 @@
   - secondary school
   - lyceum
   - lycee
-  - Gymnasium
+  - gymnasium
   - middle school
   partOfSpeech: n
 08301768-n:
@@ -21746,7 +21746,7 @@
   - 08180691-n
   ili: i80902
   members:
-  - Bench
+  - bench
   partOfSpeech: n
 08345803-n:
   definition:
@@ -24223,7 +24223,7 @@
   - 08390976-n
   ili: i81117
   members:
-  - Plantation
+  - plantation
   partOfSpeech: n
 08391958-n:
   definition:

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -626,7 +626,8 @@
   - 08516868-n
   ili: i81722
   members:
-  - Crown Colony
+  - Crown colony
+  - royal colony
   partOfSpeech: n
 08517241-n:
   definition:
@@ -3532,8 +3533,8 @@
   - 00027365-n
   ili: i81981
   members:
-  - Earth
   - earth
+  - Earth
   partOfSpeech: n
 08579780-n:
   definition:
@@ -4219,7 +4220,7 @@
   - 08559644-n
   ili: i82039
   members:
-  - Frigid Zone
+  - frigid zone
   - polar zone
   - polar region
   partOfSpeech: n
@@ -13585,7 +13586,7 @@
   - 09339360-n
   ili: i82855
   members:
-  - Caribbean Island
+  - Caribbean island
   partOfSpeech: n
 08764887-n:
   definition:
@@ -29195,8 +29196,8 @@
   - 08591861-n
   ili: i84029
   members:
-  - Baltic State
-  - Baltic Republic
+  - Baltic state
+  - Baltic republic
   partOfSpeech: n
 09034667-n:
   definition:
@@ -31376,7 +31377,8 @@
   - 08591861-n
   ili: i84185
   members:
-  - Colony
+  - colony
+  - British colony in the Americas
   partOfSpeech: n
 09071336-n:
   definition:
@@ -40223,7 +40225,7 @@
   hypernym:
   - 08508836-n
   members:
-  - Governorate-General
+  - governorate-general
   partOfSpeech: n
   source: plWordNet 4.0
 92408452-n:

--- a/src/yaml/noun.object.yaml
+++ b/src/yaml/noun.object.yaml
@@ -14916,7 +14916,7 @@
   - 09339360-n
   ili: i86226
   members:
-  - South Sea Islands
+  - South Sea islands
   partOfSpeech: n
 09465050-n:
   definition:

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -25655,7 +25655,7 @@
   - 10184340-n
   ili: i88906
   members:
-  - Prime Minister
+  - prime minister
   - PM
   - premier
   partOfSpeech: n
@@ -25666,8 +25666,8 @@
   - 09905462-n
   ili: i88907
   members:
-  - Chancellor of the Exchequer
-  - Chancellor
+  - chancellor of the exchequer
+  - chancellor
   partOfSpeech: n
   wikidata: Q531471
 09927024-n:
@@ -26188,7 +26188,7 @@
   - 09912467-n
   ili: i88957
   members:
-  - Chief Constable
+  - chief constable
   partOfSpeech: n
 09935806-n:
   definition:
@@ -26253,7 +26253,8 @@
   - 09905462-n
   ili: i88963
   members:
-  - Chief Secretary
+  - chief secretary
+  - chief secretary to the Treasury
   partOfSpeech: n
 09937051-n:
   definition:
@@ -28063,7 +28064,7 @@
   - 10392072-n
   ili: i89136
   members:
-  - Comptroller General
+  - comptroller general
   partOfSpeech: n
 09969797-n:
   definition:
@@ -33735,7 +33736,7 @@
   - 10432655-n
   ili: i89672
   members:
-  - Earl Marshal
+  - earl marshal
   partOfSpeech: n
   wikidata: Q1265164
 10061492-n:
@@ -34807,7 +34808,7 @@
   - 10080429-n
   ili: i89777
   members:
-  - Green
+  - green
   partOfSpeech: n
 10080851-n:
   definition:
@@ -42840,8 +42841,8 @@
   - 09905462-n
   ili: i90550
   members:
-  - Home Secretary
-  - Secretary of State for the Home Department
+  - home secretary
+  - secretary of state for the Home Department
   partOfSpeech: n
 10202443-n:
   definition:
@@ -46499,7 +46500,7 @@
   - 10103592-n
   ili: i90898
   members:
-  - Lady
+  - lady
   - noblewoman
   - peeress
   partOfSpeech: n
@@ -48398,7 +48399,7 @@
   - 10306910-n
   ili: i91084
   members:
-  - Lord
+  - lord
   - noble
   - nobleman
   partOfSpeech: n
@@ -48412,8 +48413,8 @@
   - 09905462-n
   ili: i91085
   members:
-  - Lord Chancellor
-  - Lord High Chancellor
+  - lord chancellor
+  - lord high chancellor
   partOfSpeech: n
 10292072-n:
   definition:
@@ -49878,7 +49879,7 @@
   - 10602198-n
   ili: i91223
   members:
-  - Marine
+  - marine
   - devil dog
   - leatherneck
   - shipboard soldier
@@ -56448,8 +56449,8 @@
   - 10273692-n
   ili: i91864
   members:
-  - Parliamentarian
-  - Member of Parliament
+  - parliamentarian
+  - member of parliament
   partOfSpeech: n
 10420317-n:
   definition:
@@ -57705,8 +57706,8 @@
   - 10560786-n
   ili: i91983
   members:
-  - Pharaoh
-  - Pharaoh of Egypt
+  - pharaoh
+  - pharaoh of Egypt
   partOfSpeech: n
 10440928-n:
   definition:
@@ -60130,10 +60131,10 @@
   - 10184340-n
   ili: i92216
   members:
-  - President of the United States
-  - United States President
-  - President
-  - Chief Executive
+  - president of the United States
+  - United States president
+  - president
+  - chief executive
   partOfSpeech: n
 10488144-n:
   definition:
@@ -60219,7 +60220,7 @@
   - 09945050-n
   ili: i92225
   members:
-  - Pretender
+  - pretender
   partOfSpeech: n
 10489717-n:
   definition:
@@ -60397,7 +60398,7 @@
   - 10492384-n
   ili: i92241
   members:
-  - Elector
+  - elector
   partOfSpeech: n
 10493038-n:
   definition:
@@ -61765,8 +61766,8 @@
   - 10633021-n
   ili: i92371
   members:
-  - Pygmy
-  - Pigmy
+  - pygmy
+  - pigmy
   partOfSpeech: n
 10516211-n:
   definition:
@@ -62702,7 +62703,7 @@
   - 10529403-n
   ili: i92463
   members:
-  - Realtor
+  - realtor
   partOfSpeech: n
 10529838-n:
   definition:
@@ -64377,8 +64378,8 @@
   - 10072812-n
   ili: i92624
   members:
-  - Roman Emperor
-  - Emperor of Rome
+  - Roman emperor
+  - emperor of Rome
   partOfSpeech: n
 10557265-n:
   definition:
@@ -65809,8 +65810,8 @@
   - 10577282-n
   ili: i92760
   members:
-  - Schoolman
-  - medieval Schoolman
+  - schoolman
+  - medieval schoolman
   partOfSpeech: n
 10579268-n:
   definition:
@@ -66469,9 +66470,9 @@
   - 10589463-n
   ili: i92824
   members:
-  - Attorney General
-  - United States Attorney General
-  - US Attorney General
+  - attorney general
+  - United States attorney general
+  - US attorney general
   partOfSpeech: n
 10590148-n:
   definition:
@@ -66483,8 +66484,8 @@
   - 10589463-n
   ili: i92825
   members:
-  - Secretary of Agriculture
-  - Agriculture Secretary
+  - secretary of agriculture
+  - agriculture secretary
   partOfSpeech: n
 10590405-n:
   definition:
@@ -66495,8 +66496,8 @@
   - 10589463-n
   ili: i92826
   members:
-  - Secretary of Commerce
-  - Commerce Secretary
+  - secretary of commerce
+  - commerce secretary
   partOfSpeech: n
 10590646-n:
   definition:
@@ -66507,8 +66508,8 @@
   - 10589463-n
   ili: i92827
   members:
-  - Secretary of Defense
-  - Defense Secretary
+  - secretary of defense
+  - defense secretary
   partOfSpeech: n
 10590879-n:
   definition:
@@ -66519,8 +66520,8 @@
   - 10589463-n
   ili: i92828
   members:
-  - Secretary of Education
-  - Education Secretary
+  - secretary of education
+  - education secretary
   partOfSpeech: n
 10591114-n:
   definition:
@@ -66531,8 +66532,8 @@
   - 10589463-n
   ili: i92829
   members:
-  - Secretary of Energy
-  - Energy Secretary
+  - secretary of energy
+  - energy secretary
   partOfSpeech: n
 10591351-n:
   definition:
@@ -66569,8 +66570,8 @@
   - 10589463-n
   ili: i92832
   members:
-  - Secretary of Labor
-  - Labor Secretary
+  - secretary of labor
+  - labor secretary
   partOfSpeech: n
 10592150-n:
   definition:
@@ -66592,8 +66593,8 @@
   - 10589463-n
   ili: i92834
   members:
-  - Secretary of the Interior
-  - Interior Secretary
+  - secretary of the interior
+  - interior secretary
   partOfSpeech: n
 10592573-n:
   definition:
@@ -66604,8 +66605,8 @@
   - 10589463-n
   ili: i92835
   members:
-  - Secretary of the Treasury
-  - Treasury Secretary
+  - secretary of the treasury
+  - treasury secretary
   partOfSpeech: n
 10592793-n:
   definition:
@@ -66616,8 +66617,8 @@
   - 10589463-n
   ili: i92836
   members:
-  - Secretary of Transportation
-  - Transportation Secretary
+  - secretary of transportation
+  - transportation secretary
   partOfSpeech: n
 10593040-n:
   definition:
@@ -66637,7 +66638,7 @@
   - 09789895-n
   ili: i92838
   members:
-  - Secretary General
+  - secretary general
   partOfSpeech: n
 10593401-n:
   definition:
@@ -67372,8 +67373,8 @@
   - 10648006-n
   ili: i92908
   members:
-  - Shah
-  - Shah of Iran
+  - shah
+  - shah of Iran
   partOfSpeech: n
 10605080-n:
   definition:
@@ -70239,7 +70240,7 @@
   - 10488931-n
   ili: i93182
   members:
-  - Speaker
+  - speaker
   partOfSpeech: n
 10650874-n:
   definition:
@@ -73149,7 +73150,7 @@
   - 10325302-n
   ili: i93459
   members:
-  - Surgeon General
+  - surgeon general
   partOfSpeech: n
 10699057-n:
   definition:
@@ -73158,7 +73159,8 @@
   - 10089452-n
   ili: i93460
   members:
-  - Surgeon General
+  - surgeon general
+  - surgeon general of the United States
   partOfSpeech: n
 10699170-n:
   definition:
@@ -76286,8 +76288,7 @@
   - 09905462-n
   ili: i93764
   members:
-  - Treasury
-  - First Lord of the Treasury
+  - first lord of the Treasury
   partOfSpeech: n
 10747275-n:
   definition:
@@ -77381,6 +77382,7 @@
   ili: i93872
   members:
   - Utopian
+  - utopian
   partOfSpeech: n
 10763200-n:
   definition:
@@ -123058,7 +123060,7 @@
   - 86294295-n
   - 10807146-n
   members:
-  - Negress
+  - negress
   partOfSpeech: n
 82094283-n:
   definition:

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -4141,7 +4141,7 @@
   - Sierra redwood
   - Sequoiadendron giganteum
   - Sequoia gigantea
-  - Sequoia Wellingtonia
+  - Sequoia wellingtonia
   partOfSpeech: n
   wikidata: Q149851
 11662239-n:
@@ -4861,7 +4861,7 @@
   ili: i98609
   members:
   - kahikatea
-  - New Zealand Dacryberry
+  - New Zealand dacryberry
   - New Zealand white pine
   - Dacrycarpus dacrydioides
   - Podocarpus dacrydioides
@@ -8972,7 +8972,7 @@
   ili: i98952
   members:
   - Canada anemone
-  - Anemone Canadensis
+  - Anemone canadensis
   partOfSpeech: n
 11746092-n:
   definition:
@@ -9582,7 +9582,7 @@
   - golden seal
   - yellow root
   - turmeric root
-  - Hydrastis Canadensis
+  - Hydrastis canadensis
   partOfSpeech: n
 11756291-n:
   definition:
@@ -21843,7 +21843,7 @@
   ili: i99988
   members:
   - Swan River daisy
-  - Brachycome Iberidifolia
+  - Brachycome iberidifolia
   partOfSpeech: n
 11962613-n:
   definition:
@@ -26797,7 +26797,7 @@
   members:
   - Easter daisy
   - stemless daisy
-  - Townsendia Exscapa
+  - Townsendia exscapa
   partOfSpeech: n
   wikidata: Q5601406
 12047233-n:
@@ -29228,8 +29228,8 @@
   ili: i100602
   members:
   - green adder's mouth
-  - Malaxis-unifolia
   - Malaxis ophioglossoides
+  - Malaxis unifolia
   partOfSpeech: n
 12092920-n:
   definition:
@@ -37982,7 +37982,7 @@
   ili: i101318
   members:
   - waratah
-  - Telopea Oreades
+  - Telopea oreades
   partOfSpeech: n
 12244281-n:
   definition:
@@ -40521,7 +40521,7 @@
   - 12286734-n
   ili: i101522
   members:
-  - Coigue
+  - coigue
   - Nothofagus dombeyi
   partOfSpeech: n
 12287313-n:
@@ -42318,7 +42318,7 @@
   - bitter floom
   - American centaury
   - Sabbatia stellaris
-  - Sabbatia Angularis
+  - Sabbatia angularis
   partOfSpeech: n
 12319154-n:
   definition:
@@ -42644,7 +42644,7 @@
   ili: i101697
   members:
   - white ash
-  - Fraxinus Americana
+  - Fraxinus americana
   partOfSpeech: n
   wikidata: Q1193369
 12324803-n:
@@ -45986,7 +45986,7 @@
   - shellflower
   - shall-flower
   - shell ginger
-  - Alpinia Zerumbet
+  - Alpinia zerumbet
   - Alpinia speciosa
   - Languas speciosa
   partOfSpeech: n
@@ -46839,7 +46839,7 @@
   - wild cinnamon
   - white cinnamon tree
   - Canella winterana
-  - Canella-alba
+  - Canella alba
   mero_part:
   - 12393037-n
   partOfSpeech: n
@@ -50589,7 +50589,7 @@
   members:
   - wild garlic
   - wood garlic
-  - Ramsons
+  - ramsons
   - Allium ursinum
   partOfSpeech: n
 12456282-n:
@@ -55895,7 +55895,7 @@
   members:
   - Indian coral tree
   - Erythrina variegata
-  - Erythrina Indica
+  - Erythrina indica
   partOfSpeech: n
 12549725-n:
   definition:
@@ -61668,7 +61668,7 @@
   - 13133423-n
   ili: i103222
   members:
-  - Juneberry
+  - juneberry
   - serviceberry
   - service tree
   - shadbush
@@ -61696,7 +61696,7 @@
   - 12644285-n
   ili: i103224
   members:
-  - Bartram Juneberry
+  - Bartram juneberry
   - Amelanchier bartramiana
   partOfSpeech: n
 12645010-n:
@@ -64328,7 +64328,7 @@
   - genipap fruit
   - jagua
   - marmalade box
-  - Genipa Americana
+  - Genipa americana
   mero_part:
   - 07779459-n
   partOfSpeech: n
@@ -66060,7 +66060,7 @@
   - margosa
   - arishth
   - Azadirachta indica
-  - Melia Azadirachta
+  - Melia azadirachta
   mero_part:
   - 12717591-n
   partOfSpeech: n
@@ -80234,7 +80234,7 @@
   members:
   - garden angelica
   - archangel
-  - Angelica Archangelica
+  - Angelica archangelica
   partOfSpeech: n
   wikidata: Q207745
 12953125-n:
@@ -81006,7 +81006,7 @@
   ili: i104779
   members:
   - European sanicle
-  - Sanicula Europaea
+  - Sanicula europaea
   partOfSpeech: n
   wikidata: Q157846
 12964998-n:
@@ -81123,8 +81123,8 @@
   - 12226211-n
   ili: i104789
   members:
-  - Alexander
-  - Alexanders
+  - alexander
+  - alexanders
   - black lovage
   - horse parsley
   - Smyrnium olusatrum
@@ -93687,7 +93687,7 @@
   ili: i105897
   members:
   - snake polypody
-  - Microgramma-piloselloides
+  - Microgramma piloselloides
   partOfSpeech: n
 13197421-n:
   definition:
@@ -93973,7 +93973,7 @@
   ili: i105921
   members:
   - ebony spleenwort
-  - Scott's Spleenwort
+  - Scott's spleenwort
   - Asplenium platyneuron
   partOfSpeech: n
 13202304-n:
@@ -94437,7 +94437,7 @@
   - ball fern
   - Davalia bullata
   - Davalia bullata mariesii
-  - Davallia Mariesii
+  - Davallia mariesii
   partOfSpeech: n
   wikidata: Q5873778
 13209871-n:
@@ -96362,7 +96362,7 @@
   ili: i106119
   members:
   - wood horsetail
-  - Equisetum Sylvaticum
+  - Equisetum sylvaticum
   partOfSpeech: n
   wikidata: Q1355107
 13241561-n:

--- a/src/yaml/noun.quantity.yaml
+++ b/src/yaml/noun.quantity.yaml
@@ -10137,7 +10137,7 @@
   - 13630750-n
   ili: i108993
   members:
-  - Calorie
+  - calorie
   - kilogram calorie
   - kilocalorie
   - large calorie

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -30953,7 +30953,7 @@
   - 14482633-n
   ili: i112998
   members:
-  - God's Will
+  - God's will
   partOfSpeech: n
 14482870-n:
   attribute:

--- a/src/yaml/noun.substance.yaml
+++ b/src/yaml/noun.substance.yaml
@@ -22295,7 +22295,7 @@
   members:
   - naval brass
   - Admiralty brass
-  - Admiralty Metal
+  - Admiralty metal
   - Tobin bronze
   partOfSpeech: n
 14984596-n:


### PR DESCRIPTION
When searching for proper nouns, I found a number of terms that are capitalized but should not generally be. The main kinds of changes are

1. **Binomial names**: Binomial names should capitalize the first word and not the second, e.g., 'Anemone Canadensis' => 'Anemone canadensis'
2. **Role words**: Role words are always common nouns and should be lowercased, e.g., 'president of the United States'. We apply this even to formal titles as the synsets refer to the person holding the role, e.g., 'the chancellor of the exchequer' holds the title of 'Chancellor of the Exchequer'
3. **Brand/place names used generically**: For example 'armageddon' to refer to 'any catastrophically destructive battle' but still 'Armageddon' for '(New Testament) the scene of the final battle between the kings of the Earth at the end of the world'