### PR TITLE
Update Wikidata Links

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -390,11 +390,14 @@ def main():
         else:
             ilis.add(synset.ili)
 
-        if synset.wikidata and synset.wikidata in wikidatas:
-            print(f"ERROR: QID {synset.wikidata} is duplicated")
-            errors += 1
-        else:
-            wikidatas.add(synset.wikidata)
+        if synset.wikidata:
+            ss_wikidatas = synset.wikidata if isinstance(synset.wikidata, list) else [synset.wikidata]
+            for wikidata in ss_wikidatas:
+                if wikidata in wikidatas:
+                    print(f"ERROR: QID {wikidata} is duplicated")
+                    errors += 1
+                else:
+                    wikidatas.add(wikidata)
 
     for synset in wn.synsets:
         for sr in synset.synset_relations:

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -72218,7 +72218,6 @@
   partOfSpeech: n
   wikidata:
   - Q846848
-  - Q7316195
 01310245-n:
   definition:
   - the revolution against the czarist government which led to the abdication of Nicholas

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -4213,7 +4213,9 @@
   - breaking ball
   - bender
   partOfSpeech: n
-  wikidata: Q44891
+  wikidata:
+  - Q44891
+  - Q15710733
 00108901-n:
   definition:
   - a pitch thrown deliberately close to the batter
@@ -10955,7 +10957,9 @@
   - carnage
   - butchery
   partOfSpeech: n
-  wikidata: Q750215
+  wikidata:
+  - Q750215
+  - Q3199915
 00225127-n:
   definition:
   - indiscriminate slaughter
@@ -11296,7 +11300,7 @@
   members:
   - layoff
   partOfSpeech: n
-  wikidata: Q1462531
+  wikidata: Q685744
 00230801-n:
   definition:
   - the act of extinguishing; causing to stop burning
@@ -13163,7 +13167,7 @@
   - redevelopment
   - overhaul
   partOfSpeech: n
-  wikidata: Q1441983
+  wikidata: Q2144402
 00266316-n:
   definition:
   - a renovation that improves the outward appearance (as of a building) but usually
@@ -15392,7 +15396,9 @@
   - parasailing
   - paragliding
   partOfSpeech: n
-  wikidata: Q178380
+  wikidata:
+  - Q178380
+  - Q1194872
 00305268-n:
   definition:
   - a flight by an aircraft over a particular area (especially over an area in foreign
@@ -22815,7 +22821,7 @@
   members:
   - headstand
   partOfSpeech: n
-  wikidata: Q2281572
+  wikidata: Q500622
 00438728-n:
   definition:
   - an acrobatic feat of rolling or turning end over end
@@ -25766,7 +25772,9 @@
   - penuchle
   - bezique
   partOfSpeech: n
-  wikidata: Q1019517
+  wikidata:
+  - Q1019517
+  - Q1898942
 00495304-n:
   definition:
   - a card game for two players using a reduced pack of 32 cards
@@ -30796,7 +30804,7 @@
   members:
   - socage
   partOfSpeech: n
-  wikidata: Q1369542
+  wikidata: Q74616232
 00581014-n:
   definition:
   - land tenure by service in the lord's army
@@ -32574,7 +32582,9 @@
   - woodworking
   - woodwork
   partOfSpeech: n
-  wikidata: Q816871
+  wikidata:
+  - Q816871
+  - Q203605
 00609152-n:
   definition:
   - the craft of drawing blueprints
@@ -33100,7 +33110,9 @@
   - shoe repairing
   - cobbling
   partOfSpeech: n
-  wikidata: Q6408486
+  wikidata:
+  - Q6408486
+  - Q5915560
 00619229-n:
   definition:
   - the craft of a roofer
@@ -33343,7 +33355,7 @@
   - travail
   - sweat
   partOfSpeech: n
-  wikidata: Q723375
+  wikidata: Q14536140
 00623308-n:
   definition:
   - strenuous effort
@@ -53636,7 +53648,9 @@
   - volley
   - burst
   partOfSpeech: n
-  wikidata: Q5510053
+  wikidata:
+  - Q5510053
+  - Q1572895
 00990642-n:
   definition:
   - fire delivered on a specific target in response to a request from the supported
@@ -66249,7 +66263,7 @@
   - daycare
   - day care
   partOfSpeech: n
-  wikidata: Q364005
+  wikidata: Q1542572
 01213037-n:
   definition:
   - a service that provides information and assistance to the users of a computer
@@ -68619,7 +68633,9 @@
   - hooliganism
   - malicious mischief
   partOfSpeech: n
-  wikidata: Q219954
+  wikidata:
+  - Q219954
+  - Q6160
 01252578-n:
   definition:
   - the act of ceding back
@@ -70847,7 +70863,7 @@
   members:
   - Macedonian War
   partOfSpeech: n
-  wikidata: Q75626
+  wikidata: Q75813
 01288277-n:
   definition:
   - a battle in 1859 in which the French and Sardinian forces under Napoleon III defeated
@@ -70903,7 +70919,9 @@
   - Mantinea
   - Mantineia
   partOfSpeech: n
-  wikidata: Q233399
+  wikidata:
+  - Q233399
+  - Q1160195
 01289062-n:
   definition:
   - a battle in 490 BC in which the Athenians and their allies defeated the Persians
@@ -71949,7 +71967,7 @@
   - Chinese Communist Revolution
   - Chinese Revolution
   partOfSpeech: n
-  wikidata: Q32993
+  wikidata: Q190517
 01306230-n:
   definition:
   - a war in Crimea between Russia and a group of nations including England and France
@@ -72198,7 +72216,9 @@
   members:
   - Restoration
   partOfSpeech: n
-  wikidata: Q846848
+  wikidata:
+  - Q846848
+  - Q7316195
 01310245-n:
   definition:
   - the revolution against the czarist government which led to the abdication of Nicholas
@@ -72212,7 +72232,9 @@
   - Russian Revolution
   - February Revolution
   partOfSpeech: n
-  wikidata: Q8729
+  wikidata:
+  - Q8729
+  - Q101534
 01310499-n:
   definition:
   - the coup d'etat by the Bolsheviks under Lenin in November 1917 that led to a period

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -32823,7 +32823,6 @@
   - bluebill
   - broadbill
   partOfSpeech: n
-  wikidata: Q833243
 01854214-n:
   definition:
   - large scaup of North America having a greenish iridescence on the head of the

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -4579,7 +4579,7 @@
   - paramecium
   - paramecia
   partOfSpeech: n
-  wikidata: Q7135166
+  wikidata: Q199456
 01398811-n:
   definition:
   - protozoa having four membranous ciliary organelles
@@ -6422,7 +6422,9 @@
   - Plasmodium vivax
   - malaria parasite
   partOfSpeech: n
-  wikidata: Q311376
+  wikidata:
+  - Q311376
+  - Q130948
 01427248-n:
   definition:
   - bird parasites
@@ -7808,7 +7810,7 @@
   - John Dory
   - Zeus faber
   partOfSpeech: n
-  wikidata: Q6229838
+  wikidata: Q7045
 01455829-n:
   definition:
   - boarfishes
@@ -9974,7 +9976,9 @@
   mero_member:
   - 01490147-n
   partOfSpeech: n
-  wikidata: Q574070
+  wikidata:
+  - Q574070
+  - Q578852
 01490147-n:
   definition:
   - shallow-water shark with sharp jagged teeth found on both sides of Atlantic; sometimes
@@ -12278,7 +12282,7 @@
   - crossbill
   - Loxia curvirostra
   partOfSpeech: n
-  wikidata: Q339517
+  wikidata: Q26552
 01536675-n:
   definition:
   - bullfinches
@@ -12581,7 +12585,7 @@
   - yellow bunting
   - Emberiza citrinella
   partOfSpeech: n
-  wikidata: Q1588177
+  wikidata: Q26205
 01541003-n:
   definition:
   - common in Russia and Siberia
@@ -13382,7 +13386,7 @@
   - wood pewee
   - Contopus virens
   partOfSpeech: n
-  wikidata: Q868932
+  wikidata: Q606809
 01552282-n:
   definition:
   - small flycatcher of western North America
@@ -14703,7 +14707,7 @@
   - yellowbird
   - Dendroica petechia
   partOfSpeech: n
-  wikidata: Q754042
+  wikidata: Q21962227
 01571701-n:
   definition:
   - black-and-white North American wood warbler having an orange-and-black head and
@@ -14716,7 +14720,9 @@
   - Blackburnian warbler
   - Dendroica fusca
   partOfSpeech: n
-  wikidata: Q1410964
+  wikidata:
+  - Q1410964
+  - Q27075919
 01571903-n:
   definition:
   - common warbler of western North America
@@ -23544,7 +23550,7 @@
   - hadrosaurus
   - duck-billed dinosaur
   partOfSpeech: n
-  wikidata: Q271841
+  wikidata: Q14511
 01708888-n:
   definition:
   - genus of large duck-billed dinosaurs; late Cretaceous
@@ -24023,7 +24029,7 @@
   - tyrannosaurus
   - Tyrannosaurus rex
   partOfSpeech: n
-  wikidata: Q14332
+  wikidata: Q13098211
 01716700-n:
   definition:
   - carnivorous dinosaur of North America; late Jurassic
@@ -29025,7 +29031,7 @@
   - sage hen
   - Centrocercus urophasianus
   partOfSpeech: n
-  wikidata: Q7399126
+  wikidata: Q747372
 01800408-n:
   definition:
   - ruffed grouse
@@ -29651,7 +29657,7 @@
   - blue peafowl
   - Pavo cristatus
   partOfSpeech: n
-  wikidata: Q3641130
+  wikidata: Q61865
 01809108-n:
   definition:
   - peafowl of southeast Asia
@@ -32817,7 +32823,7 @@
   - bluebill
   - broadbill
   partOfSpeech: n
-  wikidata: Q601997
+  wikidata: Q833243
 01854214-n:
   definition:
   - large scaup of North America having a greenish iridescence on the head of the
@@ -38946,7 +38952,9 @@
   mero_member:
   - 01957157-n
   partOfSpeech: n
-  wikidata: Q1152770
+  wikidata:
+  - Q1152770
+  - Q213228
 01957157-n:
   definition:
   - deep-water wormlike mollusks lacking calcareous plates on the body but having
@@ -43826,7 +43834,9 @@
   - surfbird
   - Aphriza virgata
   partOfSpeech: n
-  wikidata: Q1274741
+  wikidata:
+  - Q1274741
+  - Q28070835
 02029452-n:
   definition:
   - a genus of Scolopacidae, comprising the common sandpiper and the spotted sandpiper
@@ -46157,7 +46167,7 @@
   - giant fulmar
   - Macronectes giganteus
   partOfSpeech: n
-  wikidata: Q598979
+  wikidata: Q276185
 02062669-n:
   definition:
   - fulmars
@@ -48350,7 +48360,9 @@
   - American pit bull terrier
   - pit bull terrier
   partOfSpeech: n
-  wikidata: Q37688
+  wikidata:
+  - Q37688
+  - Q1144318
 02096299-n:
   definition:
   - a light terrier groomed to resemble a lamb
@@ -48430,7 +48442,9 @@
   - rat terrier
   - ratter
   partOfSpeech: n
-  wikidata: Q38431
+  wikidata:
+  - Q38431
+  - Q2132945
 02097373-n:
   definition:
   - a breed of short-haired rat terrier with a black-and-tan coat that was developed
@@ -54308,7 +54322,7 @@
   - louse
   - sucking louse
   partOfSpeech: n
-  wikidata: Q26870
+  wikidata: Q6481228
 02186766-n:
   definition:
   - 'true lice: human lice and related forms'
@@ -79564,7 +79578,7 @@
   - white seabass
   - Lates calcarifer
   partOfSpeech: n
-  wikidata: Q1188144
+  wikidata: Q74411
 02563454-n:
   definition:
   - pikes; pickerels; muskellunges
@@ -84982,7 +84996,7 @@
   - duckbill
   - Polyodon spathula
   partOfSpeech: n
-  wikidata: Q858011
+  wikidata: Q827142
 02642416-n:
   definition:
   - a genus of Polyodontidae

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -17091,7 +17091,6 @@
   - line
   - transmission line
   partOfSpeech: n
-  wikidata: Q188447
 02937835-n:
   definition:
   - a conveyance for passengers or freight on a cable railway
@@ -58504,9 +58503,7 @@
   - scroll saw
   - fretsaw
   partOfSpeech: n
-  wikidata:
-  - Q853756
-  - Q1140903
+  wikidata: Q853756
 03604123-n:
   definition:
   - a puzzle that requires you to reassemble a picture that has been mounted on a
@@ -91162,7 +91159,6 @@
   wikidata:
   - Q2282074
   - Q3475711
-  - Q1140903
 04129105-n:
   definition:
   - an oral vaccine (containing live but weakened poliovirus) that is given to provide

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -190,7 +190,9 @@
   - Abstract Expressionism
   - action painting
   partOfSpeech: n
-  wikidata: Q177725
+  wikidata:
+  - Q177725
+  - Q217213
 02671631-n:
   definition:
   - an abstract painting
@@ -543,7 +545,7 @@
   - Tempra
   - Anacin III
   partOfSpeech: n
-  wikidata: Q4120713
+  wikidata: Q57055
 02677766-n:
   definition:
   - a solid odourless chemical of leaf or flake-like appearance; used in rubber accelerator,
@@ -1642,7 +1644,9 @@
   - air pump
   - vacuum pump
   partOfSpeech: n
-  wikidata: Q636009
+  wikidata:
+  - Q636009
+  - Q745837
 02695539-n:
   definition:
   - a shipboard radar that searches for aircraft
@@ -2124,7 +2128,10 @@
   - altarpiece
   - reredos
   partOfSpeech: n
-  wikidata: Q46686
+  wikidata:
+  - Q46686
+  - Q15711026
+  - Q3714446
 02702774-n:
   definition:
   - an instrument that measures the altitude and azimuth of celestial bodies; used
@@ -3320,7 +3327,9 @@
   - antimycotic
   - antimycotic agent
   partOfSpeech: n
-  wikidata: Q193237
+  wikidata:
+  - Q193237
+  - Q578726
 02723487-n:
   definition:
   - pressure suit worn by fliers and astronauts to counteract the forces of gravity
@@ -12154,7 +12163,10 @@
   - skimmer
   - straw hat
   partOfSpeech: n
-  wikidata: Q741814
+  wikidata:
+  - Q741814
+  - Q2286991
+  - Q25312663
 02862683-n:
   definition:
   - pole-handled hook used to pull or push boats
@@ -12390,7 +12402,9 @@
   - 04527182-n
   - 04546934-n
   partOfSpeech: n
-  wikidata: Q485027
+  wikidata:
+  - Q485027
+  - Q50414774
 02866110-n:
   definition:
   - a bag in which the body of a dead soldier is placed
@@ -12781,7 +12795,9 @@
   - air-raid shelter
   - bombproof
   partOfSpeech: n
-  wikidata: Q389959
+  wikidata:
+  - Q389959
+  - Q17003536
 02872210-n:
   definition:
   - a sighting device in an aircraft for aiming bombs
@@ -16174,7 +16190,7 @@
   - Guided Bomb Unit-28
   - GBU-28
   partOfSpeech: n
-  wikidata: Q1484837
+  wikidata: Q953874
 02924413-n:
   definition:
   - a gas burner used in laboratories; has an air valve to regulate the mixture of
@@ -16417,7 +16433,7 @@
   - 04112532-n
   - 04595668-n
   partOfSpeech: n
-  wikidata: Q2632308
+  wikidata: Q5638
 02927938-n:
   definition:
   - a car that is old and unreliable
@@ -16802,7 +16818,9 @@
   - doodlebug
   - V-1
   partOfSpeech: n
-  wikidata: Q3268741
+  wikidata:
+  - Q3268741
+  - Q153348
 02933464-n:
   definition:
   - a signaling device that makes a buzzing sound
@@ -17073,7 +17091,7 @@
   - line
   - transmission line
   partOfSpeech: n
-  wikidata: Q693004
+  wikidata: Q188447
 02937835-n:
   definition:
   - a conveyance for passengers or freight on a cable railway
@@ -17592,7 +17610,7 @@
   - Cambridge University
   - Cambridge
   partOfSpeech: n
-  wikidata: Q1055028
+  wikidata: Q35794
 02945804-n:
   definition:
   - a portable television camera and videocassette recorder
@@ -18654,7 +18672,7 @@
   mero_part:
   - 04373203-n
   partOfSpeech: n
-  wikidata: Q7132141
+  wikidata: Q752392
 02963788-n:
   definition:
   - where passengers ride up and down
@@ -20810,7 +20828,9 @@
   - censer
   - thurible
   partOfSpeech: n
-  wikidata: Q1264081
+  wikidata:
+  - Q1264081
+  - Q373066
 02997001-n:
   definition:
   - a building dedicated to a particular activity
@@ -22592,7 +22612,7 @@
   members:
   - Chisholm Trail
   partOfSpeech: n
-  wikidata: Q104853588
+  wikidata: Q477217
 03024804-n:
   definition:
   - a woolen tunic worn by men and women in ancient Greece
@@ -28517,7 +28537,9 @@
   - countersink
   - countersink bit
   partOfSpeech: n
-  wikidata: Q2442900
+  wikidata:
+  - Q2442900
+  - Q1313250
 03122427-n:
   definition:
   - a medicine applied locally to produce superficial inflammation in order to reduce
@@ -33857,7 +33879,9 @@
   - diphenhydramine
   - Benadryl
   partOfSpeech: n
-  wikidata: Q4886804
+  wikidata:
+  - Q4886804
+  - Q413486
 03208125-n:
   definition:
   - an anticonvulsant drug (trade name Dilantin) used to treat epilepsy and that is
@@ -36778,7 +36802,9 @@
   mero_part:
   - 03254982-n
   partOfSpeech: n
-  wikidata: Q212892
+  wikidata:
+  - Q212892
+  - Q11404
 03254659-n:
   definition:
   - a cylindrical metal container, commonly used for shipping or storage of liquids
@@ -37391,7 +37417,9 @@
   - smock
   - dust coat
   partOfSpeech: n
-  wikidata: Q5515378
+  wikidata:
+  - Q5515378
+  - Q1743902
 03263608-n:
   definition:
   - a dry swab for dusting floors
@@ -40378,7 +40406,9 @@
   - 04559236-n
   - 04606292-n
   partOfSpeech: n
-  wikidata: Q5849500
+  wikidata:
+  - Q5849500
+  - Q28823
 03318278-n:
   definition:
   - the face or front of a building
@@ -41750,7 +41780,7 @@
   - fighter aircraft
   - attack aircraft
   partOfSpeech: n
-  wikidata: Q208187
+  wikidata: Q127771
 03340278-n:
   definition:
   - a fixed chair from which a saltwater angler can fight a hooked fish
@@ -45014,7 +45044,9 @@
   - evening dress
   - evening clothes
   partOfSpeech: n
-  wikidata: Q1151364
+  wikidata:
+  - Q1151364
+  - Q2144456
 03389963-n:
   definition:
   - a particular spatial arrangement
@@ -49218,7 +49250,9 @@
   - Holy Grail
   - Sangraal
   partOfSpeech: n
-  wikidata: Q1595294
+  wikidata:
+  - Q1595294
+  - Q162808
 03456999-n:
   definition:
   - an antibiotic produced by a soil bacterium; used chiefly as an antiseptic in treating
@@ -52984,7 +53018,7 @@
   - 02867090-n
   - 04047545-n
   partOfSpeech: n
-  wikidata: Q2429341
+  wikidata: Q11880006
 03514538-n:
   definition:
   - electric heater consisting of a high-power incandescent lamp that emits infrared
@@ -53632,7 +53666,9 @@
   - highroad
   - trunk road
   partOfSpeech: n
-  wikidata: Q2145163
+  wikidata:
+  - Q2145163
+  - Q1304276
 03524837-n:
   definition:
   - a dining table in a dining-hall raised on a platform; seats are reserved for distinguished
@@ -58468,7 +58504,9 @@
   - scroll saw
   - fretsaw
   partOfSpeech: n
-  wikidata: Q853756
+  wikidata:
+  - Q853756
+  - Q1140903
 03604123-n:
   definition:
   - a puzzle that requires you to reassemble a picture that has been mounted on a
@@ -62208,7 +62246,9 @@
   - lending library
   - circulating library
   partOfSpeech: n
-  wikidata: Q3639678
+  wikidata:
+  - Q3639678
+  - Q779419
 03661557-n:
   definition:
   - a section of something that is long and narrow
@@ -62289,7 +62329,9 @@
   - body suit
   - cat suit
   partOfSpeech: n
-  wikidata: Q1820061
+  wikidata:
+  - Q1820061
+  - Q890119
 03663151-n:
   definition:
   - the size dose that will cause death
@@ -66334,7 +66376,9 @@
   - marimba
   - xylophone
   partOfSpeech: n
-  wikidata: Q165666
+  wikidata:
+  - Q165666
+  - Q220971
 03727081-n:
   definition:
   - a fancy dock for small yachts and cabin cruisers
@@ -67184,7 +67228,7 @@
   - measuring system
   - measuring device
   partOfSpeech: n
-  wikidata: Q1584378
+  wikidata: Q2041172
 03741128-n:
   definition:
   - measuring instrument having a sequence of marks at regular intervals; used as
@@ -70144,7 +70188,10 @@
   - howitzer
   - trench mortar
   partOfSpeech: n
-  wikidata: Q180126
+  wikidata:
+  - Q180126
+  - Q11464003
+  - Q7905205
 03792434-n:
   definition:
   - a bowl-shaped vessel in which substances can be ground and mixed with a pestle
@@ -70296,7 +70343,9 @@
   - Mother Hubbard
   - muumuu
   partOfSpeech: n
-  wikidata: Q599820
+  wikidata:
+  - Q599820
+  - Q3434328
 03794547-n:
   definition:
   - a design or figure that consists of recurring shapes or colors, as in architecture
@@ -74221,7 +74270,7 @@
   - optical fibre
   - glass fibre
   partOfSpeech: n
-  wikidata: Q5861
+  wikidata: Q162
 03857800-n:
   definition:
   - an instrument designed to aid vision
@@ -77633,7 +77682,9 @@
   - pedal pushers
   - toreador pants
   partOfSpeech: n
-  wikidata: Q7158978
+  wikidata:
+  - Q7158978
+  - Q1034971
 03909987-n:
   definition:
   - an architectural support or base (as for a column or statue)
@@ -81016,7 +81067,7 @@
   - plaster
   - plasterwork
   partOfSpeech: n
-  wikidata: Q572879
+  wikidata: Q274988
 03964056-n:
   definition:
   - wallboard with a gypsum plaster core bonded to layers of paper or fiberboard;
@@ -86651,7 +86702,7 @@
   members:
   - railway junction
   partOfSpeech: n
-  wikidata: Q1311696
+  wikidata: Q336764
 04056210-n:
   definition:
   - a terminal/node where trains load or unload passengers or goods
@@ -90207,7 +90258,9 @@
   members:
   - rope bridge
   partOfSpeech: n
-  wikidata: Q157942
+  wikidata:
+  - Q157942
+  - Q3916505
 04116002-n:
   definition:
   - a ladder with side pieces of rope
@@ -91106,7 +91159,10 @@
   - jigsaw
   - reciprocating saw
   partOfSpeech: n
-  wikidata: Q2282074
+  wikidata:
+  - Q2282074
+  - Q3475711
+  - Q1140903
 04129105-n:
   definition:
   - an oral vaccine (containing live but weakened poliovirus) that is given to provide
@@ -91467,7 +91523,9 @@
   - safety lamp
   - Davy lamp
   partOfSpeech: n
-  wikidata: Q902796
+  wikidata:
+  - Q902796
+  - Q371150
 04134081-n:
   definition:
   - a paper match that strikes only on a specially prepared surface
@@ -98957,7 +99015,9 @@
   - smoke bomb
   - smoke grenade
   partOfSpeech: n
-  wikidata: Q967352
+  wikidata:
+  - Q967352
+  - Q1067247
 04253761-n:
   definition:
   - a vent (as in a roof) for smoke to escape
@@ -100224,7 +100284,9 @@
   - 03574473-n
   - 03784533-n
   partOfSpeech: n
-  wikidata: Q40218
+  wikidata:
+  - Q40218
+  - Q11449356
 04272385-n:
   definition:
   - heater consisting of a self-contained (usually portable) unit to warm a room
@@ -103148,7 +103210,9 @@
   - steamroller
   - road roller
   partOfSpeech: n
-  wikidata: Q216842
+  wikidata:
+  - Q216842
+  - Q1158891
 04317485-n:
   definition:
   - a line responsible for the operation of a fleet of steamships
@@ -105689,7 +105753,7 @@
   - sulpha
   - sulfonamide
   partOfSpeech: n
-  wikidata: Q7394972
+  wikidata: Q411398
 04359513-n:
   definition:
   - a sulfa drug used like sulfadiazine and also in veterinary medicine
@@ -107313,7 +107377,7 @@
   - Tabernacle
   - Mormon Tabernacle
   partOfSpeech: n
-  wikidata: Q7673025
+  wikidata: Q2140759
 04386043-n:
   definition:
   - a sock with a separation for the big toe; worn with thong sandals by the Japanese
@@ -107973,7 +108037,9 @@
   - tank
   - storage tank
   partOfSpeech: n
-  wikidata: Q1756525
+  wikidata:
+  - Q1756525
+  - Q1047832
 04396120-n:
   definition:
   - an enclosed armored military vehicle; has a cannon and moves on caterpillar treads
@@ -109268,7 +109334,7 @@
   - Temple of Jerusalem
   - Temple of Solomon
   partOfSpeech: n
-  wikidata: Q223644
+  wikidata: Q3906600
 04416006-n:
   definition:
   - a connection intended to be used for a limited time
@@ -114238,7 +114304,7 @@
   - Trojan Horse
   - Wooden Horse
   partOfSpeech: n
-  wikidata: Q50193
+  wikidata: Q107439070
 04494190-n:
   definition:
   - a fisherman's lure that is used in trolling
@@ -119177,7 +119243,7 @@
   - arm
   - weapon system
   partOfSpeech: n
-  wikidata: Q7978064
+  wikidata: Q728
 04573249-n:
   definition:
   - a weapon that kills or injures civilian as well as military personnel (nuclear

--- a/src/yaml/noun.body.yaml
+++ b/src/yaml/noun.body.yaml
@@ -1771,7 +1771,9 @@
   - anastomosis
   - inosculation
   partOfSpeech: n
-  wikidata: Q2722903
+  wikidata:
+  - Q2722903
+  - Q15177
 05257118-n:
   definition:
   - an aperture or hole that opens into a bodily cavity
@@ -3855,7 +3857,9 @@
   - zygomatic arch
   - arcus zygomaticus
   partOfSpeech: n
-  wikidata: Q730302
+  wikidata:
+  - Q730302
+  - Q186102
 05292600-n:
   definition:
   - the socket part of the ball-and-socket joint between the head of the femur and
@@ -12394,7 +12398,7 @@
   - cistron
   - factor
   partOfSpeech: n
-  wikidata: Q7060602
+  wikidata: Q7187
 05445176-n:
   definition:
   - gene that produces the same phenotype in the organism whether or not its allele
@@ -20199,7 +20203,7 @@
   members:
   - gluteus minimus
   partOfSpeech: n
-  wikidata: Q5572491
+  wikidata: Q523799
 05578335-n:
   definition:
   - one of the tendons at the back of the knee
@@ -21743,7 +21747,7 @@
   - 05286906-n
   - 05603759-n
   partOfSpeech: n
-  wikidata: Q2943862
+  wikidata: Q713102
 05604805-n:
   definition:
   - the space bounded by the bones of the pelvis and containing the pelvic viscera

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -2740,7 +2740,9 @@
   - chromatic vision
   - trichromacy
   partOfSpeech: n
-  wikidata: Q1317719
+  wikidata:
+  - Q1317719
+  - Q374259
 05664263-n:
   definition:
   - vision for objects that a 20 feet or more from the viewer
@@ -5330,7 +5332,9 @@
   - operation
   - cognitive operation
   partOfSpeech: n
-  wikidata: Q781413
+  wikidata:
+  - Q781413
+  - Q2200417
 05709685-n:
   definition:
   - a mental process that you are not directly aware of
@@ -25397,7 +25401,7 @@
   - physics
   - natural philosophy
   partOfSpeech: n
-  wikidata: Q269323
+  wikidata: Q413
 06104194-n:
   definition:
   - the physical properties, phenomena, and laws of something
@@ -26221,7 +26225,9 @@
   - fluid mechanics
   - hydraulics
   partOfSpeech: n
-  wikidata: Q172145
+  wikidata:
+  - Q172145
+  - Q177784
 06122777-n:
   definition:
   - the branch of mechanics that deals with the mechanical properties of gases

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -11160,9 +11160,7 @@
   - 06444919-n
   - 06445145-n
   partOfSpeech: n
-  wikidata:
-  - Q162062
-  - Q34990
+  wikidata: Q162062
 06463893-n:
   definition:
   - the whole body of the Jewish sacred writings and tradition including the oral

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -1503,7 +1503,9 @@
   - radiocommunication
   - wireless
   partOfSpeech: n
-  wikidata: Q2697287
+  wikidata:
+  - Q2697287
+  - Q872
 06287933-n:
   definition:
   - broadcasting visual images of stationary or moving objects
@@ -2440,7 +2442,9 @@
   - nonce word
   - hapax legomenon
   partOfSpeech: n
-  wikidata: Q168417
+  wikidata:
+  - Q168417
+  - Q1499602
 06305497-n:
   definition:
   - word having stress or an acute accent on the last syllable
@@ -2508,7 +2512,9 @@
   members:
   - ghost word
   partOfSpeech: n
-  wikidata: Q2398560
+  wikidata:
+  - Q2398560
+  - Q1511109
 06311183-n:
   definition:
   - (linguistics) the form of a word after all affixes are removed
@@ -5730,7 +5736,9 @@
   - postcode
   - postal code
   partOfSpeech: n
-  wikidata: Q136208
+  wikidata:
+  - Q136208
+  - Q37447
 06367301-n:
   definition:
   - (computer science) the symbolic arrangement of data or instructions in a computer
@@ -6400,7 +6408,9 @@
   - dime novel
   - penny dreadful
   partOfSpeech: n
-  wikidata: Q1593709
+  wikidata:
+  - Q1593709
+  - Q3374808
 06380048-n:
   definition:
   - fiction with a large amount of imagination in it
@@ -11150,7 +11160,9 @@
   - 06444919-n
   - 06445145-n
   partOfSpeech: n
-  wikidata: Q162062
+  wikidata:
+  - Q162062
+  - Q34990
 06463893-n:
   definition:
   - the whole body of the Jewish sacred writings and tradition including the oral
@@ -11179,7 +11191,9 @@
   - 06464271-n
   - 06464994-n
   partOfSpeech: n
-  wikidata: Q83367
+  wikidata:
+  - Q83367
+  - Q732870
 06464271-n:
   definition:
   - the second of three divisions of the Hebrew Scriptures
@@ -11633,7 +11647,7 @@
   - Ecclesiasticus
   - Wisdom of Jesus the Son of Sirach
   partOfSpeech: n
-  wikidata: Q3092598
+  wikidata: Q155980
 06472194-n:
   definition:
   - an Apocryphal book consisting mainly of a meditation on wisdom; although ascribed
@@ -17412,7 +17426,9 @@
   - subpoena
   - subpoena ad testificandum
   partOfSpeech: n
-  wikidata: Q5608642
+  wikidata:
+  - Q5608642
+  - Q883270
 06569308-n:
   definition:
   - a writ issued by a court at the request of one of the parties to a suit; it requires
@@ -17910,7 +17926,7 @@
   - software package
   - package
   partOfSpeech: n
-  wikidata: Q2429814
+  wikidata: Q7397
 06578832-n:
   definition:
   - a software module that extends or enhances the capabilities of an existing application
@@ -18207,7 +18223,9 @@
   members:
   - Netscape
   partOfSpeech: n
-  wikidata: Q235419
+  wikidata:
+  - Q235419
+  - Q266990
 06584114-n:
   definition:
   - a commercial browser developed by Opera Software
@@ -20055,7 +20073,9 @@
   - intension
   - connotation
   partOfSpeech: n
-  wikidata: Q1923256
+  wikidata:
+  - Q1923256
+  - Q661062
 06615483-n:
   definition:
   - something that refers; a term that refers to another term
@@ -20997,7 +21017,7 @@
   - documentary film
   - infotainment
   partOfSpeech: n
-  wikidata: Q40632
+  wikidata: Q93204
 06629518-n:
   definition:
   - a movie that shows ordinary people in actual activities without being controlled
@@ -29405,7 +29425,9 @@
   members:
   - half-truth
   partOfSpeech: n
-  wikidata: Q3234422
+  wikidata:
+  - Q3234422
+  - Q2104404
 06771409-n:
   definition:
   - a showy misrepresentation intended to conceal something unpleasant
@@ -34640,7 +34662,9 @@
   - brand
   - marque
   partOfSpeech: n
-  wikidata: Q2519914
+  wikidata:
+  - Q2519914
+  - Q431289
 06864566-n:
   definition:
   - trade name of a company that produces musical recordings
@@ -43757,7 +43781,9 @@
   - Wandala language
   - Mandara language
   partOfSpeech: n
-  wikidata: Q3441249
+  wikidata:
+  - Q3441249
+  - Q3285424
 06996907-n:
   definition:
   - a Chadic language spoken south of Lake Chad, especially in the Far North Region,
@@ -45314,7 +45340,9 @@
   - theatrical production
   - staging
   partOfSpeech: n
-  wikidata: Q7777570
+  wikidata:
+  - Q7777570
+  - Q3508687
 07020457-n:
   definition:
   - a highly successful theatrical production
@@ -46056,7 +46084,7 @@
   - musical comedy
   - musical theater
   partOfSpeech: n
-  wikidata: Q1548170
+  wikidata: Q2743
 07032510-n:
   definition:
   - a short play presented before the main play
@@ -46667,7 +46695,7 @@
   - continuo
   - thorough bass
   partOfSpeech: n
-  wikidata: Q724321
+  wikidata: Q349603
 07046240-n:
   definition:
   - the appropriation of a new style (especially in popular music) by combining elements
@@ -46692,7 +46720,9 @@
   - religious music
   - church music
   partOfSpeech: n
-  wikidata: Q1065742
+  wikidata:
+  - Q1065742
+  - Q8812109
 07046732-n:
   definition:
   - a verse or song to be chanted or sung in response

--- a/src/yaml/noun.food.yaml
+++ b/src/yaml/noun.food.yaml
@@ -584,7 +584,9 @@
   - oatmeal
   - rolled oats
   partOfSpeech: n
-  wikidata: Q1208221
+  wikidata:
+  - Q1208221
+  - Q2089240
 07584190-n:
   definition:
   - meal made from dried peas
@@ -1818,7 +1820,9 @@
   - minestrone
   - vegetable soup
   partOfSpeech: n
-  wikidata: Q581462
+  wikidata:
+  - Q581462
+  - Q1501244
 07602594-n:
   definition:
   - thick (often creamy) soup
@@ -9140,7 +9144,9 @@
   - Brussels biscuit
   - twice-baked bread
   partOfSpeech: n
-  wikidata: Q4122049
+  wikidata:
+  - Q4122049
+  - Q5477096
 07705764-n:
   definition:
   - a long bun shaped to hold a frankfurter
@@ -15590,7 +15596,9 @@
   - finnan
   - smoked haddock
   partOfSpeech: n
-  wikidata: Q3125526
+  wikidata:
+  - Q3125526
+  - Q5450695
 07805887-n:
   definition:
   - codfish preserved in salt; must be desalted and flaked by soaking in water and
@@ -18942,7 +18950,7 @@
   - albumen
   - ovalbumin
   partOfSpeech: n
-  wikidata: Q420291
+  wikidata: Q796758
 07857321-n:
   definition:
   - the yellow spherical part of an egg that is surrounded by the albumen

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -1706,7 +1706,9 @@
   - pressure group
   - third house
   partOfSpeech: n
-  wikidata: Q431603
+  wikidata:
+  - Q431603
+  - Q1666019
 07985639-n:
   definition:
   - groups that seek to control a social system or activity from which they derive
@@ -3360,7 +3362,9 @@
   - mathematical space
   - topological space
   partOfSpeech: n
-  wikidata: Q179899
+  wikidata:
+  - Q179899
+  - Q472971
 08018457-n:
   definition:
   - a company that manages tv or radio stations
@@ -4254,7 +4258,9 @@
   - FAR
   - Interahamwe
   partOfSpeech: n
-  wikidata: Q755973
+  wikidata:
+  - Q755973
+  - Q2862906
 08034010-n:
   definition:
   - an extremist Palestinian Sunni group active in Lebanon in the early 1990s that
@@ -4445,7 +4451,10 @@
   - Black September
   - Revolutionary Organization of Socialist Muslims
   partOfSpeech: n
-  wikidata: Q29014225
+  wikidata:
+  - Q29014225
+  - Q1638579
+  - Q152211
 08037538-n:
   definition:
   - a terrorist group organized by Yasser Arafat in 1995 as the armed wing of al-Fatah;
@@ -4853,7 +4862,9 @@
   - Jund-ul-Islam
   - Soldiers of God
   partOfSpeech: n
-  wikidata: Q20387047
+  wikidata:
+  - Q20387047
+  - Q1048651
 08045150-n:
   definition:
   - a terrorist organization founded for Jewish defense; fights antisemitism and hopes
@@ -4907,7 +4918,9 @@
   - Party of Democratic Kampuchea
   - Communist Party of Kampuchea
   partOfSpeech: n
-  wikidata: Q191764
+  wikidata:
+  - Q191764
+  - Q8711543
 08046174-n:
   definition:
   - a secret society of white Southerners in the United States; was formed in the
@@ -5261,7 +5274,9 @@
   - Nestor Paz Zamora Commission
   - CNPZ
   partOfSpeech: n
-  wikidata: Q1322079
+  wikidata:
+  - Q1322079
+  - Q7071479
 08052354-n:
   definition:
   - a Marxist terrorist group formed in 1963 by Colombian intellectuals who were inspired
@@ -5467,7 +5482,9 @@
   - Popular Struggle Front
   - PSF
   partOfSpeech: n
-  wikidata: Q7127396
+  wikidata:
+  - Q7127396
+  - Q960776
 08056064-n:
   definition:
   - a terrorist organization formed in 1979 by a faction of the Popular Front for
@@ -15104,7 +15121,9 @@
   - percussion
   - rhythm section
   partOfSpeech: n
-  wikidata: Q1456785
+  wikidata:
+  - Q1456785
+  - Q7167191
 08234659-n:
   definition:
   - the section of a band or orchestra that plays trumpets or cornets
@@ -23791,7 +23810,9 @@
   - 07983333-n
   - 08381475-n
   partOfSpeech: n
-  wikidata: Q273005
+  wikidata:
+  - Q273005
+  - Q159810
 08384027-n:
   definition:
   - a non-market economy in which government intervention is important in allocating
@@ -26578,7 +26599,7 @@
   - school board
   - board of education
   partOfSpeech: n
-  wikidata: Q7432149
+  wikidata: Q399541
 08430486-n:
   definition:
   - a board of officials who divide an area into zones that are subject to different

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -4454,7 +4454,6 @@
   wikidata:
   - Q29014225
   - Q1638579
-  - Q152211
 08037538-n:
   definition:
   - a terrorist group organized by Yasser Arafat in 1995 as the armed wing of al-Fatah;

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -267,7 +267,7 @@
   members:
   - Appalachia
   partOfSpeech: n
-  wikidata: Q7833491
+  wikidata: Q2673740
 08510715-n:
   definition:
   - the path of a rocket or projectile or aircraft through the air
@@ -875,7 +875,7 @@
   members:
   - Nicaea
   partOfSpeech: n
-  wikidata: Q7024349
+  wikidata: Q739037
 08521396-n:
   definition:
   - an ancient region of northeastern Africa (southern Egypt and northern Sudan) on
@@ -2216,7 +2216,9 @@
   - urban sprawl
   - sprawl
   partOfSpeech: n
-  wikidata: Q192042
+  wikidata:
+  - Q192042
+  - Q245260
 08557456-n:
   definition:
   - monotonous urban sprawl of standardized buildings
@@ -3580,7 +3582,9 @@
   mero_part:
   - 08580294-n
   partOfSpeech: n
-  wikidata: Q1149081
+  wikidata:
+  - Q1149081
+  - Q205653
 08580294-n:
   definition:
   - a popular expression for the countries of eastern Asia (usually including China
@@ -9961,7 +9965,9 @@
   - American frontier
   - Wild West
   partOfSpeech: n
-  wikidata: Q190267
+  wikidata:
+  - Q190267
+  - Q14947899
 08701024-n:
   definition:
   - a field planted with wheat
@@ -10783,7 +10789,7 @@
   - 09348436-n
   - 09407116-n
   partOfSpeech: n
-  wikidata: Q1415585
+  wikidata: Q889
 08721786-n:
   definition:
   - a city in northwestern Afghanistan on the site of several ancient cities
@@ -10938,7 +10944,7 @@
   members:
   - Annaba
   partOfSpeech: n
-  wikidata: Q3095638
+  wikidata: Q45942
 08724213-n:
   definition:
   - a town in north central Algeria
@@ -11045,7 +11051,9 @@
   members:
   - Numidia
   partOfSpeech: n
-  wikidata: Q12901244
+  wikidata:
+  - Q12901244
+  - Q102679
 08725731-n:
   definition:
   - a republic in southwestern Africa on the Atlantic Ocean; achieved independence
@@ -11640,7 +11648,7 @@
   - 08734892-n
   - 09373421-n
   partOfSpeech: n
-  wikidata: Q2638486
+  wikidata: Q424
 08734892-n:
   definition:
   - the capital and largest city of Kampuchea
@@ -12318,7 +12326,7 @@
   - Hangzhou
   - Hangchow
   partOfSpeech: n
-  wikidata: Q68481
+  wikidata: Q4970
 08745639-n:
   definition:
   - a walled city in southeastern China on the Gan Jiang
@@ -12340,7 +12348,7 @@
   - Nanning
   - Nan-ning
   partOfSpeech: n
-  wikidata: Q68534
+  wikidata: Q179608
 08745899-n:
   definition:
   - a city in eastern China on the Yangtze River; a former capital of China; the scene
@@ -12566,7 +12574,9 @@
   - Macao
   - Macau
   partOfSpeech: n
-  wikidata: Q3916279
+  wikidata:
+  - Q3916279
+  - Q14773
 08749439-n:
   definition:
   - a peninsula of southeastern Asia that includes Myanmar and Cambodia and Laos and
@@ -13358,7 +13368,7 @@
   members:
   - Matamoros
   partOfSpeech: n
-  wikidata: Q984646
+  wikidata: Q738353
 08761778-n:
   definition:
   - a port city in western Mexico on the Pacific Ocean; tourist center
@@ -14403,7 +14413,7 @@
   - 08777685-n
   - 09394062-n
   partOfSpeech: n
-  wikidata: Q1108659
+  wikidata: Q962
 08777517-n:
   definition:
   - the capital of Benin in southwestern part of country on a coastal lagoon
@@ -14528,7 +14538,9 @@
   - 08780213-n
   - 08971730-n
   partOfSpeech: n
-  wikidata: Q35
+  wikidata:
+  - Q35
+  - Q756617
 08779530-n:
   definition:
   - the largest island of Denmark and the site of Copenhagen
@@ -14777,7 +14789,7 @@
   members:
   - Bergen
   partOfSpeech: n
-  wikidata: Q373191
+  wikidata: Q26793
 08783293-n:
   definition:
   - a port city in southwestern Norway; center for shipbuilding industry
@@ -15056,7 +15068,7 @@
   members:
   - Bremen
   partOfSpeech: n
-  wikidata: Q1209
+  wikidata: Q24879
 08788107-n:
   definition:
   - a port city in northwestern Germany at the mouth of the Weser River on the North
@@ -15315,7 +15327,7 @@
   - Nuremberg
   - Nurnberg
   partOfSpeech: n
-  wikidata: Q80130
+  wikidata: Q2090
 08792379-n:
   definition:
   - a city in northeastern Germany; site of the Potsdam Conference in the summer of
@@ -15402,7 +15414,9 @@
   members:
   - Brandenburg
   partOfSpeech: n
-  wikidata: Q157367
+  wikidata:
+  - Q157367
+  - Q148499
 08793617-n:
   definition:
   - a former kingdom in north-central Europe including present-day northern Germany
@@ -15433,7 +15447,9 @@
   - Ruhr
   - Ruhr Valley
   partOfSpeech: n
-  wikidata: Q2175121
+  wikidata:
+  - Q2175121
+  - Q151993
 08794153-n:
   definition:
   - a historical region of southern Germany
@@ -16300,7 +16316,7 @@
   mero_member:
   - 09731150-n
   partOfSpeech: n
-  wikidata: Q170054
+  wikidata: Q12898802
 08808347-n:
   definition:
   - the southern peninsula of Greece; dominated by Sparta until the 4th century BC
@@ -16369,7 +16385,9 @@
   - 09055808-n
   - 09061886-n
   partOfSpeech: n
-  wikidata: Q7204
+  wikidata:
+  - Q7204
+  - Q48214
 08809830-n:
   definition:
   - Arab part of the Middle East
@@ -16767,7 +16785,9 @@
   - 08817558-n
   - 09344807-n
   partOfSpeech: n
-  wikidata: Q23792
+  wikidata:
+  - Q23792
+  - Q48175
 08816623-n:
   definition:
   - a former British mandate on the east coast of the Mediterranean; divided between
@@ -16801,7 +16821,9 @@
   - Judea
   - Judaea
   partOfSpeech: n
-  wikidata: Q104028
+  wikidata:
+  - Q104028
+  - Q1003997
 08817314-n:
   definition:
   - an ancient city in central Palestine founded in the 9th century BC as the capital
@@ -17480,7 +17502,7 @@
   - Sardinia
   - Sardegna
   partOfSpeech: n
-  wikidata: Q3760293
+  wikidata: Q1462
 08828851-n:
   definition:
   - the largest island in the Mediterranean
@@ -17856,7 +17878,9 @@
   - 08835270-n
   - 09285993-n
   partOfSpeech: n
-  wikidata: Q838261
+  wikidata:
+  - Q838261
+  - Q37024
 08834659-n:
   definition:
   - partially recognized country in southeastern Europe
@@ -18007,7 +18031,7 @@
   members:
   - Zagreb
   partOfSpeech: n
-  wikidata: Q27038
+  wikidata: Q1435
 08837075-n:
   definition:
   - a historical region of Croatia on the Adriatic Sea; mountainous with many islands
@@ -18119,7 +18143,7 @@
   - Laurentian Highlands
   - Canadian Shield
   partOfSpeech: n
-  wikidata: Q75596
+  wikidata: Q76034
 08840570-n:
   definition:
   - the collective name for the Canadian provinces of New Brunswick and Nova Scotia
@@ -18617,7 +18641,7 @@
   - 09344244-n
   - 09353510-n
   partOfSpeech: n
-  wikidata: Q251668
+  wikidata: Q176
 08848309-n:
   definition:
   - the French-speaking capital of the province of Quebec; situated on the Saint Lawrence
@@ -18856,7 +18880,7 @@
   members:
   - Wagga Wagga
   partOfSpeech: n
-  wikidata: Q820153
+  wikidata: Q459600
 08852674-n:
   definition:
   - a state in southeastern Australia
@@ -18957,7 +18981,7 @@
   - Perth Township
   - Perth
   partOfSpeech: n
-  wikidata: Q7170903
+  wikidata: Q3183
 08853908-n:
   definition:
   - a territory in north central Australia
@@ -19029,7 +19053,9 @@
   - 08855878-n
   - 08860659-n
   partOfSpeech: n
-  wikidata: Q538
+  wikidata:
+  - Q538
+  - Q55643
 08855157-n:
   definition:
   - Australia, New Zealand, and neighboring islands in the South Pacific
@@ -19330,7 +19356,10 @@
   - Tarawa
   - Bairiki
   partOfSpeech: n
-  wikidata: Q2486
+  wikidata:
+  - Q2486
+  - Q131233
+  - Q999487
 08860067-n:
   definition:
   - a former British possession in Micronesia
@@ -19923,7 +19952,7 @@
   - Antwerp
   - Anvers
   partOfSpeech: n
-  wikidata: Q1116
+  wikidata: Q12892
 08870026-n:
   definition:
   - a city in northwestern Belgium that is connected by canal to the North Sea; in
@@ -19982,7 +20011,7 @@
   members:
   - Namur
   partOfSpeech: n
-  wikidata: Q1125
+  wikidata: Q134121
 08871057-n:
   definition:
   - a town in central Belgium where in 1815 Napoleon met his final defeat
@@ -20166,7 +20195,7 @@
   - Santa Maria de Belem
   - St. Mary of Bethlehem
   partOfSpeech: n
-  wikidata: Q792606
+  wikidata: Q12829733
 08874118-n:
   definition:
   - city in southeastern Brazil to the north of Rio de Janeiro; the first of Brazil's
@@ -20578,7 +20607,9 @@
   mero_member:
   - 09723453-n
   partOfSpeech: n
-  wikidata: Q168052
+  wikidata:
+  - Q168052
+  - Q205905
 08893639-n:
   definition:
   - a popular tourist area in northwestern England including England's largest lake
@@ -20727,7 +20758,7 @@
   - 08896505-n
   - 08896662-n
   partOfSpeech: n
-  wikidata: Q1669574
+  wikidata: Q179351
 08896070-n:
   definition:
   - the London residence of the British sovereign
@@ -20795,7 +20826,7 @@
   members:
   - Wimbledon
   partOfSpeech: n
-  wikidata: Q41520
+  wikidata: Q736742
 08897202-n:
   definition:
   - a city in northwestern England (30 miles to the east of Liverpool); heart of the
@@ -20982,7 +21013,9 @@
   - Portsmouth
   - Pompey
   partOfSpeech: n
-  wikidata: Q72259
+  wikidata:
+  - Q72259
+  - Q21683233
 08900094-n:
   definition:
   - an industrial city in central England; devastated by air raids during World War
@@ -21058,7 +21091,9 @@
   mero_part:
   - 08427988-n
   partOfSpeech: n
-  wikidata: Q1094226
+  wikidata:
+  - Q1094226
+  - Q172157
 08901244-n:
   definition:
   - a cathedral city in west central England on the River Severn
@@ -21148,7 +21183,9 @@
   members:
   - Essex
   partOfSpeech: n
-  wikidata: Q23240
+  wikidata:
+  - Q23240
+  - Q67442940
 08902451-n:
   definition:
   - a county in southwestern England in the lower Severn valley
@@ -21543,7 +21580,9 @@
   - Man
   - Isle of Man
   partOfSpeech: n
-  wikidata: Q27508141
+  wikidata:
+  - Q27508141
+  - Q9676
 08908068-n:
   definition:
   - a division of the United Kingdom located on the northern part of the island of
@@ -22420,7 +22459,9 @@
   - Delhi
   - New Delhi
   partOfSpeech: n
-  wikidata: Q987
+  wikidata:
+  - Q987
+  - Q1353
 08923320-n:
   definition:
   - an industrial city in south central India (west of Chennai)
@@ -22486,7 +22527,9 @@
   members:
   - Hyderabad
   partOfSpeech: n
-  wikidata: Q15340
+  wikidata:
+  - Q15340
+  - Q1361
 08924360-n:
   definition:
   - a city in Tamil Nadu on the Bay of Bengal; formerly Madras
@@ -22735,7 +22778,7 @@
   - 08929310-n
   - 09198812-n
   partOfSpeech: n
-  wikidata: Q188161
+  wikidata: Q252
 08928021-n:
   definition:
   - an island in Indonesia to the south of Borneo; one of the world's most densely
@@ -23279,7 +23322,9 @@
   mero_part:
   - 08938021-n
   partOfSpeech: n
-  wikidata: Q47690
+  wikidata:
+  - Q47690
+  - Q200969
 08937654-n:
   definition:
   - an ancient region of Mesopotamia lying between the Euphrates delta and the Persian
@@ -23596,7 +23641,7 @@
   members:
   - Yokohama
   partOfSpeech: n
-  wikidata: Q1190021
+  wikidata: Q38283
 08944173-n:
   definition:
   - the largest island of the central Ryukyu Islands
@@ -23609,7 +23654,7 @@
   mero_part:
   - 08944333-n
   partOfSpeech: n
-  wikidata: Q697589
+  wikidata: Q600614
 08944333-n:
   definition:
   - the chief city in the Ryukyu Islands
@@ -24291,7 +24336,7 @@
   members:
   - Le Havre
   partOfSpeech: n
-  wikidata: Q1129891
+  wikidata: Q42810
 08956249-n:
   definition:
   - an industrial city in northern France near the Belgian border; was the medieval
@@ -24468,7 +24513,7 @@
   members:
   - Vienne
   partOfSpeech: n
-  wikidata: Q12804
+  wikidata: Q26849
 08958974-n:
   definition:
   - a coastal area between La Spezia in Italy and Cannes in France
@@ -24538,7 +24583,7 @@
   - Aquitaine
   - Aquitania
   partOfSpeech: n
-  wikidata: Q715376
+  wikidata: Q1179
 08960443-n:
   definition:
   - a former province of northern France near the English Channel (between Picardy
@@ -24550,7 +24595,7 @@
   - County of Artois
   - Artois
   partOfSpeech: n
-  wikidata: Q778266
+  wikidata: Q159987
 08960608-n:
   definition:
   - a region in central France
@@ -24609,7 +24654,7 @@
   - Centre-Val de Loire
   - Centre
   partOfSpeech: n
-  wikidata: Q3123388
+  wikidata: Q13947
 08961308-n:
   definition:
   - a region of northeastern France
@@ -24644,7 +24689,9 @@
   - Corse
   - Corsica
   partOfSpeech: n
-  wikidata: Q3336
+  wikidata:
+  - Q3336
+  - Q14112
 08961864-n:
   definition:
   - an island in the Mediterranean; with adjacent islets it constitutes a region of
@@ -25199,7 +25246,9 @@
   members:
   - Apeldoorn
   partOfSpeech: n
-  wikidata: Q3018561
+  wikidata:
+  - Q3018561
+  - Q101918
 08970003-n:
   definition:
   - a city in the central Netherlands on the lower Rhine River; site of a battle in
@@ -25276,7 +25325,7 @@
   members:
   - Utrecht
   partOfSpeech: n
-  wikidata: Q776
+  wikidata: Q803
 08971158-n:
   definition:
   - one of the northernmost provinces of the Netherlands
@@ -25592,7 +25641,7 @@
   - Gwangju
   - Kwangju
   partOfSpeech: n
-  wikidata: Q42069
+  wikidata: Q41283
 08976234-n:
   definition:
   - a city in southeastern South Korea
@@ -25659,7 +25708,9 @@
   mero_member:
   - 09739429-n
   partOfSpeech: n
-  wikidata: Q5700
+  wikidata:
+  - Q5700
+  - Q62132
 08977154-n:
   definition:
   - an Asian republic at east end of Mediterranean
@@ -25990,7 +26041,7 @@
   - 08983017-n
   - 09355300-n
   partOfSpeech: n
-  wikidata: Q1649306
+  wikidata: Q1020
 08982724-n:
   definition:
   - city in southern Malawi; largest city and commercial center of Malawi
@@ -26324,7 +26375,7 @@
   - 08988436-n
   - 09394062-n
   partOfSpeech: n
-  wikidata: Q508014
+  wikidata: Q912
 08988309-n:
   definition:
   - the capital of Mali; located in the south on the Niger
@@ -26532,7 +26583,7 @@
   - 08991474-n
   - 09192698-n
   partOfSpeech: n
-  wikidata: Q212056
+  wikidata: Q711
 08991474-n:
   definition:
   - the capital and largest city of Mongolia
@@ -26942,7 +26993,7 @@
   mero_part:
   - 08997805-n
   partOfSpeech: n
-  wikidata: Q157734
+  wikidata: Q842
 08997805-n:
   definition:
   - a port on the Gulf of Oman and capital of the sultanate of Oman
@@ -27005,7 +27056,7 @@
   - 09407116-n
   - 09482244-n
   partOfSpeech: n
-  wikidata: Q2342822
+  wikidata: Q843
 08999169-n:
   definition:
   - city in northeast Pakistan, the third largest metropolis in Pakistan
@@ -27026,7 +27077,7 @@
   members:
   - Hyderabad
   partOfSpeech: n
-  wikidata: Q1361
+  wikidata: Q1640079
 08999405-n:
   definition:
   - the capital of Pakistan in the north on a plateau; the site was chosen in 1959
@@ -27079,7 +27130,7 @@
   members:
   - Rawalpindi
   partOfSpeech: n
-  wikidata: Q24440
+  wikidata: Q93230
 09000215-n:
   definition:
   - a region of southeastern Pakistan
@@ -27609,7 +27660,9 @@
   members:
   - Braga
   partOfSpeech: n
-  wikidata: Q3344946
+  wikidata:
+  - Q3344946
+  - Q83247
 09008436-n:
   definition:
   - capital and largest city and economic and cultural center of Portugal; a major
@@ -27912,7 +27965,9 @@
   - Tubuai Islands
   - Austral Islands
   partOfSpeech: n
-  wikidata: Q514626
+  wikidata:
+  - Q514626
+  - Q930426
 09013214-n:
   definition:
   - a group of islands in the south central Pacific; part of French Polynesia
@@ -29670,7 +29725,9 @@
   mero_member:
   - 09660722-n
   partOfSpeech: n
-  wikidata: Q31354462
+  wikidata:
+  - Q31354462
+  - Q23334
 09041962-n:
   definition:
   - an autonomous province of Georgia on the Black Sea
@@ -30267,7 +30324,9 @@
   mero_member:
   - 09768342-n
   partOfSpeech: n
-  wikidata: Q690347
+  wikidata:
+  - Q690347
+  - Q1410
 09051612-n:
   definition:
   - a region of northern Africa to the south of the Sahara and Libyan deserts; extends
@@ -30983,7 +31042,9 @@
   - Adana
   - Seyhan
   partOfSpeech: n
-  wikidata: Q524349
+  wikidata:
+  - Q524349
+  - Q38545
 09063076-n:
   definition:
   - the capital of Turkey; located in west-central Turkey; it was formerly known as
@@ -32536,7 +32597,7 @@
   - Santa Catalina
   - Catalina Island
   partOfSpeech: n
-  wikidata: Q1477398
+  wikidata: Q845229
 09089615-n:
   definition:
   - a town in western California on Monterey Bay; a tourist center
@@ -33032,7 +33093,7 @@
   members:
   - Pensacola
   partOfSpeech: n
-  wikidata: Q7164674
+  wikidata: Q486306
 09097212-n:
   definition:
   - a town in west central Florida on the Gulf of Mexico
@@ -34505,7 +34566,9 @@
   - Massachusetts
   - Massachusetts Bay Colony
   partOfSpeech: n
-  wikidata: Q2079909
+  wikidata:
+  - Q2079909
+  - Q1191350
 09118343-n:
   definition:
   - state capital and largest city of Massachusetts; a major center for banking and
@@ -34655,7 +34718,7 @@
   members:
   - Worcester
   partOfSpeech: n
-  wikidata: Q54093
+  wikidata: Q49179
 09120619-n:
   definition:
   - a Massachusetts peninsula to the north of Boston extending into the Atlantic Ocean
@@ -35411,7 +35474,7 @@
   members:
   - Great Falls
   partOfSpeech: n
-  wikidata: Q37774
+  wikidata: Q466190
 09131810-n:
   definition:
   - capital of the state of Montana; located in western Montana
@@ -35465,7 +35528,7 @@
   members:
   - Grand Island
   partOfSpeech: n
-  wikidata: Q5594682
+  wikidata: Q461826
 09132519-n:
   definition:
   - capital of the state of Nebraska; located in southeastern Nebraska; site of the
@@ -35779,7 +35842,7 @@
   members:
   - Cape May
   partOfSpeech: n
-  wikidata: Q138548
+  wikidata: Q2065437
 09137054-n:
   definition:
   - an island in New York Bay to the southwest of Manhattan where the Statue of Liberty
@@ -36134,7 +36197,7 @@
   members:
   - Bronx
   partOfSpeech: n
-  wikidata: Q855974
+  wikidata: Q18426
 09142754-n:
   definition:
   - a borough of New York City, the most populous and second-largest in area of New
@@ -37796,7 +37859,7 @@
   members:
   - Galveston
   partOfSpeech: n
-  wikidata: Q26587
+  wikidata: Q135744
 09167342-n:
   definition:
   - an island at the entrance of Galveston Bay
@@ -38118,7 +38181,7 @@
   mero_part:
   - 04520343-n
   partOfSpeech: n
-  wikidata: Q26065
+  wikidata: Q31058
 09171620-n:
   definition:
   - a town in central Vermont
@@ -38771,7 +38834,7 @@
   members:
   - Wausau
   partOfSpeech: n
-  wikidata: Q7975214
+  wikidata: Q998675
 09181789-n:
   definition:
   - a state in the western United States; mountainous in the west and north with the
@@ -39663,7 +39726,7 @@
   mero_part:
   - 09193685-n
   partOfSpeech: n
-  wikidata: Q3889421
+  wikidata: Q6583
 09195377-n:
   definition:
   - the region of Africa to the south of the Sahara Desert

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -17490,7 +17490,6 @@
   - Sardinia
   - Sardegna
   partOfSpeech: n
-  wikidata: Q1462
 08828638-n:
   definition:
   - the Italian region on the island of Sardinia; the kingdom of Sardinia was the
@@ -23322,9 +23321,7 @@
   mero_part:
   - 08938021-n
   partOfSpeech: n
-  wikidata:
-  - Q47690
-  - Q200969
+  wikidata: Q47690
 08937654-n:
   definition:
   - an ancient region of Mesopotamia lying between the Euphrates delta and the Persian
@@ -24689,9 +24686,7 @@
   - Corse
   - Corsica
   partOfSpeech: n
-  wikidata:
-  - Q3336
-  - Q14112
+  wikidata: Q3336
 08961864-n:
   definition:
   - an island in the Mediterranean; with adjacent islets it constitutes a region of

--- a/src/yaml/noun.motive.yaml
+++ b/src/yaml/noun.motive.yaml
@@ -200,7 +200,7 @@
   - alcoholism
   - potomania
   partOfSpeech: n
-  wikidata: Q7235099
+  wikidata: Q15326
 09205039-n:
   definition:
   - an intense and irresistible love for yourself and concern for your own needs

--- a/src/yaml/noun.object.yaml
+++ b/src/yaml/noun.object.yaml
@@ -715,7 +715,7 @@
   - Annapurna
   - Anapurna
   partOfSpeech: n
-  wikidata: Q159621
+  wikidata: Q16466024
 09220984-n:
   definition:
   - an extremely cold continent at the south pole almost entirely below the Antarctic
@@ -2256,7 +2256,9 @@
   members:
   - Blue Nile
   partOfSpeech: n
-  wikidata: Q753897
+  wikidata:
+  - Q753897
+  - Q882739
 09247232-n:
   definition:
   - a range of the Appalachians extending from southern Pennsylvania to northern Georgia
@@ -3923,7 +3925,7 @@
   - Stalin Peak
   - Mount Garmo
   partOfSpeech: n
-  wikidata: Q619132
+  wikidata: Q41413
 09274984-n:
   definition:
   - a major African river (one of the world's longest); flows through Congo into the
@@ -4410,7 +4412,9 @@
   mero_part:
   - 09284313-n
   partOfSpeech: n
-  wikidata: Q1143656
+  wikidata:
+  - Q1143656
+  - Q1143699
 09284678-n:
   definition:
   - a dark cloud of great vertical extent charged with electricity; associated with
@@ -5100,7 +5104,7 @@
   - Elbe
   - Elbe River
   partOfSpeech: n
-  wikidata: Q896094
+  wikidata: Q1644
 09294680-n:
   definition:
   - a dipole with equal and opposite electric charges
@@ -8672,7 +8676,7 @@
   - Lake Vanern
   - Vanern
   partOfSpeech: n
-  wikidata: Q10717345
+  wikidata: Q173596
 09356955-n:
   definition:
   - the largest lake in Africa and the 2nd largest fresh water lake in the world;
@@ -9237,7 +9241,7 @@
   members:
   - Long Island Sound
   partOfSpeech: n
-  wikidata: Q7493967
+  wikidata: Q867460
 09366493-n:
   definition:
   - Irish word for a lake
@@ -12376,7 +12380,7 @@
   - polar star
   - polestar
   partOfSpeech: n
-  wikidata: Q662656
+  wikidata: Q12980
 09419876-n:
   definition:
   - low-lying land that has been reclaimed and is protected by dikes (especially in
@@ -14187,7 +14191,7 @@
   - Severn
   - Severn River
   partOfSpeech: n
-  wikidata: Q681048
+  wikidata: Q1239783
 09454037-n:
   definition:
   - a Turkish river flowing south southwest into the Mediterranean
@@ -14899,7 +14903,7 @@
   - South Platte
   - South Platte River
   partOfSpeech: n
-  wikidata: Q7567293
+  wikidata: Q130892
 09464779-n:
   definition:
   - any sea to the south of the equator (but especially the South Pacific)
@@ -15461,7 +15465,7 @@
   members:
   - Sun River
   partOfSpeech: n
-  wikidata: Q955787
+  wikidata: Q3503758
 09473857-n:
   definition:
   - an extremely bright star of very large diameter and low density

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -2775,9 +2775,7 @@
   - Mitra Samaja
   - Mitra
   partOfSpeech: n
-  wikidata:
-  - Q1332956
-  - Q6497135
+  wikidata: Q1332956
 09550588-n:
   definition:
   - Hindu god of rain; sometimes identified with Indra

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -2128,7 +2128,9 @@
   - Nintinugga
   - Gula
   partOfSpeech: n
-  wikidata: Q1265256
+  wikidata:
+  - Q1265256
+  - Q1028642
 09541713-n:
   definition:
   - any of a group of heavenly spirits under the god Anu
@@ -2773,7 +2775,9 @@
   - Mitra Samaja
   - Mitra
   partOfSpeech: n
-  wikidata: Q1332956
+  wikidata:
+  - Q1332956
+  - Q6497135
 09550588-n:
   definition:
   - Hindu god of rain; sometimes identified with Indra
@@ -3114,7 +3118,9 @@
   - Mithras
   - Mithra
   partOfSpeech: n
-  wikidata: Q6497135
+  wikidata:
+  - Q6497135
+  - Q12614595
 09555087-n:
   definition:
   - chief deity of Zoroastrianism; source of light and embodiment of good
@@ -3555,7 +3561,7 @@
   - Holy Spirit
   - Paraclete
   partOfSpeech: n
-  wikidata: Q37302
+  wikidata: Q58646537
 09561132-n:
   definition:
   - any of the three persons of the Godhead constituting the Trinity especially the
@@ -3587,7 +3593,9 @@
   - Jehovah
   - JHVH
   partOfSpeech: n
-  wikidata: Q105173
+  wikidata:
+  - Q105173
+  - Q3678579
 09561655-n:
   definition:
   - Muslim name for the one and only God
@@ -3597,7 +3605,7 @@
   members:
   - Allah
   partOfSpeech: n
-  wikidata: Q2095353
+  wikidata: Q234801
 09561744-n:
   definition:
   - a subordinate deity, in some philosophies the creator of the universe
@@ -4295,7 +4303,9 @@
   - Hesperides
   - Atlantides
   partOfSpeech: n
-  wikidata: Q9161674
+  wikidata:
+  - Q9161674
+  - Q165938
 09572545-n:
   definition:
   - (Greek mythology) 7 daughters of Atlas and half-sisters of the Pleiades; they
@@ -4541,7 +4551,7 @@
   members:
   - Hero
   partOfSpeech: n
-  wikidata: Q5742616
+  wikidata: Q19776360
 09577634-n:
   definition:
   - (Greek mythology) a youth beloved of Hero who drowned in a storm in the Hellespont
@@ -5617,7 +5627,9 @@
   - Kore
   - Cora
   partOfSpeech: n
-  wikidata: Q45967
+  wikidata:
+  - Q45967
+  - Q1146978
 09592838-n:
   definition:
   - (Greek mythology) a mythical giant who was a thief and murderer; he would capture
@@ -6959,7 +6971,7 @@
   - Bond
   - James Bond
   partOfSpeech: n
-  wikidata: Q844
+  wikidata: Q2009573
 09613669-n:
   definition:
   - a Valkyrie or a queen in the Nibelungenlied who loved the hero Siegfried; when
@@ -16253,7 +16265,9 @@
   - abbot
   - archimandrite
   partOfSpeech: n
-  wikidata: Q213159
+  wikidata:
+  - Q213159
+  - Q103163
 09773872-n:
   definition:
   - a person who abjures
@@ -16689,7 +16703,9 @@
   - comptroller
   - controller
   partOfSpeech: n
-  wikidata: Q673633
+  wikidata:
+  - Q673633
+  - Q326653
 09781176-n:
   definition:
   - someone in charge of a client's account for an advertising agency or brokerage
@@ -19140,7 +19156,10 @@
   - prelate
   - primate
   partOfSpeech: n
-  wikidata: Q1190552
+  wikidata:
+  - Q1190552
+  - Q326330
+  - Q725440
 09826802-n:
   definition:
   - a member of the council of the Areopagus
@@ -30219,7 +30238,7 @@
   - pastor
   - rector
   partOfSpeech: n
-  wikidata: Q1753370
+  wikidata: Q1423891
 10003419-n:
   definition:
   - the custodian of a collection (as a museum or library)
@@ -60873,7 +60892,9 @@
   - coder
   - software engineer
   partOfSpeech: n
-  wikidata: Q1709010
+  wikidata:
+  - Q1709010
+  - Q5482740
 10501146-n:
   definition:
   - the person who operates the projector in a movie house
@@ -61063,7 +61084,7 @@
   - prosecuting officer
   - prosecuting attorney
   partOfSpeech: n
-  wikidata: Q7257507
+  wikidata: Q600751
 10504753-n:
   definition:
   - a new convert; especially a gentile converted to Judaism
@@ -62693,7 +62714,9 @@
   - land agent
   - house agent
   partOfSpeech: n
-  wikidata: Q519076
+  wikidata:
+  - Q519076
+  - Q16148831
 10529671-n:
   definition:
   - a real estate agent who is a member of the National Association of Realtors
@@ -65239,7 +65262,9 @@
   - Saint Nick
   - St. Nick
   partOfSpeech: n
-  wikidata: Q315796
+  wikidata:
+  - Q315796
+  - Q1580236
 10570508-n:
   definition:
   - (Middle Ages) the nephew of the king of Cornwall who (according to legend) fell
@@ -77319,7 +77344,9 @@
   - moneylender
   - shylock
   partOfSpeech: n
-  wikidata: Q2893189
+  wikidata:
+  - Q2893189
+  - Q1975715
 10762203-n:
   definition:
   - one who wrongfully or illegally seizes and holds the place of another
@@ -88793,7 +88820,7 @@
   - Daimler
   - Gottlieb Daimler
   partOfSpeech: n
-  wikidata: Q27530
+  wikidata: Q57098
 10940970-n:
   definition:
   - surrealist Spanish painter (1904-1989)
@@ -92905,7 +92932,7 @@
   - Fuentes
   - Carlos Fuentes
   partOfSpeech: n
-  wikidata: Q5750390
+  wikidata: Q154691
 11004975-n:
   definition:
   - South African playwright whose plays feature the racial tensions in South Africa
@@ -101322,7 +101349,7 @@
   - Krupp
   - Friedrich Krupp
   partOfSpeech: n
-  wikidata: Q61543
+  wikidata: Q63030
 11131835-n:
   definition:
   - German arms manufacturer and son of Friedrich Krupp; his firm provided ordnance
@@ -102035,7 +102062,7 @@
   - Timothy Leary
   - Timothy Francis Leary
   partOfSpeech: n
-  wikidata: Q7803817
+  wikidata: Q211731
 11142815-n:
   definition:
   - English writer of novels of espionage (born in 1931)
@@ -106947,7 +106974,7 @@
   - Morris
   - Robert Morris
   partOfSpeech: n
-  wikidata: Q7412232
+  wikidata: Q464876
 11212057-n:
   definition:
   - English poet and craftsman (1834-1896)
@@ -110980,7 +111007,7 @@
   - Pyrrhus of Epirus
   - Pyrrhus
   partOfSpeech: n
-  wikidata: Q94848
+  wikidata: Q172353
 11270046-n:
   definition:
   - Greek philosopher and mathematician who proved the Pythagorean theorem; considered
@@ -117653,7 +117680,7 @@
   - Arnold Toynbee
   - Arnold Joseph Toynbee
   partOfSpeech: n
-  wikidata: Q537152
+  wikidata: Q185381
 11367514-n:
   definition:
   - United States film actor who appeared in many films with Katharine Hepburn (1900-1967)

--- a/src/yaml/noun.phenomenon.yaml
+++ b/src/yaml/noun.phenomenon.yaml
@@ -4803,7 +4803,9 @@
   - potential drop
   - voltage
   partOfSpeech: n
-  wikidata: Q55451
+  wikidata:
+  - Q55451
+  - Q25428
 11514476-n:
   definition:
   - the electrical response of the central nervous system produced by an external
@@ -5848,7 +5850,9 @@
   - electric arc
   - electric discharge
   partOfSpeech: n
-  wikidata: Q488071
+  wikidata:
+  - Q488071
+  - Q207456
 11532198-n:
   definition:
   - a change (usually undesired) in the waveform of an acoustic or analog electrical

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -96354,7 +96354,6 @@
   mero_part:
   - 11703311-n
   partOfSpeech: n
-  wikidata: Q28114
 13240731-n:
   definition:
   - of Eurasia and Greenland and North America

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -395,7 +395,9 @@
   - bryophyte
   - nonvascular plant
   partOfSpeech: n
-  wikidata: Q29993
+  wikidata:
+  - Q29993
+  - Q3239742
 11557957-n:
   definition:
   - tiny leafy-stemmed flowerless plants
@@ -1974,7 +1976,9 @@
   - Macrozamia communis
   - Macrozamia spiralis
   partOfSpeech: n
-  wikidata: Q5402509
+  wikidata:
+  - Q5402509
+  - Q5472958
 11624676-n:
   definition:
   - fossil gymnospermous plants of the Carboniferous
@@ -2648,7 +2652,9 @@
   - Georgia pine
   - Pinus palustris
   partOfSpeech: n
-  wikidata: Q3300799
+  wikidata:
+  - Q3300799
+  - Q148542
 11636711-n:
   definition:
   - large pine of southern United States having short needles in bunches of 2-3 and
@@ -2992,7 +2998,9 @@
   - Abies concolor
   - Abies lowiana
   partOfSpeech: n
-  wikidata: Q967962
+  wikidata:
+  - Q967962
+  - Q145939
 11642401-n:
   definition:
   - medium-sized fir of northeastern North America; leaves smell of balsam when crushed;
@@ -5598,7 +5606,9 @@
   - 13161312-n
   - 13169385-n
   partOfSpeech: n
-  wikidata: Q8316
+  wikidata:
+  - Q8316
+  - Q1307404
 11687305-n:
   definition:
   - flowering plant with two cotyledons; the stem grows by deposit on its outside
@@ -6321,7 +6331,9 @@
   - strobilus
   - strobile
   partOfSpeech: n
-  wikidata: Q2653441
+  wikidata:
+  - Q2653441
+  - Q22710
 11703574-n:
   definition:
   - the seed-producing cone of a fir tree
@@ -6989,7 +7001,9 @@
   - 11739937-n
   - 11759999-n
   partOfSpeech: n
-  wikidata: Q21021
+  wikidata:
+  - Q21021
+  - Q14848818
 11714035-n:
   definition:
   - chiefly tropical trees or shrubs
@@ -14741,7 +14755,9 @@
   - Amaranthus albus
   - Amaranthus graecizans
   partOfSpeech: n
-  wikidata: Q164118
+  wikidata:
+  - Q164118
+  - Q162295
 11844041-n:
   definition:
   - young leaves widely used as leaf vegetables; seeds used as cereal
@@ -19697,7 +19713,9 @@
   - bocconia
   - Macleaya cordata
   partOfSpeech: n
-  wikidata: Q159327
+  wikidata:
+  - Q159327
+  - Q1974044
 11927182-n:
   definition:
   - herbs almost entirely of mountains of China and Tibet; often monocarpic
@@ -19894,7 +19912,7 @@
   - fumeroot
   - Fumaria officinalis
   partOfSpeech: n
-  wikidata: Q157496
+  wikidata: Q157618
 11930214-n:
   definition:
   - 'one species: climbing fumitory'
@@ -24995,7 +25013,9 @@
   - Matricaria recutita
   - Matricaria chamomilla
   partOfSpeech: n
-  wikidata: Q3978815
+  wikidata:
+  - Q3978815
+  - Q28437
 12015865-n:
   definition:
   - annual aromatic weed of Pacific coastal areas (United States and northeastern
@@ -25718,7 +25738,7 @@
   - Rhodanthe manglesii
   - Helipterum manglesii
   partOfSpeech: n
-  wikidata: Q2704490
+  wikidata: Q7320876
 12028486-n:
   definition:
   - North American perennial herbs with showy cone-shaped flower heads
@@ -26074,7 +26094,9 @@
   - Seriphidium canum
   - Artemisia cana
   partOfSpeech: n
-  wikidata: Q583160
+  wikidata:
+  - Q583160
+  - Q1431474
 12034824-n:
   definition:
   - plants of western and northern European coasts
@@ -37959,7 +37981,7 @@
   mero_substance:
   - 12246286-n
   partOfSpeech: n
-  wikidata: Q7607619
+  wikidata: Q4879779
 12243922-n:
   definition:
   - waratahs (Telopea)
@@ -44452,7 +44474,9 @@
   mero_member:
   - 12353570-n
   partOfSpeech: n
-  wikidata: Q2470494
+  wikidata:
+  - Q2470494
+  - Q3004081
 12353570-n:
   definition:
   - small evergreen tropical tree native to Brazil and West Indies but introduced
@@ -44664,7 +44688,9 @@
   mero_substance:
   - 12359607-n
   partOfSpeech: n
-  wikidata: Q5850228
+  wikidata:
+  - Q5850228
+  - Q162822
 12357103-n:
   definition:
   - medium-sized swamp gum of New South Wales and Victoria
@@ -46530,7 +46556,9 @@
   - Garcinia cambogia
   - Garcinia gummi-gutta
   partOfSpeech: n
-  wikidata: Q2089493
+  wikidata:
+  - Q2089493
+  - Q767747
 12387639-n:
   definition:
   - used in some classification systems for plants usually included among the Guttiferae
@@ -46791,7 +46819,9 @@
   mero_part:
   - 07779605-n
   partOfSpeech: n
-  wikidata: Q163522
+  wikidata:
+  - Q163522
+  - Q343300
 12392221-n:
   definition:
   - ornamental vine of eastern Asia having yellow edible fruit and leaves with silver-white
@@ -47339,7 +47369,7 @@
   - idesia
   - Idesia polycarpa
   partOfSpeech: n
-  wikidata: Q1284309
+  wikidata: Q3147858
 12401114-n:
   definition:
   - small genus of South African shrubs or small trees
@@ -52754,7 +52784,9 @@
   - Polygonatum biflorum
   - Polygonatum commutatum
   partOfSpeech: n
-  wikidata: Q4117736
+  wikidata:
+  - Q4117736
+  - Q7226448
 12495125-n:
   definition:
   - one of many subfamilies into which some classification systems subdivide the Liliaceae,
@@ -53396,7 +53428,7 @@
   - butterfly bush
   - buddleia
   partOfSpeech: n
-  wikidata: Q5002966
+  wikidata: Q158011
 12506316-n:
   definition:
   - evergreen twining shrubs of Americas and southeastern Asia
@@ -54254,7 +54286,9 @@
   - Senna obtusifolia
   - Cassia tora
   partOfSpeech: n
-  wikidata: Q1378803
+  wikidata:
+  - Q1378803
+  - Q21872227
 12521256-n:
   definition:
   - very leafy malodorous tropical weedy shrub whose seeds have been used as an adulterant
@@ -55064,7 +55098,9 @@
   - Chamaecytisus palmensis
   - Cytesis proliferus
   partOfSpeech: n
-  wikidata: Q7675170
+  wikidata:
+  - Q7675170
+  - Q15531292
 12535307-n:
   definition:
   - '2 species of small New Zealand trees: weeping tree broom; endangered'
@@ -56149,7 +56185,7 @@
   - American liquorice
   - Glycyrrhiza lepidota
   partOfSpeech: n
-  wikidata: Q164138
+  wikidata: Q8000935
 12553942-n:
   definition:
   - root of licorice used in flavoring e.g. candy and liqueurs and medicines
@@ -57255,7 +57291,7 @@
   - Onobrychis viciifolia
   - Onobrychis viciaefolia
   partOfSpeech: n
-  wikidata: Q7400491
+  wikidata: Q157933
 12573163-n:
   definition:
   - 'genus of European subshrubs or herbs having pink or purple or yellow solitary
@@ -61900,7 +61936,7 @@
   - summer haw
   - Crataegus aestivalis
   partOfSpeech: n
-  wikidata: Q6797256
+  wikidata: Q631650
 12648511-n:
   definition:
   - thorny Eurasian shrub of small tree having dense clusters of white to scarlet
@@ -62985,7 +63021,9 @@
   mero_part:
   - 07766562-n
   partOfSpeech: n
-  wikidata: Q39918
+  wikidata:
+  - Q39918
+  - Q15545507
 12666291-n:
   definition:
   - almond trees having white blossoms and poisonous nuts yielding an oil used for
@@ -63156,7 +63194,7 @@
   mero_part:
   - 07766980-n
   partOfSpeech: n
-  wikidata: Q3900720
+  wikidata: Q13189
 12668957-n:
   definition:
   - variety or mutation of the peach bearing fruit with smooth skin and (usually)
@@ -63442,7 +63480,9 @@
   - Rubus cissoides
   - Rubus australis
   partOfSpeech: n
-  wikidata: Q7376205
+  wikidata:
+  - Q7376205
+  - Q7376203
 12674394-n:
   definition:
   - European trailing bramble with red berrylike fruits
@@ -64129,7 +64169,9 @@
   - Cinchona ledgeriana
   - Cinchona calisaya
   partOfSpeech: n
-  wikidata: Q5120189
+  wikidata:
+  - Q5120189
+  - Q3091779
 12685230-n:
   definition:
   - small tree of Ecuador and Peru having very large glossy leaves and large panicles
@@ -68444,7 +68486,7 @@
   - buckleya
   - Buckleya distichophylla
   partOfSpeech: n
-  wikidata: Q2380527
+  wikidata: Q4983376
 12756824-n:
   definition:
   - small genus of chiefly North American parasitic plants
@@ -72409,7 +72451,7 @@
   - parnassia
   - grass-of-Parnassus
   partOfSpeech: n
-  wikidata: Q161633
+  wikidata: Q159077
 12822541-n:
   definition:
   - plant having ovate leaves in a basal rosette and white starlike flowers netted
@@ -84771,7 +84813,7 @@
   - fairy ring
   - fairy circle
   partOfSpeech: n
-  wikidata: Q380571
+  wikidata: Q843581
 13027955-n:
   definition:
   - agarics with white spores and caps having an eccentric stem; an important mushroom
@@ -85870,7 +85912,7 @@
   - brewer's yeast
   - Saccharomyces cerevisiae
   partOfSpeech: n
-  wikidata: Q911712
+  wikidata: Q719725
 13046775-n:
   definition:
   - used in making wine
@@ -90483,7 +90525,7 @@
   - xerophile
   - xerophilous plant
   partOfSpeech: n
-  wikidata: Q980491
+  wikidata: Q212337
 13142108-n:
   definition:
   - land plant growing in surroundings having an average supply of water; compare
@@ -91706,7 +91748,7 @@
   - lotus tree
   - Ziziphus lotus
   partOfSpeech: n
-  wikidata: Q1724064
+  wikidata: Q405596
 13164403-n:
   definition:
   - thorny Eurasian shrubs
@@ -93784,7 +93826,9 @@
   - Platycerium bifurcatum
   - Platycerium alcicorne
   partOfSpeech: n
-  wikidata: Q4364577
+  wikidata:
+  - Q4364577
+  - Q2170121
 13199005-n:
   definition:
   - epiphytic or lithophytic or terrestrial ferns of tropical Old World
@@ -94656,7 +94700,9 @@
   - 13222137-n
   - 13222623-n
   partOfSpeech: n
-  wikidata: Q3774137
+  wikidata:
+  - Q3774137
+  - Q656683
 13213523-n:
   definition:
   - any of various ferns of the genera Dryopteris or Polystichum or Lastreopsis having
@@ -96308,7 +96354,7 @@
   mero_part:
   - 11703311-n
   partOfSpeech: n
-  wikidata: Q7676058
+  wikidata: Q28114
 13240731-n:
   definition:
   - of Eurasia and Greenland and North America

--- a/src/yaml/noun.possession.yaml
+++ b/src/yaml/noun.possession.yaml
@@ -128,7 +128,7 @@
   - tenure
   - land tenure
   partOfSpeech: n
-  wikidata: Q1483709
+  wikidata: Q66493932
 13263821-n:
   definition:
   - a medieval form of land tenure in England; a copyhold was a parcel of land granted
@@ -4447,7 +4447,7 @@
   - property tax
   - land tax
   partOfSpeech: n
-  wikidata: Q7631774
+  wikidata: Q1057250
 13333776-n:
   definition:
   - a tax levied on households by local authorities; based on the estimated value
@@ -9456,7 +9456,7 @@
   - Federal Reserve note
   - greenback
   partOfSpeech: n
-  wikidata: Q47433
+  wikidata: Q5603663
 13415352-n:
   definition:
   - formerly a bank note issued by the United States Treasury and redeemable in silver

--- a/src/yaml/noun.process.yaml
+++ b/src/yaml/noun.process.yaml
@@ -2833,7 +2833,9 @@
   - enuresis
   - urinary incontinence
   partOfSpeech: n
-  wikidata: Q281490
+  wikidata:
+  - Q281490
+  - Q3448862
 13496275-n:
   definition:
   - a geological change in the mineral content of rock after the rock has formed

--- a/src/yaml/noun.quantity.yaml
+++ b/src/yaml/noun.quantity.yaml
@@ -2617,7 +2617,7 @@
   mero_part:
   - 13645383-n
   partOfSpeech: n
-  wikidata: Q2175964
+  wikidata: Q11582
 13645904-n:
   definition:
   - a metric unit of volume or capacity equal to 10 liters
@@ -2661,7 +2661,9 @@
   mero_part:
   - 13646100-n
   partOfSpeech: n
-  wikidata: Q3972226
+  wikidata:
+  - Q3972226
+  - Q25517
 13646496-n:
   definition:
   - a unit of capacity equal to the volume of a cube one kilometer on each edge
@@ -2817,7 +2819,9 @@
   mero_part:
   - 13648798-n
   partOfSpeech: n
-  wikidata: Q79756
+  wikidata:
+  - Q79756
+  - Q79726
 13649142-n:
   definition:
   - a unit of information equal to 1000 bytes

--- a/src/yaml/noun.relation.yaml
+++ b/src/yaml/noun.relation.yaml
@@ -341,7 +341,7 @@
   - identity element
   - identity operator
   partOfSpeech: n
-  wikidata: Q185813
+  wikidata: Q321119
 13809172-n:
   definition:
   - function of an angle expressed as a ratio of the length of the sides of right-angled

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -5960,7 +5960,9 @@
   - cardiac arrest
   - cardiopulmonary arrest
   partOfSpeech: n
-  wikidata: Q752800
+  wikidata:
+  - Q752800
+  - Q202837
 14048353-n:
   definition:
   - a natural and periodic state of rest during which consciousness of the world is
@@ -7604,7 +7606,9 @@
   - acholia
   - cholestasis
   partOfSpeech: n
-  wikidata: Q8187550
+  wikidata:
+  - Q8187550
+  - Q1075923
 14078124-n:
   definition:
   - absence of gastric juices (partial or complete)
@@ -9181,7 +9185,7 @@
   mero_part:
   - 14393796-n
   partOfSpeech: n
-  wikidata: Q8264724
+  wikidata: Q12202
 14106077-n:
   definition:
   - violent uncontrollable contractions of muscles
@@ -14210,7 +14214,9 @@
   - fascioliasis
   - fasciolosis
   partOfSpeech: n
-  wikidata: Q719656
+  wikidata:
+  - Q719656
+  - Q6972442
 14199385-n:
   definition:
   - infestation with the large intestinal fluke Fasciolopsis buski; common in eastern
@@ -14545,7 +14551,7 @@
   - dermatomycosis
   - dermatophytosis
   partOfSpeech: n
-  wikidata: Q3705876
+  wikidata: Q1909343
 14205585-n:
   definition:
   - a contagious fungal infection of the scalp; occurs mainly in Africa and the Middle
@@ -24284,7 +24290,9 @@
   - labyrinthitis
   - otitis interna
   partOfSpeech: n
-  wikidata: Q7108870
+  wikidata:
+  - Q7108870
+  - Q2038371
 14372300-n:
   definition:
   - inflammation of the laminated tissue that attaches the hoof to the foot of a horse
@@ -36144,7 +36152,7 @@
   members:
   - astasia
   partOfSpeech: n
-  wikidata: Q2868369
+  wikidata: Q2385892
 14574061-n:
   definition:
   - a condition of disability resulting from the loss of one or more limbs

--- a/src/yaml/noun.substance.yaml
+++ b/src/yaml/noun.substance.yaml
@@ -1115,7 +1115,7 @@
   - ethyne
   - alkyne
   partOfSpeech: n
-  wikidata: Q159226
+  wikidata: Q133145
 14625105-n:
   definition:
   - the clay from which adobe bricks are made
@@ -5992,7 +5992,7 @@
   mero_substance:
   - 14668427-n
   partOfSpeech: n
-  wikidata: Q426635
+  wikidata: Q214769
 14714951-n:
   definition:
   - a brown form of mica consisting of hydrous silicate of potassium and magnesium
@@ -9151,7 +9151,7 @@
   - norethandrolone
   - Norlutin
   partOfSpeech: n
-  wikidata: Q421352
+  wikidata: Q7050955
 14770972-n:
   definition:
   - a progesterone derivative used in oral contraceptives and in the control of menstruation
@@ -30150,7 +30150,9 @@
   - cyanocobalamin
   - antipernicious anemia factor
   partOfSpeech: n
-  wikidata: Q252251
+  wikidata:
+  - Q252251
+  - Q187706
 15116040-n:
   definition:
   - a B vitamin that prevents skin lesions and weight loss
@@ -31242,7 +31244,9 @@
   mero_substance:
   - 14686460-n
   partOfSpeech: n
-  wikidata: Q2342917
+  wikidata:
+  - Q2342917
+  - Q178928
 15133958-n:
   definition:
   - a white crystalline oxide; used in refractories and in insulation and abrasives

--- a/src/yaml/noun.time.yaml
+++ b/src/yaml/noun.time.yaml
@@ -75,7 +75,9 @@
   - standard time
   - local time
   partOfSpeech: n
-  wikidata: Q849275
+  wikidata:
+  - Q849275
+  - Q1777301
 15141831-n:
   definition:
   - time during which clocks are set one hour ahead of local standard time; widely
@@ -3085,7 +3087,7 @@
   - Dominicus
   - Sun
   partOfSpeech: n
-  wikidata: Q1150253
+  wikidata: Q132
 15189026-n:
   definition:
   - the second day of the week; the first working day
@@ -3191,7 +3193,9 @@
   mero_part:
   - 15194183-n
   partOfSpeech: n
-  wikidata: Q986787
+  wikidata:
+  - Q986787
+  - Q7722
 15190537-n:
   definition:
   - the middle of the day
@@ -7519,7 +7523,9 @@
   - Mesolithic
   - Epipaleolithic
   partOfSpeech: n
-  wikidata: Q829005
+  wikidata:
+  - Q829005
+  - Q44155
 15258208-n:
   definition:
   - latest part of the Stone Age beginning about 10,000 BC in the Middle East (but
@@ -9143,7 +9149,9 @@
   - Middle Ages
   - Dark Ages
   partOfSpeech: n
-  wikidata: Q217192
+  wikidata:
+  - Q217192
+  - Q12554
 15284623-n:
   definition:
   - the period of European history at the close of the Middle Ages and the rise of
@@ -11472,7 +11480,7 @@
   - shivah
   - shibah
   partOfSpeech: n
-  wikidata: Q5844712
+  wikidata: Q1814631
 15321930-n:
   definition:
   - (astronomy) an arbitrarily fixed date that is the point in time relative to which

--- a/src/yaml/noun.time.yaml
+++ b/src/yaml/noun.time.yaml
@@ -9289,7 +9289,6 @@
   members:
   - Restoration
   partOfSpeech: n
-  wikidata: Q7316195
 15286783-n:
   definition:
   - the period that presses run to produce an issue of a newspaper


### PR DESCRIPTION
Some updates based on a comparison with the links given in BabelNet and in the GF linking.

This also updates the format to allow multiple links for concepts where more than one target in Wikidata is appropriate