### PR TITLE
Taxon linking

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -9,6 +9,13 @@ from wordnet import xml_id_char
 from collections import Counter
 from from_yaml import load
 
+# This is temporary list of exceptions for linking where a taxon name is 
+# used as a generic name. In this case, Wikidata has only a single entry
+# while OEWN distinguishes between the taxon and the generic name 
+# (e.g., hydrangea vs genus Hydrangea).
+WIKIDATA_DUPLICATION_EXCEPTIONS = [
+"Q134842", "Q138789", "Q161142", "Q644312", "Q1423091", "Q5309794", "Q1024025", "Q133876", "Q1783190", "Q1974044", "Q2704518", "Q2708653", "Q1362995", "Q858999", "Q26949", "Q2511051", "Q5230439", "Q4006525", "Q150242", "Q94815", "Q2719974", "Q908118", "Q2589976", "Q355080", "Q138842", "Q5222959", "Q157905", "Q2975317", "Q2496817", "Q2574724", "Q2707277", "Q161075", "Q2720105", "Q157748", "Q156851", "Q156699", "Q159077", "Q133285", "Q1754165", "Q205265", "Q133827", "Q1425929", "Q158975", "Q1969330", "Q310801", "Q648056", "Q1514169", "Q2452570", "Q1354632", "Q3338824", "Q2213704", "Q135537", "Q7840756", "Q134827", "Q199695", "Q1061596", "Q139000", "Q199456", "Q180597", "Q133017", "Q795375", "Q130948", "Q1708883", "Q2304642", "Q4795779", "Q74083", "Q990101", "Q41317", "Q1137414", "Q2136293", "Q905053", "Q300923", "Q2500468", "Q734870", "Q1518954", "Q40621", "Q132672", "Q309466", "Q1060870", "Q130902", "Q14400", "Q130988", "Q319520", "Q131688", "Q179204", "Q595983", "Q19119", "Q1329239", "Q213536", "Q752529", "Q734720", "Q788536", "Q621861", "Q46316", "Q25336", "Q3388845", "Q344662", "Q2706095", "Q185231", "Q190701", "Q756089", "Q899799", "Q369761", "Q811633", "Q185167", "Q310869", "Q132950", "Q1307559", "Q133259", "Q2166073", "Q329334", "Q1136219" ]
+
 def check_symmetry(wn, fix):
     errors = []
     for synset in wn.synsets:
@@ -393,7 +400,7 @@ def main():
         if synset.wikidata:
             ss_wikidatas = synset.wikidata if isinstance(synset.wikidata, list) else [synset.wikidata]
             for wikidata in ss_wikidatas:
-                if wikidata in wikidatas:
+                if wikidata in wikidatas and wikidata not in WIKIDATA_DUPLICATION_EXCEPTIONS:
                     print(f"ERROR: QID {wikidata} is duplicated")
                     errors += 1
                 else:

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -44,6 +44,7 @@
   - 02318832-n
   - 02319044-n
   partOfSpeech: n
+  wikidata: Q729
 01316379-n:
   definition:
   - a cell or organism in which genetic recombination has occurred
@@ -1743,7 +1744,7 @@
   - 01382277-n
   - 01391633-n
   partOfSpeech: n
-  wikidata: Q842610
+  wikidata: Q97263158
 01344910-n:
   definition:
   - organisms that typically reproduce by asexual budding or fission and whose nutritional
@@ -1983,6 +1984,7 @@
   - Heliobacter
   - genus Heliobacter
   partOfSpeech: n
+  wikidata: Q134684
 01354329-n:
   definition:
   - the type species of genus Heliobacter; produces urease and is associated with
@@ -2075,6 +2077,7 @@
   - 01356965-n
   - 01357162-n
   partOfSpeech: n
+  wikidata: Q2462359
 01356965-n:
   definition:
   - the type genus of Rhizobiaceae; usually occur in the root nodules of legumes;
@@ -2086,6 +2089,7 @@
   - Rhizobium
   - genus Rhizobium
   partOfSpeech: n
+  wikidata: Q830142
 01357162-n:
   definition:
   - small motile bacterial rods that can reduce nitrates and cause galls on plant
@@ -2169,6 +2173,7 @@
   - 01368656-n
   - 01370071-n
   partOfSpeech: n
+  wikidata: Q116698041
 01359100-n:
   definition:
   - typically rod-shaped usually Gram-positive bacteria that produce endospores
@@ -2182,6 +2187,7 @@
   - 01359311-n
   - 01359529-n
   partOfSpeech: n
+  wikidata: Q149098
 01359311-n:
   definition:
   - type genus of the Bacillaceae; includes many saprophytes important in decay of
@@ -2194,6 +2200,7 @@
   mero_member:
   - 01352589-n
   partOfSpeech: n
+  wikidata: Q212032
 01359529-n:
   definition:
   - anaerobic or micro-aerophilic rod-shaped or spindle-shaped saprophytes; nearly
@@ -2208,6 +2215,7 @@
   - 01359969-n
   - 01360148-n
   partOfSpeech: n
+  wikidata: Q327663
 01359797-n:
   definition:
   - spindle-shaped bacterial cell especially one swollen at the center by an endospore
@@ -2277,6 +2285,7 @@
   - Schizomycetes
   - class Schizomycetes
   partOfSpeech: n
+  wikidata: Q21447348
 01360900-n:
   definition:
   - 'photosynthetic bacteria found in fresh and salt water, having chlorophyll a and
@@ -2293,6 +2302,7 @@
   - 01361711-n
   - 01362129-n
   partOfSpeech: n
+  wikidata: Q21442543
 01361213-n:
   definition:
   - predominantly photosynthetic prokaryotic organisms containing a blue pigment in
@@ -2329,6 +2339,7 @@
   mero_member:
   - 01361844-n
   partOfSpeech: n
+  wikidata: Q1771045
 01361844-n:
   definition:
   - 'type genus of the family Nostocaceae: freshwater blue-green algae'
@@ -2340,6 +2351,7 @@
   mero_member:
   - 01362006-n
   partOfSpeech: n
+  wikidata: Q311257
 01362006-n:
   definition:
   - found in moist places as rounded jellylike colonies
@@ -2361,6 +2373,7 @@
   mero_member:
   - 01362272-n
   partOfSpeech: n
+  wikidata: Q15489312
 01362272-n:
   definition:
   - a genus of blue-green algae
@@ -2372,6 +2385,7 @@
   mero_member:
   - 01362403-n
   partOfSpeech: n
+  wikidata: Q7840756
 01362403-n:
   definition:
   - large colonial bacterium common in tropical open-ocean waters; important in carbon
@@ -2421,6 +2435,7 @@
   - 01365410-n
   - 01366064-n
   partOfSpeech: n
+  wikidata: Q133966
 01363353-n:
   definition:
   - rod-shaped Gram-negative bacteria; include important plant and animal pathogens
@@ -2434,6 +2449,7 @@
   - 01363578-n
   - 01364106-n
   partOfSpeech: n
+  wikidata: Q138058
 01363578-n:
   definition:
   - type genus of the family Pseudomonodaceae
@@ -2447,6 +2463,7 @@
   - 01356299-n
   - 01363902-n
   partOfSpeech: n
+  wikidata: Q131143
 01363754-n:
   definition:
   - causes brown rot in tomatoes and potatoes and tobacco etc
@@ -2480,6 +2497,7 @@
   mero_member:
   - 01364324-n
   partOfSpeech: n
+  wikidata: Q140652
 01364324-n:
   definition:
   - bacteria producing yellow non-water-soluble pigments; some pathogenic for plants
@@ -2512,6 +2530,7 @@
   - 01364837-n
   - 01365121-n
   partOfSpeech: n
+  wikidata: Q7041456
 01364837-n:
   definition:
   - rod-shaped soil bacteria
@@ -2524,6 +2543,7 @@
   mero_member:
   - 01364977-n
   partOfSpeech: n
+  wikidata: Q146274
 01364977-n:
   definition:
   - soil bacteria that convert nitrites to nitrates
@@ -2570,6 +2590,7 @@
   mero_member:
   - 01365640-n
   partOfSpeech: n
+  wikidata: Q134834
 01365640-n:
   definition:
   - a genus of motile rod-shaped gram-negative bacteria that metabolizes sulphur (Thiobacillus)
@@ -2581,6 +2602,7 @@
   mero_member:
   - 01365762-n
   partOfSpeech: n
+  wikidata: Q2421263
 01365762-n:
   definition:
   - small rod-shaped bacteria living in sewage or soil and oxidizing sulfur
@@ -2614,6 +2636,7 @@
   - 01366241-n
   - 01366649-n
   partOfSpeech: n
+  wikidata: Q7577827
 01366241-n:
   definition:
   - a genus of large, elongate, spiral-shaped, rigid, gram-negative bacteria, containing
@@ -2627,6 +2650,7 @@
   mero_member:
   - 01366360-n
   partOfSpeech: n
+  wikidata: Q69598
 01366360-n:
   definition:
   - spirally twisted elongate rodlike bacteria usually living in stagnant water
@@ -2661,6 +2685,7 @@
   - 01366970-n
   - 01367113-n
   partOfSpeech: n
+  wikidata: Q753490
 01366803-n:
   definition:
   - curved rodlike motile bacterium
@@ -2703,6 +2728,7 @@
   mero_member:
   - 01367507-n
   partOfSpeech: n
+  wikidata: Q4840030
 01367507-n:
   definition:
   - type genus of Bacteroidaceae; genus of Gram-negative rodlike anaerobic bacteria
@@ -2714,6 +2740,7 @@
   - Bacteroides
   - genus Bacteroides
   partOfSpeech: n
+  wikidata: Q133186
 01367763-n:
   definition:
   - a genus of bacterial rods containing only the one species that causes granuloma
@@ -2727,6 +2754,7 @@
   mero_member:
   - 01367963-n
   partOfSpeech: n
+  wikidata: Q62643569
 01367963-n:
   definition:
   - the species of bacteria that causes granuloma inguinale
@@ -2749,6 +2777,7 @@
   mero_member:
   - 01368325-n
   partOfSpeech: n
+  wikidata: Q3246268
 01368325-n:
   definition:
   - the type species of the genus Francisella and the causal agent of tularemia in
@@ -2783,6 +2812,7 @@
   - 01369056-n
   - 01369522-n
   partOfSpeech: n
+  wikidata: Q15932755
 01368917-n:
   definition:
   - any species of the genus Corynebacterium
@@ -2805,6 +2835,7 @@
   - 01368917-n
   - 01369341-n
   partOfSpeech: n
+  wikidata: Q133976
 01369341-n:
   definition:
   - a species of bacterium that causes diphtheria
@@ -2829,6 +2860,7 @@
   mero_member:
   - 01369724-n
   partOfSpeech: n
+  wikidata: Q746209
 01369724-n:
   definition:
   - any species of the genus Listeria
@@ -2869,6 +2901,7 @@
   - 01372783-n
   - 01373222-n
   partOfSpeech: n
+  wikidata: Q380136
 01370413-n:
   definition:
   - rod-shaped Gram-negative bacteria; most occur normally or pathogenically in intestines
@@ -2894,6 +2927,7 @@
   mero_member:
   - 01370857-n
   partOfSpeech: n
+  wikidata: Q311055
 01370857-n:
   definition:
   - a genus of enteric bacteria
@@ -2926,6 +2960,7 @@
   mero_member:
   - 01371313-n
   partOfSpeech: n
+  wikidata: Q131854
 01371313-n:
   definition:
   - a genus of nonmotile rod-shaped Gram-negative enterobacteria; some cause respiratory
@@ -2948,6 +2983,7 @@
   mero_member:
   - 01371614-n
   partOfSpeech: n
+  wikidata: Q150839
 01371614-n:
   definition:
   - rod-shaped Gram-negative enterobacteria; cause typhoid fever and food poisoning;
@@ -3024,6 +3060,7 @@
   mero_member:
   - 01372901-n
   partOfSpeech: n
+  wikidata: Q131029
 01372901-n:
   definition:
   - rod-shaped Gram-negative enterobacteria; some are pathogenic for warm-blooded
@@ -3056,6 +3093,7 @@
   mero_member:
   - 01373339-n
   partOfSpeech: n
+  wikidata: Q134827
 01373339-n:
   definition:
   - rod-shaped motile bacteria that attack plants
@@ -3088,6 +3126,7 @@
   - 01373733-n
   - 01375013-n
   partOfSpeech: n
+  wikidata: Q136644
 01373733-n:
   definition:
   - microorganism resembling bacteria inhabiting arthropod tissues but capable of
@@ -3112,6 +3151,7 @@
   members:
   - genus Rickettsia
   partOfSpeech: n
+  wikidata: Q627992
 01374124-n:
   definition:
   - any of a group of very small rod-shaped bacteria that live in biting arthropods
@@ -3178,6 +3218,7 @@
   mero_member:
   - 01375185-n
   partOfSpeech: n
+  wikidata: Q13474598
 01375185-n:
   definition:
   - 'type genus of the family Chlamydiaceae: disease-causing parasites'
@@ -3189,6 +3230,7 @@
   mero_member:
   - 01375350-n
   partOfSpeech: n
+  wikidata: Q846309
 01375350-n:
   definition:
   - coccoid rickettsia infesting birds and mammals; cause infections of eyes and lungs
@@ -3233,6 +3275,7 @@
   mero_member:
   - 01376081-n
   partOfSpeech: n
+  wikidata: Q3869074
 01376081-n:
   definition:
   - pleomorphic Gram-negative nonmotile microorganism similar to both viruses and
@@ -3246,6 +3289,7 @@
   mero_member:
   - 01376316-n
   partOfSpeech: n
+  wikidata: Q136808
 01376316-n:
   definition:
   - type and sole genus of the family Mycoplasmataceae
@@ -3257,6 +3301,7 @@
   mero_member:
   - 01376467-n
   partOfSpeech: n
+  wikidata: Q210975
 01376467-n:
   definition:
   - any of a group of small parasitic bacteria that lack cell walls and can survive
@@ -3370,6 +3415,7 @@
   mero_member:
   - 01378401-n
   partOfSpeech: n
+  wikidata: Q312213
 01378401-n:
   definition:
   - soil-inhabiting saprophytes and disease-producing plant and animal parasites
@@ -3403,6 +3449,7 @@
   mero_member:
   - 01378878-n
   partOfSpeech: n
+  wikidata: Q1144013
 01378878-n:
   definition:
   - aerobic bacteria (some of which produce the antibiotic streptomycin)
@@ -3453,6 +3500,7 @@
   mero_member:
   - 01379589-n
   partOfSpeech: n
+  wikidata: Q3331319
 01379589-n:
   definition:
   - nonmotile Gram-positive aerobic bacteria
@@ -3464,6 +3512,7 @@
   mero_member:
   - 01379733-n
   partOfSpeech: n
+  wikidata: Q194309
 01379733-n:
   definition:
   - rod-shaped bacteria some saprophytic or causing diseases
@@ -3546,6 +3595,7 @@
   - 01380778-n
   - 01381186-n
   partOfSpeech: n
+  wikidata: Q99299816
 01380778-n:
   definition:
   - bacteria living mostly in soils and on dung
@@ -3560,6 +3610,7 @@
   mero_member:
   - 01380987-n
   partOfSpeech: n
+  wikidata: Q21226524
 01380987-n:
   definition:
   - 'type genus of the family Polyangiaceae: myxobacteria with rounded fruiting bodies
@@ -3571,6 +3622,7 @@
   - Polyangium
   - genus Polyangium
   partOfSpeech: n
+  wikidata: Q26271235
 01381186-n:
   definition:
   - bacteria that form colonies in self-produced slime; inhabit moist soils or decaying
@@ -3600,6 +3652,7 @@
   - 01381757-n
   - 01381893-n
   partOfSpeech: n
+  wikidata: Q1365581
 01381757-n:
   definition:
   - type genus of the family Micrococcaceae
@@ -3610,6 +3663,7 @@
   - Micrococcus
   - genus Micrococcus
   partOfSpeech: n
+  wikidata: Q1954952
 01381893-n:
   definition:
   - includes many pathogenic species
@@ -3621,6 +3675,7 @@
   mero_member:
   - 01382030-n
   partOfSpeech: n
+  wikidata: Q199695
 01382030-n:
   definition:
   - spherical Gram-positive parasitic bacteria that tend to form irregular colonies;
@@ -3651,6 +3706,7 @@
   - 01383130-n
   - 01383543-n
   partOfSpeech: n
+  wikidata: Q578677
 01382595-n:
   definition:
   - type genus of the family Lactobacillaceae
@@ -3663,6 +3719,7 @@
   - 01382759-n
   - 01382939-n
   partOfSpeech: n
+  wikidata: Q1061596
 01382759-n:
   definition:
   - a Gram-positive rod-shaped bacterium that produces lactic acid (especially in
@@ -3729,6 +3786,7 @@
   mero_member:
   - 01383685-n
   partOfSpeech: n
+  wikidata: Q190161
 01383685-n:
   definition:
   - spherical Gram-positive bacteria occurring in pairs or chains; cause e.g. scarlet
@@ -3807,6 +3865,7 @@
   - 01385480-n
   - 01385973-n
   partOfSpeech: n
+  wikidata: Q110107986
 01385123-n:
   definition:
   - 'type genus of Treponemataceae: anaerobic spirochetes with an undulating rigid
@@ -3819,6 +3878,7 @@
   mero_member:
   - 01385340-n
   partOfSpeech: n
+  wikidata: Q134745
 01385340-n:
   definition:
   - spirochete that causes disease in humans (e.g. syphilis and yaws)
@@ -3840,6 +3900,7 @@
   - 01385668-n
   - 01385792-n
   partOfSpeech: n
+  wikidata: Q115528
 01385668-n:
   definition:
   - cause of e.g. European and African relapsing fever
@@ -3871,6 +3932,7 @@
   mero_member:
   - 01386143-n
   partOfSpeech: n
+  wikidata: Q133841
 01386143-n:
   definition:
   - important pathogens causing Weil's disease or canicola fever
@@ -4068,6 +4130,7 @@
   - 01416192-n
   - 01423653-n
   partOfSpeech: n
+  wikidata: Q2113650
 01389706-n:
   definition:
   - any of the unicellular protists
@@ -4129,6 +4192,7 @@
   - Pyrrophyta
   - phylum Pyrrophyta
   partOfSpeech: n
+  wikidata: Q9358965
 01391829-n:
   definition:
   - in some classifications considered a superphylum or a subkingdom; comprises flagellates,
@@ -4146,6 +4210,7 @@
   - 01418995-n
   - 01424137-n
   partOfSpeech: n
+  wikidata: Q6088705
 01392148-n:
   definition:
   - any of diverse minute acellular or unicellular organisms usually nonphotosynthetic
@@ -4173,6 +4238,7 @@
   - 01392928-n
   - 01393815-n
   partOfSpeech: n
+  wikidata: Q21400186
 01392764-n:
   definition:
   - protozoa that move and capture food by forming pseudopods
@@ -4218,6 +4284,7 @@
   mero_member:
   - 01393404-n
   partOfSpeech: n
+  wikidata: Q968988
 01393404-n:
   definition:
   - protozoa with spherical bodies and stiff radiating pseudopods
@@ -4239,6 +4306,7 @@
   mero_member:
   - 01393669-n
   partOfSpeech: n
+  wikidata: Q107920
 01393669-n:
   definition:
   - protozoa with amoeba-like bodies and radiating filamentous pseudopods
@@ -4299,6 +4367,7 @@
   members:
   - genus Amoeba
   partOfSpeech: n
+  wikidata: Q46729
 01394574-n:
   definition:
   - a large family of endoparasitic amebas that invade the digestive tract
@@ -4311,6 +4380,7 @@
   mero_member:
   - 01394763-n
   partOfSpeech: n
+  wikidata: Q113942
 01394763-n:
   definition:
   - the type genus of the family Endamoebidae
@@ -4368,6 +4438,7 @@
   - 01396005-n
   - 01396245-n
   partOfSpeech: n
+  wikidata: Q107027
 01395671-n:
   definition:
   - marine microorganism having a calcareous shell with openings where pseudopods
@@ -4399,6 +4470,7 @@
   members:
   - genus Globigerina
   partOfSpeech: n
+  wikidata: Q5571051
 01396127-n:
   definition:
   - marine protozoan having a rounded shell with spiny processes
@@ -4420,6 +4492,7 @@
   mero_member:
   - 01396394-n
   partOfSpeech: n
+  wikidata: Q175868
 01396394-n:
   definition:
   - large fossil protozoan of the Tertiary period
@@ -4443,6 +4516,7 @@
   - 01396834-n
   - 01397276-n
   partOfSpeech: n
+  wikidata: Q21447806
 01396681-n:
   definition:
   - any of various rhizopods of the order Testacea characterized by having a shell
@@ -4464,6 +4538,7 @@
   mero_member:
   - 01397007-n
   partOfSpeech: n
+  wikidata: Q2442353
 01397007-n:
   definition:
   - type genus of the Arcellidae
@@ -4475,6 +4550,7 @@
   mero_member:
   - 01397133-n
   partOfSpeech: n
+  wikidata: Q971534
 01397133-n:
   definition:
   - an amoeba-like protozoan with a chitinous shell resembling an umbrella
@@ -4495,6 +4571,7 @@
   mero_member:
   - 01397412-n
   partOfSpeech: n
+  wikidata: Q139000
 01397412-n:
   definition:
   - a protozoan with an ovoid shell of cemented sand grains
@@ -4525,6 +4602,7 @@
   - 01399099-n
   - 01399417-n
   partOfSpeech: n
+  wikidata: Q27212391
 01397895-n:
   definition:
   - a protozoan with a microscopic appendage extending from the surface of the cell
@@ -4569,6 +4647,7 @@
   mero_member:
   - 01398689-n
   partOfSpeech: n
+  wikidata: Q199456
 01398689-n:
   definition:
   - any member of the genus Paramecium
@@ -4591,6 +4670,7 @@
   mero_member:
   - 01398963-n
   partOfSpeech: n
+  wikidata: Q1198419
 01398963-n:
   definition:
   - relative of the paramecium; often used in genetics research
@@ -4611,6 +4691,7 @@
   mero_member:
   - 01399258-n
   partOfSpeech: n
+  wikidata: Q1202152
 01399258-n:
   definition:
   - any of several trumpet-shaped ciliate protozoans that are members of the genus
@@ -4632,6 +4713,7 @@
   mero_member:
   - 01399592-n
   partOfSpeech: n
+  wikidata: Q82743
 01399592-n:
   definition:
   - any of various protozoa having a transparent goblet-shaped body with a retractile
@@ -4852,6 +4934,7 @@
   - Heterokontae
   - class Heterokontae
   partOfSpeech: n
+  wikidata: Q1763065
 01403413-n:
   definition:
   - yellow-green algae
@@ -4862,6 +4945,7 @@
   - Xanthophyceae
   - class Xanthophyceae
   partOfSpeech: n
+  wikidata: Q745912
 01403532-n:
   definition:
   - 'marine and freshwater eukaryotic algae: diatoms'
@@ -4876,6 +4960,7 @@
   mero_member:
   - 01403747-n
   partOfSpeech: n
+  wikidata: Q2878349
 01403747-n:
   definition:
   - microscopic unicellular marine or freshwater colonial alga having cell walls impregnated
@@ -4900,6 +4985,7 @@
   mero_member:
   - 01404158-n
   partOfSpeech: n
+  wikidata: Q11065859
 01404158-n:
   definition:
   - simple filamentous freshwater yellow-green algae
@@ -4912,6 +4998,7 @@
   mero_member:
   - 01404327-n
   partOfSpeech: n
+  wikidata: Q18674107
 01404327-n:
   definition:
   - type genus of Tribonemaceae
@@ -5135,6 +5222,7 @@
   - 01407748-n
   - 01407891-n
   partOfSpeech: n
+  wikidata: Q180597
 01407648-n:
   definition:
   - any member of the genus Fucus
@@ -5180,6 +5268,7 @@
   - Ascophyllum
   - genus Ascophyllum
   partOfSpeech: n
+  wikidata: Q16034614
 01408257-n:
   definition:
   - similar to and found with black rockweed
@@ -5201,6 +5290,7 @@
   mero_member:
   - 01408499-n
   partOfSpeech: n
+  wikidata: Q865061
 01408499-n:
   definition:
   - brown algae with rounded bladders forming dense floating masses in tropical Atlantic
@@ -5239,6 +5329,7 @@
   mero_member:
   - 01409067-n
   partOfSpeech: n
+  wikidata: Q2356588
 01409067-n:
   definition:
   - considered green algae
@@ -5251,6 +5342,7 @@
   mero_member:
   - 01409206-n
   partOfSpeech: n
+  wikidata: Q2132226
 01409206-n:
   definition:
   - 'type genus of the family Euglenaceae: green algae with a single flagellum'
@@ -5262,6 +5354,7 @@
   mero_member:
   - 01409377-n
   partOfSpeech: n
+  wikidata: Q236001
 01409377-n:
   definition:
   - minute single-celled green freshwater organism having a single flagella; often
@@ -5317,6 +5410,7 @@
   - 01413488-n
   - 01414197-n
   partOfSpeech: n
+  wikidata: Q132609
 01410439-n:
   definition:
   - algae that are clear green in color; often growing on wet ricks or damp wood or
@@ -5351,6 +5445,7 @@
   mero_member:
   - 01411024-n
   partOfSpeech: n
+  wikidata: Q1367727
 01411024-n:
   definition:
   - thin flat or tubular green algae
@@ -5378,6 +5473,7 @@
   mero_member:
   - 01411384-n
   partOfSpeech: n
+  wikidata: Q1109330
 01411384-n:
   definition:
   - seaweed with edible translucent crinkly green fronds
@@ -5414,6 +5510,7 @@
   mero_member:
   - 01411885-n
   partOfSpeech: n
+  wikidata: Q654492
 01411885-n:
   definition:
   - type genus of the Volvocaceae; minute pale green flagellates occurring in tiny
@@ -5425,6 +5522,7 @@
   - Volvox
   - genus Volvox
   partOfSpeech: n
+  wikidata: Q310495
 01412118-n:
   definition:
   - green algae some of which are colored red by hematochrome
@@ -5450,6 +5548,7 @@
   - Chlamydomonas
   - genus Chlamydomonas
   partOfSpeech: n
+  wikidata: Q133008
 01412581-n:
   definition:
   - pond scums; desmids
@@ -5464,6 +5563,7 @@
   mero_member:
   - 01412750-n
   partOfSpeech: n
+  wikidata: Q497859
 01412750-n:
   definition:
   - 'pond scums: common freshwater algae forming green slimy masses'
@@ -5489,6 +5589,7 @@
   - Zygnema
   - genus Zygnema
   partOfSpeech: n
+  wikidata: Q150137
 01413098-n:
   definition:
   - free-floating freshwater green algae
@@ -5509,6 +5610,7 @@
   mero_member:
   - 01413330-n
   partOfSpeech: n
+  wikidata: Q148710
 01413330-n:
   definition:
   - freshwater algae consisting of minute filaments containing spiral chlorophyll
@@ -5544,6 +5646,7 @@
   - Chlorococcum
   - genus Chlorococcum
   partOfSpeech: n
+  wikidata: Q4271430
 01413881-n:
   definition:
   - nonmotile unicellular green algae potentially important as source of high-grade
@@ -5556,6 +5659,7 @@
   mero_member:
   - 01414091-n
   partOfSpeech: n
+  wikidata: Q133017
 01414091-n:
   definition:
   - any alga of the genus Chlorella
@@ -5578,6 +5682,7 @@
   mero_member:
   - 01414368-n
   partOfSpeech: n
+  wikidata: Q1188910
 01414368-n:
   definition:
   - filamentous green algae
@@ -5590,6 +5695,7 @@
   mero_member:
   - 01414512-n
   partOfSpeech: n
+  wikidata: Q15211115
 01414512-n:
   definition:
   - type genus of Oedogoniaceae; freshwater green algae having long unbranched filaments;
@@ -5615,6 +5721,7 @@
   - 01414920-n
   - 01415829-n
   partOfSpeech: n
+  wikidata: Q1208690
 01414920-n:
   definition:
   - 'small order of macroscopic fresh and brackish water algae with a distinct axis:
@@ -5628,6 +5735,7 @@
   mero_member:
   - 01415120-n
   partOfSpeech: n
+  wikidata: Q14920463
 01415120-n:
   definition:
   - 'green algae superficially resembling horsetail ferns: stoneworts'
@@ -5642,6 +5750,7 @@
   - 01415566-n
   - 01415712-n
   partOfSpeech: n
+  wikidata: Q1559048
 01415335-n:
   definition:
   - any of various submerged aquatic algae of the genus Chara having nodes with whorled
@@ -5662,6 +5771,7 @@
   - Chara
   - genus Chara
   partOfSpeech: n
+  wikidata: Q860112
 01415712-n:
   definition:
   - fragile branching stoneworts
@@ -5672,6 +5782,7 @@
   - Nitella
   - genus Nitella
   partOfSpeech: n
+  wikidata: Q3011489
 01415829-n:
   definition:
   - unicellular algae
@@ -5684,6 +5795,7 @@
   mero_member:
   - 01415965-n
   partOfSpeech: n
+  wikidata: Q1307414
 01415965-n:
   definition:
   - a genus of protoctist, containing algae (Desmidium)
@@ -5781,6 +5893,7 @@
   mero_member:
   - 01417274-n
   partOfSpeech: n
+  wikidata: Q14759694
 01417274-n:
   definition:
   - dark purple edible seaweed of the Atlantic coasts of Europe and North America
@@ -5806,6 +5919,7 @@
   mero_member:
   - 01417627-n
   partOfSpeech: n
+  wikidata: Q18509172
 01417627-n:
   definition:
   - type genus of the family Rhodymeniaceae
@@ -5818,6 +5932,7 @@
   mero_member:
   - 01417780-n
   partOfSpeech: n
+  wikidata: Q7321257
 01417780-n:
   definition:
   - coarse edible red seaweed
@@ -5840,6 +5955,7 @@
   mero_member:
   - 01418034-n
   partOfSpeech: n
+  wikidata: Q2717889
 01418034-n:
   definition:
   - a genus of protoctist, containing red algal laver (Porphyra)
@@ -5852,6 +5968,7 @@
   mero_member:
   - 01418165-n
   partOfSpeech: n
+  wikidata: Q2104475
 01418165-n:
   definition:
   - edible red seaweeds
@@ -5914,6 +6031,7 @@
   - 01420878-n
   - 01423296-n
   partOfSpeech: n
+  wikidata: Q240433
 01419226-n:
   definition:
   - a usually nonphotosynthetic free-living protozoan with whiplike appendages; some
@@ -5945,6 +6063,7 @@
   - 01420194-n
   - 01420448-n
   partOfSpeech: n
+  wikidata: Q21447017
 01420002-n:
   definition:
   - chiefly marine protozoa having two flagella; a chief constituent of plankton
@@ -5966,6 +6085,7 @@
   mero_member:
   - 01420315-n
   partOfSpeech: n
+  wikidata: Q3342595
 01420315-n:
   definition:
   - large bioluminescent marine protozoan
@@ -5989,6 +6109,7 @@
   - 01420623-n
   - 01420755-n
   partOfSpeech: n
+  wikidata: Q15241090
 01420623-n:
   definition:
   - type genus of the family Peridiniidae
@@ -5999,6 +6120,7 @@
   - Peridinium
   - genus Peridinium
   partOfSpeech: n
+  wikidata: Q147258
 01420755-n:
   definition:
   - flagellate with a thick test composed of plates
@@ -6033,6 +6155,7 @@
   - Leishmania
   - genus Leishmania
   partOfSpeech: n
+  wikidata: Q524818
 01421261-n:
   definition:
   - flagellate protozoan lacking photosynthesis and other plant-like characteristics
@@ -6055,6 +6178,7 @@
   mero_member:
   - 01421588-n
   partOfSpeech: n
+  wikidata: Q21446496
 01421588-n:
   definition:
   - flagellate symbiotic in the intestines of e.g. termites
@@ -6081,6 +6205,7 @@
   - 01422805-n
   - 01422955-n
   partOfSpeech: n
+  wikidata: Q55706286
 01421973-n:
   definition:
   - flagellates with several flagella
@@ -6101,6 +6226,7 @@
   mero_member:
   - 01422214-n
   partOfSpeech: n
+  wikidata: Q87188765
 01422214-n:
   definition:
   - a flagellate that is the cause of the frequently fatal fish disease costiasis
@@ -6122,6 +6248,7 @@
   mero_member:
   - 01422529-n
   partOfSpeech: n
+  wikidata: Q1469628
 01422529-n:
   definition:
   - a suspected cause of diarrhea in humans
@@ -6141,6 +6268,7 @@
   - Chilomastix
   - genus Chilomastix
   partOfSpeech: n
+  wikidata: Q2963624
 01422805-n:
   definition:
   - flagellates free-living or parasitic in intestines of birds
@@ -6151,6 +6279,7 @@
   - Hexamita
   - genus Hexamita
   partOfSpeech: n
+  wikidata: Q1759900
 01422955-n:
   definition:
   - flagellates parasitic in alimentary or genitourinary tracts of vertebrates and
@@ -6163,6 +6292,7 @@
   mero_member:
   - 01423166-n
   partOfSpeech: n
+  wikidata: Q309497
 01423166-n:
   definition:
   - cause of trichomoniasis in women and cattle and birds
@@ -6205,6 +6335,7 @@
   mero_member:
   - 01423805-n
   partOfSpeech: n
+  wikidata: Q18668642
 01423805-n:
   definition:
   - motile usually brownish-green protozoa-like algae
@@ -6217,6 +6348,7 @@
   mero_member:
   - 01423974-n
   partOfSpeech: n
+  wikidata: Q488032
 01423974-n:
   definition:
   - common in fresh and salt water appearing along the shore as algal blooms
@@ -6244,6 +6376,7 @@
   - 01428458-n
   - 01429425-n
   partOfSpeech: n
+  wikidata: Q3967020
 01424448-n:
   definition:
   - parasitic spore-forming protozoan
@@ -6310,6 +6443,7 @@
   - 01425642-n
   - 01425943-n
   partOfSpeech: n
+  wikidata: Q1147204
 01425642-n:
   definition:
   - a family of protoctist in the order Coccidia
@@ -6322,6 +6456,7 @@
   mero_member:
   - 01425801-n
   partOfSpeech: n
+  wikidata: Q795581
 01425801-n:
   definition:
   - type genus of the family Eimeriidae; includes serious pathogens
@@ -6331,6 +6466,7 @@
   members:
   - genus Eimeria
   partOfSpeech: n
+  wikidata: Q795375
 01425943-n:
   definition:
   - parasitic on the digestive epithelium of vertebrates and higher invertebrates
@@ -6354,6 +6490,7 @@
   mero_member:
   - 01426258-n
   partOfSpeech: n
+  wikidata: Q18692916
 01426258-n:
   definition:
   - vermiform protozoans parasitic in insects and other invertebrates
@@ -6379,6 +6516,7 @@
   - 01427248-n
   - 01427977-n
   partOfSpeech: n
+  wikidata: Q21446124
 01426612-n:
   definition:
   - minute protozoans parasitic at some stage of the life cycle in blood cells of
@@ -6411,6 +6549,7 @@
   mero_member:
   - 01427061-n
   partOfSpeech: n
+  wikidata: Q130948
 01427061-n:
   definition:
   - parasitic protozoan of the genus Plasmodium that causes malaria in humans
@@ -6459,6 +6598,7 @@
   - Haemoproteus
   - genus Haemoproteus
   partOfSpeech: n
+  wikidata: Q5638270
 01427717-n:
   definition:
   - a genus of protoctist, containing parasitic protozoa which use blackflies as their
@@ -6472,6 +6612,7 @@
   mero_member:
   - 01427864-n
   partOfSpeech: n
+  wikidata: Q1708883
 01427864-n:
   definition:
   - parasitic in birds
@@ -6496,6 +6637,7 @@
   - 01428142-n
   - 01428275-n
   partOfSpeech: n
+  wikidata: Q18618857
 01428142-n:
   definition:
   - type genus of the family Babesiidae
@@ -6506,6 +6648,7 @@
   - genus Babesia
   - genus Piroplasma
   partOfSpeech: n
+  wikidata: Q797656
 01428275-n:
   definition:
   - minute parasite of red blood cells of mammals transmitted by a tick and causing
@@ -6541,6 +6684,7 @@
   mero_member:
   - 01428801-n
   partOfSpeech: n
+  wikidata: Q3178497
 01428801-n:
   definition:
   - chief genus of the order Sarcosporidia
@@ -6553,6 +6697,7 @@
   mero_member:
   - 01428955-n
   partOfSpeech: n
+  wikidata: Q2658061
 01428955-n:
   definition:
   - parasite of the muscles of vertebrates
@@ -6576,6 +6721,7 @@
   mero_member:
   - 01429266-n
   partOfSpeech: n
+  wikidata: Q137449
 01429266-n:
   definition:
   - parasite in invertebrates and lower vertebrates of no known economic importance
@@ -6612,6 +6758,7 @@
   mero_member:
   - 01429784-n
   partOfSpeech: n
+  wikidata: Q21445641
 01429784-n:
   definition:
   - of or relating to parasites of worms
@@ -6633,6 +6780,7 @@
   mero_member:
   - 01430040-n
   partOfSpeech: n
+  wikidata: Q132652
 01430040-n:
   definition:
   - parasite of arthropods and fishes that invade and destroy host cells
@@ -6656,6 +6804,7 @@
   mero_member:
   - 01430344-n
   partOfSpeech: n
+  wikidata: Q3694990
 01430344-n:
   definition:
   - mostly parasitic in fishes and including various serious pathogens
@@ -6826,6 +6975,7 @@
   - 01445767-n
   - 01446039-n
   partOfSpeech: n
+  wikidata: Q35047
 01441762-n:
   definition:
   - soft-finned mainly freshwater fishes typically having toothless jaws and cycloid
@@ -6858,6 +7008,7 @@
   mero_member:
   - 01442449-n
   partOfSpeech: n
+  wikidata: Q134653
 01442449-n:
   definition:
   - large Old World freshwater bottom-feeding fish introduced into Europe from Asia;
@@ -6903,6 +7054,7 @@
   mero_member:
   - 01443108-n
   partOfSpeech: n
+  wikidata: Q282584
 01443108-n:
   definition:
   - European freshwater fish having a flattened body and silvery scales; of little
@@ -6926,6 +7078,7 @@
   mero_member:
   - 01443405-n
   partOfSpeech: n
+  wikidata: Q15963609
 01443405-n:
   definition:
   - freshwater dace-like game fish of Europe and western Asia noted for ability to
@@ -6950,6 +7103,7 @@
   - 01443758-n
   - 01443913-n
   partOfSpeech: n
+  wikidata: Q312225
 01443758-n:
   definition:
   - small European freshwater fish with a slender bluish-green body
@@ -6992,6 +7146,7 @@
   mero_member:
   - 01444551-n
   partOfSpeech: n
+  wikidata: Q2521639
 01444383-n:
   definition:
   - small blunt-nosed fish of Great Lakes and Mississippi valley with a greenish luster
@@ -7023,6 +7178,7 @@
   - Notemigonus
   - genus Notemigonus
   partOfSpeech: n
+  wikidata: Q18650996
 01444807-n:
   definition:
   - shiner of eastern North America having golden glints; sometimes also called ‘bream’
@@ -7069,6 +7225,7 @@
   mero_member:
   - 01445351-n
   partOfSpeech: n
+  wikidata: Q302677
 01445351-n:
   definition:
   - European freshwater fish resembling the roach
@@ -7114,6 +7271,7 @@
   mero_member:
   - 01445884-n
   partOfSpeech: n
+  wikidata: Q310652
 01445884-n:
   definition:
   - small slender European freshwater fish often used as bait by anglers
@@ -7138,6 +7296,7 @@
   - 01446178-n
   - 01446472-n
   partOfSpeech: n
+  wikidata: Q237800
 01446178-n:
   definition:
   - small golden or orange-red freshwater fishes of Eurasia used as pond or aquarium
@@ -7181,6 +7340,7 @@
   mero_member:
   - 01446805-n
   partOfSpeech: n
+  wikidata: Q16631805
 01446805-n:
   definition:
   - type genus of the family Electrophoridae; electric eels
@@ -7193,6 +7353,7 @@
   mero_member:
   - 01446980-n
   partOfSpeech: n
+  wikidata: Q18926800
 01446980-n:
   definition:
   - eel-shaped freshwater fish of South America having electric organs in its body
@@ -7220,6 +7381,7 @@
   - 01448359-n
   - 01448639-n
   partOfSpeech: n
+  wikidata: Q826807
 01447424-n:
   definition:
   - a cypriniform fish of the family Catostomidae
@@ -7251,6 +7413,7 @@
   - Catostomus
   - genus Catostomus
   partOfSpeech: n
+  wikidata: Q2271225
 01447946-n:
   definition:
   - buffalo fishes
@@ -7320,6 +7483,7 @@
   mero_member:
   - 01448793-n
   partOfSpeech: n
+  wikidata: Q2707493
 01448793-n:
   definition:
   - North American sucker with reddish fins
@@ -7348,6 +7512,7 @@
   - 01450806-n
   - 01451137-n
   partOfSpeech: n
+  wikidata: Q134865
 01449230-n:
   definition:
   - any member of the family Cyprinodontidae
@@ -7380,6 +7545,7 @@
   - 01449780-n
   - 01449972-n
   partOfSpeech: n
+  wikidata: Q2359231
 01449780-n:
   definition:
   - silver-and-black killifish of saltwater marshes along the Atlantic coast of the
@@ -7416,6 +7582,7 @@
   mero_member:
   - 01450299-n
   partOfSpeech: n
+  wikidata: Q798213
 01450299-n:
   definition:
   - found in small streams of tropical America; often kept in aquariums; usually hermaphroditic
@@ -7462,6 +7629,7 @@
   mero_member:
   - 01450932-n
   partOfSpeech: n
+  wikidata: Q132098
 01450932-n:
   definition:
   - freshwater fish of Central America having a long swordlike tail; popular aquarium
@@ -7485,6 +7653,7 @@
   - Lebistes
   - genus Lebistes
   partOfSpeech: n
+  wikidata: Q310951
 01451235-n:
   definition:
   - small freshwater fish of South America and the West Indies; often kept in aquariums
@@ -7562,6 +7731,7 @@
   mero_member:
   - 01452353-n
   partOfSpeech: n
+  wikidata: Q107269289
 01452353-n:
   definition:
   - small stocky Mexican fish; popular aquarium fish
@@ -7584,6 +7754,7 @@
   mero_member:
   - 01452621-n
   partOfSpeech: n
+  wikidata: Q11784877
 01452621-n:
   definition:
   - popular aquarium fish
@@ -7607,6 +7778,7 @@
   - 01452922-n
   - 01454165-n
   partOfSpeech: n
+  wikidata: Q749596
 01452922-n:
   definition:
   - squirrelfishes and soldierfishes
@@ -7620,6 +7792,7 @@
   - 01453094-n
   - 01453302-n
   partOfSpeech: n
+  wikidata: Q1335080
 01453094-n:
   definition:
   - type genus of the family Holocentridae; squirrelfishes
@@ -7698,6 +7871,7 @@
   - 01454692-n
   - 01454841-n
   partOfSpeech: n
+  wikidata: Q1346261
 01454367-n:
   definition:
   - type genus of the family Anomalopidae
@@ -7709,6 +7883,7 @@
   mero_member:
   - 01454504-n
   partOfSpeech: n
+  wikidata: Q2304642
 01454504-n:
   definition:
   - fish having a luminous organ beneath eye; of warm waters of the western Pacific
@@ -7731,6 +7906,7 @@
   - Krypterophaneron
   - genus Krypterophaneron
   partOfSpeech: n
+  wikidata: Q2489985
 01454841-n:
   definition:
   - a genus of flashlight fishes in the family Anomalopidae, found around reefs in
@@ -7766,6 +7942,7 @@
   - 01455274-n
   - 01455829-n
   partOfSpeech: n
+  wikidata: Q768334
 01455274-n:
   definition:
   - a family of fish in the order Zeomorphi
@@ -7779,6 +7956,7 @@
   - 01455439-n
   - 01455595-n
   partOfSpeech: n
+  wikidata: Q1476897
 01455439-n:
   definition:
   - marine fishes widely distributed in mid-waters and deep slope waters
@@ -7800,6 +7978,7 @@
   mero_member:
   - 01455728-n
   partOfSpeech: n
+  wikidata: Q1960850
 01455728-n:
   definition:
   - European dory
@@ -7824,6 +8003,7 @@
   - 01455971-n
   - 01456232-n
   partOfSpeech: n
+  wikidata: Q1278800
 01455971-n:
   definition:
   - a genus of fish in the family Caproidae, commonly known as boarfish (Capros)
@@ -7836,6 +8016,7 @@
   mero_member:
   - 01456116-n
   partOfSpeech: n
+  wikidata: Q5036326
 01456116-n:
   definition:
   - fish with a projecting snout
@@ -7858,6 +8039,7 @@
   mero_member:
   - 01456383-n
   partOfSpeech: n
+  wikidata: Q145289
 01456383-n:
   definition:
   - fish with large eyes and long snouts
@@ -7886,6 +8068,7 @@
   - 01459917-n
   - 01460217-n
   partOfSpeech: n
+  wikidata: Q14364531
 01456901-n:
   definition:
   - cornetfishes
@@ -7898,6 +8081,7 @@
   mero_member:
   - 01457034-n
   partOfSpeech: n
+  wikidata: Q9260095
 01457034-n:
   definition:
   - type genus of the family Fistulariidae
@@ -7910,6 +8094,7 @@
   mero_member:
   - 01457186-n
   partOfSpeech: n
+  wikidata: Q1411094
 01457186-n:
   definition:
   - slender tropical fish with a long tubular snout and bony plates instead of scales
@@ -7932,6 +8117,7 @@
   - 01457497-n
   - 01457782-n
   partOfSpeech: n
+  wikidata: Q215420
 01457497-n:
   definition:
   - small (2-4 inches) pugnacious mostly scaleless spiny-backed fishes of northern
@@ -7956,6 +8142,7 @@
   - 01457958-n
   - 01458102-n
   partOfSpeech: n
+  wikidata: Q134491
 01457958-n:
   definition:
   - of rivers and coastal regions
@@ -7991,6 +8178,7 @@
   - 01458937-n
   - 01459272-n
   partOfSpeech: n
+  wikidata: Q213534
 01458419-n:
   definition:
   - fish with long tubular snout and slim body covered with bony plates
@@ -8013,6 +8201,7 @@
   mero_member:
   - 01458778-n
   partOfSpeech: n
+  wikidata: Q606703
 01458778-n:
   definition:
   - small (4 inches) fish found off the Florida Gulf Coast
@@ -8035,6 +8224,7 @@
   mero_member:
   - 01459095-n
   partOfSpeech: n
+  wikidata: Q1824775
 01459095-n:
   definition:
   - a fish 8 inches long; found from eastern Florida to western Caribbean
@@ -8057,6 +8247,7 @@
   mero_member:
   - 01459397-n
   partOfSpeech: n
+  wikidata: Q74363
 01459397-n:
   definition:
   - small fish with horse-like heads bent sharply downward and curled tails; swim
@@ -8080,6 +8271,7 @@
   mero_member:
   - 01459723-n
   partOfSpeech: n
+  wikidata: Q10672751
 01459723-n:
   definition:
   - small bottom-dwelling fish of warm seas having a compressed body and a long snout
@@ -8103,6 +8295,7 @@
   mero_member:
   - 01460048-n
   partOfSpeech: n
+  wikidata: Q1366524
 01460048-n:
   definition:
   - slender tropical shallow-water East Indian fish covered with transparent plates
@@ -8126,6 +8319,7 @@
   mero_member:
   - 01460349-n
   partOfSpeech: n
+  wikidata: Q610041
 01460349-n:
   definition:
   - type genus of the Aulostomidae
@@ -8138,6 +8332,7 @@
   mero_member:
   - 01460493-n
   partOfSpeech: n
+  wikidata: Q2513729
 01460493-n:
   definition:
   - tropical Atlantic fish with a long snout; swims snout down
@@ -8728,6 +8923,7 @@
   mero_member:
   - 01470445-n
   partOfSpeech: n
+  wikidata: Q107268725
 01470445-n:
   definition:
   - small translucent lancet-shaped burrowing marine animal; primitive forerunner
@@ -8783,6 +8979,7 @@
   - 01471353-n
   - 01473536-n
   partOfSpeech: n
+  wikidata: Q190090
 01471353-n:
   definition:
   - minute sedentary marine invertebrate having a saclike body with siphons through
@@ -8828,6 +9025,7 @@
   - 01472066-n
   - 01472527-n
   partOfSpeech: n
+  wikidata: Q610887
 01472066-n:
   definition:
   - a small family of tunicates in the class Thaliacea
@@ -8840,6 +9038,7 @@
   mero_member:
   - 01472227-n
   partOfSpeech: n
+  wikidata: Q1068611
 01472227-n:
   definition:
   - type (perhaps sole) genus of the Salpidae
@@ -8851,6 +9050,7 @@
   mero_member:
   - 01472364-n
   partOfSpeech: n
+  wikidata: Q3470198
 01472364-n:
   definition:
   - minute floating marine tunicate having a transparent body with an opening at each
@@ -8874,6 +9074,7 @@
   mero_member:
   - 01472659-n
   partOfSpeech: n
+  wikidata: Q4923287
 01472659-n:
   definition:
   - type genus of the Doliolidae
@@ -8885,6 +9086,7 @@
   mero_member:
   - 01472786-n
   partOfSpeech: n
+  wikidata: Q4795779
 01472786-n:
   definition:
   - free-swimming oceanic tunicate with a barrel-shaped transparent body
@@ -8908,6 +9110,7 @@
   - 01473120-n
   - 01473227-n
   partOfSpeech: n
+  wikidata: Q26206847
 01473120-n:
   definition:
   - any member of the class Larvacea
@@ -8928,6 +9131,7 @@
   mero_member:
   - 01473374-n
   partOfSpeech: n
+  wikidata: Q21444273
 01473374-n:
   definition:
   - free-swimming tadpole-shaped pelagic tunicate resembling larvae of other tunicates
@@ -9144,6 +9348,7 @@
   - 01477666-n
   - 01478062-n
   partOfSpeech: n
+  wikidata: Q74083
 01477505-n:
   definition:
   - extinct fish-like jawless vertebrate having a heavily armored body; of the Paleozoic
@@ -9240,6 +9445,7 @@
   mero_member:
   - 01479059-n
   partOfSpeech: n
+  wikidata: Q34613085
 01479059-n:
   definition:
   - small (2 inches long) extinct eellike fish with a finned tail and a notochord
@@ -9276,6 +9482,7 @@
   - 01480714-n
   - 01480941-n
   partOfSpeech: n
+  wikidata: Q150893
 01479721-n:
   definition:
   - primitive aquatic vertebrate
@@ -9335,6 +9542,7 @@
   mero_member:
   - 01480516-n
   partOfSpeech: n
+  wikidata: Q3377629
 01480516-n:
   definition:
   - large anadromous lamprey sometimes used as food; destructive of native fish fauna
@@ -9377,6 +9585,7 @@
   - 01481707-n
   - 01481970-n
   partOfSpeech: n
+  wikidata: Q75713
 01481152-n:
   definition:
   - eellike cyclostome having a tongue with horny teeth in a round mouth surrounded
@@ -9401,6 +9610,7 @@
   mero_member:
   - 01481610-n
   partOfSpeech: n
+  wikidata: Q740209
 01481610-n:
   definition:
   - typical hagfish
@@ -9421,6 +9631,7 @@
   mero_member:
   - 01481854-n
   partOfSpeech: n
+  wikidata: Q990101
 01481854-n:
   definition:
   - a fossil hagfish of the genus Eptatretus
@@ -9443,6 +9654,7 @@
   mero_member:
   - 01482100-n
   partOfSpeech: n
+  wikidata: Q20859372
 01482100-n:
   definition:
   - fossil hagfish of the Pennsylvanian period (c. 300 million years ago) that resembled
@@ -9486,6 +9698,7 @@
   mero_member:
   - 01482747-n
   partOfSpeech: n
+  wikidata: Q130932
 01482747-n:
   definition:
   - fish-like vertebrate with bony plates on head and upper body; dominant in seas
@@ -9510,6 +9723,7 @@
   - 01483356-n
   - 01484240-n
   partOfSpeech: n
+  wikidata: Q25371
 01483157-n:
   definition:
   - fishes in which the skeleton may be calcified but not ossified
@@ -9568,6 +9782,7 @@
   mero_member:
   - 01483972-n
   partOfSpeech: n
+  wikidata: Q19240
 01483972-n:
   definition:
   - a deep-sea fish with a tapering body, smooth skin, and long threadlike tail
@@ -9663,6 +9878,7 @@
   mero_member:
   - 01485662-n
   partOfSpeech: n
+  wikidata: Q311682
 01485662-n:
   definition:
   - large primitive shark widely distributed in warm seas
@@ -9702,6 +9918,7 @@
   mero_member:
   - 01486621-n
   partOfSpeech: n
+  wikidata: Q35077862
 01486163-n:
   definition:
   - fierce pelagic and oceanic sharks
@@ -9723,6 +9940,7 @@
   mero_member:
   - 01486471-n
   partOfSpeech: n
+  wikidata: Q137078
 01486471-n:
   definition:
   - voracious pointed-nose shark of northern Atlantic and Pacific
@@ -9746,6 +9964,7 @@
   mero_member:
   - 01486738-n
   partOfSpeech: n
+  wikidata: Q171298
 01486738-n:
   definition:
   - powerful mackerel shark of the Atlantic and Pacific
@@ -9827,6 +10046,7 @@
   mero_member:
   - 01488120-n
   partOfSpeech: n
+  wikidata: Q2947096
 01487947-n:
   definition:
   - in some older classifications considered the family of the basking sharks
@@ -9837,6 +10057,7 @@
   - Cetorhinidae
   - family Cetorhinidae
   partOfSpeech: n
+  wikidata: Q16542604
 01488120-n:
   definition:
   - large harmless plankton-eating northern shark; often swims slowly or floats at
@@ -9860,6 +10081,7 @@
   mero_member:
   - 01488442-n
   partOfSpeech: n
+  wikidata: Q17280257
 01488442-n:
   definition:
   - type genus of the family Alopiidae; in some classifications considered a genus
@@ -9873,6 +10095,7 @@
   mero_member:
   - 01488651-n
   partOfSpeech: n
+  wikidata: Q627902
 01488651-n:
   definition:
   - large pelagic shark of warm seas with a whiplike tail used to round up small fish
@@ -9936,6 +10159,7 @@
   mero_member:
   - 01489479-n
   partOfSpeech: n
+  wikidata: Q17283693
 01489479-n:
   definition:
   - small bottom-dwelling shark of warm shallow waters on both coasts of North America
@@ -10017,6 +10241,7 @@
   mero_member:
   - 01490679-n
   partOfSpeech: n
+  wikidata: Q17284129
 01490679-n:
   definition:
   - large spotted shark of warm surface waters worldwide; resembles a whale and feeds
@@ -10040,6 +10265,7 @@
   mero_member:
   - 01491026-n
   partOfSpeech: n
+  wikidata: Q17149
 01491026-n:
   definition:
   - small bottom-dwelling sharks with cat-like eyes; found along continental slopes
@@ -10067,6 +10293,7 @@
   - 01493876-n
   - 01494161-n
   partOfSpeech: n
+  wikidata: Q48191
 01491559-n:
   definition:
   - any of numerous sharks from small relatively harmless bottom-dwellers to large
@@ -10093,6 +10320,7 @@
   - 01492753-n
   - 01493001-n
   partOfSpeech: n
+  wikidata: Q312359
 01492142-n:
   definition:
   - a most common shark in temperate and tropical coastal waters worldwide; heavy-bodied
@@ -10188,6 +10416,7 @@
   mero_member:
   - 01493647-n
   partOfSpeech: n
+  wikidata: Q15695051
 01493647-n:
   definition:
   - slender cosmopolitan, pelagic shark; blue body shades to white belly; dangerous
@@ -10212,6 +10441,7 @@
   mero_member:
   - 01494002-n
   partOfSpeech: n
+  wikidata: Q2186811
 01494002-n:
   definition:
   - large dangerous warm-water shark with striped or spotted body
@@ -10234,6 +10464,7 @@
   mero_member:
   - 01494302-n
   partOfSpeech: n
+  wikidata: Q608028
 01494302-n:
   definition:
   - Pacific shark valued for its fins (used by Chinese in soup) and liver (rich in
@@ -10270,6 +10501,7 @@
   - 01494998-n
   - 01495653-n
   partOfSpeech: n
+  wikidata: Q756279
 01494853-n:
   definition:
   - smooth dogfishes
@@ -10283,6 +10515,7 @@
   - 01495349-n
   - 01495501-n
   partOfSpeech: n
+  wikidata: Q2061110
 01494998-n:
   definition:
   - small bottom-dwelling shark found along both Atlantic coasts
@@ -10335,6 +10568,7 @@
   mero_member:
   - 01495787-n
   partOfSpeech: n
+  wikidata: Q2806074
 01495787-n:
   definition:
   - smooth dogfish of Pacific and Indian Oceans and Red Sea having white-tipped dorsal
@@ -10360,6 +10594,7 @@
   - 01496182-n
   - 01496328-n
   partOfSpeech: n
+  wikidata: Q1245778
 01496182-n:
   definition:
   - small bottom-dwelling dogfishes
@@ -10417,6 +10652,7 @@
   mero_member:
   - 01496980-n
   partOfSpeech: n
+  wikidata: Q208490
 01496980-n:
   definition:
   - type genus of the Sphyrnidae
@@ -10429,6 +10665,7 @@
   mero_member:
   - 01497116-n
   partOfSpeech: n
+  wikidata: Q132998
 01497116-n:
   definition:
   - medium-sized live-bearing shark with eyes at either end of a flattened hammer-shaped
@@ -10485,6 +10722,7 @@
   mero_member:
   - 01497981-n
   partOfSpeech: n
+  wikidata: Q15207726
 01497981-n:
   definition:
   - 'type genus of the Squatinidae: angel sharks'
@@ -10497,6 +10735,7 @@
   mero_member:
   - 01498134-n
   partOfSpeech: n
+  wikidata: Q756731
 01498134-n:
   definition:
   - sharks with broad flat bodies and winglike pectoral fins but that swim the way
@@ -10533,6 +10772,7 @@
   mero_member:
   - 01498840-n
   partOfSpeech: n
+  wikidata: Q41317
 01498840-n:
   definition:
   - electric rays
@@ -10595,6 +10835,7 @@
   - 01499759-n
   - 01499919-n
   partOfSpeech: n
+  wikidata: Q190736
 01499759-n:
   definition:
   - primitive ray with sharp teeth on each edge of a long flattened snout
@@ -10616,6 +10857,7 @@
   mero_member:
   - 01500054-n
   partOfSpeech: n
+  wikidata: Q683945
 01500054-n:
   definition:
   - commonly found in tropical bays and estuaries; not aggressive
@@ -10686,6 +10928,7 @@
   mero_member:
   - 01501047-n
   partOfSpeech: n
+  wikidata: Q902487
 01501047-n:
   definition:
   - one of the largest stingrays; found from Cape Cod to Cape Hatteras
@@ -10708,6 +10951,7 @@
   mero_member:
   - 01501340-n
   partOfSpeech: n
+  wikidata: Q3122687
 01501340-n:
   definition:
   - a stingray with a short tail and a broad fin
@@ -10754,6 +10998,7 @@
   mero_member:
   - 01502037-n
   partOfSpeech: n
+  wikidata: Q2825690
 01502037-n:
   definition:
   - ray with back covered with white or yellow spots; widely distributed in warm seas
@@ -10777,6 +11022,7 @@
   mero_member:
   - 01502373-n
   partOfSpeech: n
+  wikidata: Q1428166
 01502373-n:
   definition:
   - large ray found along eastern coast of North America
@@ -10802,6 +11048,7 @@
   - 01503001-n
   - 01503362-n
   partOfSpeech: n
+  wikidata: Q16354702
 01502732-n:
   definition:
   - extremely large pelagic tropical ray that feeds on plankton and small fishes;
@@ -10825,6 +11072,7 @@
   mero_member:
   - 01503117-n
   partOfSpeech: n
+  wikidata: Q1536199
 01503117-n:
   definition:
   - largest manta (to 22 feet across wings); found worldwide but common in Gulf of
@@ -10872,6 +11120,7 @@
   - 01503801-n
   - 01504091-n
   partOfSpeech: n
+  wikidata: Q837104
 01503801-n:
   definition:
   - large edible rays having a long snout and thick tail with pectoral fins continuous
@@ -10897,6 +11146,7 @@
   - 01504589-n
   - 01504742-n
   partOfSpeech: n
+  wikidata: Q1834465
 01504282-n:
   definition:
   - common European skate used as food
@@ -10989,6 +11239,7 @@
   - 02057934-n
   - 02060132-n
   partOfSpeech: n
+  wikidata: Q5113
 01505702-n:
   definition:
   - warm-blooded egg-laying vertebrates characterized by feathers and forelimbs modified
@@ -11161,6 +11412,7 @@
   mero_member:
   - 01518224-n
   partOfSpeech: n
+  wikidata: Q284477
 01518224-n:
   definition:
   - most primitive avian type known; extinct bird of the Triassic having bird-like
@@ -11199,6 +11451,7 @@
   mero_member:
   - 01518853-n
   partOfSpeech: n
+  wikidata: Q100196
 01518853-n:
   definition:
   - extinct primitive toothed bird of the Jurassic period having a long feathered
@@ -11222,6 +11475,7 @@
   mero_member:
   - 01519250-n
   partOfSpeech: n
+  wikidata: Q19776304
 01519250-n:
   definition:
   - sparrow-sized fossil bird of the Jurassic period to the Cretaceous period having
@@ -11244,6 +11498,7 @@
   mero_member:
   - 01519677-n
   partOfSpeech: n
+  wikidata: Q19622300
 01519677-n:
   definition:
   - sparrow-sized fossil bird of the Cretaceous period having a vestigial tail; found
@@ -11326,6 +11581,7 @@
   mero_member:
   - 01521205-n
   partOfSpeech: n
+  wikidata: Q840849
 01521205-n:
   definition:
   - 'tall terrestrial birds: ostriches'
@@ -11338,6 +11594,7 @@
   mero_member:
   - 01521359-n
   partOfSpeech: n
+  wikidata: Q1569770
 01521359-n:
   definition:
   - 'type genus of the Struthionidae: African ostriches'
@@ -11350,6 +11607,7 @@
   mero_member:
   - 01521519-n
   partOfSpeech: n
+  wikidata: Q2576337
 01521519-n:
   definition:
   - fast-running African flightless bird with two-toed feet; largest living bird
@@ -11373,6 +11631,7 @@
   - 01521869-n
   - 01522360-n
   partOfSpeech: n
+  wikidata: Q19173
 01521869-n:
   definition:
   - a family of large ostrich-like birds including cassowaries
@@ -11385,6 +11644,7 @@
   mero_member:
   - 01522042-n
   partOfSpeech: n
+  wikidata: Q756871
 01522042-n:
   definition:
   - 'type and sole genus of the Casuaridae: cassowaries'
@@ -11397,6 +11657,7 @@
   mero_member:
   - 01522204-n
   partOfSpeech: n
+  wikidata: Q201231
 01522204-n:
   definition:
   - large black flightless bird of Australia and New Guinea having a horny head crest
@@ -11418,6 +11679,7 @@
   mero_member:
   - 01522514-n
   partOfSpeech: n
+  wikidata: Q858264
 01522514-n:
   definition:
   - large Australian flightless bird similar to the ostrich but smaller
@@ -11442,6 +11704,7 @@
   mero_member:
   - 01522925-n
   partOfSpeech: n
+  wikidata: Q11085824
 01522925-n:
   definition:
   - coextensive with the order Apterygiformes
@@ -11454,6 +11717,7 @@
   mero_member:
   - 01523083-n
   partOfSpeech: n
+  wikidata: Q3621064
 01523083-n:
   definition:
   - 'type genus of the Apterygidae: kiwis'
@@ -11465,6 +11729,7 @@
   mero_member:
   - 01523217-n
   partOfSpeech: n
+  wikidata: Q43642
 01523217-n:
   definition:
   - nocturnal flightless bird of New Zealand having a long neck and stout legs; only
@@ -11503,6 +11768,7 @@
   - 01523838-n
   - 01524243-n
   partOfSpeech: n
+  wikidata: Q12214029
 01523838-n:
   definition:
   - type genus of the Rheidae; large tall flightless South American birds similar
@@ -11515,6 +11781,7 @@
   mero_member:
   - 01524040-n
   partOfSpeech: n
+  wikidata: Q19171
 01524040-n:
   definition:
   - larger of two tall fast-running flightless birds similar to ostriches but three-toed;
@@ -11538,6 +11805,7 @@
   mero_member:
   - 01524397-n
   partOfSpeech: n
+  wikidata: Q6090573
 01524397-n:
   definition:
   - smaller of two tall fast-running flightless birds similar to ostriches but three-toed;
@@ -11562,6 +11830,7 @@
   mero_member:
   - 01524788-n
   partOfSpeech: n
+  wikidata: Q3605955
 01524788-n:
   definition:
   - coextensive with the order Aepyorniformes
@@ -11574,6 +11843,7 @@
   mero_member:
   - 01524946-n
   partOfSpeech: n
+  wikidata: Q214508
 01524946-n:
   definition:
   - 'type genus of the Aepyornidae: elephant birds'
@@ -11585,6 +11855,7 @@
   mero_member:
   - 01525091-n
   partOfSpeech: n
+  wikidata: Q2638301
 01525091-n:
   definition:
   - huge (to 9 ft.) extinct flightless bird of Madagascar
@@ -11622,6 +11893,7 @@
   - 01525746-n
   - 01526020-n
   partOfSpeech: n
+  wikidata: Q15865426
 01525593-n:
   definition:
   - 'type genus of the Dinornithidae: large moas'
@@ -11634,6 +11906,7 @@
   mero_member:
   - 01525889-n
   partOfSpeech: n
+  wikidata: Q899705
 01525746-n:
   definition:
   - extinct flightless bird of New Zealand
@@ -11664,6 +11937,7 @@
   mero_member:
   - 01526134-n
   partOfSpeech: n
+  wikidata: Q1131762
 01526134-n:
   definition:
   - the smallest moa; slender moa about the size of a large turkey
@@ -11707,6 +11981,7 @@
   - 01549784-n
   - 01586645-n
   partOfSpeech: n
+  wikidata: Q25341
 01527000-n:
   definition:
   - perching birds mostly small and living near the ground with feet having 4 toes
@@ -11843,6 +12118,7 @@
   mero_member:
   - 01529835-n
   partOfSpeech: n
+  wikidata: Q3924795
 01529835-n:
   definition:
   - small sparrow-like songbird of mountainous regions of Eurasia
@@ -11877,6 +12153,7 @@
   - 01530258-n
   - 01530415-n
   partOfSpeech: n
+  wikidata: Q29858
 01530258-n:
   definition:
   - any of numerous predominantly Old World birds noted for their singing
@@ -11898,6 +12175,7 @@
   mero_member:
   - 01530558-n
   partOfSpeech: n
+  wikidata: Q378278
 01530558-n:
   definition:
   - brown-speckled European lark noted for singing while hovering at a great height
@@ -11921,6 +12199,7 @@
   - 01530885-n
   - 01531183-n
   partOfSpeech: n
+  wikidata: Q205943
 01530885-n:
   definition:
   - 'type genus of the Motacillidae: wagtails'
@@ -11955,6 +12234,7 @@
   mero_member:
   - 01531295-n
   partOfSpeech: n
+  wikidata: Q193807
 01531295-n:
   definition:
   - a songbird that lives mainly on the ground in open country; has streaky brown
@@ -12012,6 +12292,7 @@
   - 01544696-n
   - 01544957-n
   partOfSpeech: n
+  wikidata: Q160835
 01532313-n:
   definition:
   - any of numerous small songbirds with short stout bills adapted for crushing seeds
@@ -12034,6 +12315,7 @@
   - 01533080-n
   - 01533216-n
   partOfSpeech: n
+  wikidata: Q581391
 01533080-n:
   definition:
   - small European finch with a cheerful song
@@ -12158,6 +12440,7 @@
   - 01534966-n
   - 01535152-n
   partOfSpeech: n
+  wikidata: Q5261336
 01534966-n:
   definition:
   - American finch whose male has yellow body plumage in summer
@@ -12194,6 +12477,7 @@
   - 01535470-n
   - 01535641-n
   partOfSpeech: n
+  wikidata: Q843168
 01535470-n:
   definition:
   - small finch originally of the western United States and Mexico
@@ -12272,6 +12556,7 @@
   mero_member:
   - 01536534-n
   partOfSpeech: n
+  wikidata: Q339517
 01536534-n:
   definition:
   - finch with a bill whose tips cross when closed
@@ -12317,6 +12602,7 @@
   mero_member:
   - 01537074-n
   partOfSpeech: n
+  wikidata: Q857319
 01537074-n:
   definition:
   - small North American finch seen chiefly in winter
@@ -12359,6 +12645,7 @@
   mero_member:
   - 01537781-n
   partOfSpeech: n
+  wikidata: Q10808271
 01537781-n:
   definition:
   - common North American finch noted for its evening song
@@ -12421,6 +12708,7 @@
   - 01538827-n
   - 01538975-n
   partOfSpeech: n
+  wikidata: Q955626
 01538676-n:
   definition:
   - small North American finch common in urban areas
@@ -12466,6 +12754,7 @@
   - 01539285-n
   - 01539421-n
   partOfSpeech: n
+  wikidata: Q1073612
 01539285-n:
   definition:
   - small songbird common in North America
@@ -12523,6 +12812,7 @@
   mero_member:
   - 01540185-n
   partOfSpeech: n
+  wikidata: Q609717
 01540185-n:
   definition:
   - small deep blue North American bunting
@@ -12608,6 +12898,7 @@
   mero_member:
   - 01541271-n
   partOfSpeech: n
+  wikidata: Q1073197
 01541271-n:
   definition:
   - white Arctic bunting
@@ -12636,6 +12927,7 @@
   - 01541596-n
   - 01541777-n
   partOfSpeech: n
+  wikidata: Q10749446
 01541596-n:
   definition:
   - small bright-colored tropical American songbird with a curved bill for sucking
@@ -12681,6 +12973,7 @@
   - 01542214-n
   - 01542413-n
   partOfSpeech: n
+  wikidata: Q28922
 01542214-n:
   definition:
   - any of several small dull-colored singing birds feeding on seeds or insects
@@ -12704,6 +12997,7 @@
   - 01542566-n
   - 01542731-n
   partOfSpeech: n
+  wikidata: Q28753
 01542566-n:
   definition:
   - small hardy brown-and-grey bird native to Europe
@@ -12770,6 +13064,7 @@
   mero_member:
   - 01543473-n
   partOfSpeech: n
+  wikidata: Q868144
 01543473-n:
   definition:
   - a common large finch of Eurasia
@@ -12793,6 +13088,7 @@
   mero_member:
   - 01543743-n
   partOfSpeech: n
+  wikidata: Q310865
 01543743-n:
   definition:
   - large grosbeak of coniferous forests of Old and New Worlds
@@ -12815,6 +13111,7 @@
   mero_member:
   - 01544027-n
   partOfSpeech: n
+  wikidata: Q858444
 01544027-n:
   definition:
   - crested thick-billed North American finch having bright red plumage in the male
@@ -12873,6 +13170,7 @@
   mero_member:
   - 01544809-n
   partOfSpeech: n
+  wikidata: Q613202
 01544809-n:
   definition:
   - common towhee of eastern North America
@@ -12923,6 +13221,7 @@
   - 01546458-n
   - 01546708-n
   partOfSpeech: n
+  wikidata: Q211601
 01545427-n:
   definition:
   - finch-like African and Asian colonial birds noted for their elaborately woven
@@ -12945,6 +13244,7 @@
   - Ploceus
   - genus Ploceus
   partOfSpeech: n
+  wikidata: Q1093619
 01545816-n:
   definition:
   - common Indian weaverbird
@@ -12967,6 +13267,7 @@
   mero_member:
   - 01546024-n
   partOfSpeech: n
+  wikidata: Q3467715
 01546024-n:
   definition:
   - mostly black African weaverbird
@@ -12990,6 +13291,7 @@
   mero_member:
   - 01546273-n
   partOfSpeech: n
+  wikidata: Q1094968
 01546273-n:
   definition:
   - small finch-like Indonesian weaverbird that frequents rice fields
@@ -13038,6 +13340,7 @@
   - 01546849-n
   - 01547030-n
   partOfSpeech: n
+  wikidata: Q1079034
 01546849-n:
   definition:
   - usually brightly-colored Australian weaverbirds; often kept as cage birds
@@ -13072,6 +13375,7 @@
   - 01547345-n
   - 01547518-n
   partOfSpeech: n
+  wikidata: Q13167346
 01547345-n:
   definition:
   - small to medium-sized finches of the Hawaiian islands
@@ -13094,6 +13398,7 @@
   mero_member:
   - 01547651-n
   partOfSpeech: n
+  wikidata: Q909836
 01547651-n:
   definition:
   - black honeycreepers with yellow feathers around the tail; now extinct
@@ -13128,6 +13433,7 @@
   mero_member:
   - 01548066-n
   partOfSpeech: n
+  wikidata: Q13170975
 01548066-n:
   definition:
   - type and sole genus of the family Menuridae
@@ -13140,6 +13446,7 @@
   mero_member:
   - 01548215-n
   partOfSpeech: n
+  wikidata: Q214096
 01548215-n:
   definition:
   - Australian bird that resembles a pheasant; the courting male displays long tail
@@ -13162,6 +13469,7 @@
   mero_member:
   - 01548530-n
   partOfSpeech: n
+  wikidata: Q12809511
 01548530-n:
   definition:
   - type genus of the Atrichornithidae
@@ -13174,6 +13482,7 @@
   mero_member:
   - 01548680-n
   partOfSpeech: n
+  wikidata: Q122250
 01548680-n:
   definition:
   - small fast-running Australian bird resembling a wren and frequenting brush or
@@ -13210,6 +13519,7 @@
   mero_member:
   - 01549147-n
   partOfSpeech: n
+  wikidata: Q214621
 01549147-n:
   definition:
   - small birds of the Old World tropics having bright plumage and short wide bills
@@ -13303,6 +13613,7 @@
   - 01550942-n
   - 01557946-n
   partOfSpeech: n
+  wikidata: Q935894
 01550942-n:
   definition:
   - large American flycatcher
@@ -13372,6 +13683,7 @@
   mero_member:
   - 01552071-n
   partOfSpeech: n
+  wikidata: Q868932
 01552071-n:
   definition:
   - small olive-colored woodland flycatchers of eastern North America
@@ -13433,6 +13745,7 @@
   mero_member:
   - 01552813-n
   partOfSpeech: n
+  wikidata: Q15881075
 01552813-n:
   definition:
   - tropical American flycatcher found as far north as southern Texas and Arizona;
@@ -13460,6 +13773,7 @@
   - 01554556-n
   - 01554833-n
   partOfSpeech: n
+  wikidata: Q647533
 01553266-n:
   definition:
   - 'type genus of the Cotingidae: cotingas'
@@ -13471,6 +13785,7 @@
   mero_member:
   - 01553402-n
   partOfSpeech: n
+  wikidata: Q869377
 01553402-n:
   definition:
   - passerine bird of New World tropics
@@ -13493,6 +13808,7 @@
   mero_member:
   - 01553721-n
   partOfSpeech: n
+  wikidata: Q669771
 01553721-n:
   definition:
   - tropical bird of northern South America the male having brilliant red or orange
@@ -13526,6 +13842,7 @@
   mero_member:
   - 01554190-n
   partOfSpeech: n
+  wikidata: Q379200
 01554190-n:
   definition:
   - type genus of the Pipridae containing the typical manakins
@@ -13538,6 +13855,7 @@
   mero_member:
   - 01554352-n
   partOfSpeech: n
+  wikidata: Q1195360
 01554352-n:
   definition:
   - any of numerous small bright-colored birds of Central America and South America
@@ -13560,6 +13878,7 @@
   mero_member:
   - 01554675-n
   partOfSpeech: n
+  wikidata: Q1079212
 01554675-n:
   definition:
   - any of several tropical American birds of the genus Procnias having a bell-like
@@ -13582,6 +13901,7 @@
   mero_member:
   - 01554974-n
   partOfSpeech: n
+  wikidata: Q859561
 01554974-n:
   definition:
   - black tropical American bird having a large overhanging crest and long feathered
@@ -13618,6 +13938,7 @@
   mero_member:
   - 01555454-n
   partOfSpeech: n
+  wikidata: Q429074
 01555454-n:
   definition:
   - small brownish South American birds that build oven-shaped clay nests
@@ -13642,6 +13963,7 @@
   - 01556261-n
   - 01556520-n
   partOfSpeech: n
+  wikidata: Q461021
 01555783-n:
   definition:
   - any of various dull-colored South American birds that feeding on ants some following
@@ -13665,6 +13987,7 @@
   mero_member:
   - 01556168-n
   partOfSpeech: n
+  wikidata: Q1002963
 01556168-n:
   definition:
   - a kind of antbird, with species spanning the genera Formicarius and Chamaeza
@@ -13686,6 +14009,7 @@
   mero_member:
   - 01556403-n
   partOfSpeech: n
+  wikidata: Q375593
 01556403-n:
   definition:
   - antbirds superficially resembling shrikes
@@ -13707,6 +14031,7 @@
   mero_member:
   - 01556658-n
   partOfSpeech: n
+  wikidata: Q539321
 01556658-n:
   definition:
   - a kind of antbird found in Honduras, Nicaragua, Costa Rica and Panama, also Colombia
@@ -13732,6 +14057,7 @@
   - 01556952-n
   - 01557089-n
   partOfSpeech: n
+  wikidata: Q672414
 01556952-n:
   definition:
   - type genus of the Dendrocolaptidae
@@ -13742,6 +14068,7 @@
   - Dendrocolaptes
   - genus Dendrocolaptes
   partOfSpeech: n
+  wikidata: Q903934
 01557089-n:
   definition:
   - any of numerous South American and Central American birds with a curved bill and
@@ -13767,6 +14094,7 @@
   mero_member:
   - 01557466-n
   partOfSpeech: n
+  wikidata: Q217472
 01557466-n:
   definition:
   - type genus of the Pittidae; a large genus of birds of southern Asia and Australia
@@ -13777,6 +14105,7 @@
   members:
   - genus Pitta
   partOfSpeech: n
+  wikidata: Q3389415
 01557645-n:
   definition:
   - any bird of the genus Pitta; brilliantly colored chiefly terrestrial birds with
@@ -13815,6 +14144,7 @@
   - 01559669-n
   - 01565619-n
   partOfSpeech: n
+  wikidata: Q200989
 01558450-n:
   definition:
   - any of a large group of small songbirds that feed on insects taken on the wing
@@ -13838,6 +14168,7 @@
   mero_member:
   - 01558823-n
   partOfSpeech: n
+  wikidata: Q1088541
 01558823-n:
   definition:
   - common European woodland flycatcher with greyish-brown plumage
@@ -13893,6 +14224,7 @@
   - 01564254-n
   - 01564757-n
   partOfSpeech: n
+  wikidata: Q26050
 01559669-n:
   definition:
   - alternative classification for the thrushes
@@ -14042,6 +14374,7 @@
   - 01562118-n
   - 01562280-n
   partOfSpeech: n
+  wikidata: Q10770214
 01562118-n:
   definition:
   - North American thrush noted for its complex and appealing song
@@ -14130,6 +14463,7 @@
   mero_member:
   - 01563277-n
   partOfSpeech: n
+  wikidata: Q906092
 01563277-n:
   definition:
   - songbirds having a chattering call
@@ -14172,6 +14506,7 @@
   mero_member:
   - 01563822-n
   partOfSpeech: n
+  wikidata: Q1088544
 01563822-n:
   definition:
   - a dull grey North American thrush noted for its beautiful song
@@ -14193,6 +14528,7 @@
   mero_member:
   - 01564093-n
   partOfSpeech: n
+  wikidata: Q240088
 01564093-n:
   definition:
   - European songbird with a reddish breast and tail; related to Old World robins
@@ -14236,6 +14572,7 @@
   mero_member:
   - 01564655-n
   partOfSpeech: n
+  wikidata: Q853286
 01564655-n:
   definition:
   - blue North American songbird
@@ -14258,6 +14595,7 @@
   - 01564906-n
   - 01565092-n
   partOfSpeech: n
+  wikidata: Q855800
 01564906-n:
   definition:
   - small Old World songbird with a reddish breast
@@ -14301,6 +14639,7 @@
   - 01568445-n
   - 01568723-n
   partOfSpeech: n
+  wikidata: Q187014
 01565619-n:
   definition:
   - alternative classification for the Old World warblers
@@ -14354,6 +14693,7 @@
   mero_member:
   - 01566387-n
   partOfSpeech: n
+  wikidata: Q208716
 01566387-n:
   definition:
   - small birds resembling warblers but having some of the habits of titmice
@@ -14417,6 +14757,7 @@
   mero_member:
   - 01567414-n
   partOfSpeech: n
+  wikidata: Q15931206
 01567414-n:
   definition:
   - small brownish-grey warbler with a black crown
@@ -14460,6 +14801,7 @@
   - Phylloscopus
   - genus Phylloscopus
   partOfSpeech: n
+  wikidata: Q214627
 01567986-n:
   definition:
   - European woodland warbler with dull yellow plumage
@@ -14480,6 +14822,7 @@
   - Acrocephalus
   - genus Acrocephalus
   partOfSpeech: n
+  wikidata: Q637716
 01568240-n:
   definition:
   - small European warbler that breeds among reeds and wedges and winters in Africa
@@ -14528,6 +14871,7 @@
   mero_member:
   - 01568848-n
   partOfSpeech: n
+  wikidata: Q18340387
 01568848-n:
   definition:
   - tropical Asian warbler that stitches leaves together to form and conceal its nest
@@ -14550,6 +14894,7 @@
   mero_member:
   - 01569150-n
   partOfSpeech: n
+  wikidata: Q408457
 01569150-n:
   definition:
   - type genus of the Timaliidae
@@ -14562,6 +14907,7 @@
   mero_member:
   - 01569286-n
   partOfSpeech: n
+  wikidata: Q10826912
 01569286-n:
   definition:
   - any of various insectivorous Old World birds with a loud incessant song; in some
@@ -14591,6 +14937,7 @@
   - 01572753-n
   - 01573190-n
   partOfSpeech: n
+  wikidata: Q739200
 01569774-n:
   definition:
   - small bright-colored American songbird with a weak unmusical song
@@ -14613,6 +14960,7 @@
   mero_member:
   - 01570319-n
   partOfSpeech: n
+  wikidata: Q980233
 01570319-n:
   definition:
   - small grey-blue wood warbler with yellow throat and breast; of eastern North America
@@ -14685,6 +15033,7 @@
   - 01572064-n
   - 01572207-n
   partOfSpeech: n
+  wikidata: Q13571873
 01571361-n:
   definition:
   - North American wood warbler; olive green and yellow striped with black
@@ -14768,6 +15117,7 @@
   mero_member:
   - 01572477-n
   partOfSpeech: n
+  wikidata: Q10772647
 01572477-n:
   definition:
   - birds having a chattering call
@@ -14833,6 +15183,7 @@
   mero_member:
   - 01573317-n
   partOfSpeech: n
+  wikidata: Q923089
 01573317-n:
   definition:
   - small olive-colored American warblers with yellow breast and throat
@@ -14867,6 +15218,7 @@
   - 01573767-n
   - 01573938-n
   partOfSpeech: n
+  wikidata: Q179333
 01573767-n:
   definition:
   - any of numerous brilliantly colored plumed birds of the New Guinea area
@@ -14886,6 +15238,7 @@
   - Ptloris
   - genus Ptloris
   partOfSpeech: n
+  wikidata: Q1080561
 01574051-n:
   definition:
   - velvety black Australian bird of paradise with green and purple iridescence on
@@ -14917,6 +15270,7 @@
   - 01577638-n
   - 01577911-n
   partOfSpeech: n
+  wikidata: Q748159
 01574545-n:
   definition:
   - American songbird; male is black and orange or yellow
@@ -14941,6 +15295,7 @@
   - 01574969-n
   - 01575423-n
   partOfSpeech: n
+  wikidata: Q1424573
 01574969-n:
   definition:
   - a kind of New World oriole
@@ -14996,6 +15351,7 @@
   mero_member:
   - 01575715-n
   partOfSpeech: n
+  wikidata: Q1431050
 01575715-n:
   definition:
   - North American songbirds having a yellow breast
@@ -15039,6 +15395,7 @@
   mero_member:
   - 01576268-n
   partOfSpeech: n
+  wikidata: Q1821411
 01576268-n:
   definition:
   - black-and-red or black-and-yellow orioles of the American tropics
@@ -15061,6 +15418,7 @@
   mero_member:
   - 01576539-n
   partOfSpeech: n
+  wikidata: Q10756454
 01576539-n:
   definition:
   - migratory American songbird
@@ -15095,6 +15453,7 @@
   mero_member:
   - 01577031-n
   partOfSpeech: n
+  wikidata: Q612008
 01577031-n:
   definition:
   - long-tailed American blackbird having iridescent black plumage
@@ -15151,6 +15510,7 @@
   mero_member:
   - 01577758-n
   partOfSpeech: n
+  wikidata: Q1137414
 01577758-n:
   definition:
   - North American blackbird that follows cattle and lays eggs in other birds' nests
@@ -15173,6 +15533,7 @@
   mero_member:
   - 01578042-n
   partOfSpeech: n
+  wikidata: Q2003332
 01578042-n:
   definition:
   - North American blackbird with scarlet patches on the wings
@@ -15245,6 +15606,7 @@
   mero_member:
   - 01578999-n
   partOfSpeech: n
+  wikidata: Q2417877
 01578999-n:
   definition:
   - greenish-yellow Australian oriole feeding chiefly on figs and other fruits
@@ -15269,6 +15631,7 @@
   - 01580459-n
   - 01580727-n
   partOfSpeech: n
+  wikidata: Q185237
 01579336-n:
   definition:
   - gregarious birds native to the Old World
@@ -15291,6 +15654,7 @@
   - 01579676-n
   - 01579906-n
   partOfSpeech: n
+  wikidata: Q333842
 01579676-n:
   definition:
   - gregarious bird having plumage with dark metallic gloss; builds nests around dwellings
@@ -15375,6 +15739,7 @@
   - Gracula
   - genus Gracula
   partOfSpeech: n
+  wikidata: Q259424
 01580821-n:
   definition:
   - glossy black Asiatic starling often taught to mimic speech
@@ -15428,6 +15793,7 @@
   - 01582051-n
   - 01582219-n
   partOfSpeech: n
+  wikidata: Q43365
 01581669-n:
   definition:
   - black birds having a raucous call
@@ -15556,6 +15922,7 @@
   mero_member:
   - 01583511-n
   partOfSpeech: n
+  wikidata: Q826027
 01583413-n:
   definition:
   - a North American jay
@@ -15588,6 +15955,7 @@
   mero_member:
   - 01583807-n
   partOfSpeech: n
+  wikidata: Q953996
 01583807-n:
   definition:
   - a jay of northern North America with black-capped head and no crest; noted for
@@ -15625,6 +15993,7 @@
   mero_member:
   - 01584371-n
   partOfSpeech: n
+  wikidata: Q1951909
 01584371-n:
   definition:
   - speckled birds that feed on nuts
@@ -15666,6 +16035,7 @@
   mero_member:
   - 01584861-n
   partOfSpeech: n
+  wikidata: Q271634
 01584861-n:
   definition:
   - long-tailed black-and-white crow that utters a raucous chattering call
@@ -15710,6 +16080,7 @@
   - 01586014-n
   - 01586277-n
   partOfSpeech: n
+  wikidata: Q373682
 01585497-n:
   definition:
   - black-and-white oscine birds that resemble magpies
@@ -15732,6 +16103,7 @@
   mero_member:
   - 01585850-n
   partOfSpeech: n
+  wikidata: Q2718273
 01585850-n:
   definition:
   - large carnivorous Australian bird with the shrike-like habit of impaling prey
@@ -15754,6 +16126,7 @@
   mero_member:
   - 01586136-n
   partOfSpeech: n
+  wikidata: Q2136293
 01586136-n:
   definition:
   - bluish black fruit-eating bird with a bell-like call
@@ -15777,6 +16150,7 @@
   mero_member:
   - 01586469-n
   partOfSpeech: n
+  wikidata: Q10763400
 01586469-n:
   definition:
   - crow-sized black-and-white bird; a good mimic often caged
@@ -15831,6 +16205,7 @@
   - 01587336-n
   - 01587494-n
   partOfSpeech: n
+  wikidata: Q3888717
 01587336-n:
   definition:
   - small wren of coniferous forests of Northern Hemisphere
@@ -15864,6 +16239,7 @@
   mero_member:
   - 01587762-n
   partOfSpeech: n
+  wikidata: Q867629
 01587762-n:
   definition:
   - a wren of the genus Cistothorus that frequents marshes
@@ -15906,6 +16282,7 @@
   mero_member:
   - 01588356-n
   partOfSpeech: n
+  wikidata: Q10812327
 01588356-n:
   definition:
   - wren inhabiting badlands and mesa country of western United States and Mexico
@@ -15928,6 +16305,7 @@
   mero_member:
   - 01588661-n
   partOfSpeech: n
+  wikidata: Q11848605
 01588661-n:
   definition:
   - large United States wren with a musical call
@@ -15978,6 +16356,7 @@
   - 01590047-n
   - 01590354-n
   partOfSpeech: n
+  wikidata: Q753221
 01589432-n:
   definition:
   - 'type genus of the family Mimidae: mockingbirds'
@@ -15990,6 +16369,7 @@
   mero_member:
   - 01589582-n
   partOfSpeech: n
+  wikidata: Q2498241
 01589582-n:
   definition:
   - long-tailed grey-and-white songbird of the southern United States able to mimic
@@ -16014,6 +16394,7 @@
   mero_member:
   - 01589919-n
   partOfSpeech: n
+  wikidata: Q2165737
 01589919-n:
   definition:
   - mockingbird of Mexico
@@ -16036,6 +16417,7 @@
   mero_member:
   - 01590167-n
   partOfSpeech: n
+  wikidata: Q10757040
 01590167-n:
   definition:
   - North American songbird whose call resembles a cat's mewing
@@ -16061,6 +16443,7 @@
   mero_member:
   - 01590475-n
   partOfSpeech: n
+  wikidata: Q430477
 01590475-n:
   definition:
   - thrush-like American songbird able to mimic other birdsongs
@@ -16098,6 +16481,7 @@
   - 01591230-n
   - 01591499-n
   partOfSpeech: n
+  wikidata: Q537702
 01591072-n:
   definition:
   - birds of New Zealand that resemble wrens
@@ -16119,6 +16503,7 @@
   mero_member:
   - 01591366-n
   partOfSpeech: n
+  wikidata: Q621253
 01591366-n:
   definition:
   - short-tailed bird resembling a wren
@@ -16141,6 +16526,7 @@
   mero_member:
   - 01591637-n
   partOfSpeech: n
+  wikidata: Q10730467
 01591637-n:
   definition:
   - small green-and-bronze bird
@@ -16165,6 +16551,7 @@
   - 01592223-n
   - 01592683-n
   partOfSpeech: n
+  wikidata: Q205938
 01591927-n:
   definition:
   - any of various small insectivorous birds of the Northern Hemisphere that climb
@@ -16188,6 +16575,7 @@
   mero_member:
   - 01592359-n
   partOfSpeech: n
+  wikidata: Q1991437
 01592359-n:
   definition:
   - a common creeper in North America with a down-curved bill
@@ -16221,6 +16609,7 @@
   mero_member:
   - 01592861-n
   partOfSpeech: n
+  wikidata: Q10826827
 01592861-n:
   definition:
   - crimson-and-grey songbird that inhabits town walls and mountain cliffs of southern
@@ -16272,6 +16661,7 @@
   - 01593764-n
   - 01593942-n
   partOfSpeech: n
+  wikidata: Q858577
 01593646-n:
   definition:
   - a kind of nuthatch
@@ -16320,6 +16710,7 @@
   - 01595797-n
   - 01596064-n
   partOfSpeech: n
+  wikidata: Q168473
 01594338-n:
   definition:
   - small insectivorous birds
@@ -16344,6 +16735,7 @@
   - 01595028-n
   - 01595335-n
   partOfSpeech: n
+  wikidata: Q719380
 01594725-n:
   definition:
   - any of various small grey-and-black songbirds of North America
@@ -16414,6 +16806,7 @@
   mero_member:
   - 01595669-n
   partOfSpeech: n
+  wikidata: Q16070731
 01595669-n:
   definition:
   - active grey titmice of western North America
@@ -16436,6 +16829,7 @@
   mero_member:
   - 01595923-n
   partOfSpeech: n
+  wikidata: Q10745525
 01595923-n:
   definition:
   - small brown bird of California resembling a wren
@@ -16458,6 +16852,7 @@
   mero_member:
   - 01596194-n
   partOfSpeech: n
+  wikidata: Q10736288
 01596194-n:
   definition:
   - very small yellow-headed titmouse of western North America
@@ -16481,6 +16876,7 @@
   mero_member:
   - 01596498-n
   partOfSpeech: n
+  wikidata: Q180423
 01596498-n:
   definition:
   - 'type genus of the Irenidae: fairy bluebirds'
@@ -16493,6 +16889,7 @@
   mero_member:
   - 01596645-n
   partOfSpeech: n
+  wikidata: Q3154331
 01596645-n:
   definition:
   - fruit-eating mostly brilliant blue songbird of the East Indies
@@ -16519,6 +16916,7 @@
   - 01598783-n
   - 01599120-n
   partOfSpeech: n
+  wikidata: Q39861
 01597013-n:
   definition:
   - small long-winged songbird noted for swift graceful flight and the regularity
@@ -16543,6 +16941,7 @@
   - 01597609-n
   - 01597809-n
   partOfSpeech: n
+  wikidata: Q28135
 01597428-n:
   definition:
   - common swallow of North America and Europe that nests in barns etc.
@@ -16587,6 +16986,7 @@
   - Iridoprocne
   - genus Iridoprocne
   partOfSpeech: n
+  wikidata: Q261763
 01598091-n:
   definition:
   - bluish-green-and-white North American swallow; nests in tree cavities
@@ -16620,6 +17020,7 @@
   mero_member:
   - 01598615-n
   partOfSpeech: n
+  wikidata: Q310857
 01598615-n:
   definition:
   - common small European martin that builds nests under the eaves of houses
@@ -16644,6 +17045,7 @@
   mero_member:
   - 01598914-n
   partOfSpeech: n
+  wikidata: Q901041
 01598914-n:
   definition:
   - swallow of the Northern Hemisphere that nests in tunnels dug in clay or sand banks
@@ -16671,6 +17073,7 @@
   mero_member:
   - 01599249-n
   partOfSpeech: n
+  wikidata: Q665719
 01599249-n:
   definition:
   - large North American martin of which the male is blue-black
@@ -16693,6 +17096,7 @@
   mero_member:
   - 01599528-n
   partOfSpeech: n
+  wikidata: Q842378
 01599528-n:
   definition:
   - type genus of the Artamidae
@@ -16705,6 +17109,7 @@
   mero_member:
   - 01599663-n
   partOfSpeech: n
+  wikidata: Q2483684
 01599663-n:
   definition:
   - Australasian and Asiatic bird related to the shrikes and resembling a swallow
@@ -16728,6 +17133,7 @@
   - 01599977-n
   - 01600192-n
   partOfSpeech: n
+  wikidata: Q666222
 01599977-n:
   definition:
   - any of numerous New World woodland birds having brightly colored males
@@ -16752,6 +17158,7 @@
   - 01600715-n
   - 01600912-n
   partOfSpeech: n
+  wikidata: Q225353
 01600378-n:
   definition:
   - the male is bright red with black wings and tail
@@ -16812,6 +17219,7 @@
   - 01601461-n
   - 01602560-n
   partOfSpeech: n
+  wikidata: Q171052
 01601229-n:
   definition:
   - any of numerous Old World birds having a strong hooked bill that feed on smaller
@@ -16835,6 +17243,7 @@
   - 01601629-n
   - 01602197-n
   partOfSpeech: n
+  wikidata: Q754657
 01601629-n:
   definition:
   - shrikes that impale their prey on thorns
@@ -16929,6 +17338,7 @@
   mero_member:
   - 01602982-n
   partOfSpeech: n
+  wikidata: Q14437812
 01602982-n:
   definition:
   - a kind of bush shrike
@@ -16953,6 +17363,7 @@
   - 01603550-n
   - 01603909-n
   partOfSpeech: n
+  wikidata: Q215603
 01603298-n:
   definition:
   - any of various birds of the Australian region whose males build ornamented structures
@@ -16976,6 +17387,7 @@
   mero_member:
   - 01603709-n
   partOfSpeech: n
+  wikidata: Q10809555
 01603709-n:
   definition:
   - of southeast Australia; male is glossy violet blue; female is light grey-green
@@ -16999,6 +17411,7 @@
   mero_member:
   - 01604051-n
   partOfSpeech: n
+  wikidata: Q860867
 01604051-n:
   definition:
   - large bowerbird of northern Australia
@@ -17023,6 +17436,7 @@
   - 01604335-n
   - 01604560-n
   partOfSpeech: n
+  wikidata: Q15631675
 01604335-n:
   definition:
   - small stocky diving bird without webbed feet; frequents fast-flowing streams and
@@ -17047,6 +17461,7 @@
   - 01604721-n
   - 01604850-n
   partOfSpeech: n
+  wikidata: Q192575
 01604721-n:
   definition:
   - a water ouzel of Europe
@@ -17091,6 +17506,7 @@
   mero_member:
   - 01605271-n
   partOfSpeech: n
+  wikidata: Q259857
 01605271-n:
   definition:
   - any of various small insectivorous American birds chiefly olive-grey in color
@@ -17144,6 +17560,7 @@
   mero_member:
   - 01606119-n
   partOfSpeech: n
+  wikidata: Q11897625
 01606119-n:
   definition:
   - waxwings
@@ -17156,6 +17573,7 @@
   mero_member:
   - 01606241-n
   partOfSpeech: n
+  wikidata: Q208940
 01606241-n:
   definition:
   - brown velvety-plumaged songbirds of the Northern Hemisphere having crested heads
@@ -17228,6 +17646,7 @@
   - 01620861-n
   - 01621312-n
   partOfSpeech: n
+  wikidata: Q25370
 01607609-n:
   definition:
   - in some classifications an alternative name for the Falconiformes
@@ -17372,6 +17791,7 @@
   - 01610453-n
   - 01610603-n
   partOfSpeech: n
+  wikidata: Q235152
 01609950-n:
   definition:
   - any hawk of the genus Buteo
@@ -17436,6 +17856,7 @@
   mero_member:
   - 01610906-n
   partOfSpeech: n
+  wikidata: Q6377551
 01610906-n:
   definition:
   - Old World hawk that feeds on bee larvae and small rodents and reptiles
@@ -17489,6 +17910,7 @@
   mero_member:
   - 01611703-n
   partOfSpeech: n
+  wikidata: Q10758200
 01611703-n:
   definition:
   - graceful North American black-and-white kite
@@ -17539,6 +17961,7 @@
   - 01612741-n
   - 01612867-n
   partOfSpeech: n
+  wikidata: Q207796
 01612392-n:
   definition:
   - hawks that hunt over meadows and marshes and prey on small terrestrial animals
@@ -17592,6 +18015,7 @@
   mero_member:
   - 01613193-n
   partOfSpeech: n
+  wikidata: Q867544
 01613193-n:
   definition:
   - any of numerous large Old World hawks intermediate in some respects between typical
@@ -17617,6 +18041,7 @@
   - 01613893-n
   - 01615444-n
   partOfSpeech: n
+  wikidata: Q21744
 01613596-n:
   definition:
   - diurnal birds of prey having long pointed powerful wings adapted for swift flight
@@ -17643,6 +18068,7 @@
   - 01614916-n
   - 01615117-n
   partOfSpeech: n
+  wikidata: Q43489
 01614113-n:
   definition:
   - a widely distributed falcon formerly used in falconry
@@ -17742,6 +18168,7 @@
   - 01615596-n
   - 01615818-n
   partOfSpeech: n
+  wikidata: Q1238727
 01615596-n:
   definition:
   - widespread from southern United States to Central America; rusty black with black-and-white
@@ -17805,6 +18232,7 @@
   mero_member:
   - 01616679-n
   partOfSpeech: n
+  wikidata: Q15138218
 01616679-n:
   definition:
   - large black-and-white crested eagle of tropical America
@@ -17829,6 +18257,7 @@
   - 01616984-n
   - 01617197-n
   partOfSpeech: n
+  wikidata: Q30085
 01616984-n:
   definition:
   - large eagle of mountainous regions of the Northern Hemisphere having a golden-brown
@@ -17872,6 +18301,7 @@
   - 01617566-n
   - 01617762-n
   partOfSpeech: n
+  wikidata: Q147403
 01617566-n:
   definition:
   - a large eagle of North America that has a white head and dark wings and body
@@ -17941,6 +18371,7 @@
   mero_member:
   - 01618590-n
   partOfSpeech: n
+  wikidata: Q28240
 01618590-n:
   definition:
   - type genus of the Pandionidae
@@ -17953,6 +18384,7 @@
   mero_member:
   - 01618727-n
   partOfSpeech: n
+  wikidata: Q3893145
 01618727-n:
   definition:
   - large harmless hawk found worldwide that feeds on fish and builds a bulky nest
@@ -17989,6 +18421,7 @@
   - Aegypiidae
   - family Aegypiidae
   partOfSpeech: n
+  wikidata: Q13428438
 01619405-n:
   definition:
   - any of several large vultures of Africa and Eurasia
@@ -18033,6 +18466,7 @@
   - Gypaetus
   - genus Gypaetus
   partOfSpeech: n
+  wikidata: Q13649293
 01620084-n:
   definition:
   - the largest Eurasian bird of prey; having black feathers hanging around the bill
@@ -18058,6 +18492,7 @@
   mero_member:
   - 01620407-n
   partOfSpeech: n
+  wikidata: Q3347141
 01620407-n:
   definition:
   - small mostly white vulture of Africa and southern Eurasia
@@ -18082,6 +18517,7 @@
   mero_member:
   - 01620723-n
   partOfSpeech: n
+  wikidata: Q13428439
 01620723-n:
   definition:
   - of southern Eurasia and northern Africa
@@ -18104,6 +18540,7 @@
   mero_member:
   - 01620997-n
   partOfSpeech: n
+  wikidata: Q2346527
 01620997-n:
   definition:
   - type genus of the Sagittariidae
@@ -18116,6 +18553,7 @@
   mero_member:
   - 01621144-n
   partOfSpeech: n
+  wikidata: Q15042109
 01621144-n:
   definition:
   - large long-legged African bird of prey that feeds on reptiles
@@ -18143,6 +18581,7 @@
   - 01622923-n
   - 01623216-n
   partOfSpeech: n
+  wikidata: Q184858
 01621563-n:
   definition:
   - large birds of prey superficially similar to Old World vultures
@@ -18201,6 +18640,7 @@
   mero_member:
   - 01622476-n
   partOfSpeech: n
+  wikidata: Q15042113
 01622476-n:
   definition:
   - large vulture of the high Andes having black plumage and white neck ruff
@@ -18221,6 +18661,7 @@
   - Gymnogyps
   - genus Gymnogyps
   partOfSpeech: n
+  wikidata: Q10763377
 01622776-n:
   definition:
   - North American condor; chiefly dull black; almost extinct
@@ -18243,6 +18684,7 @@
   mero_member:
   - 01623055-n
   partOfSpeech: n
+  wikidata: Q14786570
 01623055-n:
   definition:
   - American vulture smaller than the turkey buzzard
@@ -18266,6 +18708,7 @@
   mero_member:
   - 01623376-n
   partOfSpeech: n
+  wikidata: Q15734727
 01623376-n:
   definition:
   - large black-and-white vulture of South America and Central America; have colorful
@@ -18292,6 +18735,7 @@
   - 01624355-n
   - 01627916-n
   partOfSpeech: n
+  wikidata: Q25222
 01623768-n:
   definition:
   - nocturnal bird of prey with hawk-like beak and claws and large head with front-facing
@@ -18332,6 +18776,7 @@
   - 01627348-n
   - 01627628-n
   partOfSpeech: n
+  wikidata: Q26012
 01624635-n:
   definition:
   - a genus of Strigidae containing the spotted owlet, little owl, forest owlet, and
@@ -18345,6 +18790,7 @@
   mero_member:
   - 01624761-n
   partOfSpeech: n
+  wikidata: Q663507
 01624761-n:
   definition:
   - small European owl
@@ -18368,6 +18814,7 @@
   mero_member:
   - 01624993-n
   partOfSpeech: n
+  wikidata: Q214293
 01624993-n:
   definition:
   - large owls having prominent ear tufts
@@ -18402,6 +18849,7 @@
   - 01625751-n
   - 01626521-n
   partOfSpeech: n
+  wikidata: Q241515
 01625420-n:
   definition:
   - large dish-faced owl of northern North America and western Eurasia
@@ -18447,6 +18895,7 @@
   - 01626066-n
   - 01626347-n
   partOfSpeech: n
+  wikidata: Q832329
 01626066-n:
   definition:
   - small North American owl having hornlike tufts of feathers whose call sounds like
@@ -18528,6 +18977,7 @@
   mero_member:
   - 01627178-n
   partOfSpeech: n
+  wikidata: Q10822188
 01627178-n:
   definition:
   - grey-and-white diurnal hawk-like owl of northern parts of the Northern Hemisphere
@@ -18550,6 +19000,7 @@
   mero_member:
   - 01627474-n
   partOfSpeech: n
+  wikidata: Q648422
 01627474-n:
   definition:
   - slender European owl of coniferous forests with long ear tufts
@@ -18573,6 +19024,7 @@
   mero_member:
   - 01627762-n
   partOfSpeech: n
+  wikidata: Q18088155
 01627762-n:
   definition:
   - almost extinct owl of New Zealand
@@ -18596,6 +19048,7 @@
   mero_member:
   - 01628058-n
   partOfSpeech: n
+  wikidata: Q27112
 01628058-n:
   definition:
   - type and only genus of the family Tytonidae
@@ -18641,6 +19094,7 @@
   - 01658981-n
   - 02472103-n
   partOfSpeech: n
+  wikidata: Q10908
 01628775-n:
   definition:
   - any family of amphibians
@@ -18683,6 +19137,7 @@
   mero_member:
   - 01630617-n
   partOfSpeech: n
+  wikidata: Q132802
 01630617-n:
   definition:
   - fossil amphibian of the Devonian having well-developed forelimbs; found in Pennsylvania
@@ -18703,6 +19158,7 @@
   mero_member:
   - 01630972-n
   partOfSpeech: n
+  wikidata: Q131475
 01630972-n:
   definition:
   - early tetrapod amphibian found in Greenland
@@ -18734,6 +19190,7 @@
   - 01641123-n
   - 01641593-n
   partOfSpeech: n
+  wikidata: Q53663
 01631411-n:
   definition:
   - amphibians that resemble lizards
@@ -18760,6 +19217,7 @@
   - 01633436-n
   - 01633676-n
   partOfSpeech: n
+  wikidata: Q319469
 01631734-n:
   definition:
   - type genus of the Salamandridae
@@ -18774,6 +19232,7 @@
   - 01632603-n
   - 01632789-n
   partOfSpeech: n
+  wikidata: Q62181
 01631917-n:
   definition:
   - any of various typically terrestrial amphibians that resemble lizards and that
@@ -18838,6 +19297,7 @@
   mero_member:
   - 01633311-n
   partOfSpeech: n
+  wikidata: Q310391
 01633311-n:
   definition:
   - small semiaquatic salamander
@@ -19024,6 +19484,7 @@
   - 01635891-n
   - 01636219-n
   partOfSpeech: n
+  wikidata: Q754032
 01635891-n:
   definition:
   - type genus of the Cryptobranchidae
@@ -19036,6 +19497,7 @@
   mero_member:
   - 01636047-n
   partOfSpeech: n
+  wikidata: Q2120568
 01636047-n:
   definition:
   - large salamander of North American rivers and streams
@@ -19059,6 +19521,7 @@
   mero_member:
   - 01636422-n
   partOfSpeech: n
+  wikidata: Q922164
 01636422-n:
   definition:
   - large (up to more than three feet) edible salamander of Asia
@@ -19082,6 +19545,7 @@
   - 01636733-n
   - 01637033-n
   partOfSpeech: n
+  wikidata: Q743692
 01636733-n:
   definition:
   - type genus of the Proteidae
@@ -19094,6 +19558,7 @@
   mero_member:
   - 01636868-n
   partOfSpeech: n
+  wikidata: Q2743186
 01636868-n:
   definition:
   - European aquatic salamander with permanent external gills that lives in caves
@@ -19142,6 +19607,7 @@
   - 01637668-n
   - 01637984-n
   partOfSpeech: n
+  wikidata: Q14547873
 01637532-n:
   definition:
   - type genus of the Dicamptodontidae
@@ -19153,6 +19619,7 @@
   mero_member:
   - 01637817-n
   partOfSpeech: n
+  wikidata: Q905053
 01637668-n:
   definition:
   - salamanders found near cold streams throughout the year
@@ -19230,6 +19697,7 @@
   - 01638993-n
   - 01639151-n
   partOfSpeech: n
+  wikidata: Q2256290
 01638768-n:
   definition:
   - mostly terrestrial salamanders that breathe through their thin moist skin; lay
@@ -19273,6 +19741,7 @@
   mero_member:
   - 01639470-n
   partOfSpeech: n
+  wikidata: Q2698057
 01639470-n:
   definition:
   - common North American salamander mottled with dull brown or greyish-black
@@ -19294,6 +19763,7 @@
   mero_member:
   - 01639753-n
   partOfSpeech: n
+  wikidata: Q2698192
 01639753-n:
   definition:
   - any of several North American salamanders adapted for climbing with well-developed
@@ -19327,6 +19797,7 @@
   mero_member:
   - 01640256-n
   partOfSpeech: n
+  wikidata: Q786876
 01640256-n:
   definition:
   - any of several small slim salamanders of the Pacific coast of the United States
@@ -19393,6 +19864,7 @@
   mero_member:
   - 01641252-n
   partOfSpeech: n
+  wikidata: Q11841073
 01641252-n:
   definition:
   - the genus of congo snakes (Amphiuma)
@@ -19404,6 +19876,7 @@
   mero_member:
   - 01641363-n
   partOfSpeech: n
+  wikidata: Q300923
 01641363-n:
   definition:
   - aquatic eel-shaped salamander having two pairs of very small feet; of still muddy
@@ -19430,6 +19903,7 @@
   mero_member:
   - 01641712-n
   partOfSpeech: n
+  wikidata: Q240755
 01641712-n:
   definition:
   - a genus of Sirenidae
@@ -19441,6 +19915,7 @@
   mero_member:
   - 01641828-n
   partOfSpeech: n
+  wikidata: Q2103674
 01641828-n:
   definition:
   - eellike aquatic North American salamander with small forelimbs and no hind limbs;
@@ -19477,6 +19952,7 @@
   - 01655224-n
   - 01656251-n
   partOfSpeech: n
+  wikidata: Q53636
 01642406-n:
   definition:
   - any of various tailless stout-bodied amphibians with long hind limbs for leaping;
@@ -19526,6 +20002,7 @@
   - 01645032-n
   - 01645180-n
   partOfSpeech: n
+  wikidata: Q72738
 01643487-n:
   definition:
   - insectivorous usually semiaquatic web-footed amphibian with smooth moist skin
@@ -19657,6 +20134,7 @@
   - 01646015-n
   - 01646328-n
   partOfSpeech: n
+  wikidata: Q55475
 01645584-n:
   definition:
   - 'toothed frogs: terrestrial or aquatic or arboreal'
@@ -19701,6 +20179,7 @@
   mero_member:
   - 01646148-n
   partOfSpeech: n
+  wikidata: Q2101311
 01646148-n:
   definition:
   - of southwest United States and Mexico; call is like a dog's bark
@@ -19725,6 +20204,7 @@
   mero_member:
   - 01646537-n
   partOfSpeech: n
+  wikidata: Q2501775
 01646537-n:
   definition:
   - large toothed frog of South America and Central America resembling the bullfrog
@@ -19748,6 +20228,7 @@
   mero_member:
   - 01646886-n
   partOfSpeech: n
+  wikidata: Q56065
 01646886-n:
   definition:
   - type genus of the Polypedatidae
@@ -19758,6 +20239,7 @@
   - Polypedates
   - genus Polypedates
   partOfSpeech: n
+  wikidata: Q945221
 01647014-n:
   definition:
   - any of various Old World arboreal frogs distinguished from true frogs by adhesive
@@ -19794,6 +20276,7 @@
   mero_member:
   - 01647541-n
   partOfSpeech: n
+  wikidata: Q2925426
 01647541-n:
   definition:
   - western North American frog with a taillike copulatory organ
@@ -19821,6 +20304,7 @@
   mero_member:
   - 01647919-n
   partOfSpeech: n
+  wikidata: Q55477
 01647919-n:
   definition:
   - type and sole genus of the family Leiopelmatidae
@@ -19859,6 +20343,7 @@
   - 01648417-n
   - 01648775-n
   partOfSpeech: n
+  wikidata: Q55372
 01648417-n:
   definition:
   - tailless amphibian similar to a frog but more terrestrial and having drier warty
@@ -19880,6 +20365,7 @@
   mero_member:
   - 01648933-n
   partOfSpeech: n
+  wikidata: Q639022
 01648933-n:
   definition:
   - any toad of the genus Bufo
@@ -20026,6 +20512,7 @@
   - 01650780-n
   - 01650997-n
   partOfSpeech: n
+  wikidata: Q1762264
 01650780-n:
   definition:
   - European toad whose male carries the fertilized eggs wrapped around its hind legs
@@ -20060,6 +20547,7 @@
   mero_member:
   - 01651261-n
   partOfSpeech: n
+  wikidata: Q1515577
 01651261-n:
   definition:
   - toad of central and eastern Europe having red or orange patches mixed with black
@@ -20099,6 +20587,7 @@
   - 01652197-n
   - 01652367-n
   partOfSpeech: n
+  wikidata: Q2317066
 01651811-n:
   definition:
   - a burrowing toad of the Northern Hemisphere with a horny spade-like projection
@@ -20157,6 +20646,7 @@
   - 01654541-n
   - 01654804-n
   partOfSpeech: n
+  wikidata: Q53696
 01652808-n:
   definition:
   - arboreal amphibians usually having adhesive disks at the tip of each toe; of southeast
@@ -20183,6 +20673,7 @@
   - 01653542-n
   - 01653700-n
   partOfSpeech: n
+  wikidata: Q826861
 01653331-n:
   definition:
   - a small brown tree toad having a shrill call heard near wetlands of eastern United
@@ -20237,6 +20728,7 @@
   mero_member:
   - 01654128-n
   partOfSpeech: n
+  wikidata: Q481983
 01654128-n:
   definition:
   - either of two frogs with a clicking call
@@ -20301,6 +20793,7 @@
   mero_member:
   - 01654938-n
   partOfSpeech: n
+  wikidata: Q3410266
 01654938-n:
   definition:
   - terrestrial burrowing nocturnal frog of grassy terrain and scrub forests having
@@ -20329,6 +20822,7 @@
   - 01655491-n
   - 01656025-n
   partOfSpeech: n
+  wikidata: Q56057
 01655491-n:
   definition:
   - primarily tropical narrow-mouthed toads
@@ -20342,6 +20836,7 @@
   - 01655667-n
   - 01655864-n
   partOfSpeech: n
+  wikidata: Q523202
 01655667-n:
   definition:
   - small secretive toad with smooth tough skin of central and western North America
@@ -20374,6 +20869,7 @@
   mero_member:
   - 01656150-n
   partOfSpeech: n
+  wikidata: Q2272745
 01656150-n:
   definition:
   - mostly of Central America
@@ -20418,6 +20914,7 @@
   - Pipa
   - genus Pipa
   partOfSpeech: n
+  wikidata: Q2351631
 01656724-n:
   definition:
   - a South American toad; incubates its young in pits in the skin of its back
@@ -20441,6 +20938,7 @@
   - Xenopodidae
   - family Xenopodidae
   partOfSpeech: n
+  wikidata: Q33141532
 01657070-n:
   definition:
   - an African clawed frog; in some classifications made the type genus of a separate
@@ -20454,6 +20952,7 @@
   mero_member:
   - 01657278-n
   partOfSpeech: n
+  wikidata: Q1342298
 01657278-n:
   definition:
   - a tongueless frog native to Africa; established in the United States as result
@@ -20487,6 +20986,7 @@
   mero_member:
   - 01657757-n
   partOfSpeech: n
+  wikidata: Q4758
 01657757-n:
   definition:
   - 'coextensive with the order Gymnophiona: legless amphibians'
@@ -20501,6 +21001,7 @@
   mero_member:
   - 01657985-n
   partOfSpeech: n
+  wikidata: Q913066
 01657985-n:
   definition:
   - any of the small slender limbless burrowing wormlike amphibians of the order Gymnophiona;
@@ -20549,6 +21050,7 @@
   - Stereospondyli
   - order Stereospondyli
   partOfSpeech: n
+  wikidata: Q3495411
 01658981-n:
   definition:
   - in former classifications a division of class Amphibia comprising all pre-Jurassic
@@ -20560,6 +21062,7 @@
   - Stegocephalia
   - order Stegocephalia
   partOfSpeech: n
+  wikidata: Q18595307
 01659217-n:
   definition:
   - formerly a suborder of Stegocephalia; large Carboniferous and Permian amphibians
@@ -20571,6 +21074,7 @@
   - Temnospondyli
   - order Temnospondyli
   partOfSpeech: n
+  wikidata: Q131447
 01659454-n:
   definition:
   - a family of reptiles
@@ -20607,6 +21111,7 @@
   - 01697900-n
   - 01721816-n
   partOfSpeech: n
+  wikidata: Q10811
 01663732-n:
   definition:
   - any cold-blooded vertebrate of the class Reptilia including tortoises, turtles,
@@ -20687,6 +21192,7 @@
   - 01672524-n
   - 01674515-n
   partOfSpeech: n
+  wikidata: Q223044
 01665263-n:
   definition:
   - a reptile of the order Chelonia
@@ -20751,6 +21257,7 @@
   mero_member:
   - 01666423-n
   partOfSpeech: n
+  wikidata: Q14566112
 01666423-n:
   definition:
   - large tropical turtle with greenish flesh used for turtle soup
@@ -20774,6 +21281,7 @@
   mero_member:
   - 01666706-n
   partOfSpeech: n
+  wikidata: Q2938164
 01666706-n:
   definition:
   - very large carnivorous sea turtle; wide-ranging in warm open seas
@@ -20797,6 +21305,7 @@
   mero_member:
   - 01667010-n
   partOfSpeech: n
+  wikidata: Q810578
 01667010-n:
   definition:
   - a marine turtle
@@ -20842,6 +21351,7 @@
   mero_member:
   - 01667631-n
   partOfSpeech: n
+  wikidata: Q14566111
 01667631-n:
   definition:
   - pugnacious tropical sea turtle with a hawk-like beak; source of food and the best
@@ -20868,6 +21378,7 @@
   mero_member:
   - 01668013-n
   partOfSpeech: n
+  wikidata: Q2738058
 01668013-n:
   definition:
   - 'type genus of the Dermochelyidae: leatherback turtles'
@@ -20880,6 +21391,7 @@
   mero_member:
   - 01668182-n
   partOfSpeech: n
+  wikidata: Q11693960
 01668182-n:
   definition:
   - wide-ranging marine turtle with flexible leathery carapace; largest living turtle
@@ -20906,6 +21418,7 @@
   - 01668743-n
   - 01669072-n
   partOfSpeech: n
+  wikidata: Q650212
 01668573-n:
   definition:
   - large aggressive freshwater turtle with powerful jaws
@@ -20952,6 +21465,7 @@
   mero_member:
   - 01669226-n
   partOfSpeech: n
+  wikidata: Q107273008
 01669226-n:
   definition:
   - large species having three ridges on its back; found in southeastern United States
@@ -20976,6 +21490,7 @@
   - 01669608-n
   - 01669943-n
   partOfSpeech: n
+  wikidata: Q387150
 01669608-n:
   definition:
   - type genus of the Kinosternidae
@@ -20988,6 +21503,7 @@
   mero_member:
   - 01669755-n
   partOfSpeech: n
+  wikidata: Q2500468
 01669755-n:
   definition:
   - bottom-dwelling freshwater turtle inhabiting muddy rivers of North America and
@@ -21061,6 +21577,7 @@
   mero_member:
   - 01670732-n
   partOfSpeech: n
+  wikidata: Q14566115
 01670732-n:
   definition:
   - of marshes along Atlantic and Gulf Coasts of United States
@@ -21086,6 +21603,7 @@
   - 01671306-n
   - 01671533-n
   partOfSpeech: n
+  wikidata: Q1281025
 01671077-n:
   definition:
   - freshwater turtle of Chesapeake Bay tributaries having red markings on the lower
@@ -21136,6 +21654,7 @@
   mero_member:
   - 01671832-n
   partOfSpeech: n
+  wikidata: Q734870
 01671832-n:
   definition:
   - chiefly terrestrial turtle of North America; shell can be closed tightly
@@ -21169,6 +21688,7 @@
   mero_member:
   - 01672295-n
   partOfSpeech: n
+  wikidata: Q14566117
 01672295-n:
   definition:
   - freshwater turtles having bright yellow and red markings; common in the eastern
@@ -21198,6 +21718,7 @@
   - 01673602-n
   - 01673953-n
   partOfSpeech: n
+  wikidata: Q46360
 01672733-n:
   definition:
   - usually herbivorous land turtles having clawed elephant-like limbs; worldwide
@@ -21221,6 +21742,7 @@
   - 01673176-n
   - 01673443-n
   partOfSpeech: n
+  wikidata: Q662605
 01673176-n:
   definition:
   - small land tortoise of southern Europe
@@ -21267,6 +21789,7 @@
   - 01674120-n
   - 01674346-n
   partOfSpeech: n
+  wikidata: Q1012045
 01673766-n:
   definition:
   - burrowing edible land tortoise of southeastern North America
@@ -21323,6 +21846,7 @@
   - 01674673-n
   - 01674916-n
   partOfSpeech: n
+  wikidata: Q374835
 01674673-n:
   definition:
   - voracious aquatic turtle with a flat flexible shell covered by a leathery skin;
@@ -21393,6 +21917,7 @@
   mero_member:
   - 01675759-n
   partOfSpeech: n
+  wikidata: Q15099738
 01675759-n:
   definition:
   - 'coextensive with the order Rhynchocephalia: tuataras'
@@ -21405,6 +21930,7 @@
   mero_member:
   - 01675923-n
   partOfSpeech: n
+  wikidata: Q163283
 01675923-n:
   definition:
   - only extant member of the order Rhynchocephalia of large spiny lizard-like diapsid
@@ -21429,6 +21955,7 @@
   - 01676309-n
   - 01729031-n
   partOfSpeech: n
+  wikidata: Q122422
 01676309-n:
   definition:
   - true lizards; including chameleons and geckos
@@ -21493,6 +22020,7 @@
   - 01677866-n
   - 01678240-n
   partOfSpeech: n
+  wikidata: Q15872
 01677631-n:
   definition:
   - any of various small chiefly tropical and usually nocturnal insectivorous terrestrial
@@ -21515,6 +22043,7 @@
   mero_member:
   - 01677993-n
   partOfSpeech: n
+  wikidata: Q1394970
 01677993-n:
   definition:
   - a gecko that has membranous expansions along the sides of its body and limbs and
@@ -21539,6 +22068,7 @@
   mero_member:
   - 01678363-n
   partOfSpeech: n
+  wikidata: Q2509308
 01678363-n:
   definition:
   - any of several geckos with dark bands across the body and differing from typical
@@ -21562,6 +22092,7 @@
   mero_member:
   - 01678754-n
   partOfSpeech: n
+  wikidata: Q849482
 01678754-n:
   definition:
   - type genus of the Pygopodidae; snake-shaped pleurodont lizard with no forelimbs
@@ -21603,7 +22134,7 @@
   - 01684934-n
   - 01685229-n
   partOfSpeech: n
-  wikidata: Q661136
+  wikidata: Q235589
 01679396-n:
   definition:
   - lizards of the New World and Madagascar and some Pacific islands; typically having
@@ -21626,6 +22157,7 @@
   mero_member:
   - 01680007-n
   partOfSpeech: n
+  wikidata: Q205531
 01680007-n:
   definition:
   - large herbivorous tropical American arboreal lizards with a spiny crest along
@@ -21650,6 +22182,7 @@
   mero_member:
   - 01680388-n
   partOfSpeech: n
+  wikidata: Q14179741
 01680388-n:
   definition:
   - shore-dwelling seaweed-eating lizard of the Galapagos Islands
@@ -21672,6 +22205,7 @@
   mero_member:
   - 01680684-n
   partOfSpeech: n
+  wikidata: Q14422490
 01680684-n:
   definition:
   - small long-tailed lizard of arid areas of southwestern United States and northwestern
@@ -21693,6 +22227,7 @@
   - Sauromalus
   - genus Sauromalus
   partOfSpeech: n
+  wikidata: Q2016288
 01680984-n:
   definition:
   - a herbivorous lizard that lives among rocks in the arid parts of southwestern
@@ -21717,6 +22252,7 @@
   mero_member:
   - 01681298-n
   partOfSpeech: n
+  wikidata: Q14422461
 01681298-n:
   definition:
   - swift lizard with long black-banded tail and long legs; of deserts of United States
@@ -21741,6 +22277,7 @@
   mero_member:
   - 01681646-n
   partOfSpeech: n
+  wikidata: Q2427811
 01681646-n:
   definition:
   - with long pointed scales around toes; of deserts of United States and Mexico
@@ -21764,6 +22301,7 @@
   mero_member:
   - 01681948-n
   partOfSpeech: n
+  wikidata: Q2707849
 01681948-n:
   definition:
   - 'any of several slender lizards without external ear openings: of plains of western
@@ -21809,6 +22347,7 @@
   mero_member:
   - 01682603-n
   partOfSpeech: n
+  wikidata: Q607912
 01682603-n:
   definition:
   - any of several large lizards with many dark spots; of western United States and
@@ -21832,6 +22371,7 @@
   mero_member:
   - 01682905-n
   partOfSpeech: n
+  wikidata: Q2118277
 01682905-n:
   definition:
   - any of numerous lizards with overlapping ridged pointed scales; of North America
@@ -21900,6 +22440,7 @@
   mero_member:
   - 01683969-n
   partOfSpeech: n
+  wikidata: Q613830
 01683969-n:
   definition:
   - one of the most abundant lizards in the arid western United States
@@ -21923,6 +22464,7 @@
   mero_member:
   - 01684294-n
   partOfSpeech: n
+  wikidata: Q2535475
 01684294-n:
   definition:
   - a climbing lizard of western United States and northern Mexico
@@ -21946,6 +22488,7 @@
   mero_member:
   - 01684581-n
   partOfSpeech: n
+  wikidata: Q288720
 01684581-n:
   definition:
   - insectivorous lizard with hornlike spines on the head and spiny scales on the
@@ -21980,6 +22523,7 @@
   mero_member:
   - 01685076-n
   partOfSpeech: n
+  wikidata: Q256400
 01685076-n:
   definition:
   - small crested arboreal lizard able to run on its hind legs; of tropical America
@@ -22001,6 +22545,7 @@
   mero_member:
   - 01685355-n
   partOfSpeech: n
+  wikidata: Q311348
 01685355-n:
   definition:
   - small arboreal tropical American insectivorous lizards with the ability to change
@@ -22038,6 +22583,7 @@
   mero_member:
   - 01685842-n
   partOfSpeech: n
+  wikidata: Q26187
 01685842-n:
   definition:
   - a lizard of the genus Amphisbaena; harmless wormlike limbless lizard of warm or
@@ -22060,6 +22606,7 @@
   mero_member:
   - 01686199-n
   partOfSpeech: n
+  wikidata: Q260342
 01686199-n:
   definition:
   - small secretive nocturnal lizard of southwestern North America and Cuba; bear
@@ -22085,6 +22632,7 @@
   - 01686774-n
   - 01687076-n
   partOfSpeech: n
+  wikidata: Q272206
 01686541-n:
   definition:
   - type genus of Scincidae
@@ -22106,6 +22654,7 @@
   - Scincella
   - genus Scincella
   partOfSpeech: n
+  wikidata: Q1073830
 01686774-n:
   definition:
   - alert agile lizard with reduced limbs and an elongated body covered with shiny
@@ -22177,6 +22726,7 @@
   - Cordylus
   - genus Cordylus
   partOfSpeech: n
+  wikidata: Q536460
 01687918-n:
   definition:
   - whiptails, etc.
@@ -22215,6 +22765,7 @@
   mero_member:
   - 01688449-n
   partOfSpeech: n
+  wikidata: Q1004429
 01688449-n:
   definition:
   - any of numerous very agile and alert New World lizards
@@ -22330,6 +22881,7 @@
   - 01691069-n
   - 01691453-n
   partOfSpeech: n
+  wikidata: Q191102
 01690306-n:
   definition:
   - a lizard of the family Agamidae
@@ -22351,6 +22903,7 @@
   mero_member:
   - 01690619-n
   partOfSpeech: n
+  wikidata: Q1153386
 01690619-n:
   definition:
   - small terrestrial lizard of warm regions of the Old World
@@ -22372,6 +22925,7 @@
   mero_member:
   - 01690884-n
   partOfSpeech: n
+  wikidata: Q14425550
 01690884-n:
   definition:
   - large arboreal insectivorous Australian lizard with a ruff of skin around the
@@ -22395,6 +22949,7 @@
   mero_member:
   - 01691230-n
   partOfSpeech: n
+  wikidata: Q1142794
 01691230-n:
   definition:
   - any of several small tropical Asian lizards capable of gliding by spreading winglike
@@ -22419,6 +22974,7 @@
   - 01691602-n
   - 01691722-n
   partOfSpeech: n
+  wikidata: Q14089811
 01691602-n:
   definition:
   - any lizard of the genus Moloch
@@ -22454,6 +23010,7 @@
   - 01692646-n
   - 01692980-n
   partOfSpeech: n
+  wikidata: Q191059
 01692052-n:
   definition:
   - any of a small family of lizards widely distributed in warm areas; all are harmless
@@ -22499,6 +23056,7 @@
   mero_member:
   - 01692790-n
   partOfSpeech: n
+  wikidata: Q2046334
 01692790-n:
   definition:
   - small burrowing legless European lizard with tiny eyes; popularly believed to
@@ -22523,6 +23081,7 @@
   mero_member:
   - 01693107-n
   partOfSpeech: n
+  wikidata: Q1518954
 01693107-n:
   definition:
   - snakelike lizard of Europe and Asia and North America with vestigial hind limbs
@@ -22548,6 +23107,7 @@
   mero_member:
   - 01693498-n
   partOfSpeech: n
+  wikidata: Q13416819
 01693498-n:
   definition:
   - 'type and sole genus of Xenosauridae: slender-bodied Mexican lizards having the
@@ -22559,6 +23119,7 @@
   - Xenosaurus
   - genus Xenosaurus
   partOfSpeech: n
+  wikidata: Q855694
 01693726-n:
   definition:
   - legless lizards
@@ -22571,6 +23132,7 @@
   mero_member:
   - 01693858-n
   partOfSpeech: n
+  wikidata: Q2851721
 01693858-n:
   definition:
   - degenerate wormlike burrowing lizard of California closely related to alligator
@@ -22593,6 +23155,7 @@
   mero_member:
   - 01694166-n
   partOfSpeech: n
+  wikidata: Q13033818
 01694166-n:
   definition:
   - a genus containing the species Lanthanotus borneensis, or earless monitor lizard
@@ -22606,6 +23169,7 @@
   mero_member:
   - 01694293-n
   partOfSpeech: n
+  wikidata: Q14177398
 01694293-n:
   definition:
   - a stout-bodied pleurodont lizard of Borneo
@@ -22629,6 +23193,7 @@
   - 01694592-n
   - 01694784-n
   partOfSpeech: n
+  wikidata: Q13417716
 01694592-n:
   definition:
   - any of two or three large heavy-bodied lizards; only known venomous lizards
@@ -22651,6 +23216,7 @@
   - 01694974-n
   - 01695164-n
   partOfSpeech: n
+  wikidata: Q729412
 01694974-n:
   definition:
   - large orange and black lizard of southwestern United States; not dangerous unless
@@ -22712,6 +23278,7 @@
   - 01695816-n
   - 01695975-n
   partOfSpeech: n
+  wikidata: Q312232
 01695816-n:
   definition:
   - a common and widely distributed lizard of Europe and central Asia
@@ -22750,6 +23317,7 @@
   - 01696424-n
   - 01696636-n
   partOfSpeech: n
+  wikidata: Q37686
 01696424-n:
   definition:
   - lizard of Africa and Madagascar able to change skin color and having a projectile
@@ -22775,6 +23343,7 @@
   - 01696819-n
   - 01696952-n
   partOfSpeech: n
+  wikidata: Q1767161
 01696819-n:
   definition:
   - a chameleon found in Africa
@@ -22821,6 +23390,7 @@
   mero_member:
   - 01697350-n
   partOfSpeech: n
+  wikidata: Q81228
 01697350-n:
   definition:
   - any of various large tropical carnivorous lizards of Africa and Asia and Australia;
@@ -22913,6 +23483,7 @@
   - Proterochampsa
   - genus Proterochampsa
   partOfSpeech: n
+  wikidata: Q1008080
 01698923-n:
   definition:
   - crocodiles, alligators, caimans, gavials
@@ -22930,6 +23501,7 @@
   - 01700785-n
   - 01702056-n
   partOfSpeech: n
+  wikidata: Q25363
 01699166-n:
   definition:
   - former name for the order Crocodylia
@@ -22978,6 +23550,7 @@
   mero_member:
   - 01699819-n
   partOfSpeech: n
+  wikidata: Q309495
 01699819-n:
   definition:
   - large voracious aquatic reptile having a long snout with massive jaws and sharp
@@ -23054,6 +23627,7 @@
   - 01700944-n
   - 01701577-n
   partOfSpeech: n
+  wikidata: Q6184764
 01700944-n:
   definition:
   - type genus of the Alligatoridae
@@ -23065,6 +23639,7 @@
   mero_member:
   - 01701075-n
   partOfSpeech: n
+  wikidata: Q530397
 01701075-n:
   definition:
   - either of two amphibious reptiles related to crocodiles but with shorter broader
@@ -23108,6 +23683,7 @@
   mero_member:
   - 01701681-n
   partOfSpeech: n
+  wikidata: Q11001288
 01701681-n:
   definition:
   - a semiaquatic reptile of Central and South America that resembles an alligator
@@ -23141,6 +23717,7 @@
   mero_member:
   - 01702178-n
   partOfSpeech: n
+  wikidata: Q878388
 01702178-n:
   definition:
   - type genus of the Gavialidae
@@ -23213,6 +23790,7 @@
   mero_member:
   - 01703565-n
   partOfSpeech: n
+  wikidata: Q44246
 01703565-n:
   definition:
   - primitive dinosaur found in Argentina
@@ -23234,6 +23812,7 @@
   mero_member:
   - 01703846-n
   partOfSpeech: n
+  wikidata: Q131145
 01703846-n:
   definition:
   - primitive dinosaur found in Brazil
@@ -23279,6 +23858,7 @@
   mero_member:
   - 01704500-n
   partOfSpeech: n
+  wikidata: Q14388
 01704500-n:
   definition:
   - herbivorous ornithischian dinosaur with a row of bony plates along its back and
@@ -23303,6 +23883,7 @@
   - 01704897-n
   - 01705120-n
   partOfSpeech: n
+  wikidata: Q40621
 01704897-n:
   definition:
   - having the back covered with thick bony plates; thought to have walked with a
@@ -23419,6 +24000,7 @@
   members:
   - genus Protoceratops
   partOfSpeech: n
+  wikidata: Q14506
 01706744-n:
   definition:
   - small horned dinosaur
@@ -23439,6 +24021,7 @@
   mero_member:
   - 01706964-n
   partOfSpeech: n
+  wikidata: Q14384
 01706964-n:
   definition:
   - huge ceratopsian dinosaur having three horns and the neck heavily armored with
@@ -23460,6 +24043,7 @@
   mero_member:
   - 01707267-n
   partOfSpeech: n
+  wikidata: Q14483
 01707267-n:
   definition:
   - an unusual ceratopsian dinosaur having many large spikes around the edge of its
@@ -23482,6 +24066,7 @@
   mero_member:
   - 01707651-n
   partOfSpeech: n
+  wikidata: Q132672
 01707651-n:
   definition:
   - primitive dinosaur actually lacking horns and having only the beginning of a frill;
@@ -23538,6 +24123,7 @@
   - 01709174-n
   - 01709506-n
   partOfSpeech: n
+  wikidata: Q271841
 01708575-n:
   definition:
   - any of numerous large bipedal ornithischian dinosaurs having a horny duck-like
@@ -23562,6 +24148,7 @@
   mero_member:
   - 01709042-n
   partOfSpeech: n
+  wikidata: Q14510
 01709042-n:
   definition:
   - one of the largest and most famous duck-billed dinosaurs
@@ -23582,6 +24169,7 @@
   mero_member:
   - 01709327-n
   partOfSpeech: n
+  wikidata: Q131078
 01709327-n:
   definition:
   - duck-billed dinosaur with nasal passages that expand into a crest like a hollow
@@ -23604,6 +24192,7 @@
   mero_member:
   - 01709641-n
   partOfSpeech: n
+  wikidata: Q309466
 01709641-n:
   definition:
   - duck-billed dinosaur from Canada found as a fossilized mummy with skin
@@ -23625,6 +24214,7 @@
   mero_member:
   - 01709935-n
   partOfSpeech: n
+  wikidata: Q1060870
 01709935-n:
   definition:
   - large duck-billed dinosaur of the Cretaceous period
@@ -23648,6 +24238,7 @@
   mero_member:
   - 01710207-n
   partOfSpeech: n
+  wikidata: Q2569164
 01710207-n:
   definition:
   - type genus of the Iguanodontidae
@@ -23659,6 +24250,7 @@
   mero_member:
   - 01710339-n
   partOfSpeech: n
+  wikidata: Q130980
 01710339-n:
   definition:
   - massive herbivorous bipedal dinosaur with a long heavy tail; common in Europe
@@ -23682,6 +24274,7 @@
   - 01710747-n
   - 01710973-n
   partOfSpeech: n
+  wikidata: Q186334
 01710747-n:
   definition:
   - herbivorous or carnivorous dinosaur having a three-pronged pelvis like that of
@@ -23759,6 +24352,7 @@
   mero_member:
   - 01712125-n
   partOfSpeech: n
+  wikidata: Q14326
 01712125-n:
   definition:
   - huge quadrupedal herbivorous dinosaur common in North America in the late Jurassic
@@ -23784,6 +24378,7 @@
   mero_member:
   - 01712517-n
   partOfSpeech: n
+  wikidata: Q309390
 01712517-n:
   definition:
   - a dinosaur that could grow to be as tall as a building five stories tall
@@ -23805,6 +24400,7 @@
   mero_member:
   - 01712818-n
   partOfSpeech: n
+  wikidata: Q14330
 01712818-n:
   definition:
   - a huge quadrupedal herbivore with long neck and tail; of late Jurassic in western
@@ -23842,6 +24438,7 @@
   - 01713388-n
   - 01713634-n
   partOfSpeech: n
+  wikidata: Q131547
 01713388-n:
   definition:
   - amphibious quadrupedal herbivorous dinosaur with a long thin neck and whiplike
@@ -23864,6 +24461,7 @@
   mero_member:
   - 01713801-n
   partOfSpeech: n
+  wikidata: Q130859
 01713801-n:
   definition:
   - huge herbivorous dinosaur of Cretaceous found in Argentina
@@ -23885,6 +24483,7 @@
   mero_member:
   - 01714137-n
   partOfSpeech: n
+  wikidata: Q11084998
 01714137-n:
   definition:
   - huge herbivorous dinosaur of the Cretaceous found in western North America
@@ -23951,6 +24550,7 @@
   mero_member:
   - 01715811-n
   partOfSpeech: n
+  wikidata: Q130902
 01715393-n:
   definition:
   - primitive medium-sized theropod; swift-running bipedal carnivorous dinosaur having
@@ -23973,6 +24573,7 @@
   members:
   - genus Coelophysis
   partOfSpeech: n
+  wikidata: Q309392
 01715811-n:
   definition:
   - one of the oldest known dinosaurs; late Triassic; cannibalistic
@@ -24016,6 +24617,7 @@
   mero_member:
   - 01716405-n
   partOfSpeech: n
+  wikidata: Q14332
 01716405-n:
   definition:
   - large carnivorous bipedal dinosaur having enormous teeth with knifelike serrations;
@@ -24042,6 +24644,7 @@
   mero_member:
   - 01716872-n
   partOfSpeech: n
+  wikidata: Q14400
 01716872-n:
   definition:
   - late Jurassic carnivorous dinosaur; similar to but somewhat smaller than tyrannosaurus
@@ -24064,6 +24667,7 @@
   mero_member:
   - 01717177-n
   partOfSpeech: n
+  wikidata: Q130880
 01717177-n:
   definition:
   - very small bipedal carnivorous dinosaur of the late Jurassic in Bavaria
@@ -24085,6 +24689,7 @@
   mero_member:
   - 01717484-n
   partOfSpeech: n
+  wikidata: Q131014
 01717484-n:
   definition:
   - a kind of theropod dinosaur found in Argentina
@@ -24107,6 +24712,7 @@
   mero_member:
   - 01717775-n
   partOfSpeech: n
+  wikidata: Q130988
 01717775-n:
   definition:
   - a theropod dinosaur of the genus Eoraptor
@@ -24129,6 +24735,7 @@
   mero_member:
   - 01718024-n
   partOfSpeech: n
+  wikidata: Q131632
 01718024-n:
   definition:
   - type genus of the Megalosauridae
@@ -24140,6 +24747,7 @@
   mero_member:
   - 01718159-n
   partOfSpeech: n
+  wikidata: Q131056
 01718159-n:
   definition:
   - gigantic carnivorous bipedal dinosaur of the Jurassic or early Cretaceous in Europe
@@ -24185,6 +24793,7 @@
   mero_member:
   - 01718939-n
   partOfSpeech: n
+  wikidata: Q310535
 01718939-n:
   definition:
   - small light-boned toothless dinosaur resembling an ostrich in size and proportions
@@ -24205,6 +24814,7 @@
   mero_member:
   - 01719235-n
   partOfSpeech: n
+  wikidata: Q131142
 01719235-n:
   definition:
   - lightly built medium-sized theropod with long limbs and neck
@@ -24263,6 +24873,7 @@
   mero_member:
   - 01720108-n
   partOfSpeech: n
+  wikidata: Q14403
 01720108-n:
   definition:
   - small active carnivore that probably fed on protoceratops; possibly related more
@@ -24287,6 +24898,7 @@
   - 01720598-n
   - 01720917-n
   partOfSpeech: n
+  wikidata: Q130995
 01720501-n:
   definition:
   - a kind of maniraptor
@@ -24308,6 +24920,7 @@
   mero_member:
   - 01720737-n
   partOfSpeech: n
+  wikidata: Q14405
 01720737-n:
   definition:
   - swift agile wolf-sized bipedal dinosaur having a large curved claw on each hind
@@ -24330,6 +24943,7 @@
   mero_member:
   - 01721055-n
   partOfSpeech: n
+  wikidata: Q131193
 01721055-n:
   definition:
   - large (20-ft) and swift carnivorous dinosaur having an upright slashing claw 15
@@ -24352,6 +24966,7 @@
   mero_member:
   - 01721449-n
   partOfSpeech: n
+  wikidata: Q131421
 01721449-n:
   definition:
   - a turkey-sized long-legged fossil 75 million years old found in the Gobi Desert
@@ -24427,6 +25042,7 @@
   mero_member:
   - 01722907-n
   partOfSpeech: n
+  wikidata: Q1941356
 01722907-n:
   definition:
   - shrew-sized protomammal from the Alberta region of Canada; from about 55 million
@@ -24517,6 +25133,7 @@
   mero_member:
   - 01724208-n
   partOfSpeech: n
+  wikidata: Q21646750
 01724208-n:
   definition:
   - intermediate in form between the therapsids and most primitive true mammals
@@ -24540,6 +25157,7 @@
   - 01724726-n
   - 01725179-n
   partOfSpeech: n
+  wikidata: Q319520
 01724539-n:
   definition:
   - large primitive reptile having a tall spinal sail; of the Permian or late Paleozoic
@@ -24563,6 +25181,7 @@
   mero_member:
   - 01724895-n
   partOfSpeech: n
+  wikidata: Q987588
 01724895-n:
   definition:
   - type genus of the Edaphosauridae
@@ -24574,6 +25193,7 @@
   mero_member:
   - 01725030-n
   partOfSpeech: n
+  wikidata: Q131688
 01725030-n:
   definition:
   - heavy-bodied reptile with a dorsal sail or crest; of the late Paleozoic
@@ -24595,6 +25215,7 @@
   mero_member:
   - 01725311-n
   partOfSpeech: n
+  wikidata: Q130869
 01725311-n:
   definition:
   - carnivorous dinosaur of the Permian in North America having a crest or dorsal
@@ -24618,6 +25239,7 @@
   - 01725639-n
   - 01725900-n
   partOfSpeech: n
+  wikidata: Q179204
 01725639-n:
   definition:
   - an extinct reptile of the Jurassic and Cretaceous having a bird-like beak and
@@ -24642,6 +25264,7 @@
   mero_member:
   - 01726066-n
   partOfSpeech: n
+  wikidata: Q21446884
 01726066-n:
   definition:
   - a reptile genus of Pterodactylidae
@@ -24726,6 +25349,7 @@
   - 01727344-n
   - 01727588-n
   partOfSpeech: n
+  wikidata: Q1095663
 01727344-n:
   definition:
   - type genus of the Ichthyosauridae
@@ -24737,6 +25361,7 @@
   mero_member:
   - 01727481-n
   partOfSpeech: n
+  wikidata: Q131565
 01727481-n:
   definition:
   - ichthyosaurs of the Jurassic
@@ -24757,6 +25382,7 @@
   mero_member:
   - 01727727-n
   partOfSpeech: n
+  wikidata: Q134608
 01727727-n:
   definition:
   - an ichthyosaur of the genus Stenopterygius
@@ -24804,6 +25430,7 @@
   mero_member:
   - 01728354-n
   partOfSpeech: n
+  wikidata: Q857081
 01728354-n:
   definition:
   - extinct marine reptile with a small head on a long neck and a short tail and four
@@ -24838,6 +25465,7 @@
   mero_member:
   - 01728844-n
   partOfSpeech: n
+  wikidata: Q910989
 01728844-n:
   definition:
   - extinct marine reptile with longer more slender limbs than plesiosaurs and less
@@ -24919,6 +25547,7 @@
   - 01742646-n
   - 01743757-n
   partOfSpeech: n
+  wikidata: Q182751
 01730287-n:
   definition:
   - mostly harmless temperate-to-tropical terrestrial or arboreal or aquatic snakes
@@ -24976,6 +25605,7 @@
   mero_member:
   - 01731561-n
   partOfSpeech: n
+  wikidata: Q14427058
 01731561-n:
   definition:
   - any of numerous small nonvenomous North American snakes with a yellow or orange
@@ -25000,6 +25630,7 @@
   mero_member:
   - 01731963-n
   partOfSpeech: n
+  wikidata: Q2698783
 01731963-n:
   definition:
   - harmless North American snake with upturned nose; may spread its head and neck
@@ -25024,6 +25655,7 @@
   mero_member:
   - 01732313-n
   partOfSpeech: n
+  wikidata: Q511283
 01732313-n:
   definition:
   - any of various pale blotched snakes with a blunt snout of southwestern North America
@@ -25045,6 +25677,7 @@
   mero_member:
   - 01732618-n
   partOfSpeech: n
+  wikidata: Q783773
 01732618-n:
   definition:
   - either of two North American chiefly insectivorous snakes that are green in color
@@ -25088,6 +25721,7 @@
   mero_member:
   - 01733204-n
   partOfSpeech: n
+  wikidata: Q2606543
 01733204-n:
   definition:
   - any of numerous African colubrid snakes
@@ -25110,6 +25744,7 @@
   - 01733453-n
   - 01733918-n
   partOfSpeech: n
+  wikidata: Q226788
 01733453-n:
   definition:
   - slender fast-moving North American snakes
@@ -25162,6 +25797,7 @@
   mero_member:
   - 01734186-n
   partOfSpeech: n
+  wikidata: Q2578729
 01734186-n:
   definition:
   - any of several small fast-moving snakes with long whiplike tails
@@ -25230,6 +25866,7 @@
   - 01735430-n
   - 01735630-n
   partOfSpeech: n
+  wikidata: Q1924850
 01735255-n:
   definition:
   - large harmless snake of southeastern United States; often on farms
@@ -25275,6 +25912,7 @@
   mero_member:
   - 01735855-n
   partOfSpeech: n
+  wikidata: Q2326607
 01735855-n:
   definition:
   - enter buildings in pursuit of prey
@@ -25297,6 +25935,7 @@
   mero_member:
   - 01736107-n
   partOfSpeech: n
+  wikidata: Q14089080
 01736107-n:
   definition:
   - nocturnal burrowing snake of western United States with shiny tan scales
@@ -25319,6 +25958,7 @@
   mero_member:
   - 01736398-n
   partOfSpeech: n
+  wikidata: Q1992326
 01736398-n:
   definition:
   - any of several large harmless rodent-eating North American burrowing snakes
@@ -25409,6 +26049,7 @@
   mero_member:
   - 01737830-n
   partOfSpeech: n
+  wikidata: Q1149509
 01737830-n:
   definition:
   - any of numerous nonvenomous longitudinally-striped viviparous North American and
@@ -25488,6 +26129,7 @@
   mero_member:
   - 01739016-n
   partOfSpeech: n
+  wikidata: Q3490685
 01739016-n:
   definition:
   - small shy brightly-ringed terrestrial snake of arid or semiarid areas of western
@@ -25513,6 +26155,7 @@
   mero_member:
   - 01739437-n
   partOfSpeech: n
+  wikidata: Q290763
 01739437-n:
   definition:
   - in some classifications placed in genus Haldea; small reddish-grey snake of eastern
@@ -25547,6 +26190,7 @@
   - 01740113-n
   - 01740369-n
   partOfSpeech: n
+  wikidata: Q955683
 01739997-n:
   definition:
   - North American water snakes
@@ -25615,6 +26259,7 @@
   mero_member:
   - 01740947-n
   partOfSpeech: n
+  wikidata: Q310717
 01740947-n:
   definition:
   - harmless woodland snake of southeastern United States
@@ -25670,6 +26315,7 @@
   mero_member:
   - 01741735-n
   partOfSpeech: n
+  wikidata: Q2345428
 01741735-n:
   definition:
   - small secretive ground-living snake; found from central United States to Argentina
@@ -25747,6 +26393,7 @@
   mero_member:
   - 01742772-n
   partOfSpeech: n
+  wikidata: Q3022965
 01742772-n:
   definition:
   - nocturnal prowler of western United States and Mexico
@@ -25767,6 +26414,7 @@
   - Typhlopidae
   - family Typhlopidae
   partOfSpeech: n
+  wikidata: Q664781
 01743034-n:
   definition:
   - slender blind snakes or thread snakes (Leptotyphlopidae)
@@ -25780,6 +26428,7 @@
   - 01743192-n
   - 01743362-n
   partOfSpeech: n
+  wikidata: Q339827
 01743192-n:
   definition:
   - wormlike burrowing snake of warm regions having vestigial eyes
@@ -25825,6 +26474,7 @@
   - Drymarchon
   - genus Drymarchon
   partOfSpeech: n
+  wikidata: Q2363493
 01743873-n:
   definition:
   - large dark-blue nonvenomous snake that invades burrows; found in southern North
@@ -25873,6 +26523,7 @@
   - 01745608-n
   - 01745864-n
   partOfSpeech: n
+  wikidata: Q45556
 01744584-n:
   definition:
   - any of several chiefly tropical constrictors with vestigial hind limbs
@@ -25905,6 +26556,7 @@
   mero_member:
   - 01745088-n
   partOfSpeech: n
+  wikidata: Q1023539
 01745088-n:
   definition:
   - boa of grasslands and woodlands of western North America; looks and feels like
@@ -25929,6 +26581,7 @@
   mero_member:
   - 01745462-n
   partOfSpeech: n
+  wikidata: Q14423602
 01745462-n:
   definition:
   - boa of rocky desert of southwestern United States
@@ -25952,6 +26605,7 @@
   mero_member:
   - 01745727-n
   partOfSpeech: n
+  wikidata: Q188622
 01745727-n:
   definition:
   - large arboreal boa of tropical South America
@@ -25986,6 +26640,7 @@
   - Pythonidae
   - family Pythonidae
   partOfSpeech: n
+  wikidata: Q184018
 01746246-n:
   definition:
   - large Old World boas
@@ -26008,6 +26663,7 @@
   - 01746911-n
   - 01747042-n
   partOfSpeech: n
+  wikidata: Q271218
 01746577-n:
   definition:
   - Australian python with a variegated pattern on its back
@@ -26086,6 +26742,7 @@
   - 01753561-n
   - 01753994-n
   partOfSpeech: n
+  wikidata: Q186554
 01747766-n:
   definition:
   - any of numerous venomous fanged snakes of warmer parts of both hemispheres
@@ -26143,6 +26800,7 @@
   mero_member:
   - 01748832-n
   partOfSpeech: n
+  wikidata: Q11779559
 01748832-n:
   definition:
   - ranges from Central America to southwestern United States
@@ -26199,6 +26857,7 @@
   mero_member:
   - 01749593-n
   partOfSpeech: n
+  wikidata: Q169897
 01749593-n:
   definition:
   - small widely distributed arboreal snake of southern Africa banded in black and
@@ -26222,6 +26881,7 @@
   mero_member:
   - 01749926-n
   partOfSpeech: n
+  wikidata: Q56171665
 01749926-n:
   definition:
   - small venomous but harmless snake marked with black-and-white on red
@@ -26244,6 +26904,7 @@
   mero_member:
   - 01750230-n
   partOfSpeech: n
+  wikidata: Q195268
 01750230-n:
   definition:
   - venomous but sluggish reddish-brown snake of Australia
@@ -26268,6 +26929,7 @@
   - 01751030-n
   - 01751327-n
   partOfSpeech: n
+  wikidata: Q220475
 01750526-n:
   definition:
   - venomous Asiatic and African elapid snakes that can expand the skin of the neck
@@ -26324,6 +26986,7 @@
   mero_member:
   - 01751547-n
   partOfSpeech: n
+  wikidata: Q14564444
 01751327-n:
   definition:
   - aggressive cobra widely distributed in Africa; rarely bites but spits venom that
@@ -26359,6 +27022,7 @@
   - Hemachatus
   - genus Hemachatus
   partOfSpeech: n
+  wikidata: Q15148378
 01751885-n:
   definition:
   - highly venomous snake of southern Africa able to spit venom up to seven feet
@@ -26385,6 +27049,7 @@
   mero_member:
   - 01752223-n
   partOfSpeech: n
+  wikidata: Q194425
 01752223-n:
   definition:
   - arboreal snake of central and southern Africa whose bite is often fatal
@@ -26449,6 +27114,7 @@
   mero_member:
   - 01753078-n
   partOfSpeech: n
+  wikidata: Q169658
 01753078-n:
   definition:
   - highly venomous brown-and-yellow snake of Australia and Tasmania
@@ -26494,6 +27160,7 @@
   mero_member:
   - 01753677-n
   partOfSpeech: n
+  wikidata: Q752389
 01753677-n:
   definition:
   - brightly colored venomous but nonaggressive snake of southeastern Asia and Malay
@@ -26527,6 +27194,7 @@
   mero_member:
   - 01754113-n
   partOfSpeech: n
+  wikidata: Q852348
 01754113-n:
   definition:
   - large highly venomous snake of northeastern Australia
@@ -26549,6 +27217,7 @@
   mero_member:
   - 01754389-n
   partOfSpeech: n
+  wikidata: Q44512085
 01754389-n:
   definition:
   - any of numerous venomous aquatic viviparous snakes having a fin-like tail; of
@@ -26598,6 +27267,7 @@
   - 01755226-n
   - 01755377-n
   partOfSpeech: n
+  wikidata: Q662672
 01755226-n:
   definition:
   - small terrestrial viper common in northern Eurasia
@@ -26633,6 +27303,7 @@
   - 01755673-n
   - 01755821-n
   partOfSpeech: n
+  wikidata: Q574527
 01755673-n:
   definition:
   - large African viper that inflates its body when alarmed
@@ -26666,6 +27337,7 @@
   mero_member:
   - 01756129-n
   partOfSpeech: n
+  wikidata: Q73178
 01756129-n:
   definition:
   - highly venomous viper of northern Africa and southwestern Asia having a horny
@@ -26697,6 +27369,7 @@
   - 01760188-n
   - 01760660-n
   partOfSpeech: n
+  wikidata: Q595983
 01756600-n:
   definition:
   - New World vipers with hollow fangs and a heat-sensitive pit on each side of the
@@ -26723,6 +27396,7 @@
   - 01757011-n
   - 01757174-n
   partOfSpeech: n
+  wikidata: Q1257508
 01757011-n:
   definition:
   - common coppery brown pit viper of upland eastern United States
@@ -26786,6 +27460,7 @@
   - 01759756-n
   - 01759984-n
   partOfSpeech: n
+  wikidata: Q463637
 01758222-n:
   definition:
   - large deadly rattlesnake with diamond-shaped markings
@@ -26913,6 +27588,7 @@
   mero_member:
   - 01760318-n
   partOfSpeech: n
+  wikidata: Q244198
 01760318-n:
   definition:
   - pygmy rattlesnake found in moist areas from the Great Lakes to Mexico; feeds on
@@ -26948,6 +27624,7 @@
   mero_member:
   - 01760782-n
   partOfSpeech: n
+  wikidata: Q468875
 01760782-n:
   definition:
   - large extremely venomous pit viper of Central America and South America
@@ -27061,6 +27738,7 @@
   - 02161923-n
   - 02162607-n
   partOfSpeech: n
+  wikidata: Q1360
 01770302-n:
   definition:
   - invertebrate having jointed limbs and a segmented body with an exoskeleton made
@@ -27140,6 +27818,7 @@
   - 01774607-n
   - 01778520-n
   partOfSpeech: n
+  wikidata: Q1358
 01771988-n:
   definition:
   - air-breathing arthropods characterized by simple eyes and four pairs of legs
@@ -27190,6 +27869,7 @@
   mero_member:
   - 01772722-n
   partOfSpeech: n
+  wikidata: Q747605
 01772722-n:
   definition:
   - spiderlike arachnid with a small rounded body and very long thin legs
@@ -27214,6 +27894,7 @@
   mero_member:
   - 01773034-n
   partOfSpeech: n
+  wikidata: Q6122550
 01773034-n:
   definition:
   - arachnid of warm dry regions having a long segmented tail ending in a venomous
@@ -27241,6 +27922,7 @@
   - 01773436-n
   - 01773608-n
   partOfSpeech: n
+  wikidata: Q19119
 01773436-n:
   definition:
   - small nonvenomous arachnid resembling a tailless scorpion
@@ -27264,6 +27946,7 @@
   mero_member:
   - 01773741-n
   partOfSpeech: n
+  wikidata: Q18511096
 01773741-n:
   definition:
   - minute arachnid sometimes found in old papers
@@ -27380,6 +28063,7 @@
   - 01775626-n
   - 01775960-n
   partOfSpeech: n
+  wikidata: Q33134055
 01775626-n:
   definition:
   - the type genus of Argiopidae; small genus of orb-weaving spiders
@@ -27392,6 +28076,7 @@
   mero_member:
   - 01775798-n
   partOfSpeech: n
+  wikidata: Q862644
 01775798-n:
   definition:
   - a widely distributed North American garden spider
@@ -27418,6 +28103,7 @@
   - 01776190-n
   - 01776438-n
   partOfSpeech: n
+  wikidata: Q1413947
 01776190-n:
   definition:
   - an orange and tan spider with darkly banded legs that spins an orb web daily
@@ -27476,6 +28162,7 @@
   mero_member:
   - 01777025-n
   partOfSpeech: n
+  wikidata: Q385932
 01777025-n:
   definition:
   - venomous New World spider; the female is black with an hourglass-shaped red mark
@@ -27499,6 +28186,7 @@
   mero_member:
   - 01777391-n
   partOfSpeech: n
+  wikidata: Q213383
 01777391-n:
   definition:
   - large hairy tropical spider with fangs that can inflict painful but not highly
@@ -27545,6 +28233,7 @@
   mero_member:
   - 01778011-n
   partOfSpeech: n
+  wikidata: Q13320847
 01778011-n:
   definition:
   - large southern European spider once thought to be the cause of tarantism (uncontrollable
@@ -27569,6 +28258,7 @@
   mero_member:
   - 01778371-n
   partOfSpeech: n
+  wikidata: Q8713
 01778371-n:
   definition:
   - American spider that constructs a silk-lined nest with a hinged lid
@@ -27600,6 +28290,7 @@
   - 01784211-n
   - 01784691-n
   partOfSpeech: n
+  wikidata: Q3111386
 01778833-n:
   definition:
   - mite or tick
@@ -27633,6 +28324,7 @@
   - 01779673-n
   - 01781625-n
   partOfSpeech: n
+  wikidata: Q1429304
 01779346-n:
   definition:
   - ticks having a hard shield on the back and mouth parts that project from the head
@@ -27662,6 +28354,7 @@
   - 01781262-n
   - 01781442-n
   partOfSpeech: n
+  wikidata: Q1951212
 01779945-n:
   definition:
   - a northeastern tick now recognized as same species as Ixodes scapularis
@@ -27760,6 +28453,7 @@
   mero_member:
   - 01781789-n
   partOfSpeech: n
+  wikidata: Q2714520
 01781789-n:
   definition:
   - common tick that can transmit Rocky Mountain spotted fever and tularemia
@@ -27784,6 +28478,7 @@
   mero_member:
   - 01782104-n
   partOfSpeech: n
+  wikidata: Q640684
 01782104-n:
   definition:
   - tick lacking a dorsal shield and having mouth parts on the under side of the head
@@ -27825,6 +28520,7 @@
   mero_member:
   - 01782783-n
   partOfSpeech: n
+  wikidata: Q1931942
 01782783-n:
   definition:
   - very small free-living arachnid that is parasitic on animals or plants; related
@@ -27847,6 +28543,7 @@
   mero_member:
   - 01783067-n
   partOfSpeech: n
+  wikidata: Q853453
 01783067-n:
   definition:
   - mite that in all stages feeds on other arthropods
@@ -27893,6 +28590,7 @@
   mero_member:
   - 01783712-n
   partOfSpeech: n
+  wikidata: Q14830884
 01783712-n:
   definition:
   - larval mite that sucks the blood of vertebrates including human beings causing
@@ -27918,6 +28616,7 @@
   mero_member:
   - 01784051-n
   partOfSpeech: n
+  wikidata: Q3950491
 01784051-n:
   definition:
   - 'type genus of the family Sarcoptidae: itch mites'
@@ -27977,6 +28676,7 @@
   - 01784850-n
   - 01785019-n
   partOfSpeech: n
+  wikidata: Q676204
 01784850-n:
   definition:
   - web-spinning mite that attacks garden plants and fruit trees
@@ -27999,6 +28699,7 @@
   mero_member:
   - 01785157-n
   partOfSpeech: n
+  wikidata: Q10616065
 01785157-n:
   definition:
   - small web-spinning mite; a serious orchard pest
@@ -28043,6 +28744,7 @@
   - Pauropoda
   - class Pauropoda
   partOfSpeech: n
+  wikidata: Q217512
 01786025-n:
   definition:
   - small class of minute arthropods; unimportant except for the garden centipede
@@ -28055,6 +28757,7 @@
   mero_member:
   - 01786212-n
   partOfSpeech: n
+  wikidata: Q244147
 01786212-n:
   definition:
   - garden centipedes
@@ -28096,6 +28799,7 @@
   mero_member:
   - 01786934-n
   partOfSpeech: n
+  wikidata: Q5194
 01786934-n:
   definition:
   - an arthropod of the division Tardigrada
@@ -28122,6 +28826,7 @@
   - 01788033-n
   - 01788472-n
   partOfSpeech: n
+  wikidata: Q43447
 01787316-n:
   definition:
   - chiefly nocturnal predacious arthropod having a flattened body of 15 to 173 segments
@@ -28175,6 +28880,7 @@
   mero_member:
   - 01788173-n
   partOfSpeech: n
+  wikidata: Q856136
 01788173-n:
   definition:
   - a genus of Scutigeridae
@@ -28187,6 +28893,7 @@
   mero_member:
   - 01788308-n
   partOfSpeech: n
+  wikidata: Q3476556
 01788308-n:
   definition:
   - long-legged centipede common in damp places as e.g. cellars
@@ -28210,6 +28917,7 @@
   mero_member:
   - 01788689-n
   partOfSpeech: n
+  wikidata: Q2664614
 01788689-n:
   definition:
   - small extremely elongate centipedes that live in earth
@@ -28222,6 +28930,7 @@
   mero_member:
   - 01788860-n
   partOfSpeech: n
+  wikidata: Q4039348
 01788860-n:
   definition:
   - 'type genus of the Geophilidae: a cosmopolitan genus of centipedes sometimes called
@@ -28233,6 +28942,7 @@
   - Geophilus
   - genus Geophilus
   partOfSpeech: n
+  wikidata: Q4039347
 01789043-n:
   definition:
   - 'arthropods having the body composed of numerous double somites each with two
@@ -28248,7 +28958,7 @@
   mero_member:
   - 01789287-n
   partOfSpeech: n
-  wikidata: Q25823
+  wikidata: Q167367
 01789287-n:
   definition:
   - any of numerous herbivorous nonpoisonous arthropods having a cylindrical body
@@ -28273,6 +28983,7 @@
   mero_member:
   - 01789647-n
   partOfSpeech: n
+  wikidata: Q19106
 01789647-n:
   definition:
   - any of various small spiderlike marine arthropods having small thin bodies and
@@ -28297,6 +29008,7 @@
   - 01790042-n
   - 01791061-n
   partOfSpeech: n
+  wikidata: Q19105
 01790042-n:
   definition:
   - horseshoe crabs and extinct forms
@@ -28323,6 +29035,7 @@
   - 01790334-n
   - 01790798-n
   partOfSpeech: n
+  wikidata: Q1329239
 01790334-n:
   definition:
   - type genus of the family Limulidae
@@ -28335,6 +29048,7 @@
   mero_member:
   - 01790476-n
   partOfSpeech: n
+  wikidata: Q2104567
 01790476-n:
   definition:
   - large marine arthropod of the Atlantic coast of North America having a domed carapace
@@ -28362,6 +29076,7 @@
   mero_member:
   - 01790932-n
   partOfSpeech: n
+  wikidata: Q1929002
 01790932-n:
   definition:
   - horseshoe crab of the coast of eastern Asia
@@ -28383,6 +29098,7 @@
   mero_member:
   - 01791220-n
   partOfSpeech: n
+  wikidata: Q19436
 01791220-n:
   definition:
   - large extinct scorpion-like arthropod considered related to horseshoe crabs
@@ -28533,6 +29249,7 @@
   - 01792381-n
   - 01793748-n
   partOfSpeech: n
+  wikidata: Q222951
 01793748-n:
   definition:
   - small Asiatic wild bird; believed to be ancestral to domestic fowl
@@ -28754,6 +29471,7 @@
   - 01796629-n
   - 01797101-n
   partOfSpeech: n
+  wikidata: Q11777078
 01796629-n:
   definition:
   - 'type genus of the Meleagrididae: wild and domestic turkeys'
@@ -28766,6 +29484,7 @@
   mero_member:
   - 01796799-n
   partOfSpeech: n
+  wikidata: Q43794
 01796799-n:
   definition:
   - large gallinaceous bird with fan-shaped tail; widely domesticated for food
@@ -28800,6 +29519,7 @@
   mero_member:
   - 01797292-n
   partOfSpeech: n
+  wikidata: Q127565572
 01797292-n:
   definition:
   - wild turkey of Central America and northern South America
@@ -28830,6 +29550,7 @@
   - 01800693-n
   - 01800993-n
   partOfSpeech: n
+  wikidata: Q201240
 01797729-n:
   definition:
   - popular game bird having a plump body and feathered legs and feet
@@ -28853,6 +29574,7 @@
   mero_member:
   - 01798186-n
   partOfSpeech: n
+  wikidata: Q728995
 01798186-n:
   definition:
   - grouse of which the male is bluish-black
@@ -28918,6 +29640,7 @@
   mero_member:
   - 01798981-n
   partOfSpeech: n
+  wikidata: Q162029
 01798981-n:
   definition:
   - large Arctic and subarctic grouse with feathered feet and usually white winter
@@ -28972,6 +29695,7 @@
   mero_member:
   - 01799661-n
   partOfSpeech: n
+  wikidata: Q756174
 01799661-n:
   definition:
   - large black Old World grouse
@@ -28997,6 +29721,7 @@
   mero_member:
   - 01799948-n
   partOfSpeech: n
+  wikidata: Q117243536
 01799948-n:
   definition:
   - North American grouse that feeds on evergreen buds and needles
@@ -29044,6 +29769,7 @@
   mero_member:
   - 01800527-n
   partOfSpeech: n
+  wikidata: Q10740725
 01800527-n:
   definition:
   - valued as a game bird in eastern United States and Canada
@@ -29148,6 +29874,7 @@
   - 01802683-n
   - 01802927-n
   partOfSpeech: n
+  wikidata: Q725342
 01801943-n:
   definition:
   - any of several large turkey-like game birds of the family Cracidae; native to
@@ -29170,6 +29897,7 @@
   mero_member:
   - 01802320-n
   partOfSpeech: n
+  wikidata: Q869569
 01802320-n:
   definition:
   - large crested arboreal game bird of warm parts of the Americas having long legs
@@ -29190,6 +29918,7 @@
   - Penelope
   - genus Penelope
   partOfSpeech: n
+  wikidata: Q1071983
 01802683-n:
   definition:
   - genus of large crested guans (the piping guans)
@@ -29202,6 +29931,7 @@
   mero_member:
   - 01802836-n
   partOfSpeech: n
+  wikidata: Q2415068
 01802836-n:
   definition:
   - a kind of guan
@@ -29224,6 +29954,7 @@
   - 01803065-n
   - 01803274-n
   partOfSpeech: n
+  wikidata: Q777139
 01803065-n:
   definition:
   - slender arboreal guan resembling a wild turkey; native to Central America and
@@ -29260,6 +29991,7 @@
   - 01804394-n
   - 01804674-n
   partOfSpeech: n
+  wikidata: Q213536
 01803604-n:
   definition:
   - type genus of the Megapodiidae
@@ -29296,6 +30028,7 @@
   mero_member:
   - 01804120-n
   partOfSpeech: n
+  wikidata: Q4120496
 01804120-n:
   definition:
   - Australian mound bird; incubates eggs naturally in sandy mounds
@@ -29329,6 +30062,7 @@
   mero_member:
   - 01804517-n
   partOfSpeech: n
+  wikidata: Q10731928
 01804517-n:
   definition:
   - black megapode of wooded regions of Australia and New Guinea
@@ -29351,6 +30085,7 @@
   mero_member:
   - 01804800-n
   partOfSpeech: n
+  wikidata: Q10789354
 01804800-n:
   definition:
   - Celebes megapode that lays eggs in holes in sandy beaches
@@ -29387,6 +30122,7 @@
   - 01809906-n
   - 01811426-n
   partOfSpeech: n
+  wikidata: Q26375
 01805362-n:
   definition:
   - a kind of game bird in the family Phasianidae
@@ -29440,6 +30176,7 @@
   members:
   - genus Afropavo
   partOfSpeech: n
+  wikidata: Q10730907
 01806282-n:
   definition:
   - both sexes are brightly colored
@@ -29463,6 +30200,7 @@
   mero_member:
   - 01806534-n
   partOfSpeech: n
+  wikidata: Q2718257
 01806534-n:
   definition:
   - large brilliantly patterned East Indian pheasant
@@ -29542,6 +30280,7 @@
   mero_member:
   - 01807562-n
   partOfSpeech: n
+  wikidata: Q1869243
 01807562-n:
   definition:
   - small game bird with a rounded body and small tail
@@ -29574,6 +30313,7 @@
   mero_member:
   - 01807962-n
   partOfSpeech: n
+  wikidata: Q569957
 01807962-n:
   definition:
   - brilliantly colored pheasant of southern Asia
@@ -29595,6 +30335,7 @@
   - Odontophorus
   - genus Odontophorus
   partOfSpeech: n
+  wikidata: Q1080907
 01808333-n:
   definition:
   - peafowl
@@ -29607,6 +30348,7 @@
   mero_member:
   - 01808442-n
   partOfSpeech: n
+  wikidata: Q3917160
 01808442-n:
   definition:
   - very large terrestrial southeast Asian pheasant often raised as an ornamental
@@ -29690,6 +30432,7 @@
   - Lofortyx
   - genus Lofortyx
   partOfSpeech: n
+  wikidata: Q857531
 01809488-n:
   definition:
   - plump chunky bird of coastal California and Oregon
@@ -29711,6 +30454,7 @@
   mero_member:
   - 01809746-n
   partOfSpeech: n
+  wikidata: Q838744
 01809746-n:
   definition:
   - brilliantly colored Asian pheasant having wattles and two fleshy processes on
@@ -29760,6 +30504,7 @@
   mero_member:
   - 01810469-n
   partOfSpeech: n
+  wikidata: Q732487
 01810469-n:
   definition:
   - common European partridge
@@ -29785,6 +30530,7 @@
   - 01810781-n
   - 01810932-n
   partOfSpeech: n
+  wikidata: Q526626
 01810781-n:
   definition:
   - common western European partridge with red legs
@@ -29819,6 +30565,7 @@
   mero_member:
   - 01811237-n
   partOfSpeech: n
+  wikidata: Q10803028
 01811237-n:
   definition:
   - California partridge; slightly larger than the California quail
@@ -29857,6 +30604,7 @@
   mero_member:
   - 01811747-n
   partOfSpeech: n
+  wikidata: Q16724410
 01811747-n:
   definition:
   - a west African bird having dark plumage mottled with white; native to Africa but
@@ -29892,6 +30640,7 @@
   mero_member:
   - 01812233-n
   partOfSpeech: n
+  wikidata: Q942816
 01812233-n:
   definition:
   - 'type genus of the Opisthocomidae: hoatzins'
@@ -29904,6 +30653,7 @@
   mero_member:
   - 01812393-n
   partOfSpeech: n
+  wikidata: Q17190683
 01812393-n:
   definition:
   - crested ill-smelling South American bird whose young have claws on the first and
@@ -29929,6 +30679,7 @@
   mero_member:
   - 01812773-n
   partOfSpeech: n
+  wikidata: Q12355980
 01812773-n:
   definition:
   - comprising the tinamous
@@ -29941,6 +30692,7 @@
   mero_member:
   - 01812909-n
   partOfSpeech: n
+  wikidata: Q19172
 01812909-n:
   definition:
   - heavy-bodied small-winged South American game bird resembling a gallinaceous bird
@@ -29967,6 +30719,7 @@
   - 01814323-n
   - 01818072-n
   partOfSpeech: n
+  wikidata: Q28078
 01813341-n:
   definition:
   - a cosmopolitan order of land birds having small heads and short legs with four
@@ -29990,6 +30743,7 @@
   - 01813745-n
   - 01814035-n
   partOfSpeech: n
+  wikidata: Q551092
 01813745-n:
   definition:
   - 'type genus of the Raphidae: dodos'
@@ -30002,6 +30756,7 @@
   mero_member:
   - 01813884-n
   partOfSpeech: n
+  wikidata: Q10811276
 01813884-n:
   definition:
   - extinct heavy flightless bird of Mauritius related to pigeons
@@ -30024,6 +30779,7 @@
   mero_member:
   - 01814183-n
   partOfSpeech: n
+  wikidata: Q21446278
 01814183-n:
   definition:
   - extinct flightless bird related to the dodo
@@ -30051,6 +30807,7 @@
   - 01816732-n
   - 01817776-n
   partOfSpeech: n
+  wikidata: Q10856
 01814550-n:
   definition:
   - wild and domesticated birds having a heavy body and short legs
@@ -30094,6 +30851,7 @@
   - 01815507-n
   - 01815729-n
   partOfSpeech: n
+  wikidata: Q209239
 01815303-n:
   definition:
   - pale grey Eurasian pigeon having black-striped wings from which most domestic
@@ -30184,6 +30942,7 @@
   mero_member:
   - 01816589-n
   partOfSpeech: n
+  wikidata: Q905420
 01816589-n:
   definition:
   - small Australian dove
@@ -30207,6 +30966,7 @@
   mero_member:
   - 01816858-n
   partOfSpeech: n
+  wikidata: Q375342
 01816858-n:
   definition:
   - wild dove of the United States having a mournful call
@@ -30289,6 +31049,7 @@
   mero_member:
   - 01817911-n
   partOfSpeech: n
+  wikidata: Q8424076
 01817911-n:
   definition:
   - gregarious North American migratory pigeon now extinct
@@ -30313,6 +31074,7 @@
   - 01818496-n
   - 01818977-n
   partOfSpeech: n
+  wikidata: Q179983
 01818242-n:
   definition:
   - pigeon-like bird of arid regions of the Old World having long pointed wings and
@@ -30371,6 +31133,7 @@
   mero_member:
   - 01819115-n
   partOfSpeech: n
+  wikidata: Q1874877
 01819115-n:
   definition:
   - Eurasiatic sandgrouse with a black patch on the belly
@@ -30395,6 +31158,7 @@
   - 01819528-n
   - 01820065-n
   partOfSpeech: n
+  wikidata: Q31431
 01819528-n:
   definition:
   - usually brightly colored zygodactyl tropical birds with short hooked beaks and
@@ -30459,6 +31223,7 @@
   mero_member:
   - 01820594-n
   partOfSpeech: n
+  wikidata: Q10809423
 01820594-n:
   definition:
   - commonly domesticated grey parrot with red-and-black tail and white face; native
@@ -30483,6 +31248,7 @@
   mero_member:
   - 01820940-n
   partOfSpeech: n
+  wikidata: Q456513
 01820940-n:
   definition:
   - mainly green tropical American parrots
@@ -30504,6 +31270,7 @@
   mero_member:
   - 01821156-n
   partOfSpeech: n
+  wikidata: Q213984
 01821156-n:
   definition:
   - long-tailed brilliantly colored parrot of Central America and South America; among
@@ -30528,6 +31295,7 @@
   mero_member:
   - 01821473-n
   partOfSpeech: n
+  wikidata: Q508474
 01821473-n:
   definition:
   - large brownish-green New Zealand parrot
@@ -30553,6 +31321,7 @@
   mero_member:
   - 01821756-n
   partOfSpeech: n
+  wikidata: Q827257
 01821756-n:
   definition:
   - white or light-colored crested parrot of the Australian region; often kept as
@@ -30596,6 +31365,7 @@
   mero_member:
   - 01822375-n
   partOfSpeech: n
+  wikidata: Q10801919
 01822375-n:
   definition:
   - small grey Australian parrot with a yellow crested head
@@ -30620,6 +31390,7 @@
   mero_member:
   - 01822693-n
   partOfSpeech: n
+  wikidata: Q515217
 01822693-n:
   definition:
   - small African parrot noted for showing affection for their mates
@@ -30697,6 +31468,7 @@
   mero_member:
   - 01823717-n
   partOfSpeech: n
+  wikidata: Q921139
 01823717-n:
   definition:
   - a kind of lorikeet
@@ -30734,6 +31506,7 @@
   mero_member:
   - 01824195-n
   partOfSpeech: n
+  wikidata: Q10749858
 01824195-n:
   definition:
   - extinct parakeet whose range extended far into the United States
@@ -30757,6 +31530,7 @@
   mero_member:
   - 01824510-n
   partOfSpeech: n
+  wikidata: Q10792667
 01824510-n:
   definition:
   - small Australian parakeet usually light green with black and yellow markings in
@@ -30812,6 +31586,7 @@
   - 01825414-n
   - 01827650-n
   partOfSpeech: n
+  wikidata: Q183364
 01825243-n:
   definition:
   - birds having zygodactyl feet (except for the touracos)
@@ -30861,6 +31636,7 @@
   mero_member:
   - 01826055-n
   partOfSpeech: n
+  wikidata: Q746658
 01826055-n:
   definition:
   - common cuckoo of Europe having a distinctive two-note call; lays eggs in the nests
@@ -30884,6 +31660,7 @@
   mero_member:
   - 01826381-n
   partOfSpeech: n
+  wikidata: Q592593
 01826381-n:
   definition:
   - North American cuckoo; builds a nest and rears its own young
@@ -30907,6 +31684,7 @@
   mero_member:
   - 01826676-n
   partOfSpeech: n
+  wikidata: Q1452250
 01826676-n:
   definition:
   - speedy largely terrestrial bird found from California and Mexico to Texas
@@ -30930,6 +31708,7 @@
   mero_member:
   - 01826985-n
   partOfSpeech: n
+  wikidata: Q548753
 01826985-n:
   definition:
   - black tropical American cuckoo
@@ -30951,6 +31730,7 @@
   mero_member:
   - 01827216-n
   partOfSpeech: n
+  wikidata: Q657775
 01827216-n:
   definition:
   - Old World ground-living cuckoo having a long dagger-like hind claw
@@ -30994,6 +31774,7 @@
   - 01827796-n
   - 01827919-n
   partOfSpeech: n
+  wikidata: Q213827
 01827796-n:
   definition:
   - type genus of the Musophagidae
@@ -31038,6 +31819,7 @@
   - 01833264-n
   - 01833719-n
   partOfSpeech: n
+  wikidata: Q484131
 01828399-n:
   definition:
   - term used in some classifications as nearly equivalent to the order Coraciiformes
@@ -31070,6 +31852,7 @@
   - 01829005-n
   - 01829183-n
   partOfSpeech: n
+  wikidata: Q44245
 01829005-n:
   definition:
   - Old World bird that tumbles or rolls in flight; related to kingfishers
@@ -31161,6 +31944,7 @@
   mero_member:
   - 01830434-n
   partOfSpeech: n
+  wikidata: Q583551
 01830434-n:
   definition:
   - small kingfisher with greenish-blue and orange plumage
@@ -31183,6 +31967,7 @@
   mero_member:
   - 01830737-n
   partOfSpeech: n
+  wikidata: Q10745257
 01830737-n:
   definition:
   - greyish-blue North American kingfisher with a chestnut band on its chest
@@ -31206,6 +31991,7 @@
   mero_member:
   - 01831197-n
   partOfSpeech: n
+  wikidata: Q340041
 01831038-n:
   definition:
   - a large kingfisher widely distributed in warmer parts of the Old World
@@ -31216,6 +32002,7 @@
   - Halcyon
   - genus Halcyon
   partOfSpeech: n
+  wikidata: Q371767
 01831197-n:
   definition:
   - Australian kingfisher having a loud cackling cry
@@ -31240,6 +32027,7 @@
   - 01831497-n
   - 01831611-n
   partOfSpeech: n
+  wikidata: Q183147
 01831497-n:
   definition:
   - type genus of the Meropidae
@@ -31250,6 +32038,7 @@
   - Merops
   - genus Merops
   partOfSpeech: n
+  wikidata: Q269203
 01831611-n:
   definition:
   - colorful chiefly tropical Old World bird having a strong graceful flight; feeds
@@ -31273,6 +32062,7 @@
   - 01831929-n
   - 01832054-n
   partOfSpeech: n
+  wikidata: Q26773
 01831929-n:
   definition:
   - type genus of the family Bucerotidae
@@ -31283,6 +32073,7 @@
   - Buceros
   - genus Buceros
   partOfSpeech: n
+  wikidata: Q850627
 01832054-n:
   definition:
   - bird of tropical Africa and Asia having a very large bill surmounted by a bony
@@ -31352,6 +32143,7 @@
   mero_member:
   - 01832957-n
   partOfSpeech: n
+  wikidata: Q752529
 01832957-n:
   definition:
   - type and only genus of the family Phoeniculidae
@@ -31389,6 +32181,7 @@
   - 01833440-n
   - 01833556-n
   partOfSpeech: n
+  wikidata: Q734720
 01833440-n:
   definition:
   - type genus of the Momotidae
@@ -31424,6 +32217,7 @@
   mero_member:
   - 01833872-n
   partOfSpeech: n
+  wikidata: Q15727501
 01833872-n:
   definition:
   - type genus of the Todidae
@@ -31488,6 +32282,7 @@
   - 01835325-n
   - 01835620-n
   partOfSpeech: n
+  wikidata: Q26617
 01834808-n:
   definition:
   - a small bird that resembles a swallow and is noted for its rapid flight
@@ -31509,6 +32304,7 @@
   mero_member:
   - 01835134-n
   partOfSpeech: n
+  wikidata: Q310465
 01835134-n:
   definition:
   - common European bird with a shrieking call that nests chiefly about eaves of buildings
@@ -31533,6 +32329,7 @@
   mero_member:
   - 01835454-n
   partOfSpeech: n
+  wikidata: Q135472
 01835454-n:
   definition:
   - American swift that nests in e.g. unused chimneys
@@ -31556,6 +32353,7 @@
   mero_member:
   - 01835753-n
   partOfSpeech: n
+  wikidata: Q133554
 01835753-n:
   definition:
   - swift of eastern Asia; produces the edible bird's nest
@@ -31578,6 +32376,7 @@
   mero_member:
   - 01836056-n
   partOfSpeech: n
+  wikidata: Q31836
 01836056-n:
   definition:
   - birds of southeast Asia and East Indies differing from true swifts in having upright
@@ -31604,6 +32403,7 @@
   - 01836925-n
   - 01837053-n
   partOfSpeech: n
+  wikidata: Q43624
 01836446-n:
   definition:
   - tiny American bird having brilliant iridescent plumage and long slender bills;
@@ -31626,6 +32426,7 @@
   mero_member:
   - 01836818-n
   partOfSpeech: n
+  wikidata: Q776502
 01836818-n:
   definition:
   - a kind of hummingbird
@@ -31688,6 +32489,7 @@
   - 01839450-n
   - 01839871-n
   partOfSpeech: n
+  wikidata: Q26125
 01837559-n:
   definition:
   - long-winged nonpasserine birds
@@ -31739,6 +32541,7 @@
   - 01838559-n
   - 01838728-n
   partOfSpeech: n
+  wikidata: Q198823
 01838410-n:
   definition:
   - Old World goatsucker
@@ -31806,6 +32609,7 @@
   mero_member:
   - 01839314-n
   partOfSpeech: n
+  wikidata: Q10804997
 01839314-n:
   definition:
   - goatsucker of western North America
@@ -31829,6 +32633,7 @@
   - 01839594-n
   - 01839713-n
   partOfSpeech: n
+  wikidata: Q788536
 01839594-n:
   definition:
   - type genus of the Podargidae
@@ -31839,6 +32644,7 @@
   - Podargus
   - genus Podargus
   partOfSpeech: n
+  wikidata: Q569096
 01839713-n:
   definition:
   - insectivorous bird of Australia and southeastern Asia having a wide frog-like
@@ -31875,6 +32681,7 @@
   mero_member:
   - 01840167-n
   partOfSpeech: n
+  wikidata: Q10821410
 01840167-n:
   definition:
   - nocturnal fruit-eating bird of South America that has fatty young yielding an
@@ -31906,6 +32713,7 @@
   - 01845583-n
   - 01845879-n
   partOfSpeech: n
+  wikidata: Q25934
 01840679-n:
   definition:
   - any of numerous nonpasserine insectivorous climbing birds usually having strong
@@ -31936,6 +32744,7 @@
   - 01844210-n
   - 01844456-n
   partOfSpeech: n
+  wikidata: Q25439
 01841239-n:
   definition:
   - bird with strong claws and a stiff tail adapted for climbing and a hard chisel-like
@@ -31960,6 +32769,7 @@
   mero_member:
   - 01841727-n
   partOfSpeech: n
+  wikidata: Q310935
 01841727-n:
   definition:
   - woodpecker of Europe and western Asia
@@ -31980,6 +32790,7 @@
   - Picoides
   - genus Picoides
   partOfSpeech: n
+  wikidata: Q921396
 01841971-n:
   definition:
   - small North American woodpecker with black and white plumage and a small bill
@@ -32001,6 +32812,7 @@
   mero_member:
   - 01842239-n
   partOfSpeech: n
+  wikidata: Q868238
 01842239-n:
   definition:
   - North American woodpecker
@@ -32056,6 +32868,7 @@
   mero_member:
   - 01843053-n
   partOfSpeech: n
+  wikidata: Q132918
 01843053-n:
   definition:
   - large black-and-white woodpecker of southern United States and Cuba having an
@@ -32080,6 +32893,7 @@
   mero_member:
   - 01843416-n
   partOfSpeech: n
+  wikidata: Q131901
 01843416-n:
   definition:
   - black-and-white North American woodpecker having a red head and neck
@@ -32103,6 +32917,7 @@
   mero_member:
   - 01843743-n
   partOfSpeech: n
+  wikidata: Q936752
 01843743-n:
   definition:
   - small American woodpecker that feeds on sap from e.g. apple and maple trees
@@ -32145,6 +32960,7 @@
   mero_member:
   - 01844320-n
   partOfSpeech: n
+  wikidata: Q31818
 01844320-n:
   definition:
   - Old World woodpecker with a peculiar habit of twisting the neck
@@ -32166,6 +32982,7 @@
   mero_member:
   - 01844584-n
   partOfSpeech: n
+  wikidata: Q926314
 01844584-n:
   definition:
   - small woodpeckers of South America and Africa and East Indies having soft rounded
@@ -32188,6 +33005,7 @@
   mero_member:
   - 01844876-n
   partOfSpeech: n
+  wikidata: Q809613
 01844876-n:
   definition:
   - small brightly colored stout-billed tropical bird having short weak wings
@@ -32209,6 +33027,7 @@
   mero_member:
   - 01845145-n
   partOfSpeech: n
+  wikidata: Q621861
 01845145-n:
   definition:
   - brownish tropical American bird having a large head with fluffed out feathers
@@ -32253,6 +33072,7 @@
   mero_member:
   - 01845706-n
   partOfSpeech: n
+  wikidata: Q212942
 01845706-n:
   definition:
   - tropical American insectivorous bird having a long sharp bill and iridescent green
@@ -32276,6 +33096,7 @@
   - 01846024-n
   - 01846217-n
   partOfSpeech: n
+  wikidata: Q1325045
 01846024-n:
   definition:
   - brilliantly colored arboreal fruit-eating bird of tropical America having a very
@@ -32298,6 +33119,7 @@
   mero_member:
   - 01846360-n
   partOfSpeech: n
+  wikidata: Q781348
 01846360-n:
   definition:
   - small toucan
@@ -32319,6 +33141,7 @@
   mero_member:
   - 01846573-n
   partOfSpeech: n
+  wikidata: Q14566629
 01846573-n:
   definition:
   - coextensive with the order Trogoniformes
@@ -32333,6 +33156,7 @@
   - 01846872-n
   - 01847055-n
   partOfSpeech: n
+  wikidata: Q191469
 01846766-n:
   definition:
   - type genus of the Trogonidae
@@ -32342,6 +33166,7 @@
   members:
   - genus Trogon
   partOfSpeech: n
+  wikidata: Q945088
 01846872-n:
   definition:
   - forest bird of warm regions of the New World having brilliant lustrous plumage
@@ -32364,6 +33189,7 @@
   mero_member:
   - 01847192-n
   partOfSpeech: n
+  wikidata: Q2725371
 01847192-n:
   definition:
   - large trogon of Central America and South America having golden-green and scarlet
@@ -32421,6 +33247,7 @@
   - 01848797-n
   - 01862978-n
   partOfSpeech: n
+  wikidata: Q21651
 01848118-n:
   definition:
   - chiefly web-footed swimming birds
@@ -32547,6 +33374,7 @@
   - 01851617-n
   - 01851798-n
   partOfSpeech: n
+  wikidata: Q214264
 01850447-n:
   definition:
   - wild dabbling duck from which domestic ducks are descended; widely distributed
@@ -32675,6 +33503,7 @@
   mero_member:
   - 01852107-n
   partOfSpeech: n
+  wikidata: Q46316
 01852107-n:
   definition:
   - Old World gooselike duck slightly larger than a mallard with variegated mostly
@@ -32707,6 +33536,7 @@
   mero_member:
   - 01852504-n
   partOfSpeech: n
+  wikidata: Q844705
 01852504-n:
   definition:
   - reddish-brown stiff-tailed duck of North America and northern South America
@@ -32731,6 +33561,7 @@
   - 01852833-n
   - 01853014-n
   partOfSpeech: n
+  wikidata: Q310868
 01852833-n:
   definition:
   - small North American diving duck; males have bushy head plumage
@@ -32869,6 +33700,7 @@
   - 01854783-n
   - 01855041-n
   partOfSpeech: n
+  wikidata: Q131450
 01854783-n:
   definition:
   - showy North American duck that nests in hollow trees
@@ -32912,6 +33744,7 @@
   mero_member:
   - 01855312-n
   partOfSpeech: n
+  wikidata: Q312236
 01855312-n:
   definition:
   - large crested wild duck of Central America and South America; widely domesticated
@@ -32945,6 +33778,7 @@
   mero_member:
   - 01855836-n
   partOfSpeech: n
+  wikidata: Q690813
 01855836-n:
   definition:
   - duck of the Northern Hemisphere much valued for the fine soft down of the females
@@ -32969,6 +33803,7 @@
   mero_member:
   - 01856139-n
   partOfSpeech: n
+  wikidata: Q256760
 01856139-n:
   definition:
   - large black diving duck of northern parts of the Northern Hemisphere
@@ -33001,6 +33836,7 @@
   mero_member:
   - 01856511-n
   partOfSpeech: n
+  wikidata: Q2060384
 01856511-n:
   definition:
   - a common long-tailed sea duck of the northern parts of the United States
@@ -33041,6 +33877,7 @@
   - 01857673-n
   - 01857829-n
   partOfSpeech: n
+  wikidata: Q253789
 01857056-n:
   definition:
   - large crested fish-eating diving duck having a slender hooked bill with serrated
@@ -33107,6 +33944,7 @@
   mero_member:
   - 01858117-n
   partOfSpeech: n
+  wikidata: Q13136551
 01858117-n:
   definition:
   - small North American duck with a high circular crest on the male's head
@@ -33163,6 +34001,7 @@
   - 01859194-n
   - 01859389-n
   partOfSpeech: n
+  wikidata: Q183361
 01859021-n:
   definition:
   - very large wild goose of northeast Asia; interbreeds freely with the greylag
@@ -33234,6 +34073,7 @@
   - 01860273-n
   - 01860492-n
   partOfSpeech: n
+  wikidata: Q210416
 01859966-n:
   definition:
   - small dark geese that breed in the north and migrate southward
@@ -33301,6 +34141,7 @@
   mero_member:
   - 01860922-n
   partOfSpeech: n
+  wikidata: Q14786632
 01860922-n:
   definition:
   - large white South American bird intermediate in some respects between ducks and
@@ -33367,6 +34208,7 @@
   - 01862643-n
   - 01862828-n
   partOfSpeech: n
+  wikidata: Q29564928
 01861831-n:
   definition:
   - soundless Eurasian swan; commonly domesticated
@@ -33454,6 +34296,7 @@
   - 01863354-n
   - 01863666-n
   partOfSpeech: n
+  wikidata: Q217484
 01863138-n:
   definition:
   - gooselike aquatic bird of South America having a harsh trumpeting call
@@ -33475,6 +34318,7 @@
   mero_member:
   - 01863505-n
   partOfSpeech: n
+  wikidata: Q10733978
 01863505-n:
   definition:
   - screamer having a hornlike process projecting from the forehead
@@ -33537,6 +34381,7 @@
   - 02373177-n
   - 02373777-n
   partOfSpeech: n
+  wikidata: Q7377
 01864419-n:
   definition:
   - any warm-blooded vertebrate having the skin more or less covered with hair; young
@@ -33628,6 +34473,7 @@
   - 01874735-n
   - 01875648-n
   partOfSpeech: n
+  wikidata: Q21790
 01874516-n:
   definition:
   - the most primitive mammals comprising the only extant members of the subclass
@@ -33665,6 +34511,7 @@
   mero_member:
   - 01875042-n
   partOfSpeech: n
+  wikidata: Q12902259
 01875042-n:
   definition:
   - a burrowing monotreme mammal covered with spines and having a long snout and claws
@@ -33689,6 +34536,7 @@
   mero_member:
   - 01875413-n
   partOfSpeech: n
+  wikidata: Q784836
 01875413-n:
   definition:
   - a burrowing monotreme mammal covered with spines and having a long snout and claws
@@ -33726,6 +34574,7 @@
   mero_member:
   - 01875951-n
   partOfSpeech: n
+  wikidata: Q3745848
 01875951-n:
   definition:
   - small densely furred aquatic monotreme of Australia and Tasmania having a broad
@@ -33793,6 +34642,7 @@
   - 01885853-n
   - 01888365-n
   partOfSpeech: n
+  wikidata: Q25336
 01877075-n:
   definition:
   - mammals of which the females have a pouch (the marsupium) containing the teats
@@ -33818,6 +34668,7 @@
   - 01877569-n
   - 01877806-n
   partOfSpeech: n
+  wikidata: Q21834
 01877569-n:
   definition:
   - nocturnal arboreal marsupial having a naked prehensile tail found from southern
@@ -33876,6 +34727,7 @@
   mero_member:
   - 01878521-n
   partOfSpeech: n
+  wikidata: Q21854
 01878521-n:
   definition:
   - type genus of the family Caenolestidae
@@ -33967,6 +34819,7 @@
   - 01882342-n
   - 01882624-n
   partOfSpeech: n
+  wikidata: Q23193
 01879775-n:
   definition:
   - any of several herbivorous leaping marsupials of Australia and New Guinea having
@@ -33990,6 +34843,7 @@
   - 01880247-n
   - 01880702-n
   partOfSpeech: n
+  wikidata: Q174322
 01880247-n:
   definition:
   - very large greyish-brown Australian kangaroo formerly abundant in open wooded
@@ -34034,6 +34888,7 @@
   mero_member:
   - 01880976-n
   partOfSpeech: n
+  wikidata: Q218873
 01880976-n:
   definition:
   - small Australian wallaby that resembles a hare and has persistent teeth
@@ -34056,6 +34911,7 @@
   mero_member:
   - 01881280-n
   partOfSpeech: n
+  wikidata: Q429799
 01881280-n:
   definition:
   - small wallabies with a horny nail on the tip of the tail
@@ -34078,6 +34934,7 @@
   mero_member:
   - 01881570-n
   partOfSpeech: n
+  wikidata: Q269253
 01881570-n:
   definition:
   - slender long-legged Australian wallabies living in caves and rocky areas
@@ -34123,6 +34980,7 @@
   mero_member:
   - 01882150-n
   partOfSpeech: n
+  wikidata: Q325064
 01882150-n:
   definition:
   - arboreal wallabies of New Guinea and northern Australia having hind and forelegs
@@ -34146,6 +35004,7 @@
   mero_member:
   - 01882478-n
   partOfSpeech: n
+  wikidata: Q10770484
 01882478-n:
   definition:
   - small kangaroo of northeastern Australia
@@ -34194,6 +35053,7 @@
   mero_member:
   - 01883114-n
   partOfSpeech: n
+  wikidata: Q1475146
 01883114-n:
   definition:
   - Australian rat kangaroos
@@ -34216,6 +35076,7 @@
   - 01883357-n
   - 01883454-n
   partOfSpeech: n
+  wikidata: Q945387
 01883357-n:
   definition:
   - short-nosed rat kangaroo
@@ -34252,6 +35113,7 @@
   - 01885013-n
   - 01885248-n
   partOfSpeech: n
+  wikidata: Q23230
 01883812-n:
   definition:
   - small furry Australian arboreal marsupials having long usually prehensile tails
@@ -34274,6 +35136,7 @@
   mero_member:
   - 01884205-n
   partOfSpeech: n
+  wikidata: Q1413190
 01884205-n:
   definition:
   - woolly-haired monkey-like arboreal marsupial of New Guinea and northern Australia
@@ -34295,6 +35158,7 @@
   mero_member:
   - 01884498-n
   partOfSpeech: n
+  wikidata: Q656173
 01884498-n:
   definition:
   - bushy-tailed phalanger
@@ -34343,6 +35207,7 @@
   mero_member:
   - 01885149-n
   partOfSpeech: n
+  wikidata: Q11110566
 01885149-n:
   definition:
   - tiny flying phalanger
@@ -34389,6 +35254,7 @@
   mero_member:
   - 01885711-n
   partOfSpeech: n
+  wikidata: Q23175
 01885711-n:
   definition:
   - burrowing herbivorous Australian marsupials about the size of a badger
@@ -34416,6 +35282,7 @@
   - 01887673-n
   - 01888008-n
   partOfSpeech: n
+  wikidata: Q23133
 01886154-n:
   definition:
   - small carnivorous nocturnal marsupials of Australia and Tasmania
@@ -34438,6 +35305,7 @@
   mero_member:
   - 01886561-n
   partOfSpeech: n
+  wikidata: Q379740
 01886561-n:
   definition:
   - any of several more or less arboreal marsupials somewhat resembling martens
@@ -34506,6 +35374,7 @@
   mero_member:
   - 01887475-n
   partOfSpeech: n
+  wikidata: Q937821
 01887475-n:
   definition:
   - small ferocious carnivorous marsupial having a mostly black coat and long tail
@@ -34529,6 +35398,7 @@
   mero_member:
   - 01887799-n
   partOfSpeech: n
+  wikidata: Q1754387
 01887799-n:
   definition:
   - any of numerous small sharp-nosed insectivorous marsupials superficially resembling
@@ -34553,6 +35423,7 @@
   mero_member:
   - 01888139-n
   partOfSpeech: n
+  wikidata: Q10795872
 01888139-n:
   definition:
   - small Australian marsupial having long snout and strong claws for feeding on termites;
@@ -34578,6 +35449,7 @@
   mero_member:
   - 01888497-n
   partOfSpeech: n
+  wikidata: Q13166786
 01888497-n:
   definition:
   - 'type genus of the family Notoryctidae: comprising solely the marsupial mole'
@@ -34590,6 +35462,7 @@
   mero_member:
   - 01888686-n
   partOfSpeech: n
+  wikidata: Q234792
 01888686-n:
   definition:
   - small burrowing Australian marsupial that resembles a mole
@@ -34742,6 +35615,7 @@
   - 01896681-n
   - 01897311-n
   partOfSpeech: n
+  wikidata: Q25842
 01891462-n:
   definition:
   - moles, hedgehogs, true shrews
@@ -34787,6 +35661,7 @@
   - 01893359-n
   - 01893786-n
   partOfSpeech: n
+  wikidata: Q104825
 01892161-n:
   definition:
   - small velvety-furred burrowing mammal having small eyes and fossorial forefeet
@@ -34806,6 +35681,7 @@
   - Condylura
   - genus Condylura
   partOfSpeech: n
+  wikidata: Q10749625
 01892490-n:
   definition:
   - amphibious mole of eastern North America having pink fleshy tentacles around the
@@ -34828,6 +35704,7 @@
   - Parascalops
   - genus Parascalops
   partOfSpeech: n
+  wikidata: Q19816787
 01892785-n:
   definition:
   - mole of eastern North America
@@ -34851,6 +35728,7 @@
   mero_member:
   - 01893052-n
   partOfSpeech: n
+  wikidata: Q23351
 01893052-n:
   definition:
   - type genus of the Chrysochloridae
@@ -34863,6 +35741,7 @@
   mero_member:
   - 01893205-n
   partOfSpeech: n
+  wikidata: Q599385
 01893205-n:
   definition:
   - mole of southern Africa having iridescent guard hairs mixed with the underfur
@@ -34886,6 +35765,7 @@
   - 01893501-n
   - 01893654-n
   partOfSpeech: n
+  wikidata: Q867212
 01893501-n:
   definition:
   - slender mole having a long snout and tail
@@ -34969,6 +35849,7 @@
   - 01894671-n
   - 01895385-n
   partOfSpeech: n
+  wikidata: Q5607349
 01894671-n:
   definition:
   - common American shrew
@@ -35001,6 +35882,7 @@
   mero_member:
   - 01895026-n
   partOfSpeech: n
+  wikidata: Q468813
 01895026-n:
   definition:
   - North American shrew with tail less than half its body length
@@ -35043,6 +35925,7 @@
   - 01895662-n
   - 01895805-n
   partOfSpeech: n
+  wikidata: Q1352331
 01895662-n:
   definition:
   - widely distributed Old World water shrew
@@ -35109,6 +35992,7 @@
   mero_member:
   - 01896466-n
   partOfSpeech: n
+  wikidata: Q498993
 01896466-n:
   definition:
   - small nocturnal Old World mammal covered with both hair and protective spines
@@ -35135,6 +36019,7 @@
   - 01896848-n
   - 01897022-n
   partOfSpeech: n
+  wikidata: Q23340
 01896848-n:
   definition:
   - small often spiny insectivorous mammal of Madagascar; resembles a hedgehog
@@ -35156,6 +36041,7 @@
   mero_member:
   - 01897163-n
   partOfSpeech: n
+  wikidata: Q15402150
 01897163-n:
   definition:
   - prolific animal that feeds chiefly on earthworms
@@ -35178,6 +36064,7 @@
   mero_member:
   - 01897444-n
   partOfSpeech: n
+  wikidata: Q33135586
 01897444-n:
   definition:
   - 'type genus of the family Potamogalidae: otter shrews'
@@ -35189,6 +36076,7 @@
   mero_member:
   - 01897597-n
   partOfSpeech: n
+  wikidata: Q18175529
 01897597-n:
   definition:
   - amphibious African insectivorous mammal that resembles an otter
@@ -35937,6 +36825,7 @@
   - 01909675-n
   - 01910136-n
   partOfSpeech: n
+  wikidata: Q18960
 01909390-n:
   definition:
   - primitive multicellular marine animal whose porous body is supported by a fibrous
@@ -35992,6 +36881,7 @@
   - 01910379-n
   - 01910543-n
   partOfSpeech: n
+  wikidata: Q4137253
 01910379-n:
   definition:
   - a siliceous sponge (with glassy spicules) of the class Hyalospongiae
@@ -36013,6 +36903,7 @@
   mero_member:
   - 01910683-n
   partOfSpeech: n
+  wikidata: Q3060446
 01910683-n:
   definition:
   - a deep-water marine sponge having a cylindrical skeleton of intricate glassy latticework;
@@ -36084,6 +36975,7 @@
   - 01914152-n
   - 01916479-n
   partOfSpeech: n
+  wikidata: Q25441
 01912063-n:
   definition:
   - radially symmetrical animals having saclike bodies with only one opening and tentacles
@@ -36187,6 +37079,7 @@
   mero_member:
   - 01914044-n
   partOfSpeech: n
+  wikidata: Q976832
 01914044-n:
   definition:
   - a type of jellyfish
@@ -36212,6 +37105,7 @@
   - 01914913-n
   - 01916174-n
   partOfSpeech: n
+  wikidata: Q181989
 01914480-n:
   definition:
   - colonial coelenterates having the polyp phase dominant
@@ -36233,6 +37127,7 @@
   mero_member:
   - 01914793-n
   partOfSpeech: n
+  wikidata: Q192290
 01914793-n:
   definition:
   - small tubular solitary freshwater hydrozoan polyp
@@ -36256,6 +37151,7 @@
   - 01915329-n
   - 01915676-n
   partOfSpeech: n
+  wikidata: Q1134438
 01915095-n:
   definition:
   - a floating or swimming oceanic colony of polyps often transparent or showily colored
@@ -36276,6 +37172,7 @@
   mero_member:
   - 01915450-n
   partOfSpeech: n
+  wikidata: Q3388845
 01915450-n:
   definition:
   - small creatures resembling pieces of fuzzy rope; each with a cluster of swimming
@@ -36299,6 +37196,7 @@
   mero_member:
   - 01915807-n
   partOfSpeech: n
+  wikidata: Q2704401
 01915807-n:
   definition:
   - large siphonophore having a bladderlike float and stinging tentacles
@@ -36340,6 +37238,7 @@
   mero_member:
   - 01916332-n
   partOfSpeech: n
+  wikidata: Q3958000
 01916332-n:
   definition:
   - feathery colony of long-branched stems bearing stalkless paired polyps
@@ -36367,6 +37266,7 @@
   - 01917734-n
   - 01919379-n
   partOfSpeech: n
+  wikidata: Q28524
 01916804-n:
   definition:
   - sessile marine coelenterates including solitary and colonial polyps; the medusoid
@@ -36394,6 +37294,7 @@
   - 01917471-n
   - 01917602-n
   partOfSpeech: n
+  wikidata: Q147256
 01917250-n:
   definition:
   - marine polyps that resemble flowers but have oral rings of tentacles; differ from
@@ -36426,6 +37327,7 @@
   - Actinia
   - genus Actinia
   partOfSpeech: n
+  wikidata: Q280474
 01917734-n:
   definition:
   - corals and sea anemones having eight branches
@@ -36462,6 +37364,7 @@
   mero_member:
   - 01918182-n
   partOfSpeech: n
+  wikidata: Q1116222
 01918182-n:
   definition:
   - 'type genus of the family Pennatulidae: sea pens'
@@ -36561,6 +37464,7 @@
   - 01920075-n
   - 01920392-n
   partOfSpeech: n
+  wikidata: Q195605
 01919566-n:
   definition:
   - corals having calcareous skeletons aggregations of which form reefs and islands
@@ -36584,6 +37488,7 @@
   mero_member:
   - 01919930-n
   partOfSpeech: n
+  wikidata: Q115770614
 01919930-n:
   definition:
   - massive reef-building coral having a convoluted and furrowed surface
@@ -36626,6 +37531,7 @@
   - Fungia
   - genus Fungia
   partOfSpeech: n
+  wikidata: Q2710067
 01920523-n:
   definition:
   - flattened disk-shaped stony coral (usually solitary and unattached)
@@ -36669,6 +37575,7 @@
   - 01922819-n
   - 01922943-n
   partOfSpeech: n
+  wikidata: Q102778
 01921226-n:
   definition:
   - a locomotor organ consisting of a row of strong cilia whose bases are fused
@@ -36705,6 +37612,7 @@
   mero_member:
   - 01921899-n
   partOfSpeech: n
+  wikidata: Q136620
 01921899-n:
   definition:
   - coextensive with the class Nuda
@@ -36716,6 +37624,7 @@
   mero_member:
   - 01922026-n
   partOfSpeech: n
+  wikidata: Q3828178
 01922026-n:
   definition:
   - delicately iridescent thimble-shaped ctenophores
@@ -36740,6 +37649,7 @@
   - 01923223-n
   - 01923857-n
   partOfSpeech: n
+  wikidata: Q131799
 01922355-n:
   definition:
   - ctenophores having two long pinnate tentacles
@@ -36754,6 +37664,7 @@
   - Cydippea
   - order Cydippea
   partOfSpeech: n
+  wikidata: Q151079
 01922553-n:
   definition:
   - an order of Tentaculata
@@ -36785,6 +37696,7 @@
   - Pleurobrachiidae
   - family Pleurobrachiidae
   partOfSpeech: n
+  wikidata: Q3826253
 01922943-n:
   definition:
   - a genus of sea gooseberries (Pleurobrachia)
@@ -36797,6 +37709,7 @@
   mero_member:
   - 01923079-n
   partOfSpeech: n
+  wikidata: Q3005619
 01923079-n:
   definition:
   - ctenophore having a rounded body with longitudinal rows of cilia
@@ -36832,6 +37745,7 @@
   mero_member:
   - 01923580-n
   partOfSpeech: n
+  wikidata: Q2947068
 01923580-n:
   definition:
   - Venus's girdle
@@ -36844,6 +37758,7 @@
   mero_member:
   - 01923700-n
   partOfSpeech: n
+  wikidata: Q18518956
 01923700-n:
   definition:
   - ctenophore having a ribbon-shaped iridescent gelatinous body
@@ -36865,6 +37780,7 @@
   - Lobata
   - order Lobata
   partOfSpeech: n
+  wikidata: Q149121
 01924081-n:
   definition:
   - ciliated comb-like swimming plate of a ctenophore
@@ -36947,6 +37863,7 @@
   mero_member:
   - 01926045-n
   partOfSpeech: n
+  wikidata: Q178235
 01926045-n:
   definition:
   - any of various worms living parasitically in intestines of vertebrates having
@@ -36972,6 +37889,7 @@
   - 01926792-n
   - 01927057-n
   partOfSpeech: n
+  wikidata: Q192416
 01926531-n:
   definition:
   - any worm of the Chaetognatha; transparent marine worm with horizontal lateral
@@ -36994,6 +37912,7 @@
   mero_member:
   - 01926950-n
   partOfSpeech: n
+  wikidata: Q4404443
 01926950-n:
   definition:
   - any arrowworm of the genus Sagitta
@@ -37013,6 +37932,7 @@
   members:
   - genus Spadella
   partOfSpeech: n
+  wikidata: Q2330212
 01927231-n:
   definition:
   - flatworms
@@ -37029,6 +37949,7 @@
   - 01928110-n
   - 01929942-n
   partOfSpeech: n
+  wikidata: Q124900
 01927441-n:
   definition:
   - encysted saclike larva of the tapeworm
@@ -37092,6 +38013,7 @@
   - 01928731-n
   - 01929481-n
   partOfSpeech: n
+  wikidata: Q207547
 01928336-n:
   definition:
   - parasitic flatworms having external suckers for attaching to a host
@@ -37161,6 +38083,7 @@
   mero_member:
   - 01929330-n
   partOfSpeech: n
+  wikidata: Q19838628
 01929330-n:
   definition:
   - fluke that is parasitic on humans and swine; common in eastern Asia
@@ -37246,6 +38169,7 @@
   - 01930457-n
   - 01930714-n
   partOfSpeech: n
+  wikidata: Q141694
 01930457-n:
   definition:
   - a genus containing six parasitic species of cyclophyllid tapeworms (Echinococcus)
@@ -37257,6 +38181,7 @@
   mero_member:
   - 01930569-n
   partOfSpeech: n
+  wikidata: Q344662
 01930569-n:
   definition:
   - tapeworms whose larvae are parasitic in humans and domestic animals
@@ -37278,6 +38203,7 @@
   mero_member:
   - 01930856-n
   partOfSpeech: n
+  wikidata: Q310997
 01930856-n:
   definition:
   - tapeworms parasitic in humans which uses the pig as its intermediate host
@@ -37301,6 +38227,7 @@
   mero_member:
   - 01931158-n
   partOfSpeech: n
+  wikidata: Q185631
 01931158-n:
   definition:
   - soft unsegmented marine worms that have a threadlike proboscis and the ability
@@ -37326,6 +38253,7 @@
   mero_member:
   - 01931506-n
   partOfSpeech: n
+  wikidata: Q15229174
 01931506-n:
   definition:
   - slender animal with tentacles and a tubelike outer covering; lives on the deep
@@ -37384,6 +38312,7 @@
   - 01935983-n
   - 01936327-n
   partOfSpeech: n
+  wikidata: Q5185
 01932429-n:
   definition:
   - one of two subgroups of Nematoda used in some classification systems
@@ -37394,6 +38323,7 @@
   - Aphasmidia
   - class Aphasmidia
   partOfSpeech: n
+  wikidata: Q17156
 01932592-n:
   definition:
   - one of two subgroups of Nematoda used in some classification systems, comprises
@@ -37407,6 +38337,7 @@
   - Phasmidia
   - class Phasmidia
   partOfSpeech: n
+  wikidata: Q17157
 01932753-n:
   definition:
   - unsegmented worms with elongated rounded body pointed at both ends; mostly free-living
@@ -37432,6 +38363,7 @@
   - 01933313-n
   - 01933636-n
   partOfSpeech: n
+  wikidata: Q763856
 01933313-n:
   definition:
   - 'type genus of the family Ascaridae: roundworms with a three-lipped mouth'
@@ -37444,6 +38376,7 @@
   mero_member:
   - 01933493-n
   partOfSpeech: n
+  wikidata: Q310838
 01933493-n:
   definition:
   - intestinal parasite of humans and pigs
@@ -37467,6 +38400,7 @@
   mero_member:
   - 01933781-n
   partOfSpeech: n
+  wikidata: Q4803791
 01933781-n:
   definition:
   - intestinal parasite of domestic fowl
@@ -37490,6 +38424,7 @@
   mero_member:
   - 01934039-n
   partOfSpeech: n
+  wikidata: Q2628603
 01934039-n:
   definition:
   - a genus of pinworms (Enterobius)
@@ -37536,6 +38471,7 @@
   mero_member:
   - 01934625-n
   partOfSpeech: n
+  wikidata: Q5266809
 01934625-n:
   definition:
   - a genus of Cephalobidae
@@ -37576,6 +38512,7 @@
   mero_member:
   - 01935136-n
   partOfSpeech: n
+  wikidata: Q3546007
 01935136-n:
   definition:
   - type genus of the family Tylenchidae
@@ -37588,6 +38525,7 @@
   mero_member:
   - 01935284-n
   partOfSpeech: n
+  wikidata: Q10707022
 01935284-n:
   definition:
   - small roundworm parasitic on wheat
@@ -37612,6 +38550,7 @@
   mero_member:
   - 01935792-n
   partOfSpeech: n
+  wikidata: Q3093248
 01935577-n:
   definition:
   - parasitic nematode occurring in the intestines of pigs and rats and human beings
@@ -37645,6 +38584,7 @@
   mero_member:
   - 01936119-n
   partOfSpeech: n
+  wikidata: Q1530508
 01936119-n:
   definition:
   - slender threadlike roundworms living in the blood and tissues of vertebrates;
@@ -37667,6 +38607,7 @@
   mero_member:
   - 01936475-n
   partOfSpeech: n
+  wikidata: Q2367224
 01936475-n:
   definition:
   - type genus of the family Dracunculidae
@@ -37679,6 +38620,7 @@
   mero_member:
   - 01936629-n
   partOfSpeech: n
+  wikidata: Q2341780
 01936629-n:
   definition:
   - parasitic roundworm of India and Africa that lives in the abdomen or beneath the
@@ -37707,6 +38649,7 @@
   - 01938860-n
   - 01940360-n
   partOfSpeech: n
+  wikidata: Q25522
 01937081-n:
   definition:
   - worms with cylindrical bodies segmented both internally and externally
@@ -37730,6 +38673,7 @@
   mero_member:
   - 01937485-n
   partOfSpeech: n
+  wikidata: Q1072243
 01937485-n:
   definition:
   - small primitive marine worm lacking external segmentation and resembling polychaete
@@ -37754,6 +38698,7 @@
   - 01938036-n
   - 01938384-n
   partOfSpeech: n
+  wikidata: Q193006
 01937817-n:
   definition:
   - hermaphroditic terrestrial and aquatic annelids having bristles borne singly along
@@ -37797,6 +38742,7 @@
   mero_member:
   - 01938638-n
   partOfSpeech: n
+  wikidata: Q5168736
 01938638-n:
   definition:
   - 'type genus of the Branchiobdellidae: a small worm that lives on the gills or
@@ -37808,6 +38754,7 @@
   - Branchiobdella
   - genus Branchiobdella
   partOfSpeech: n
+  wikidata: Q5160275
 01938860-n:
   definition:
   - marine annelid worms
@@ -37822,6 +38769,7 @@
   - 01939312-n
   - 01939656-n
   partOfSpeech: n
+  wikidata: Q18952
 01939032-n:
   definition:
   - chiefly marine annelids possessing both sexes and having paired appendages (parapodia)
@@ -37882,6 +38830,7 @@
   - Terebella
   - genus Terebella
   partOfSpeech: n
+  wikidata: Q3901901
 01940063-n:
   definition:
   - genus of soft-bodied polychete marine worms
@@ -37894,6 +38843,7 @@
   mero_member:
   - 01940220-n
   partOfSpeech: n
+  wikidata: Q3904449
 01940220-n:
   definition:
   - a segmented marine worm with bright red body; often used for bait
@@ -37916,6 +38866,7 @@
   - 01940550-n
   - 01940796-n
   partOfSpeech: n
+  wikidata: Q43012
 01940550-n:
   definition:
   - carnivorous or bloodsucking aquatic or terrestrial worms typically having a sucker
@@ -37941,6 +38892,7 @@
   - 01940953-n
   - 01941259-n
   partOfSpeech: n
+  wikidata: Q5166500
 01940953-n:
   definition:
   - type genus of the family Hirudinidae
@@ -37953,6 +38905,7 @@
   mero_member:
   - 01941095-n
   partOfSpeech: n
+  wikidata: Q15455059
 01941095-n:
   definition:
   - large European freshwater leech formerly used for bloodletting
@@ -38020,6 +38973,7 @@
   - 01958104-n
   - 01970756-n
   partOfSpeech: n
+  wikidata: Q25326
 01943377-n:
   definition:
   - invertebrate having a soft unsegmented body usually enclosed in a shell
@@ -38046,6 +39000,7 @@
   mero_member:
   - 01943864-n
   partOfSpeech: n
+  wikidata: Q238314
 01943864-n:
   definition:
   - burrowing marine mollusk
@@ -38106,6 +39061,7 @@
   - 01955453-n
   - 01956843-n
   partOfSpeech: n
+  wikidata: Q4867740
 01944818-n:
   definition:
   - a class of mollusks typically having a one-piece coiled shell and flattened muscular
@@ -38129,6 +39085,7 @@
   mero_member:
   - 01945365-n
   partOfSpeech: n
+  wikidata: Q3126001
 01945365-n:
   definition:
   - type genus of the family Haliotidae
@@ -38141,6 +39098,7 @@
   mero_member:
   - 01945510-n
   partOfSpeech: n
+  wikidata: Q190093
 01945510-n:
   definition:
   - any of various large edible marine gastropods of the genus Haliotis having an
@@ -38176,6 +39134,7 @@
   - 01946008-n
   - 01946395-n
   partOfSpeech: n
+  wikidata: Q732932
 01946008-n:
   definition:
   - scorpion shells of shallow tropical waters of the eastern hemisphere
@@ -38188,6 +39147,7 @@
   mero_member:
   - 01946182-n
   partOfSpeech: n
+  wikidata: Q2637458
 01946182-n:
   definition:
   - any of numerous tropical marine snails that as adults have the outer lip of the
@@ -38210,6 +39170,7 @@
   mero_member:
   - 01946540-n
   partOfSpeech: n
+  wikidata: Q858772
 01946540-n:
   definition:
   - any of various edible tropical marine gastropods of the genus Strombus having
@@ -38243,6 +39204,7 @@
   mero_member:
   - 01947258-n
   partOfSpeech: n
+  wikidata: Q1418257
 01947031-n:
   definition:
   - freshwater or marine or terrestrial gastropod mollusk usually having an external
@@ -38268,6 +39230,7 @@
   - 01947784-n
   - 01947981-n
   partOfSpeech: n
+  wikidata: Q1937315
 01947453-n:
   definition:
   - one of the chief edible snails
@@ -38392,6 +39355,7 @@
   - 01949271-n
   - 01949468-n
   partOfSpeech: n
+  wikidata: Q3170508
 01949271-n:
   definition:
   - a neritid gastropod having a short smooth or spirally ridged shell with thick
@@ -38424,6 +39388,7 @@
   mero_member:
   - 01949780-n
   partOfSpeech: n
+  wikidata: Q1607495
 01949780-n:
   definition:
   - ornately marked and brightly colored snails of brackish waters
@@ -38445,6 +39410,7 @@
   mero_member:
   - 01950037-n
   partOfSpeech: n
+  wikidata: Q24115
 01950037-n:
   definition:
   - large carnivorous marine gastropods of coastal waters and intertidal regions having
@@ -38469,6 +39435,7 @@
   mero_member:
   - 01950376-n
   partOfSpeech: n
+  wikidata: Q35083222
 01950376-n:
   definition:
   - tropical marine gastropods having beautifully colored spiral shells
@@ -38490,6 +39457,7 @@
   mero_member:
   - 01950638-n
   partOfSpeech: n
+  wikidata: Q1563463
 01950638-n:
   definition:
   - marine gastropods having smooth rounded shells that form short spires
@@ -38525,6 +39493,7 @@
   mero_member:
   - 01951087-n
   partOfSpeech: n
+  wikidata: Q83749
 01951087-n:
   definition:
   - edible marine gastropod
@@ -38572,6 +39541,7 @@
   mero_member:
   - 01951726-n
   partOfSpeech: n
+  wikidata: Q4882696
 01951726-n:
   definition:
   - marine limpet
@@ -38594,6 +39564,7 @@
   mero_member:
   - 01951971-n
   partOfSpeech: n
+  wikidata: Q1043930
 01951971-n:
   definition:
   - 'type genus of the family Fissurellidae: keyhole limpets'
@@ -38606,6 +39577,7 @@
   mero_member:
   - 01952140-n
   partOfSpeech: n
+  wikidata: Q3168678
 01952140-n:
   definition:
   - marine limpet having a conical shell with an opening at the apex
@@ -38629,6 +39601,7 @@
   mero_member:
   - 01952458-n
   partOfSpeech: n
+  wikidata: Q3076242
 01952458-n:
   definition:
   - 'type genus of the family Ancylidae: river limpet'
@@ -38682,6 +39655,7 @@
   - 01953593-n
   - 01954113-n
   partOfSpeech: n
+  wikidata: Q733595
 01953372-n:
   definition:
   - any of various marine gastropods of the suborder Nudibranchia having a shell-less
@@ -38707,6 +39681,7 @@
   mero_member:
   - 01953748-n
   partOfSpeech: n
+  wikidata: Q618732
 01953748-n:
   definition:
   - type genus of the family Aplysiidae
@@ -38721,6 +39696,7 @@
   mero_member:
   - 01953915-n
   partOfSpeech: n
+  wikidata: Q136564
 01953915-n:
   definition:
   - naked marine gastropod having a soft body with reduced internal shell and two
@@ -38744,6 +39720,7 @@
   mero_member:
   - 01954254-n
   partOfSpeech: n
+  wikidata: Q25094548
 01954254-n:
   definition:
   - a kind of sea slug
@@ -38778,6 +39755,7 @@
   mero_member:
   - 01954670-n
   partOfSpeech: n
+  wikidata: Q1033382
 01954670-n:
   definition:
   - marine gastropod mollusk having a very small thin shell
@@ -38814,6 +39792,7 @@
   mero_member:
   - 01955198-n
   partOfSpeech: n
+  wikidata: Q881848
 01955198-n:
   definition:
   - type genus of the Physidae; freshwater air-breathing snails
@@ -38825,6 +39804,7 @@
   mero_member:
   - 01955353-n
   partOfSpeech: n
+  wikidata: Q147452
 01955353-n:
   definition:
   - any member of the genus Physa
@@ -38847,6 +39827,7 @@
   mero_member:
   - 01955673-n
   partOfSpeech: n
+  wikidata: Q1187122
 01955673-n:
   definition:
   - family of marine gastropods comprising the cowries
@@ -38978,6 +39959,7 @@
   mero_member:
   - 01957603-n
   partOfSpeech: n
+  wikidata: Q188906
 01957603-n:
   definition:
   - a genus of Polyplacophora
@@ -38989,6 +39971,7 @@
   mero_member:
   - 01957725-n
   partOfSpeech: n
+  wikidata: Q2528273
 01957725-n:
   definition:
   - primitive elongated bilaterally symmetrical marine mollusk having a mantle covered
@@ -39107,6 +40090,7 @@
   - 01960232-n
   - 01961431-n
   partOfSpeech: n
+  wikidata: Q29876893
 01959716-n:
   definition:
   - soft-shell clams
@@ -39119,6 +40103,7 @@
   mero_member:
   - 01959843-n
   partOfSpeech: n
+  wikidata: Q682450
 01959843-n:
   definition:
   - type genus of the family Myacidae
@@ -39131,6 +40116,7 @@
   mero_member:
   - 01959976-n
   partOfSpeech: n
+  wikidata: Q3331302
 01959976-n:
   definition:
   - an edible clam with thin oval-shaped shell found in coastal regions of the United
@@ -39173,6 +40159,7 @@
   mero_member:
   - 01960679-n
   partOfSpeech: n
+  wikidata: Q1408724
 01960564-n:
   definition:
   - a genus of Veneridae
@@ -39183,6 +40170,7 @@
   - Mercenaria
   - genus Mercenaria
   partOfSpeech: n
+  wikidata: Q1408734
 01960679-n:
   definition:
   - an edible American clam; the heavy shells were used as money by some American
@@ -39244,6 +40232,7 @@
   mero_member:
   - 01961555-n
   partOfSpeech: n
+  wikidata: Q910699
 01961555-n:
   definition:
   - razor clams in the family Pharidae (Ensis)
@@ -39256,6 +40245,7 @@
   mero_member:
   - 01961670-n
   partOfSpeech: n
+  wikidata: Q2706031
 01961670-n:
   definition:
   - marine clam having a long narrow curved thin shell
@@ -39279,6 +40269,7 @@
   mero_member:
   - 01961974-n
   partOfSpeech: n
+  wikidata: Q2724253
 01961974-n:
   definition:
   - 'type genus of the family Tridacnidae: giant clams'
@@ -39291,6 +40282,7 @@
   mero_member:
   - 01962133-n
   partOfSpeech: n
+  wikidata: Q2387255
 01962133-n:
   definition:
   - a large clam inhabiting reefs in the southern Pacific and weighing up to 500 pounds
@@ -39314,6 +40306,7 @@
   mero_member:
   - 01962475-n
   partOfSpeech: n
+  wikidata: Q860002
 01962475-n:
   definition:
   - 'type genus of the family Cardiidae: cockles'
@@ -39326,6 +40319,7 @@
   mero_member:
   - 01962626-n
   partOfSpeech: n
+  wikidata: Q2777123
 01962626-n:
   definition:
   - common edible, burrowing European bivalve mollusk that has a strong, rounded shell
@@ -39397,6 +40391,7 @@
   - 01963700-n
   - 01963875-n
   partOfSpeech: n
+  wikidata: Q1996210
 01963700-n:
   definition:
   - small edible oyster typically from the southern shore of Long Island
@@ -39492,6 +40487,7 @@
   mero_member:
   - 01964991-n
   partOfSpeech: n
+  wikidata: Q540805
 01964991-n:
   definition:
   - 'type genus of the family Anomiidae: saddle oysters'
@@ -39504,6 +40500,7 @@
   mero_member:
   - 01965147-n
   partOfSpeech: n
+  wikidata: Q2852294
 01965147-n:
   definition:
   - thin-shelled bivalve having the right valve deeply notched
@@ -39526,6 +40523,7 @@
   mero_member:
   - 01965429-n
   partOfSpeech: n
+  wikidata: Q18590881
 01965429-n:
   definition:
   - marine bivalve common in Philippine coastal waters characterized by a large thin
@@ -39552,6 +40550,7 @@
   mero_member:
   - 01965777-n
   partOfSpeech: n
+  wikidata: Q632636
 01965777-n:
   definition:
   - 'type genus of the family Arcidae: ark shells and blood clams'
@@ -39565,6 +40564,7 @@
   - 01965958-n
   - 01966120-n
   partOfSpeech: n
+  wikidata: Q737991
 01965958-n:
   definition:
   - marine bivalve mollusk having a heavy toothed shell with a deep boat-like inner
@@ -39606,6 +40606,7 @@
   - 01966517-n
   - 01966690-n
   partOfSpeech: n
+  wikidata: Q386633
 01966517-n:
   definition:
   - 'type genus of the family Mytilidae: smooth-shelled marine mussels'
@@ -39618,6 +40619,7 @@
   mero_member:
   - 01966912-n
   partOfSpeech: n
+  wikidata: Q21132
 01966690-n:
   definition:
   - marine bivalve mollusk having a dark elongated shell; live attached to solid objects
@@ -39665,6 +40667,7 @@
   - 01967752-n
   - 01968045-n
   partOfSpeech: n
+  wikidata: Q1434366
 01967462-n:
   definition:
   - type genus of the family Unionidae
@@ -39677,6 +40680,7 @@
   mero_member:
   - 01967598-n
   partOfSpeech: n
+  wikidata: Q1434357
 01967598-n:
   definition:
   - the pearly lining of the dark shells is a source of mother-of-pearl
@@ -39698,6 +40702,7 @@
   mero_member:
   - 01967893-n
   partOfSpeech: n
+  wikidata: Q1768065
 01967893-n:
   definition:
   - mussel with thin fragile shells having only rudimentary hinge teeth
@@ -39719,6 +40724,7 @@
   mero_member:
   - 01968170-n
   partOfSpeech: n
+  wikidata: Q4998707
 01968170-n:
   definition:
   - inch long mollusk imported accidentally from Europe; clogs utility inlet pipes
@@ -39743,6 +40749,7 @@
   - 01968530-n
   - 01968845-n
   partOfSpeech: n
+  wikidata: Q1311395
 01968530-n:
   definition:
   - edible marine bivalve having a fluted fan-shaped shell that swim by expelling
@@ -39769,6 +40776,7 @@
   - 01969018-n
   - 01969227-n
   partOfSpeech: n
+  wikidata: Q2704723
 01969018-n:
   definition:
   - a small scallop inhabiting shallow waters and mud flats of the Atlantic coast
@@ -39809,6 +40817,7 @@
   - 01969735-n
   - 01970037-n
   partOfSpeech: n
+  wikidata: Q14524890
 01969602-n:
   definition:
   - type genus of the family Teredinidae
@@ -39820,6 +40829,7 @@
   mero_member:
   - 01969949-n
   partOfSpeech: n
+  wikidata: Q3467542
 01969735-n:
   definition:
   - wormlike marine bivalve that bores into wooden piers and ships by means of drill-like
@@ -39852,6 +40862,7 @@
   mero_member:
   - 01970158-n
   partOfSpeech: n
+  wikidata: Q2882662
 01970158-n:
   definition:
   - giant shipworm of the Pacific coast of North America
@@ -39887,6 +40898,7 @@
   mero_member:
   - 01970604-n
   partOfSpeech: n
+  wikidata: Q3014615
 01970604-n:
   definition:
   - marine bivalve that bores into rock or clay or wood by means of saw-like shells
@@ -39910,6 +40922,7 @@
   - 01971232-n
   - 01971744-n
   partOfSpeech: n
+  wikidata: Q128257
 01970956-n:
   definition:
   - marine mollusk characterized by well-developed head and eyes and sucker-bearing
@@ -39933,6 +40946,7 @@
   mero_member:
   - 01971373-n
   partOfSpeech: n
+  wikidata: Q223939
 01971373-n:
   definition:
   - type genus and sole recent representative of the family Nautilidae
@@ -39944,6 +40958,7 @@
   mero_member:
   - 01971538-n
   partOfSpeech: n
+  wikidata: Q1324463
 01971538-n:
   definition:
   - cephalopod of the Indian and Pacific oceans having a spiral shell with pale pearly
@@ -40032,6 +41047,7 @@
   mero_member:
   - 01972805-n
   partOfSpeech: n
+  wikidata: Q611843
 01972805-n:
   definition:
   - bottom-living cephalopod having a soft oval body with eight long tentacles
@@ -40056,6 +41072,7 @@
   mero_member:
   - 01973143-n
   partOfSpeech: n
+  wikidata: Q2148313
 01973143-n:
   definition:
   - 'type genus of the family Argonautidae: paper nautilus'
@@ -40068,6 +41085,7 @@
   mero_member:
   - 01973308-n
   partOfSpeech: n
+  wikidata: Q2050688
 01973308-n:
   definition:
   - cephalopod mollusk of warm seas whose females have delicate papery spiral shells
@@ -40129,6 +41147,7 @@
   mero_member:
   - 01974261-n
   partOfSpeech: n
+  wikidata: Q2706095
 01974261-n:
   definition:
   - somewhat flattened cylindrical squid
@@ -40150,6 +41169,7 @@
   mero_member:
   - 01974491-n
   partOfSpeech: n
+  wikidata: Q18519392
 01974491-n:
   definition:
   - extremely active cylindrical squid with short strong arms and large rhombic terminal
@@ -40171,6 +41191,7 @@
   mero_member:
   - 01974772-n
   partOfSpeech: n
+  wikidata: Q204646
 01974772-n:
   definition:
   - largest mollusk known about but never seen (to 60 feet long)
@@ -40206,6 +41227,7 @@
   mero_member:
   - 01975182-n
   partOfSpeech: n
+  wikidata: Q286026
 01975182-n:
   definition:
   - ten-armed oval-bodied cephalopod with narrow fins as long as the body and a large
@@ -40230,6 +41252,7 @@
   mero_member:
   - 01975588-n
   partOfSpeech: n
+  wikidata: Q17302119
 01975588-n:
   definition:
   - genus of small cephalopods with many-chambered spiral shells resembling those
@@ -40242,6 +41265,7 @@
   mero_member:
   - 01975789-n
   partOfSpeech: n
+  wikidata: Q17302116
 01975789-n:
   definition:
   - a small tropical cephalopod of the genus Spirula having prominent eyes and short
@@ -40265,6 +41289,7 @@
   mero_member:
   - 01976207-n
   partOfSpeech: n
+  wikidata: Q14900832
 01976207-n:
   definition:
   - family of extinct Mesozoic cephalopods
@@ -40277,6 +41302,7 @@
   mero_member:
   - 01976364-n
   partOfSpeech: n
+  wikidata: Q21224730
 01976364-n:
   definition:
   - a conical calcareous fossil tapering to a point at one end and with a conical
@@ -40331,6 +41357,7 @@
   - 02000352-n
   - 02000673-n
   partOfSpeech: n
+  wikidata: Q25364
 01977414-n:
   definition:
   - any mainly aquatic arthropod usually having a segmented body and chitinous exoskeleton
@@ -40400,6 +41427,7 @@
   - 01988588-n
   - 01989008-n
   partOfSpeech: n
+  wikidata: Q4610
 01978787-n:
   definition:
   - crustaceans characteristically having five pairs of locomotor appendages each
@@ -40463,6 +41491,7 @@
   mero_member:
   - 01980126-n
   partOfSpeech: n
+  wikidata: Q6497159
 01980126-n:
   definition:
   - large edible crab of the southern coast of the United States (particularly Florida)
@@ -40502,6 +41531,7 @@
   - 01981096-n
   - 01981228-n
   partOfSpeech: n
+  wikidata: Q428243
 01980651-n:
   definition:
   - edible crab that has not recently molted and so has a hard shell
@@ -40591,6 +41621,7 @@
   mero_member:
   - 01981910-n
   partOfSpeech: n
+  wikidata: Q3399586
 01981910-n:
   definition:
   - crab of the English coasts
@@ -40664,6 +41695,7 @@
   mero_member:
   - 01982807-n
   partOfSpeech: n
+  wikidata: Q1329937
 01982807-n:
   definition:
   - burrowing crab of American coastal regions having one claw much enlarged in the
@@ -40700,6 +41732,7 @@
   - 01983296-n
   - 01983471-n
   partOfSpeech: n
+  wikidata: Q2791630
 01983296-n:
   definition:
   - tiny soft-bodied crab living commensally in the mantles of certain bivalve mollusks
@@ -40732,6 +41765,7 @@
   mero_member:
   - 01983778-n
   partOfSpeech: n
+  wikidata: Q1861297
 01983778-n:
   definition:
   - a genus of Lithodidae
@@ -40744,6 +41778,7 @@
   mero_member:
   - 01983917-n
   partOfSpeech: n
+  wikidata: Q3363478
 01983917-n:
   definition:
   - large edible crab of northern Pacific waters especially along the coasts of Alaska
@@ -40774,6 +41809,7 @@
   - 01984525-n
   - 01984852-n
   partOfSpeech: n
+  wikidata: Q943664
 01984343-n:
   definition:
   - any of numerous crabs with very long legs and small triangular bodies
@@ -40797,6 +41833,7 @@
   mero_member:
   - 01984709-n
   partOfSpeech: n
+  wikidata: Q2224398
 01984709-n:
   definition:
   - a large spider crab of Europe
@@ -40871,6 +41908,7 @@
   - 01985689-n
   - 01985918-n
   partOfSpeech: n
+  wikidata: Q33150195
 01985689-n:
   definition:
   - large edible marine crustaceans having large pincers on the first pair of legs
@@ -40896,6 +41934,7 @@
   - 01986315-n
   - 01986470-n
   partOfSpeech: n
+  wikidata: Q11827352
 01986122-n:
   definition:
   - lobster of Atlantic coast of America
@@ -40944,6 +41983,7 @@
   mero_member:
   - 01986772-n
   partOfSpeech: n
+  wikidata: Q33138226
 01986772-n:
   definition:
   - a genus of Nephropsidae
@@ -40954,6 +41994,7 @@
   - Nephrops
   - genus Nephrops
   partOfSpeech: n
+  wikidata: Q10336345
 01986886-n:
   definition:
   - edible European lobster resembling the American lobster but slenderer
@@ -40991,6 +42032,7 @@
   mero_member:
   - 01987336-n
   partOfSpeech: n
+  wikidata: Q2736968
 01987336-n:
   definition:
   - large edible marine crustacean having a spiny carapace but lacking the large pincers
@@ -41048,6 +42090,7 @@
   mero_member:
   - 01988134-n
   partOfSpeech: n
+  wikidata: Q1942450
 01988134-n:
   definition:
   - small crayfish of Europe and Asia and western North America
@@ -41072,6 +42115,7 @@
   mero_member:
   - 01988438-n
   partOfSpeech: n
+  wikidata: Q309206
 01988438-n:
   definition:
   - common large crayfishes of eastern North America
@@ -41108,6 +42152,7 @@
   mero_member:
   - 01988855-n
   partOfSpeech: n
+  wikidata: Q2480027
 01988855-n:
   definition:
   - small soft-bodied marine crustaceans living in cast-off shells of gastropods
@@ -41156,6 +42201,7 @@
   - Crangon
   - genus Crangon
   partOfSpeech: n
+  wikidata: Q148143
 01989447-n:
   definition:
   - small slender-bodied chiefly marine decapod crustaceans with a long tail and single
@@ -41191,6 +42237,7 @@
   mero_member:
   - 01989994-n
   partOfSpeech: n
+  wikidata: Q1404181
 01989994-n:
   definition:
   - type genus of the family Palaemonidae; widely distributed genus
@@ -41204,6 +42251,7 @@
   - 01990186-n
   - 01990368-n
   partOfSpeech: n
+  wikidata: Q1269791
 01990186-n:
   definition:
   - shrimp-like decapod crustacean having two pairs of pincers; most are edible
@@ -41238,6 +42286,7 @@
   mero_member:
   - 01990705-n
   partOfSpeech: n
+  wikidata: Q683918
 01990705-n:
   definition:
   - type genus of the family Peneidae
@@ -41250,6 +42299,7 @@
   mero_member:
   - 01990844-n
   partOfSpeech: n
+  wikidata: Q3011709
 01990844-n:
   definition:
   - edible tropical and warm-water prawn
@@ -41283,6 +42333,7 @@
   - 01991342-n
   - 01991510-n
   partOfSpeech: n
+  wikidata: Q29498
 01991342-n:
   definition:
   - shrimp-like planktonic crustaceans; major source of food for e.g. baleen whales
@@ -41313,6 +42364,7 @@
   mero_member:
   - 01991738-n
   partOfSpeech: n
+  wikidata: Q1208947
 01991738-n:
   definition:
   - small shrimp-like crustaceans
@@ -41326,6 +42378,7 @@
   - 01991895-n
   - 01992031-n
   partOfSpeech: n
+  wikidata: Q3859197
 01991895-n:
   definition:
   - type genus of the family Mysidae
@@ -41338,6 +42391,7 @@
   mero_member:
   - 01992157-n
   partOfSpeech: n
+  wikidata: Q601140
 01992031-n:
   definition:
   - a genus of Mysidae
@@ -41350,6 +42404,7 @@
   mero_member:
   - 01992157-n
   partOfSpeech: n
+  wikidata: Q3860707
 01992157-n:
   definition:
   - shrimp-like crustaceans whose females carry eggs and young in a pouch between
@@ -41374,6 +42429,7 @@
   - 01992648-n
   - 01992827-n
   partOfSpeech: n
+  wikidata: Q334855
 01992510-n:
   definition:
   - a kind of crustacean
@@ -41406,6 +42462,7 @@
   mero_member:
   - 01993024-n
   partOfSpeech: n
+  wikidata: Q665408
 01993024-n:
   definition:
   - type genus of the family Squillidae
@@ -41417,6 +42474,7 @@
   mero_member:
   - 01993157-n
   partOfSpeech: n
+  wikidata: Q3859898
 01993157-n:
   definition:
   - a kind of mantis shrimp
@@ -41442,6 +42500,7 @@
   - 01994330-n
   - 01994636-n
   partOfSpeech: n
+  wikidata: Q206338
 01993441-n:
   definition:
   - any of various small terrestrial or aquatic crustaceans with seven pairs of legs
@@ -41478,6 +42537,7 @@
   mero_member:
   - 01994021-n
   partOfSpeech: n
+  wikidata: Q1315837
 01994021-n:
   definition:
   - type genus of the Armadillidiidae
@@ -41513,6 +42573,7 @@
   mero_member:
   - 01994462-n
   partOfSpeech: n
+  wikidata: Q3012315
 01994462-n:
   definition:
   - type genus of the Oniscidae; woodlice that cannot roll into a ball
@@ -41538,6 +42599,7 @@
   mero_member:
   - 01994767-n
   partOfSpeech: n
+  wikidata: Q3012099
 01994767-n:
   definition:
   - Old World genus of isopod crustaceans
@@ -41550,6 +42612,7 @@
   mero_member:
   - 01994916-n
   partOfSpeech: n
+  wikidata: Q660684
 01994916-n:
   definition:
   - terrestrial isopod having an oval segmented body (a shape like a sow)
@@ -41585,6 +42648,7 @@
   - 01996054-n
   - 01996368-n
   partOfSpeech: n
+  wikidata: Q193418
 01995427-n:
   definition:
   - a kind of malacostracan crustacean
@@ -41606,6 +42670,7 @@
   mero_member:
   - 01995719-n
   partOfSpeech: n
+  wikidata: Q21589779
 01995719-n:
   definition:
   - type genus of the family Orchestiidae
@@ -41618,6 +42683,7 @@
   mero_member:
   - 01995868-n
   partOfSpeech: n
+  wikidata: Q3355241
 01995868-n:
   definition:
   - small amphipod crustaceans that hop like fleas; common on ocean beaches
@@ -41642,6 +42708,7 @@
   mero_member:
   - 01996179-n
   partOfSpeech: n
+  wikidata: Q3932187
 01996179-n:
   definition:
   - small amphipod crustacean having a grotesque form suggestive of the praying mantis;
@@ -41664,6 +42731,7 @@
   mero_member:
   - 01996484-n
   partOfSpeech: n
+  wikidata: Q3933445
 01996484-n:
   definition:
   - amphipod crustacean parasitic on cetaceans
@@ -41724,6 +42792,7 @@
   mero_member:
   - 01997564-n
   partOfSpeech: n
+  wikidata: Q269354
 01997564-n:
   definition:
   - minute freshwater crustacean having a round body enclosed in a transparent shell;
@@ -41747,6 +42816,7 @@
   mero_member:
   - 01997977-n
   partOfSpeech: n
+  wikidata: Q853383
 01997977-n:
   definition:
   - fairy shrimp; brine shrimp
@@ -41762,6 +42832,7 @@
   - 01998168-n
   - 01998340-n
   partOfSpeech: n
+  wikidata: Q1145843
 01998168-n:
   definition:
   - small freshwater branchiopod having a transparent body with many appendages; swims
@@ -41794,6 +42865,7 @@
   mero_member:
   - 01998629-n
   partOfSpeech: n
+  wikidata: Q3344541
 01998629-n:
   definition:
   - a family of Notostraca
@@ -41804,6 +42876,7 @@
   - Triopsidae
   - family Triopsidae
   partOfSpeech: n
+  wikidata: Q4569752
 01998745-n:
   definition:
   - 'type genus of the family Triopsidae: small crustaceans with a small third median
@@ -41817,6 +42890,7 @@
   mero_member:
   - 01998934-n
   partOfSpeech: n
+  wikidata: Q114364
 01998934-n:
   definition:
   - a kind of branchiopod crustacean
@@ -41872,6 +42946,7 @@
   mero_member:
   - 01999773-n
   partOfSpeech: n
+  wikidata: Q1421606
 01999773-n:
   definition:
   - minute free-swimming freshwater copepod having a large median eye and pear-shaped
@@ -41896,6 +42971,7 @@
   mero_member:
   - 02000259-n
   partOfSpeech: n
+  wikidata: Q841641
 02000259-n:
   definition:
   - a kind of copepod
@@ -41967,6 +43043,7 @@
   mero_member:
   - 02001253-n
   partOfSpeech: n
+  wikidata: Q266221
 02001253-n:
   definition:
   - type genus of the family Balanidae
@@ -41979,6 +43056,7 @@
   mero_member:
   - 02001395-n
   partOfSpeech: n
+  wikidata: Q2336729
 02001395-n:
   definition:
   - barnacle that attaches to rocks especially in intertidal zones
@@ -42002,6 +43080,7 @@
   mero_member:
   - 02001702-n
   partOfSpeech: n
+  wikidata: Q1812499
 02001702-n:
   definition:
   - type genus of the family Lepadidae
@@ -42042,6 +43121,7 @@
   - 02002690-n
   - 02003272-n
   partOfSpeech: n
+  wikidata: Q18596606
 02002421-n:
   definition:
   - any of numerous velvety-skinned wormlike carnivorous animals common in tropical
@@ -42077,6 +43157,7 @@
   members:
   - genus Peripatus
   partOfSpeech: n
+  wikidata: Q2418292
 02003008-n:
   definition:
   - a genus of Peripatidae
@@ -42089,6 +43170,7 @@
   mero_member:
   - 02003156-n
   partOfSpeech: n
+  wikidata: Q15149876
 02003156-n:
   definition:
   - a kind of onychophoran
@@ -42111,6 +43193,7 @@
   mero_member:
   - 02003418-n
   partOfSpeech: n
+  wikidata: Q140169
 02003418-n:
   definition:
   - type genus of Peripatopsidae; onychophorans of chiefly Asiatic and African tropical
@@ -42122,6 +43205,7 @@
   - Peripatopsis
   - genus Peripatopsis
   partOfSpeech: n
+  wikidata: Q2352640
 02003608-n:
   definition:
   - any of many long-legged birds that wade in water in search of food
@@ -42151,6 +43235,7 @@
   - 02010076-n
   - 02010375-n
   partOfSpeech: n
+  wikidata: Q21716
 02004475-n:
   definition:
   - storks
@@ -42170,6 +43255,7 @@
   - 02006997-n
   - 02007315-n
   partOfSpeech: n
+  wikidata: Q28507
 02004729-n:
   definition:
   - large mostly Old World wading birds typically having white-and-black plumage
@@ -42192,6 +43278,7 @@
   - 02005210-n
   - 02005378-n
   partOfSpeech: n
+  wikidata: Q6471715
 02005210-n:
   definition:
   - the common stork of Europe; white with black wing feathers and a red bill
@@ -42225,6 +43312,7 @@
   - 02005691-n
   - 02005858-n
   partOfSpeech: n
+  wikidata: Q577346
 02005691-n:
   definition:
   - large Indian stork with a military gait
@@ -42265,6 +43353,7 @@
   mero_member:
   - 02006231-n
   partOfSpeech: n
+  wikidata: Q728881
 02006231-n:
   definition:
   - stork with a grooved bill whose upper and lower parts touch only at the base and
@@ -42286,6 +43375,7 @@
   mero_member:
   - 02006493-n
   partOfSpeech: n
+  wikidata: Q3157022
 02006493-n:
   definition:
   - large white stork of warm regions of the world especially America
@@ -42309,6 +43399,7 @@
   mero_member:
   - 02006785-n
   partOfSpeech: n
+  wikidata: Q990042
 02006785-n:
   definition:
   - large black-and-white stork of tropical Africa; its red bill has a black band
@@ -42333,6 +43424,7 @@
   mero_member:
   - 02007146-n
   partOfSpeech: n
+  wikidata: Q18520791
 02007146-n:
   definition:
   - large mostly white Australian stork
@@ -42385,6 +43477,7 @@
   mero_member:
   - 02007892-n
   partOfSpeech: n
+  wikidata: Q13107952
 02007892-n:
   definition:
   - 'type genus of the Balaenicipitidae: shoebills'
@@ -42397,6 +43490,7 @@
   mero_member:
   - 02008053-n
   partOfSpeech: n
+  wikidata: Q18000303
 02008053-n:
   definition:
   - large stork-like bird of the valley of the White Nile with a broad bill suggesting
@@ -42424,6 +43518,7 @@
   - 02008616-n
   - 02008865-n
   partOfSpeech: n
+  wikidata: Q162085
 02008444-n:
   definition:
   - wading birds of warm regions having long slender down-curved bills
@@ -42444,6 +43539,7 @@
   mero_member:
   - 02008717-n
   partOfSpeech: n
+  wikidata: Q18515513
 02008717-n:
   definition:
   - any of several Old World birds of the genus Ibis
@@ -42467,6 +43563,7 @@
   mero_member:
   - 02009018-n
   partOfSpeech: n
+  wikidata: Q917005
 02009018-n:
   definition:
   - African ibis venerated by ancient Egyptians
@@ -42490,6 +43587,7 @@
   - 02009310-n
   - 02009481-n
   partOfSpeech: n
+  wikidata: Q127162954
 02009310-n:
   definition:
   - wading birds having a long flat bill with a tip like a spoon
@@ -42512,6 +43610,7 @@
   - 02009639-n
   - 02009815-n
   partOfSpeech: n
+  wikidata: Q208488
 02009639-n:
   definition:
   - pure white crested spoonbill of southern Eurasia and northeastern Africa
@@ -42534,6 +43633,7 @@
   mero_member:
   - 02009938-n
   partOfSpeech: n
+  wikidata: Q107272848
 02009938-n:
   definition:
   - tropical rose-colored New World spoonbill
@@ -42611,6 +43711,7 @@
   - 02011151-n
   - 02011297-n
   partOfSpeech: n
+  wikidata: Q310853
 02011151-n:
   definition:
   - large American heron having bluish-grey plumage
@@ -42656,6 +43757,7 @@
   - 02012404-n
   - 02012566-n
   partOfSpeech: n
+  wikidata: Q312272
 02011883-n:
   definition:
   - small bluish-grey heron of the western hemisphere
@@ -42701,6 +43803,7 @@
   mero_member:
   - 02012404-n
   partOfSpeech: n
+  wikidata: Q21446665
 02012404-n:
   definition:
   - widely distributed Old World white egret
@@ -42735,6 +43838,7 @@
   mero_member:
   - 02012926-n
   partOfSpeech: n
+  wikidata: Q947895
 02012926-n:
   definition:
   - small white egret widely distributed in warm regions often found around grazing
@@ -42769,6 +43873,7 @@
   mero_member:
   - 02013382-n
   partOfSpeech: n
+  wikidata: Q133003
 02013382-n:
   definition:
   - night heron of both Old and New Worlds
@@ -42815,6 +43920,7 @@
   mero_member:
   - 02013935-n
   partOfSpeech: n
+  wikidata: Q10749386
 02013935-n:
   definition:
   - tropical American heron related to night herons
@@ -42850,6 +43956,7 @@
   - 02014459-n
   - 02014597-n
   partOfSpeech: n
+  wikidata: Q739050
 02014459-n:
   definition:
   - a kind of bittern, slightly smaller than the European bitter (Botaurus lentiginosus)
@@ -42884,6 +43991,7 @@
   mero_member:
   - 02014839-n
   partOfSpeech: n
+  wikidata: Q244078
 02014839-n:
   definition:
   - small American bittern
@@ -42916,6 +44024,7 @@
   - 02022220-n
   - 02023431-n
   partOfSpeech: n
+  wikidata: Q25557
 02015369-n:
   definition:
   - cranes
@@ -42929,6 +44038,7 @@
   - 02015503-n
   - 02015688-n
   partOfSpeech: n
+  wikidata: Q25365
 02015503-n:
   definition:
   - large long-necked wading bird of marshes and plains in many parts of the world
@@ -42950,6 +44060,7 @@
   mero_member:
   - 02015831-n
   partOfSpeech: n
+  wikidata: Q47549
 02015831-n:
   definition:
   - rare North American crane having black-and-white plumage and a trumpeting call
@@ -42972,6 +44083,7 @@
   - Aramus
   - genus Aramus
   partOfSpeech: n
+  wikidata: Q12785142
 02016221-n:
   definition:
   - wading bird of South America and Central America
@@ -43007,6 +44119,7 @@
   - 02016715-n
   - 02017060-n
   partOfSpeech: n
+  wikidata: Q754030
 02016715-n:
   definition:
   - the type genus of the Cariamidae comprising only the crested cariama
@@ -43019,6 +44132,7 @@
   mero_member:
   - 02016891-n
   partOfSpeech: n
+  wikidata: Q2261506
 02016891-n:
   definition:
   - Brazilian Cariama; sole representative of the genus Cariama
@@ -43041,6 +44155,7 @@
   mero_member:
   - 02017178-n
   partOfSpeech: n
+  wikidata: Q10748080
 02017178-n:
   definition:
   - Argentinian Cariama
@@ -43095,6 +44210,7 @@
   mero_member:
   - 02018011-n
   partOfSpeech: n
+  wikidata: Q147880
 02018011-n:
   definition:
   - flightless New Zealand rail of thievish disposition having short wings each with
@@ -43128,6 +44244,7 @@
   mero_member:
   - 02018451-n
   partOfSpeech: n
+  wikidata: Q289873
 02018451-n:
   definition:
   - common Eurasian rail that frequents grain fields
@@ -43151,6 +44268,7 @@
   mero_member:
   - 02018720-n
   partOfSpeech: n
+  wikidata: Q835525
 02018720-n:
   definition:
   - Eurasian rail of swamps and marshes
@@ -43175,6 +44293,7 @@
   - 02019313-n
   - 02019470-n
   partOfSpeech: n
+  wikidata: Q853653
 02019012-n:
   definition:
   - any of various small aquatic birds of the genus Gallinula distinguished from rails
@@ -43227,6 +44346,7 @@
   - Porphyrio
   - genus Porphyrio
   partOfSpeech: n
+  wikidata: Q1137291
 02019867-n:
   definition:
   - purple gallinule of southern Europe
@@ -43249,6 +44369,7 @@
   mero_member:
   - 02020129-n
   partOfSpeech: n
+  wikidata: Q21446588
 02020129-n:
   definition:
   - American purple gallinule
@@ -43270,6 +44391,7 @@
   mero_member:
   - 02020379-n
   partOfSpeech: n
+  wikidata: Q21445741
 02020379-n:
   definition:
   - flightless New Zealand birds similar to gallinules
@@ -43295,6 +44417,7 @@
   - 02020861-n
   - 02021022-n
   partOfSpeech: n
+  wikidata: Q637533
 02020681-n:
   definition:
   - slate-black slow-flying birds somewhat resembling ducks
@@ -43352,6 +44475,7 @@
   - 02021698-n
   - 02021962-n
   partOfSpeech: n
+  wikidata: Q21755
 02021449-n:
   definition:
   - large heavy-bodied chiefly terrestrial game bird capable of powerful swift flight;
@@ -43374,6 +44498,7 @@
   mero_member:
   - 02021844-n
   partOfSpeech: n
+  wikidata: Q4288490
 02021844-n:
   definition:
   - largest European land bird
@@ -43396,6 +44521,7 @@
   mero_member:
   - 02022092-n
   partOfSpeech: n
+  wikidata: Q2194882
 02022092-n:
   definition:
   - popular Australian game bird
@@ -43419,6 +44545,7 @@
   - 02022416-n
   - 02023104-n
   partOfSpeech: n
+  wikidata: Q205320
 02022416-n:
   definition:
   - 'type genus of the Turnicidae: button quail'
@@ -43432,6 +44559,7 @@
   - 02022583-n
   - 02022999-n
   partOfSpeech: n
+  wikidata: Q1608770
 02022583-n:
   definition:
   - small quail-like terrestrial bird of southern Eurasia and northern Africa that
@@ -43476,6 +44604,7 @@
   mero_member:
   - 02023232-n
   partOfSpeech: n
+  wikidata: Q10804436
 02023232-n:
   definition:
   - small Australian bird related to the button quail; classified as wading bird but
@@ -43512,6 +44641,7 @@
   mero_member:
   - 02023704-n
   partOfSpeech: n
+  wikidata: Q10809431
 02023704-n:
   definition:
   - large gregarious crane-like bird of the forests of South America having glossy
@@ -43622,6 +44752,7 @@
   - 02027290-n
   - 02027577-n
   partOfSpeech: n
+  wikidata: Q28449
 02025995-n:
   definition:
   - any of numerous chiefly shorebirds of relatively compact build having straight
@@ -43695,6 +44826,7 @@
   mero_member:
   - 02027133-n
   partOfSpeech: n
+  wikidata: Q2359014
 02027133-n:
   definition:
   - plovers of Europe and America having the backs marked with golden-yellow spots
@@ -43716,6 +44848,7 @@
   mero_member:
   - 02027417-n
   partOfSpeech: n
+  wikidata: Q13426919
 02027417-n:
   definition:
   - large crested Old World plover having wattles and spurs
@@ -43740,6 +44873,7 @@
   mero_member:
   - 02027697-n
   partOfSpeech: n
+  wikidata: Q4865776
 02027697-n:
   definition:
   - migratory shorebirds of the plover family that turn over stones in searching for
@@ -43823,6 +44957,7 @@
   mero_member:
   - 02029283-n
   partOfSpeech: n
+  wikidata: Q10734553
 02029283-n:
   definition:
   - sandpiper-like shorebird of Pacific coasts of North America and South America
@@ -43850,6 +44985,7 @@
   - 02029602-n
   - 02029729-n
   partOfSpeech: n
+  wikidata: Q310859
 02029602-n:
   definition:
   - a variety of sandpiper
@@ -43884,6 +45020,7 @@
   - 02030011-n
   - 02030146-n
   partOfSpeech: n
+  wikidata: Q41153518
 02030011-n:
   definition:
   - smallest American sandpiper
@@ -43922,6 +45059,7 @@
   - 02030689-n
   - 02030829-n
   partOfSpeech: n
+  wikidata: Q41972
 02030551-n:
   definition:
   - large European sandpiper with greenish legs
@@ -44033,6 +45171,7 @@
   mero_member:
   - 02032032-n
   partOfSpeech: n
+  wikidata: Q107272785
 02032032-n:
   definition:
   - small sandpiper that breeds in the Arctic and migrates southward along sandy coasts
@@ -44056,6 +45195,7 @@
   mero_member:
   - 02032360-n
   partOfSpeech: n
+  wikidata: Q2789944
 02032360-n:
   definition:
   - large plover-like sandpiper of North American fields and uplands
@@ -44080,6 +45220,7 @@
   mero_member:
   - 02032689-n
   partOfSpeech: n
+  wikidata: Q15101016
 02032689-n:
   definition:
   - common Eurasian sandpiper; the male has an erectile neck ruff in breeding season
@@ -44121,6 +45262,7 @@
   mero_member:
   - 02033222-n
   partOfSpeech: n
+  wikidata: Q2312123
 02033222-n:
   definition:
   - tattler of Pacific coastal regions
@@ -44143,6 +45285,7 @@
   mero_member:
   - 02033491-n
   partOfSpeech: n
+  wikidata: Q25958002
 02033491-n:
   definition:
   - large North American shorebird of eastern and Gulf Coasts
@@ -44174,6 +45317,7 @@
   mero_member:
   - 02033952-n
   partOfSpeech: n
+  wikidata: Q642855
 02033952-n:
   definition:
   - short-legged long-billed migratory Old World woodcock
@@ -44224,6 +45368,7 @@
   - 02035009-n
   - 02035134-n
   partOfSpeech: n
+  wikidata: Q786045
 02034588-n:
   definition:
   - Old or New World straight-billed game bird of the sandpiper family; of marshy
@@ -44279,6 +45424,7 @@
   mero_member:
   - 02035423-n
   partOfSpeech: n
+  wikidata: Q10787358
 02035423-n:
   definition:
   - a small short-billed Old World snipe
@@ -44302,6 +45448,7 @@
   mero_member:
   - 02035695-n
   partOfSpeech: n
+  wikidata: Q838747
 02035695-n:
   definition:
   - shorebird of the sandpiper family that resembles a snipe
@@ -44344,6 +45491,7 @@
   mero_member:
   - 02036215-n
   partOfSpeech: n
+  wikidata: Q215166
 02036215-n:
   definition:
   - large migratory shorebirds of the sandpiper family; closely related to woodcocks
@@ -44387,6 +45535,7 @@
   mero_member:
   - 02036783-n
   partOfSpeech: n
+  wikidata: Q585636
 02036783-n:
   definition:
   - large wading bird that resembles a curlew; has a long slightly upturned bill
@@ -44423,6 +45572,7 @@
   - 02038056-n
   - 02038310-n
   partOfSpeech: n
+  wikidata: Q316342
 02037315-n:
   definition:
   - long-legged three-toed black-and-white wading bird of inland ponds and marshes
@@ -44495,6 +45645,7 @@
   - 02038707-n
   - 02038882-n
   partOfSpeech: n
+  wikidata: Q10748948
 02038707-n:
   definition:
   - long-legged three-toed wading bird of brackish marshes of Australia
@@ -44528,6 +45679,7 @@
   mero_member:
   - 02039202-n
   partOfSpeech: n
+  wikidata: Q27042
 02039202-n:
   definition:
   - 'type genus of the Recurvirostridae: avocets'
@@ -44540,6 +45692,7 @@
   mero_member:
   - 02039365-n
   partOfSpeech: n
+  wikidata: Q286072
 02039365-n:
   definition:
   - long-legged web-footed black-and-white shorebird with slender upward-curving bill
@@ -44559,6 +45712,7 @@
   - Haematopodidae
   - family Haematopodidae
   partOfSpeech: n
+  wikidata: Q12845592
 02039636-n:
   definition:
   - the genus of oystercatchers (Haematopus)
@@ -44571,6 +45725,7 @@
   mero_member:
   - 02039764-n
   partOfSpeech: n
+  wikidata: Q27515
 02039764-n:
   definition:
   - black-and-white shorebird with stout legs and bill; feed on oysters etc.
@@ -44622,6 +45777,7 @@
   - 02040795-n
   - 02041120-n
   partOfSpeech: n
+  wikidata: Q253776
 02040523-n:
   definition:
   - phalarope of northern oceans and lakes
@@ -44670,6 +45826,7 @@
   - 02042031-n
   - 02042314-n
   partOfSpeech: n
+  wikidata: Q217272
 02041491-n:
   definition:
   - 'type genus of the Glareolidae: the pratincoles'
@@ -44739,6 +45896,7 @@
   mero_member:
   - 02042434-n
   partOfSpeech: n
+  wikidata: Q10807623
 02042434-n:
   definition:
   - African courser that feeds on insect parasites on crocodiles
@@ -44761,6 +45919,7 @@
   mero_member:
   - 02042767-n
   partOfSpeech: n
+  wikidata: Q145854
 02042767-n:
   definition:
   - 'type genus of the Burhinidae: stone curlews'
@@ -44773,6 +45932,7 @@
   mero_member:
   - 02042920-n
   partOfSpeech: n
+  wikidata: Q220598
 02042920-n:
   definition:
   - large-headed large-eyed crepuscular or nocturnal shorebird of the Old World and
@@ -44860,6 +46020,7 @@
   - 02044700-n
   - 02044834-n
   partOfSpeech: n
+  wikidata: Q1887740
 02044332-n:
   definition:
   - the common gull of Eurasia and northeastern North America
@@ -44919,6 +46080,7 @@
   mero_member:
   - 02045126-n
   partOfSpeech: n
+  wikidata: Q10803699
 02045126-n:
   definition:
   - white Arctic gull; migrates as far south as England and New Brunswick
@@ -44941,6 +46103,7 @@
   mero_member:
   - 02045413-n
   partOfSpeech: n
+  wikidata: Q310848
 02045413-n:
   definition:
   - small pearl-grey gull of northern regions; nests on cliffs and has a rudimentary
@@ -44985,6 +46148,7 @@
   mero_member:
   - 02045987-n
   partOfSpeech: n
+  wikidata: Q76366
 02045987-n:
   definition:
   - common tern of Eurasia and America having white black and grey plumage
@@ -45007,6 +46171,7 @@
   mero_member:
   - 02046313-n
   partOfSpeech: n
+  wikidata: Q17190971
 02046313-n:
   definition:
   - 'type genus of the Rynchopidae: skimmers'
@@ -45019,6 +46184,7 @@
   mero_member:
   - 02046462-n
   partOfSpeech: n
+  wikidata: Q212941
 02046462-n:
   definition:
   - gull-like seabird that flies along the surface of the water with an elongated
@@ -45065,6 +46231,7 @@
   mero_member:
   - 02047171-n
   partOfSpeech: n
+  wikidata: Q1053111
 02047171-n:
   definition:
   - a variety of jaeger
@@ -45088,6 +46255,7 @@
   mero_member:
   - 02047432-n
   partOfSpeech: n
+  wikidata: Q28125230
 02047432-n:
   definition:
   - gull-like jaeger of northern seas
@@ -45130,6 +46298,7 @@
   - 02050489-n
   - 02050896-n
   partOfSpeech: n
+  wikidata: Q28294
 02048023-n:
   definition:
   - black-and-white short-necked web-footed diving bird of northern seas
@@ -45160,6 +46329,7 @@
   mero_member:
   - 02048518-n
   partOfSpeech: n
+  wikidata: Q3608921
 02048518-n:
   definition:
   - black-and-white northern Atlantic auk having a compressed sharp-edged bill
@@ -45183,6 +46353,7 @@
   mero_member:
   - 02048825-n
   partOfSpeech: n
+  wikidata: Q61883572
 02048825-n:
   definition:
   - small short-billed auk abundant in Arctic regions
@@ -45230,6 +46401,7 @@
   mero_member:
   - 02049413-n
   partOfSpeech: n
+  wikidata: Q132913
 02049413-n:
   definition:
   - small black or brown speckled auks of northern seas
@@ -45272,6 +46444,7 @@
   mero_member:
   - 02049914-n
   partOfSpeech: n
+  wikidata: Q838599
 02049914-n:
   definition:
   - black-and-white diving bird of northern seas
@@ -45326,6 +46499,7 @@
   - 02050629-n
   - 02050769-n
   partOfSpeech: n
+  wikidata: Q311761
 02050629-n:
   definition:
   - common puffin of the northern Atlantic
@@ -45358,6 +46532,7 @@
   mero_member:
   - 02051007-n
   partOfSpeech: n
+  wikidata: Q50698074
 02051007-n:
   definition:
   - northern Pacific puffin having a large yellow plume over each eye
@@ -45381,6 +46556,7 @@
   - 02051352-n
   - 02051486-n
   partOfSpeech: n
+  wikidata: Q2814783
 02051352-n:
   definition:
   - seabirds of the order Gaviiformes
@@ -45402,6 +46578,7 @@
   mero_member:
   - 02051606-n
   partOfSpeech: n
+  wikidata: Q21666
 02051606-n:
   definition:
   - 'type genus of the Gavidae: loons'
@@ -45414,6 +46591,7 @@
   mero_member:
   - 02051742-n
   partOfSpeech: n
+  wikidata: Q3758978
 02051742-n:
   definition:
   - large somewhat primitive fish-eating diving bird of the Northern Hemisphere having
@@ -45442,6 +46620,7 @@
   - 02052186-n
   - 02052326-n
   partOfSpeech: n
+  wikidata: Q20604429
 02052186-n:
   definition:
   - aquatic birds related to the loons
@@ -45477,6 +46656,7 @@
   mero_member:
   - 02052658-n
   partOfSpeech: n
+  wikidata: Q1237815
 02052658-n:
   definition:
   - small compact-bodied almost completely aquatic bird that builds floating nests;
@@ -45595,6 +46775,7 @@
   - 02054499-n
   - 02054698-n
   partOfSpeech: n
+  wikidata: Q11846678
 02054499-n:
   definition:
   - large long-winged warm-water seabird having a large bill with a distensible pouch
@@ -45651,6 +46832,7 @@
   mero_member:
   - 02055293-n
   partOfSpeech: n
+  wikidata: Q15631713
 02055293-n:
   definition:
   - type genus of the Fregatidae
@@ -45663,6 +46845,7 @@
   mero_member:
   - 02055429-n
   partOfSpeech: n
+  wikidata: Q203472
 02055429-n:
   definition:
   - long-billed warm-water seabird with wide wingspan and forked tail
@@ -45686,6 +46869,7 @@
   - 02055737-n
   - 02055933-n
   partOfSpeech: n
+  wikidata: Q208492
 02055737-n:
   definition:
   - large heavily built seabird with a long stout bill noted for its plunging dives
@@ -45709,6 +46893,7 @@
   - 02056079-n
   - 02056238-n
   partOfSpeech: n
+  wikidata: Q612817
 02056079-n:
   definition:
   - very large white gannet with black wing tips
@@ -45742,6 +46927,7 @@
   mero_member:
   - 02056513-n
   partOfSpeech: n
+  wikidata: Q3901247
 02056513-n:
   definition:
   - 'type genus: coextensive with the family Phalacrocoracidae'
@@ -45790,6 +46976,7 @@
   mero_member:
   - 02057156-n
   partOfSpeech: n
+  wikidata: Q13168473
 02057156-n:
   definition:
   - fish-eating bird of warm inland waters having a long flexible neck and slender
@@ -45824,6 +47011,7 @@
   mero_member:
   - 02057620-n
   partOfSpeech: n
+  wikidata: Q17189371
 02057620-n:
   definition:
   - type genus of the Phaethontidae
@@ -45836,6 +47024,7 @@
   mero_member:
   - 02057761-n
   partOfSpeech: n
+  wikidata: Q19264
 02057761-n:
   definition:
   - mostly white web-footed tropical seabird often found far from land
@@ -45860,6 +47049,7 @@
   - 02058085-n
   - 02058312-n
   partOfSpeech: n
+  wikidata: Q12198609
 02058085-n:
   definition:
   - comprising all existing penguins
@@ -45908,6 +47098,7 @@
   mero_member:
   - 02058882-n
   partOfSpeech: n
+  wikidata: Q609432
 02058882-n:
   definition:
   - medium-sized penguins occurring in large colonies on the Adelie Coast of Antarctica
@@ -45932,6 +47123,7 @@
   - 02059224-n
   - 02059382-n
   partOfSpeech: n
+  wikidata: Q652976
 02059224-n:
   definition:
   - large penguin on islands bordering the Antarctic Circle
@@ -45965,6 +47157,7 @@
   mero_member:
   - 02059689-n
   partOfSpeech: n
+  wikidata: Q902912
 02059689-n:
   definition:
   - small penguin of South America and southern Africa with a braying call
@@ -45987,6 +47180,7 @@
   mero_member:
   - 02059984-n
   partOfSpeech: n
+  wikidata: Q591480
 02059984-n:
   definition:
   - small penguin of the Falkland Islands and New Zealand
@@ -46013,6 +47207,7 @@
   - 02063372-n
   - 02064369-n
   partOfSpeech: n
+  wikidata: Q21685
 02060385-n:
   definition:
   - bird of the open seas
@@ -46046,6 +47241,7 @@
   - 02060875-n
   - 02061107-n
   partOfSpeech: n
+  wikidata: Q55805
 02060875-n:
   definition:
   - large web-footed birds of the Southern Hemisphere having long narrow wings; noted
@@ -46069,6 +47265,7 @@
   - 02061248-n
   - 02061401-n
   partOfSpeech: n
+  wikidata: Q905872
 02061248-n:
   definition:
   - very large albatross; white with wide black wings
@@ -46155,6 +47352,7 @@
   mero_member:
   - 02062505-n
   partOfSpeech: n
+  wikidata: Q598979
 02062505-n:
   definition:
   - large brownish petrel chiefly of Antarctic seas
@@ -46179,6 +47377,7 @@
   mero_member:
   - 02062786-n
   partOfSpeech: n
+  wikidata: Q311224
 02062786-n:
   definition:
   - heavy short-tailed oceanic bird of polar regions
@@ -46202,6 +47401,7 @@
   mero_member:
   - 02063064-n
   partOfSpeech: n
+  wikidata: Q858279
 02063064-n:
   definition:
   - long-winged oceanic bird that in flight skims close to the waves
@@ -46236,6 +47436,7 @@
   - 02063726-n
   - 02064078-n
   partOfSpeech: n
+  wikidata: Q193404
 02063542-n:
   definition:
   - any of various small petrels having dark plumage with paler underparts
@@ -46257,6 +47458,7 @@
   mero_member:
   - 02063870-n
   partOfSpeech: n
+  wikidata: Q10770062
 02063870-n:
   definition:
   - sooty black petrel with white markings; of the northern Atlantic and Mediterranean
@@ -46280,6 +47482,7 @@
   mero_member:
   - 02064213-n
   partOfSpeech: n
+  wikidata: Q2347332
 02064213-n:
   definition:
   - medium-sized storm petrel
@@ -46303,6 +47506,7 @@
   mero_member:
   - 02064506-n
   partOfSpeech: n
+  wikidata: Q18325201
 02064506-n:
   definition:
   - any of several small diving birds of Southern Hemisphere seas; somewhat resemble
@@ -46404,6 +47608,7 @@
   - 02066315-n
   - 02066499-n
   partOfSpeech: n
+  wikidata: Q782603
 02066315-n:
   definition:
   - large Arctic whalebone whale; allegedly the ‘right’ whale to hunt because of its
@@ -46426,6 +47631,7 @@
   mero_member:
   - 02066653-n
   partOfSpeech: n
+  wikidata: Q4820658
 02066653-n:
   definition:
   - large-mouthed Arctic whale
@@ -46452,6 +47658,7 @@
   - 02067261-n
   - 02068252-n
   partOfSpeech: n
+  wikidata: Q232829
 02066991-n:
   definition:
   - any of several baleen whales of the family Balaenopteridae having longitudinal
@@ -46478,6 +47685,7 @@
   - 02067916-n
   - 02068060-n
   partOfSpeech: n
+  wikidata: Q133320
 02067469-n:
   definition:
   - largest mammal ever known; bluish-grey migratory whalebone whale mostly of Southern
@@ -46538,6 +47746,7 @@
   mero_member:
   - 02068379-n
   partOfSpeech: n
+  wikidata: Q12771348
 02068379-n:
   definition:
   - large whalebone whale with long flippers noted for arching or humping its back
@@ -46575,6 +47784,7 @@
   mero_member:
   - 02068898-n
   partOfSpeech: n
+  wikidata: Q12778450
 02068898-n:
   definition:
   - medium-sized greyish-black whale of the northern Pacific
@@ -46640,6 +47850,7 @@
   mero_member:
   - 02069893-n
   partOfSpeech: n
+  wikidata: Q3382003
 02069893-n:
   definition:
   - large whale with a large cavity in the head containing spermaceti and oil; also
@@ -46666,6 +47877,7 @@
   - 02070256-n
   - 02070421-n
   partOfSpeech: n
+  wikidata: Q244293
 02070256-n:
   definition:
   - small sperm whale of warm waters of both coasts of North America
@@ -46703,6 +47915,7 @@
   - 02070859-n
   - 02071061-n
   partOfSpeech: n
+  wikidata: Q193106
 02070859-n:
   definition:
   - any of several whales inhabiting all oceans and having beaklike jaws with vestigial
@@ -46725,6 +47938,7 @@
   mero_member:
   - 02071194-n
   partOfSpeech: n
+  wikidata: Q949450
 02071194-n:
   definition:
   - northern Atlantic beaked whale with a bulbous forehead
@@ -46777,6 +47991,7 @@
   mero_member:
   - 02072065-n
   partOfSpeech: n
+  wikidata: Q312257
 02072065-n:
   definition:
   - black-and-white dolphin that leaps high out of the water
@@ -46800,6 +48015,7 @@
   mero_member:
   - 02072353-n
   partOfSpeech: n
+  wikidata: Q149069
 02072353-n:
   definition:
   - any of several dolphins with rounded forehead and well-developed beak; chiefly
@@ -46888,6 +48104,7 @@
   mero_member:
   - 02073680-n
   partOfSpeech: n
+  wikidata: Q15631679
 02073680-n:
   definition:
   - slaty-grey blunt-nosed dolphin common in northern seas
@@ -46938,6 +48155,7 @@
   mero_member:
   - 02074288-n
   partOfSpeech: n
+  wikidata: Q459616
 02074288-n:
   definition:
   - small dark-colored whale of the Atlantic coast of the United States; the largest
@@ -47001,6 +48219,7 @@
   mero_member:
   - 02075145-n
   partOfSpeech: n
+  wikidata: Q18510798
 02075145-n:
   definition:
   - small Arctic whale the male having a long spiral ivory tusk
@@ -47025,6 +48244,7 @@
   mero_member:
   - 02075450-n
   partOfSpeech: n
+  wikidata: Q16628343
 02075450-n:
   definition:
   - small northern whale that is white when adult
@@ -47059,6 +48279,7 @@
   - 02076184-n
   - 02076656-n
   partOfSpeech: n
+  wikidata: Q25431
 02075902-n:
   definition:
   - any of two families of large herbivorous aquatic mammals with paddle-shaped tails
@@ -47083,6 +48304,7 @@
   mero_member:
   - 02076331-n
   partOfSpeech: n
+  wikidata: Q10827895
 02076331-n:
   definition:
   - type and sole genus of the Trichechidae
@@ -47095,6 +48317,7 @@
   mero_member:
   - 02076483-n
   partOfSpeech: n
+  wikidata: Q42797
 02076483-n:
   definition:
   - sirenian mammal of tropical coastal waters of America; the flat tail is rounded
@@ -47130,6 +48353,7 @@
   mero_member:
   - 02077019-n
   partOfSpeech: n
+  wikidata: Q10978076
 02077019-n:
   definition:
   - sirenian tusked mammal found from eastern Africa to Australia; the flat tail is
@@ -47186,6 +48410,7 @@
   - 02443336-n
   - 02509968-n
   partOfSpeech: n
+  wikidata: Q25306
 02077948-n:
   definition:
   - a terrestrial or aquatic flesh-eating mammal
@@ -47370,6 +48595,7 @@
   mero_member:
   - 02080944-n
   partOfSpeech: n
+  wikidata: Q19817140
 02080944-n:
   definition:
   - of the southern coast of South America
@@ -47393,6 +48619,7 @@
   - 02081226-n
   - 02081390-n
   partOfSpeech: n
+  wikidata: Q135911
 02081226-n:
   definition:
   - often trained as a show animal
@@ -47426,6 +48653,7 @@
   mero_member:
   - 02081657-n
   partOfSpeech: n
+  wikidata: Q18520866
 02081657-n:
   definition:
   - largest sea lion; of the northern Pacific
@@ -47480,6 +48708,7 @@
   mero_member:
   - 02082503-n
   partOfSpeech: n
+  wikidata: Q878742
 02082503-n:
   definition:
   - small spotted seal of coastal waters of the Northern Hemisphere
@@ -47503,6 +48732,7 @@
   mero_member:
   - 02082798-n
   partOfSpeech: n
+  wikidata: Q19817285
 02082798-n:
   definition:
   - common Arctic seal; the young are all white
@@ -47526,6 +48756,7 @@
   mero_member:
   - 02083067-n
   partOfSpeech: n
+  wikidata: Q185231
 02083067-n:
   definition:
   - either of two large northern Atlantic earless seals having snouts like trunks
@@ -47549,6 +48780,7 @@
   mero_member:
   - 02083365-n
   partOfSpeech: n
+  wikidata: Q19817175
 02083365-n:
   definition:
   - medium-sized greyish to yellow seal with bristles each side of muzzle; of the
@@ -47573,6 +48805,7 @@
   mero_member:
   - 02083712-n
   partOfSpeech: n
+  wikidata: Q19817156
 02083712-n:
   definition:
   - medium-sized blackish-grey seal with large inflatable sac on the head; of Arctic
@@ -47610,6 +48843,7 @@
   mero_member:
   - 02084223-n
   partOfSpeech: n
+  wikidata: Q5361186
 02084223-n:
   definition:
   - either of two large northern marine mammals having ivory tusks and tough hide
@@ -47675,6 +48909,7 @@
   mero_member:
   - 02085150-n
   partOfSpeech: n
+  wikidata: Q1082523
 02085150-n:
   definition:
   - aardvarks
@@ -47700,6 +48935,7 @@
   mero_member:
   - 02085443-n
   partOfSpeech: n
+  wikidata: Q1975774
 02085443-n:
   definition:
   - nocturnal burrowing mammal of the grasslands of Africa that feeds on termites;
@@ -47734,6 +48970,7 @@
   - 02122613-n
   - 02123039-n
   partOfSpeech: n
+  wikidata: Q25324
 02085998-n:
   definition:
   - any of various fissiped mammals with nonretractile claws and typically long muzzles
@@ -47778,6 +49015,7 @@
   - 02116752-n
   - 02117748-n
   partOfSpeech: n
+  wikidata: Q149892
 02086723-n:
   definition:
   - a member of the genus Canis (probably descended from the common wolf) that has
@@ -49804,6 +51042,7 @@
   mero_member:
   - 02118565-n
   partOfSpeech: n
+  wikidata: Q19817116
 02118565-n:
   definition:
   - fierce wild dog of the forests of central and southeast Asia that hunts in packs
@@ -49870,6 +51109,7 @@
   - Lycaeon
   - genus Lycaeon
   partOfSpeech: n
+  wikidata: Q12061410
 02119390-n:
   definition:
   - a powerful doglike mammal of southern and eastern Africa that hunts in large packs;
@@ -49898,6 +51138,7 @@
   - 02120424-n
   - 02120710-n
   partOfSpeech: n
+  wikidata: Q42046
 02119787-n:
   definition:
   - doglike nocturnal mammal of Africa and southern Asia that feeds chiefly on carrion
@@ -49920,6 +51161,7 @@
   - 02120164-n
   - 02120298-n
   partOfSpeech: n
+  wikidata: Q1417638
 02120164-n:
   definition:
   - of northern Africa and Arabia and India
@@ -49954,6 +51196,7 @@
   mero_member:
   - 02120552-n
   partOfSpeech: n
+  wikidata: Q10750855
 02120552-n:
   definition:
   - African hyena noted for its distinctive howl
@@ -49978,6 +51221,7 @@
   mero_member:
   - 02120828-n
   partOfSpeech: n
+  wikidata: Q18510844
 02120828-n:
   definition:
   - striped hyena of southeast Africa that feeds chiefly on insects
@@ -50032,6 +51276,7 @@
   - 02122286-n
   - 02122441-n
   partOfSpeech: n
+  wikidata: Q185194
 02121674-n:
   definition:
   - the common Old World fox; having reddish-brown fur; commonly considered a single
@@ -50104,6 +51349,7 @@
   mero_member:
   - 02122731-n
   partOfSpeech: n
+  wikidata: Q223410
 02122731-n:
   definition:
   - thickly-furred fox of Arctic regions; brownish in summer and white in winter
@@ -50167,6 +51413,7 @@
   - 02133447-n
   - 02133728-n
   partOfSpeech: n
+  wikidata: Q25265
 02123649-n:
   definition:
   - any of various lithe-bodied roundheaded fissiped mammals, many with retractile
@@ -50205,6 +51452,7 @@
   - 02129292-n
   - 02129439-n
   partOfSpeech: n
+  wikidata: Q228283
 02124272-n:
   definition:
   - feline mammal usually having thick soft fur and no ability to roar
@@ -50588,6 +51836,7 @@
   mero_member:
   - 02129704-n
   partOfSpeech: n
+  wikidata: Q677014
 02129704-n:
   definition:
   - short-tailed wildcats with usually tufted ears; valued for their fur
@@ -50677,6 +51926,7 @@
   - 02131817-n
   - 02132256-n
   partOfSpeech: n
+  wikidata: Q127960
 02131037-n:
   definition:
   - large feline of African and Asian forests usually having a tawny coat with black
@@ -50822,6 +52072,7 @@
   mero_member:
   - 02132960-n
   partOfSpeech: n
+  wikidata: Q481907
 02132960-n:
   definition:
   - long-legged spotted cat of Africa and southwestern Asia having nonretractile claws;
@@ -50857,6 +52108,7 @@
   mero_member:
   - 02133577-n
   partOfSpeech: n
+  wikidata: Q188717
 02133577-n:
   definition:
   - North American sabertooth; culmination of sabertooth development
@@ -50878,6 +52130,7 @@
   mero_member:
   - 02133863-n
   partOfSpeech: n
+  wikidata: Q134562
 02133863-n:
   definition:
   - North American cat of the Miocene and Pliocene; much earlier and less specialized
@@ -50905,6 +52158,7 @@
   - 02136554-n
   - 02136892-n
   partOfSpeech: n
+  wikidata: Q11788
 02134305-n:
   definition:
   - massive plantigrade carnivorous or omnivorous mammals with long shaggy coats and
@@ -50928,6 +52182,7 @@
   mero_member:
   - 02134788-n
   partOfSpeech: n
+  wikidata: Q243359
 02134788-n:
   definition:
   - large ferocious bear of Eurasia
@@ -51085,6 +52340,7 @@
   mero_member:
   - 02137070-n
   partOfSpeech: n
+  wikidata: Q17484766
 02137070-n:
   definition:
   - common coarse-haired long-snouted bear of south-central Asia
@@ -51121,6 +52377,7 @@
   - 02140694-n
   - 02140975-n
   partOfSpeech: n
+  wikidata: Q185864
 02137623-n:
   definition:
   - small cat-like predatory mammals of warmer parts of the Old World
@@ -51172,6 +52429,7 @@
   - Viverricula
   - genus Viverricula
   partOfSpeech: n
+  wikidata: Q19817086
 02138496-n:
   definition:
   - a common civet of southeast Asia
@@ -51195,6 +52453,7 @@
   mero_member:
   - 02138755-n
   partOfSpeech: n
+  wikidata: Q19817059
 02138755-n:
   definition:
   - arboreal civet of Asia having a long prehensile tail and shaggy black hair
@@ -51217,6 +52476,7 @@
   - Cryptoprocta
   - genus Cryptoprocta
   partOfSpeech: n
+  wikidata: Q141424
 02139104-n:
   definition:
   - largest carnivore of Madagascar; intermediate in some respects between cats and
@@ -51241,6 +52501,7 @@
   mero_member:
   - 02139446-n
   partOfSpeech: n
+  wikidata: Q19817088
 02139446-n:
   definition:
   - civet of Madagascar
@@ -51263,6 +52524,7 @@
   mero_member:
   - 02139667-n
   partOfSpeech: n
+  wikidata: Q43221
 02139667-n:
   definition:
   - agile Old World viverrine having a spotted coat and long ringed tail
@@ -51285,6 +52547,7 @@
   mero_member:
   - 02139954-n
   partOfSpeech: n
+  wikidata: Q19817081
 02139954-n:
   definition:
   - an East Indian civet
@@ -51308,6 +52571,7 @@
   mero_member:
   - 02140201-n
   partOfSpeech: n
+  wikidata: Q312207
 02140201-n:
   definition:
   - agile grizzled Old World viverrine; preys on snakes and rodents
@@ -51349,6 +52613,7 @@
   mero_member:
   - 02140821-n
   partOfSpeech: n
+  wikidata: Q887918
 02140821-n:
   definition:
   - spotted or striped arboreal civet of southeast Asia and East Indies
@@ -51371,6 +52636,7 @@
   mero_member:
   - 02141093-n
   partOfSpeech: n
+  wikidata: Q19817113
 02141093-n:
   definition:
   - a mongoose-like viverrine of South Africa having a face like a lemur and only
@@ -51417,6 +52683,7 @@
   - 02142131-n
   - 02143622-n
   partOfSpeech: n
+  wikidata: Q28425
 02141851-n:
   definition:
   - nocturnal mouselike mammal with forelimbs modified to form membranous wings and
@@ -51467,6 +52734,7 @@
   mero_member:
   - 02142701-n
   partOfSpeech: n
+  wikidata: Q1241332
 02142701-n:
   definition:
   - large bat with a head that resembles the head of a fox
@@ -51507,6 +52775,7 @@
   mero_member:
   - 02143143-n
   partOfSpeech: n
+  wikidata: Q1754955
 02143143-n:
   definition:
   - any of various fruit bats of the genus Nyctimene distinguished by nostrils drawn
@@ -51532,6 +52801,7 @@
   mero_member:
   - 02143510-n
   partOfSpeech: n
+  wikidata: Q311701
 02143510-n:
   definition:
   - a variety of fruit eating bat
@@ -51618,6 +52888,7 @@
   mero_member:
   - 02145059-n
   partOfSpeech: n
+  wikidata: Q956183
 02145059-n:
   definition:
   - large-eared greyish bat of southern California and northwestern Mexico
@@ -51640,6 +52911,7 @@
   mero_member:
   - 02145386-n
   partOfSpeech: n
+  wikidata: Q1303312
 02145386-n:
   definition:
   - New World bat with a pointed nose leaf; found from southern United States to Paraguay
@@ -51670,6 +52942,7 @@
   mero_member:
   - 02145794-n
   partOfSpeech: n
+  wikidata: Q10747561
 02145794-n:
   definition:
   - small-eared Mexican bat with a long slender nose
@@ -51715,6 +52988,7 @@
   - 02146411-n
   - 02146762-n
   partOfSpeech: n
+  wikidata: Q604995
 02146411-n:
   definition:
   - horseshoe bats
@@ -51750,6 +53024,7 @@
   mero_member:
   - 02146903-n
   partOfSpeech: n
+  wikidata: Q10811563
 02146903-n:
   definition:
   - a common bat of northwestern Australia having orange or yellow fur
@@ -51773,6 +53048,7 @@
   mero_member:
   - 02147444-n
   partOfSpeech: n
+  wikidata: Q841327
 02147245-n:
   definition:
   - any New or Old World carnivorous bat erroneously thought to suck blood but in
@@ -51796,6 +53072,7 @@
   mero_member:
   - 02147588-n
   partOfSpeech: n
+  wikidata: Q221073
 02147588-n:
   definition:
   - large carnivorous Old World bat with very large ears
@@ -51851,6 +53128,7 @@
   mero_member:
   - 02148562-n
   partOfSpeech: n
+  wikidata: Q1762568
 02148562-n:
   definition:
   - common Eurasian bat with white-tipped hairs in its coat
@@ -51873,6 +53151,7 @@
   mero_member:
   - 02148853-n
   partOfSpeech: n
+  wikidata: Q116317
 02148853-n:
   definition:
   - North American bat of a brick or rusty red color with hairs tipped with white
@@ -51906,6 +53185,7 @@
   - 02149352-n
   - 02149531-n
   partOfSpeech: n
+  wikidata: Q223384
 02149352-n:
   definition:
   - the small common North American bat; widely distributed
@@ -51941,6 +53221,7 @@
   mero_member:
   - 02149825-n
   partOfSpeech: n
+  wikidata: Q736473
 02149825-n:
   definition:
   - rather large North American brown bat; widely distributed
@@ -51974,6 +53255,7 @@
   mero_member:
   - 02150243-n
   partOfSpeech: n
+  wikidata: Q10734383
 02150243-n:
   definition:
   - drab yellowish big-eared bat that lives in caves
@@ -52043,6 +53325,7 @@
   mero_member:
   - 02151164-n
   partOfSpeech: n
+  wikidata: Q10759438
 02151164-n:
   definition:
   - a large bat of the southwestern United States having spots and enormous ears
@@ -52112,6 +53395,7 @@
   mero_member:
   - 02152072-n
   partOfSpeech: n
+  wikidata: Q607105
 02152072-n:
   definition:
   - small swift insectivorous bat with leathery ears and a long tail; common in warm
@@ -52159,6 +53443,7 @@
   mero_member:
   - 02152786-n
   partOfSpeech: n
+  wikidata: Q371577
 02152786-n:
   definition:
   - a soft-furred chocolate-brown bat with folded ears and small wings; often runs
@@ -52183,6 +53468,7 @@
   - 02153382-n
   - 02153760-n
   partOfSpeech: n
+  wikidata: Q190691
 02153134-n:
   definition:
   - any of various tropical American bats of the family Desmodontidae that bite mammals
@@ -52229,6 +53515,7 @@
   mero_member:
   - 02153882-n
   partOfSpeech: n
+  wikidata: Q10755826
 02153882-n:
   definition:
   - similar in size and habits to Desmodus rotundus; of tropical America including
@@ -52779,7 +54066,7 @@
   - 02275359-n
   - 02276197-n
   partOfSpeech: n
-  wikidata: Q105146
+  wikidata: Q1390
 02162607-n:
   definition:
   - small air-breathing arthropod
@@ -52866,6 +54153,7 @@
   - Mantophasmatodea
   - order mantophasmatodea
   partOfSpeech: n
+  wikidata: Q754029
 02164596-n:
   definition:
   - an order of carnivorous insects usually having long membranous wings and long
@@ -52881,6 +54169,7 @@
   - 02165056-n
   - 02165483-n
   partOfSpeech: n
+  wikidata: Q205301
 02164887-n:
   definition:
   - any of various carnivorous insects of the order Mecoptera
@@ -52902,6 +54191,7 @@
   mero_member:
   - 02165213-n
   partOfSpeech: n
+  wikidata: Q931119
 02165213-n:
   definition:
   - any of various mecopterous insects of the family Panorpidae of the Northern Hemisphere
@@ -52925,6 +54215,7 @@
   mero_member:
   - 02165660-n
   partOfSpeech: n
+  wikidata: Q1953041
 02165660-n:
   definition:
   - any of various mecopterous insects of the family Bittacidae
@@ -52946,6 +54237,7 @@
   mero_member:
   - 02165949-n
   partOfSpeech: n
+  wikidata: Q190701
 02165949-n:
   definition:
   - any of numerous minute wingless primitive insects possessing a special abdominal
@@ -52971,6 +54263,7 @@
   mero_member:
   - 02166415-n
   partOfSpeech: n
+  wikidata: Q271631
 02166415-n:
   definition:
   - any of several minute primitive wingless and eyeless insects having a cone-shaped
@@ -53013,6 +54306,7 @@
   - 02183665-n
   - 02184515-n
   partOfSpeech: n
+  wikidata: Q22671
 02167116-n:
   definition:
   - insect having biting mouthparts and front wings modified to form horny covers
@@ -53035,6 +54329,7 @@
   mero_member:
   - 02167757-n
   partOfSpeech: n
+  wikidata: Q16718297
 02167757-n:
   definition:
   - active usually bright-colored beetle that preys on other insects
@@ -53087,6 +54382,7 @@
   mero_member:
   - 02168529-n
   partOfSpeech: n
+  wikidata: Q2665200
 02168529-n:
   definition:
   - red ladybug with a black spot on each wing
@@ -53135,6 +54431,7 @@
   mero_member:
   - 02169219-n
   partOfSpeech: n
+  wikidata: Q1952379
 02169219-n:
   definition:
   - a variety of ladybug
@@ -53158,7 +54455,7 @@
   mero_member:
   - 02169478-n
   partOfSpeech: n
-  wikidata: Q3940018
+  wikidata: Q21445747
 02169478-n:
   definition:
   - native to Australia; introduced elsewhere to control scale insects
@@ -53183,6 +54480,7 @@
   - 02170027-n
   - 02170297-n
   partOfSpeech: n
+  wikidata: Q27046
 02169803-n:
   definition:
   - predacious shining black or metallic terrestrial beetle that destroys many injurious
@@ -53206,6 +54504,7 @@
   mero_member:
   - 02170157-n
   partOfSpeech: n
+  wikidata: Q137381
 02170157-n:
   definition:
   - beetle that ejects audibly a pungent vapor when disturbed
@@ -53226,6 +54525,7 @@
   mero_member:
   - 02170472-n
   partOfSpeech: n
+  wikidata: Q1317479
 02170472-n:
   definition:
   - any beetle of the genus Calosoma
@@ -53258,6 +54558,7 @@
   mero_member:
   - 02170897-n
   partOfSpeech: n
+  wikidata: Q25420
 02170897-n:
   definition:
   - nocturnal beetle common in warm regions having luminescent abdominal organs
@@ -53349,6 +54650,7 @@
   - 02172149-n
   - 02172485-n
   partOfSpeech: n
+  wikidata: Q193407
 02172149-n:
   definition:
   - brightly colored beetle that feeds on plant leaves; larvae infest roots and stems
@@ -53380,6 +54682,7 @@
   mero_member:
   - 02172626-n
   partOfSpeech: n
+  wikidata: Q602990
 02172626-n:
   definition:
   - black-and-yellow beetle that feeds in adult and larval stages on potato leaves;
@@ -53406,6 +54709,7 @@
   mero_member:
   - 02173052-n
   partOfSpeech: n
+  wikidata: Q220932
 02173052-n:
   definition:
   - small beetle whose larvae are household pests feeding on woolen fabrics
@@ -53448,6 +54752,7 @@
   mero_member:
   - 02173645-n
   partOfSpeech: n
+  wikidata: Q377988
 02173645-n:
   definition:
   - predacious on other insects; usually brightly colored or metallic
@@ -53507,6 +54812,7 @@
   - 02176805-n
   - 02177915-n
   partOfSpeech: n
+  wikidata: Q186946
 02174521-n:
   definition:
   - any of numerous species of stout-bodied beetles having heads with horny spikes
@@ -53539,6 +54845,7 @@
   mero_member:
   - 02175170-n
   partOfSpeech: n
+  wikidata: Q771526
 02175170-n:
   definition:
   - scarabaeid beetle considered divine by ancient Egyptians
@@ -53629,6 +54936,7 @@
   mero_member:
   - 02176436-n
   partOfSpeech: n
+  wikidata: Q2235787
 02176436-n:
   definition:
   - introduced into United States from the Orient; larvae feed on roots of sugarcane
@@ -53686,6 +54994,7 @@
   mero_member:
   - 02177311-n
   partOfSpeech: n
+  wikidata: Q1780303
 02177311-n:
   definition:
   - any of various large European beetles destructive to vegetation as both larvae
@@ -53711,6 +55020,7 @@
   mero_member:
   - 02177666-n
   partOfSpeech: n
+  wikidata: Q14863800
 02177666-n:
   definition:
   - 'common North American beetle: larvae feed on roots and adults on leaves and flowers
@@ -53748,6 +55058,7 @@
   mero_member:
   - 02178221-n
   partOfSpeech: n
+  wikidata: Q608094
 02178221-n:
   definition:
   - 'a common metallic green European beetle: larvae feed on plant roots and adults
@@ -53772,6 +55083,7 @@
   mero_member:
   - 02178568-n
   partOfSpeech: n
+  wikidata: Q208786
 02178568-n:
   definition:
   - a kind of lamellicorn beetle; the male has branched mandibles resembling antlers
@@ -53795,6 +55107,7 @@
   - 02179263-n
   - 02179568-n
   partOfSpeech: n
+  wikidata: Q28457
 02178913-n:
   definition:
   - any of various widely distributed beetles
@@ -53863,6 +55176,7 @@
   mero_member:
   - 02179848-n
   partOfSpeech: n
+  wikidata: Q327149
 02179848-n:
   definition:
   - any of numerous aquatic beetles usually having a smooth oval body and flattened
@@ -53885,6 +55199,7 @@
   mero_member:
   - 02180158-n
   partOfSpeech: n
+  wikidata: Q756089
 02180158-n:
   definition:
   - aquatic beetle that circles rapidly on the water surface
@@ -53907,6 +55222,7 @@
   mero_member:
   - 02180427-n
   partOfSpeech: n
+  wikidata: Q574725
 02180427-n:
   definition:
   - bores through wood making a ticking sound popularly thought to presage death
@@ -53963,6 +55279,7 @@
   mero_member:
   - 02181369-n
   partOfSpeech: n
+  wikidata: Q1382301
 02181369-n:
   definition:
   - greyish weevil that lays its eggs in cotton bolls destroying the cotton
@@ -54032,6 +55349,7 @@
   - 02182698-n
   - 02182885-n
   partOfSpeech: n
+  wikidata: Q12379653
 02182366-n:
   definition:
   - type genus of the Scolytidae comprising numerous small bark beetles
@@ -54044,6 +55362,7 @@
   mero_member:
   - 02182543-n
   partOfSpeech: n
+  wikidata: Q310770
 02182543-n:
   definition:
   - a vector of the fungus causing Dutch elm disease
@@ -54067,6 +55386,7 @@
   mero_member:
   - 02183079-n
   partOfSpeech: n
+  wikidata: Q3013151
 02182885-n:
   definition:
   - small beetle that bores tunnels in the bark and wood of trees; related to weevils
@@ -54103,6 +55423,7 @@
   mero_member:
   - 02183527-n
   partOfSpeech: n
+  wikidata: Q467400
 02183527-n:
   definition:
   - active beetle typically having predatory or scavenging habits
@@ -54126,6 +55447,7 @@
   - 02184129-n
   - 02184251-n
   partOfSpeech: n
+  wikidata: Q615799
 02183887-n:
   definition:
   - sluggish hard-bodied black terrestrial weevil whose larvae feed on e.g. decaying
@@ -54159,6 +55481,7 @@
   mero_member:
   - 02184376-n
   partOfSpeech: n
+  wikidata: Q4273216
 02184376-n:
   definition:
   - an insect that infests flour and stored grains
@@ -54184,6 +55507,7 @@
   - 02185150-n
   - 02185448-n
   partOfSpeech: n
+  wikidata: Q13167641
 02184697-n:
   definition:
   - a small beetle that infests the seeds of legumes
@@ -54206,6 +55530,7 @@
   mero_member:
   - 02185007-n
   partOfSpeech: n
+  wikidata: Q2926499
 02185007-n:
   definition:
   - larvae live in and feed on seeds of the pea plant
@@ -54228,6 +55553,7 @@
   mero_member:
   - 02185294-n
   partOfSpeech: n
+  wikidata: Q1645100
 02185294-n:
   definition:
   - larvae live in and feed on growing or stored beans
@@ -54251,6 +55577,7 @@
   mero_member:
   - 02185582-n
   partOfSpeech: n
+  wikidata: Q1431435
 02185582-n:
   definition:
   - brown weevil that infests stored grain especially rice
@@ -54287,6 +55614,7 @@
   mero_member:
   - 02186159-n
   partOfSpeech: n
+  wikidata: Q467392
 02186159-n:
   definition:
   - any of a small order of slender typically tropical insects that nest in colonies
@@ -54311,6 +55639,7 @@
   - 02186766-n
   - 02187533-n
   partOfSpeech: n
+  wikidata: Q26870
 02186509-n:
   definition:
   - wingless usually flattened bloodsucking insect parasitic on warm-blooded animals
@@ -54334,6 +55663,7 @@
   mero_member:
   - 02186922-n
   partOfSpeech: n
+  wikidata: Q4116982
 02186922-n:
   definition:
   - 'type genus of Pediculidae: true lice infecting humans'
@@ -54348,6 +55678,7 @@
   - 02187241-n
   - 02187372-n
   partOfSpeech: n
+  wikidata: Q13655191
 02187125-n:
   definition:
   - head or body louse
@@ -54392,6 +55723,7 @@
   mero_member:
   - 02187659-n
   partOfSpeech: n
+  wikidata: Q21224264
 02187659-n:
   definition:
   - 'true lice: crab lice'
@@ -54406,6 +55738,7 @@
   mero_member:
   - 02187819-n
   partOfSpeech: n
+  wikidata: Q7257036
 02187819-n:
   definition:
   - a louse that infests the pubic region of the human body
@@ -54431,6 +55764,7 @@
   - 02188133-n
   - 02188346-n
   partOfSpeech: n
+  wikidata: Q919938
 02188133-n:
   definition:
   - wingless insect with mouth parts adapted for biting; mostly parasitic on birds
@@ -54455,6 +55789,7 @@
   mero_member:
   - 02188466-n
   partOfSpeech: n
+  wikidata: Q18095959
 02188466-n:
   definition:
   - a louse parasitic on poultry
@@ -54482,6 +55817,7 @@
   - 02190079-n
   - 02190411-n
   partOfSpeech: n
+  wikidata: Q388162
 02188805-n:
   definition:
   - any wingless bloodsucking parasitic insect noted for ability to leap
@@ -54505,6 +55841,7 @@
   - 02189238-n
   - 02189486-n
   partOfSpeech: n
+  wikidata: Q1946989
 02189238-n:
   definition:
   - type genus of the Pulicidae
@@ -54517,6 +55854,7 @@
   mero_member:
   - 02189369-n
   partOfSpeech: n
+  wikidata: Q2120770
 02189369-n:
   definition:
   - the most common flea attacking humans
@@ -54583,6 +55921,7 @@
   mero_member:
   - 02190206-n
   partOfSpeech: n
+  wikidata: Q15631005
 02190206-n:
   definition:
   - small tropical flea; the fertile female burrows under the skin of the host including
@@ -54609,6 +55948,7 @@
   mero_member:
   - 02190552-n
   partOfSpeech: n
+  wikidata: Q10479055
 02190552-n:
   definition:
   - parasitic on especially the heads of chickens
@@ -54652,6 +55992,7 @@
   - 02202364-n
   - 02208035-n
   partOfSpeech: n
+  wikidata: Q25312
 02191351-n:
   definition:
   - insects having usually a single pair of functional wings (anterior pair) with
@@ -54681,6 +56022,7 @@
   - 02192015-n
   - 02192187-n
   partOfSpeech: n
+  wikidata: Q768519
 02192015-n:
   definition:
   - fragile mosquito-like flies that produce galls on plants
@@ -54704,6 +56046,7 @@
   mero_member:
   - 02192322-n
   partOfSpeech: n
+  wikidata: Q6797107
 02192322-n:
   definition:
   - small fly whose larvae damage wheat and other grains
@@ -54737,6 +56080,7 @@
   mero_member:
   - 02193300-n
   partOfSpeech: n
+  wikidata: Q527224
 02192818-n:
   definition:
   - two-winged insects characterized by active flight
@@ -54771,6 +56115,7 @@
   mero_member:
   - 02193442-n
   partOfSpeech: n
+  wikidata: Q145574
 02193442-n:
   definition:
   - common fly that frequents human habitations and spreads many diseases
@@ -54795,6 +56140,7 @@
   mero_member:
   - 02193783-n
   partOfSpeech: n
+  wikidata: Q5336147
 02193783-n:
   definition:
   - 'type genus of the Glossinidae: tsetse flies'
@@ -54806,6 +56152,7 @@
   mero_member:
   - 02193925-n
   partOfSpeech: n
+  wikidata: Q205256
 02193925-n:
   definition:
   - bloodsucking African fly; transmits sleeping sickness etc.
@@ -54846,6 +56193,7 @@
   mero_member:
   - 02194425-n
   partOfSpeech: n
+  wikidata: Q2213438
 02194425-n:
   definition:
   - large usually hairy metallic blue or green fly; lays eggs in carrion or dung or
@@ -54880,6 +56228,7 @@
   mero_member:
   - 02194904-n
   partOfSpeech: n
+  wikidata: Q4121093
 02194904-n:
   definition:
   - blowfly with brilliant coppery green body
@@ -54902,6 +56251,7 @@
   mero_member:
   - 02195165-n
   partOfSpeech: n
+  wikidata: Q1616496
 02195165-n:
   definition:
   - fly whose larvae feed on carrion or the flesh of living animals
@@ -54925,6 +56275,7 @@
   mero_member:
   - 02195466-n
   partOfSpeech: n
+  wikidata: Q235715
 02195466-n:
   definition:
   - bristly fly whose larvae live parasitically in caterpillars and other insects;
@@ -54966,6 +56317,7 @@
   mero_member:
   - 02196148-n
   partOfSpeech: n
+  wikidata: Q17415640
 02196148-n:
   definition:
   - 'type genus of the Gasterophilidae: horse botflies'
@@ -54978,6 +56330,7 @@
   mero_member:
   - 02196317-n
   partOfSpeech: n
+  wikidata: Q13553844
 02196317-n:
   definition:
   - parasitic chiefly on horses
@@ -55001,6 +56354,7 @@
   - 02196607-n
   - 02196730-n
   partOfSpeech: n
+  wikidata: Q5196747
 02196607-n:
   definition:
   - type genus of the Cuterebridae
@@ -55011,6 +56365,7 @@
   - Cuterebra
   - genus Cuterebra
   partOfSpeech: n
+  wikidata: Q14698598
 02196730-n:
   definition:
   - larvae live under the skin of domestic mammals and humans
@@ -55023,6 +56378,7 @@
   mero_member:
   - 02196901-n
   partOfSpeech: n
+  wikidata: Q18108621
 02196901-n:
   definition:
   - large tropical American fly; parasitic on humans and other mammals
@@ -55048,6 +56404,7 @@
   - 02197251-n
   - 02197539-n
   partOfSpeech: n
+  wikidata: Q15629945
 02197251-n:
   definition:
   - 'type genus of the Oestridae: sheep botflies'
@@ -55060,6 +56417,7 @@
   mero_member:
   - 02197402-n
   partOfSpeech: n
+  wikidata: Q7078713
 02197402-n:
   definition:
   - larvae are parasitic on sheep
@@ -55084,6 +56442,7 @@
   mero_member:
   - 02197743-n
   partOfSpeech: n
+  wikidata: Q9295520
 02197743-n:
   definition:
   - hairy bee-like fly whose larvae produce lumpy abscesses (warbles) under the skin
@@ -55141,6 +56500,7 @@
   mero_member:
   - 02198471-n
   partOfSpeech: n
+  wikidata: Q676390
 02198471-n:
   definition:
   - hairy nectar-eating fly that resembles a bee; larvae are parasitic on larvae of
@@ -55163,6 +56523,7 @@
   mero_member:
   - 02198771-n
   partOfSpeech: n
+  wikidata: Q837089
 02198771-n:
   definition:
   - swift predatory fly having a strong body like a bee with the proboscis hardened
@@ -55200,6 +56561,7 @@
   - 02199700-n
   - 02200673-n
   partOfSpeech: n
+  wikidata: Q3541211
 02199413-n:
   definition:
   - a genus of Trypetidae
@@ -55237,6 +56599,7 @@
   mero_member:
   - 02199837-n
   partOfSpeech: n
+  wikidata: Q2946369
 02199837-n:
   definition:
   - small black-and-white fly that damages citrus and other fruits by implanting eggs
@@ -55274,6 +56637,7 @@
   - 02200341-n
   - 02200529-n
   partOfSpeech: n
+  wikidata: Q312154
 02200341-n:
   definition:
   - small fruit fly used by Thomas Hunt Morgan in studying basic mechanisms of inheritance
@@ -55303,6 +56667,7 @@
   - Philophylla
   - genus Philophylla
   partOfSpeech: n
+  wikidata: Q7186141
 02200781-n:
   definition:
   - any of various small moths or dipterous flies whose larvae burrow into and feed
@@ -55329,6 +56694,7 @@
   - 02201366-n
   - 02201648-n
   partOfSpeech: n
+  wikidata: Q256346
 02201184-n:
   definition:
   - bloodsucking dipterous fly parasitic on birds and mammals
@@ -55375,6 +56741,7 @@
   mero_member:
   - 02201822-n
   partOfSpeech: n
+  wikidata: Q3007506
 02201822-n:
   definition:
   - wingless fly that is an external parasite on sheep and cattle
@@ -55399,6 +56766,7 @@
   mero_member:
   - 02202154-n
   partOfSpeech: n
+  wikidata: Q5638206
 02202154-n:
   definition:
   - small black European fly introduced into North America; sucks blood from cattle
@@ -55487,6 +56855,7 @@
   - 02203502-n
   - 02203652-n
   partOfSpeech: n
+  wikidata: Q310911
 02203502-n:
   definition:
   - mosquito that transmits yellow fever and dengue
@@ -55523,6 +56892,7 @@
   - 02204149-n
   - 02204278-n
   partOfSpeech: n
+  wikidata: Q158597
 02204149-n:
   definition:
   - any mosquito of the genus Anopheles
@@ -55556,6 +56926,7 @@
   - 02204658-n
   - 02204776-n
   partOfSpeech: n
+  wikidata: Q276595
 02204658-n:
   definition:
   - common house mosquito
@@ -55623,6 +56994,7 @@
   - Ceratopogon
   - genus Ceratopogon
   partOfSpeech: n
+  wikidata: Q14551414
 02205660-n:
   definition:
   - midges
@@ -55636,6 +57008,7 @@
   - 02205804-n
   - 02205984-n
   partOfSpeech: n
+  wikidata: Q228145
 02205804-n:
   definition:
   - minute two-winged mosquito-like fly lacking biting mouthparts; appear in dancing
@@ -55656,6 +57029,7 @@
   - Chironomus
   - genus Chironomus
   partOfSpeech: n
+  wikidata: Q2704714
 02206109-n:
   definition:
   - a family of small flies, forming the bulk of those species known as fungus gnats
@@ -55669,6 +57043,7 @@
   mero_member:
   - 02206244-n
   partOfSpeech: n
+  wikidata: Q1697984
 02206244-n:
   definition:
   - mosquito-like insect whose larvae feed on fungi or decaying vegetation
@@ -55692,6 +57067,7 @@
   - 02206630-n
   - 02206736-n
   partOfSpeech: n
+  wikidata: Q753860
 02206630-n:
   definition:
   - a fly of the family Psychodidae
@@ -55713,6 +57089,7 @@
   mero_member:
   - 02206901-n
   partOfSpeech: n
+  wikidata: Q1709478
 02206901-n:
   definition:
   - any of various small dipterous flies; bloodsucking females can transmit sandfly
@@ -55737,6 +57114,7 @@
   mero_member:
   - 02207237-n
   partOfSpeech: n
+  wikidata: Q582991
 02207237-n:
   definition:
   - 'type genus of the Sciaridae: fungus gnat'
@@ -55748,6 +57126,7 @@
   mero_member:
   - 02207374-n
   partOfSpeech: n
+  wikidata: Q7433428
 02207374-n:
   definition:
   - minute blackish gregarious flies destructive to mushrooms and seedlings
@@ -55781,6 +57160,7 @@
   mero_member:
   - 02207871-n
   partOfSpeech: n
+  wikidata: Q474636
 02207871-n:
   definition:
   - long-legged slender flies that resemble large mosquitoes but do not bite
@@ -55816,6 +57196,7 @@
   mero_member:
   - 02208325-n
   partOfSpeech: n
+  wikidata: Q3280744
 02208325-n:
   definition:
   - small blackish stout-bodied biting fly having aquatic larvae; sucks the blood
@@ -55849,6 +57230,7 @@
   - 02221215-n
   - 02221886-n
   partOfSpeech: n
+  wikidata: Q22651
 02208922-n:
   definition:
   - insects having two pairs of membranous wings and an ovipositor specialized for
@@ -55965,6 +57347,7 @@
   mero_member:
   - 02210932-n
   partOfSpeech: n
+  wikidata: Q102857
 02210932-n:
   definition:
   - social bee often domesticated for the honey it produces
@@ -56030,6 +57413,7 @@
   mero_member:
   - 02212006-n
   partOfSpeech: n
+  wikidata: Q1165550
 02212006-n:
   definition:
   - large solitary bee that lays eggs in tunnels bored into wood or plant stems
@@ -56051,6 +57435,7 @@
   mero_member:
   - 02212276-n
   partOfSpeech: n
+  wikidata: Q25407
 02212276-n:
   definition:
   - robust hairy social bee of temperate regions
@@ -56074,6 +57459,7 @@
   mero_member:
   - 02212616-n
   partOfSpeech: n
+  wikidata: Q42274677
 02212616-n:
   definition:
   - a bee that is parasitic in the nests of bumblebees
@@ -56095,6 +57481,7 @@
   mero_member:
   - 02212943-n
   partOfSpeech: n
+  wikidata: Q853287
 02212943-n:
   definition:
   - a solitary burrowing short-tongued bee
@@ -56106,6 +57493,7 @@
   mero_member:
   - 02213079-n
   partOfSpeech: n
+  wikidata: Q517165
 02213079-n:
   definition:
   - a bee that is a member of the genus Andrena
@@ -56129,6 +57517,7 @@
   mero_member:
   - 02213573-n
   partOfSpeech: n
+  wikidata: Q4045452
 02213380-n:
   definition:
   - a family of small solitary bees; many are valuable pollinators for agriculture
@@ -56167,6 +57556,7 @@
   - 02214279-n
   - 02214425-n
   partOfSpeech: n
+  wikidata: Q530200
 02213935-n:
   definition:
   - 'type genus of the Megachilidae: leaf-cutting bees'
@@ -56179,6 +57569,7 @@
   mero_member:
   - 02214096-n
   partOfSpeech: n
+  wikidata: Q261844
 02214096-n:
   definition:
   - bee that cuts rounded pieces from leaves and flowers to line its nest
@@ -56211,6 +57602,7 @@
   mero_member:
   - 02214548-n
   partOfSpeech: n
+  wikidata: Q1460174
 02214548-n:
   definition:
   - solitary bee that builds nests of mud or pebbles cemented together and attached
@@ -56248,6 +57640,7 @@
   - 02216619-n
   - 02216855-n
   partOfSpeech: n
+  wikidata: Q7037230
 02215254-n:
   definition:
   - mostly social nest-building wasps
@@ -56268,6 +57661,7 @@
   - Vespa
   - genus Vespa
   partOfSpeech: n
+  wikidata: Q334422
 02215610-n:
   definition:
   - any of several social wasps that construct nests of a substance like paper
@@ -56354,6 +57748,7 @@
   mero_member:
   - 02216748-n
   partOfSpeech: n
+  wikidata: Q1955518
 02216748-n:
   definition:
   - a variety of paper wasp
@@ -56377,6 +57772,7 @@
   - 02216993-n
   - 02217151-n
   partOfSpeech: n
+  wikidata: Q1524207
 02216993-n:
   definition:
   - any of various solitary wasps that construct nests of hardened mud for their young
@@ -56408,6 +57804,7 @@
   mero_member:
   - 02217425-n
   partOfSpeech: n
+  wikidata: Q252363
 02217425-n:
   definition:
   - a solitary wasp of the family Mutillidae; the body has a coat of brightly colored
@@ -56455,6 +57852,7 @@
   - 02218148-n
   - 02219017-n
   partOfSpeech: n
+  wikidata: Q132833
 02218148-n:
   definition:
   - mud daubers
@@ -56467,6 +57865,7 @@
   mero_member:
   - 02218273-n
   partOfSpeech: n
+  wikidata: Q139681
 02218273-n:
   definition:
   - solitary wasp that constructs nests of hardened mud or clay for the young
@@ -56498,6 +57897,7 @@
   mero_member:
   - 02218718-n
   partOfSpeech: n
+  wikidata: Q1836615
 02218718-n:
   definition:
   - 'large solitary wasps: cicada killer'
@@ -56510,6 +57910,7 @@
   mero_member:
   - 02218863-n
   partOfSpeech: n
+  wikidata: Q2710050
 02218863-n:
   definition:
   - large black or rust-colored wasp that preys on cicadas
@@ -56545,6 +57946,7 @@
   - 02219702-n
   - 02219853-n
   partOfSpeech: n
+  wikidata: Q640774
 02219392-n:
   definition:
   - small solitary wasp that produces galls on oaks and other plants
@@ -56578,6 +57980,7 @@
   - Amphibolips
   - genus Amphibolips
   partOfSpeech: n
+  wikidata: Q18100234
 02219853-n:
   definition:
   - cynipid gall wasps, chiefly affecting oaks
@@ -56588,6 +57991,7 @@
   - Andricus
   - genus Andricus
   partOfSpeech: n
+  wikidata: Q2846870
 02219986-n:
   definition:
   - 'an arthropod family including: chalcidflies'
@@ -56640,6 +58044,7 @@
   mero_member:
   - 02220786-n
   partOfSpeech: n
+  wikidata: Q13635343
 02220786-n:
   definition:
   - a variety of chalcid fly
@@ -56661,6 +58066,7 @@
   mero_member:
   - 02221023-n
   partOfSpeech: n
+  wikidata: Q1138186
 02221023-n:
   definition:
   - hymenopterous insect that resembles a wasp and whose larvae are parasitic on caterpillars
@@ -56735,6 +58141,7 @@
   - 02224851-n
   - 02225111-n
   partOfSpeech: n
+  wikidata: Q7386
 02222138-n:
   definition:
   - social insect living in organized colonies; characteristically the males and fertile
@@ -56818,6 +58225,7 @@
   mero_member:
   - 02223456-n
   partOfSpeech: n
+  wikidata: Q157875
 02223456-n:
   definition:
   - ant that nests in decaying wood in which it bores tunnels for depositing eggs
@@ -56839,6 +58247,7 @@
   mero_member:
   - 02223735-n
   partOfSpeech: n
+  wikidata: Q1075697
 02223735-n:
   definition:
   - omnivorous ant of tropical and subtropical America that can inflict a painful
@@ -56863,6 +58272,7 @@
   - 02224367-n
   - 02224687-n
   partOfSpeech: n
+  wikidata: Q1194683
 02224066-n:
   definition:
   - reddish-brown European ant typically living in anthills in woodlands
@@ -56925,6 +58335,7 @@
   mero_member:
   - 02224973-n
   partOfSpeech: n
+  wikidata: Q117160
 02224973-n:
   definition:
   - any of the large fierce Australian ants of the genus Myrmecia
@@ -56974,6 +58385,7 @@
   - 02226975-n
   - 02227883-n
   partOfSpeech: n
+  wikidata: Q546583
 02225661-n:
   definition:
   - termites
@@ -56998,6 +58410,7 @@
   - Termes
   - genus Termes
   partOfSpeech: n
+  wikidata: Q13582623
 02225918-n:
   definition:
   - whitish soft-bodied ant-like social insect that feeds on wood
@@ -57031,6 +58444,7 @@
   - 02226553-n
   - 02226675-n
   partOfSpeech: n
+  wikidata: Q1074282
 02226553-n:
   definition:
   - destructive United States termite
@@ -57060,6 +58474,7 @@
   - Rhinotermitidae
   - family Rhinotermitidae
   partOfSpeech: n
+  wikidata: Q1953004
 02226975-n:
   definition:
   - primitive termites
@@ -57072,6 +58487,7 @@
   mero_member:
   - 02227118-n
   partOfSpeech: n
+  wikidata: Q11988630
 02227118-n:
   definition:
   - primitive genus of termites; mostly extinct; sometimes considered the most primitive
@@ -57087,6 +58503,7 @@
   - 02227589-n
   - 02227733-n
   partOfSpeech: n
+  wikidata: Q6785606
 02227365-n:
   definition:
   - Australian termite; sole living species of Mastotermes; called a living fossil;
@@ -57153,6 +58570,7 @@
   mero_member:
   - 02228450-n
   partOfSpeech: n
+  wikidata: Q4036734
 02228450-n:
   definition:
   - extremely destructive dry-wood termite of warm regions
@@ -57179,6 +58597,7 @@
   - 02231526-n
   - 02232037-n
   partOfSpeech: n
+  wikidata: Q167810
 02228835-n:
   definition:
   - any of various insects having leathery forewings and membranous hind wings and
@@ -57217,6 +58636,7 @@
   - 02229771-n
   - 02230082-n
   partOfSpeech: n
+  wikidata: Q7618284
 02229473-n:
   definition:
   - grasshopper with short antennae
@@ -57248,6 +58668,7 @@
   mero_member:
   - 02229899-n
   partOfSpeech: n
+  wikidata: Q15122569
 02229899-n:
   definition:
   - Old World locust that travels in vast swarms stripping large areas of vegetation
@@ -57270,6 +58691,7 @@
   mero_member:
   - 02230256-n
   partOfSpeech: n
+  wikidata: Q6811522
 02230256-n:
   definition:
   - serious pest of grain-growing and range areas of central and western United States
@@ -57293,6 +58715,7 @@
   - 02230867-n
   - 02231217-n
   partOfSpeech: n
+  wikidata: Q727919
 02230618-n:
   definition:
   - grasshoppers with long threadlike antennae and well-developed stridulating organs
@@ -57339,6 +58762,7 @@
   mero_member:
   - 02231349-n
   partOfSpeech: n
+  wikidata: Q10409546
 02231349-n:
   definition:
   - large dark wingless cricket-like katydid of arid parts of western United States
@@ -57361,6 +58785,7 @@
   mero_member:
   - 02231675-n
   partOfSpeech: n
+  wikidata: Q1956922
 02231675-n:
   definition:
   - sand crickets
@@ -57373,6 +58798,7 @@
   mero_member:
   - 02231808-n
   partOfSpeech: n
+  wikidata: Q13409318
 02231808-n:
   definition:
   - large wingless nocturnal grasshopper that burrows in loose soil along the Pacific
@@ -57432,6 +58858,7 @@
   - 02232675-n
   - 02232839-n
   partOfSpeech: n
+  wikidata: Q4033254
 02232675-n:
   definition:
   - lives in human dwellings; naturalized in parts of America
@@ -57465,6 +58892,7 @@
   mero_member:
   - 02233132-n
   partOfSpeech: n
+  wikidata: Q150934
 02233132-n:
   definition:
   - pale arboreal American cricket noted for loud stridulation
@@ -57502,6 +58930,7 @@
   - 02233959-n
   - 02234582-n
   partOfSpeech: n
+  wikidata: Q188029
 02233704-n:
   definition:
   - large cylindrical or flattened mostly tropical insects with long strong legs that
@@ -57528,6 +58957,7 @@
   - 02234139-n
   - 02234332-n
   partOfSpeech: n
+  wikidata: Q577953
 02234139-n:
   definition:
   - any of various mostly tropical insects having long twiglike bodies
@@ -57550,6 +58980,7 @@
   mero_member:
   - 02234455-n
   partOfSpeech: n
+  wikidata: Q10470521
 02234455-n:
   definition:
   - a variety of stick insect
@@ -57574,6 +59005,7 @@
   mero_member:
   - 02234738-n
   partOfSpeech: n
+  wikidata: Q282198
 02234738-n:
   definition:
   - type genus of the Phyllidae
@@ -57586,6 +59018,7 @@
   mero_member:
   - 02234875-n
   partOfSpeech: n
+  wikidata: Q2625244
 02234875-n:
   definition:
   - tropical insect having a flattened leaflike body; common in southern Asia and
@@ -57687,6 +59120,7 @@
   mero_member:
   - 02236595-n
   partOfSpeech: n
+  wikidata: Q3079510
 02236595-n:
   definition:
   - dark brown cockroach originally from orient now nearly cosmopolitan in distribution
@@ -57714,6 +59148,7 @@
   - 02237007-n
   - 02237222-n
   partOfSpeech: n
+  wikidata: Q264976
 02237007-n:
   definition:
   - large reddish brown free-flying cockroach originally from southern United States
@@ -57748,6 +59183,7 @@
   mero_member:
   - 02237500-n
   partOfSpeech: n
+  wikidata: Q10431102
 02237500-n:
   definition:
   - small light-brown cockroach brought to United States from Europe; a common household
@@ -57775,6 +59211,7 @@
   mero_member:
   - 02237857-n
   partOfSpeech: n
+  wikidata: Q2593227
 02237857-n:
   definition:
   - large tropical American cockroaches
@@ -57796,6 +59233,7 @@
   mero_member:
   - 02238117-n
   partOfSpeech: n
+  wikidata: Q21069200
 02238117-n:
   definition:
   - cockroaches
@@ -57845,6 +59283,7 @@
   mero_member:
   - 02238696-n
   partOfSpeech: n
+  wikidata: Q507307
 02238696-n:
   definition:
   - predacious long-bodied large-eyed insect of warm regions; rests with forelimbs
@@ -57897,6 +59336,7 @@
   - 02243836-n
   - 02248244-n
   partOfSpeech: n
+  wikidata: Q26371
 02239548-n:
   definition:
   - insects with sucking mouthparts and forewings thickened and leathery at the base;
@@ -57960,6 +59400,7 @@
   mero_member:
   - 02240520-n
   partOfSpeech: n
+  wikidata: Q7207293
 02240520-n:
   definition:
   - yellow or orange leaf bug with four black stripes down the back; widespread in
@@ -57985,6 +59426,7 @@
   mero_member:
   - 02240887-n
   partOfSpeech: n
+  wikidata: Q3024203
 02240887-n:
   definition:
   - vector of viral plant diseases
@@ -58016,6 +59458,7 @@
   mero_member:
   - 02241246-n
   partOfSpeech: n
+  wikidata: Q1472961
 02241246-n:
   definition:
   - small bug having body and wings covered with a lacy network of raised lines
@@ -58061,6 +59504,7 @@
   mero_member:
   - 02241844-n
   partOfSpeech: n
+  wikidata: Q10431364
 02241844-n:
   definition:
   - small black-and-white insect that feeds on cereal grasses
@@ -58169,6 +59613,7 @@
   mero_member:
   - 02243169-n
   partOfSpeech: n
+  wikidata: Q10452938
 02243169-n:
   definition:
   - bug of temperate regions that infests especially beds and feeds on human blood
@@ -58207,6 +59652,7 @@
   mero_member:
   - 02243660-n
   partOfSpeech: n
+  wikidata: Q3767510
 02243660-n:
   definition:
   - predaceous aquatic insect that swims on its back and may inflict painful bites
@@ -58320,6 +59766,7 @@
   - Nepa
   - genus Nepa
   partOfSpeech: n
+  wikidata: Q6994314
 02245468-n:
   definition:
   - elongate very slender water scorpions
@@ -58330,6 +59777,7 @@
   - Ranatra
   - genus Ranatra
   partOfSpeech: n
+  wikidata: Q1154489
 02245594-n:
   definition:
   - water bugs, known in the US as water boatmen (Corixidae)
@@ -58355,6 +59803,7 @@
   mero_member:
   - 02245861-n
   partOfSpeech: n
+  wikidata: Q5170727
 02245861-n:
   definition:
   - carnivorous aquatic bug having paddle-like hind legs
@@ -58380,6 +59829,7 @@
   - 02246214-n
   - 02246396-n
   partOfSpeech: n
+  wikidata: Q3761252
 02246214-n:
   definition:
   - long-legged bug that skims about on the surface of water
@@ -58403,6 +59853,7 @@
   mero_member:
   - 02246530-n
   partOfSpeech: n
+  wikidata: Q10504469
 02246530-n:
   definition:
   - a variety of water strider
@@ -58427,6 +59878,7 @@
   - 02247048-n
   - 02247322-n
   partOfSpeech: n
+  wikidata: Q768510
 02246825-n:
   definition:
   - 'a true bug: long-legged predacious bug living mostly on other insects; a few
@@ -58450,6 +59902,7 @@
   mero_member:
   - 02247167-n
   partOfSpeech: n
+  wikidata: Q1889325
 02247167-n:
   definition:
   - large bloodsucking bug
@@ -58475,6 +59928,7 @@
   mero_member:
   - 02247449-n
   partOfSpeech: n
+  wikidata: Q15707964
 02247449-n:
   definition:
   - large predatory North American bug that sucks the blood of other insects
@@ -58522,6 +59976,7 @@
   mero_member:
   - 02248095-n
   partOfSpeech: n
+  wikidata: Q10478309
 02248095-n:
   definition:
   - 'a true bug: bug that damages and stains the lint of developing cotton'
@@ -58593,6 +60048,7 @@
   mero_member:
   - 02249593-n
   partOfSpeech: n
+  wikidata: Q2150614
 02249280-n:
   definition:
   - minute insect that feeds on plant juices; related to scale insects
@@ -58659,6 +60115,7 @@
   - 02250163-n
   - 02250307-n
   partOfSpeech: n
+  wikidata: Q2767258
 02250163-n:
   definition:
   - a variety of whitefly
@@ -58747,6 +60204,7 @@
   - 02251539-n
   - 02251663-n
   partOfSpeech: n
+  wikidata: Q1632202
 02251539-n:
   definition:
   - an insect active in all stages
@@ -58767,6 +60225,7 @@
   mero_member:
   - 02251786-n
   partOfSpeech: n
+  wikidata: Q775953
 02251786-n:
   definition:
   - pest on citrus trees
@@ -58799,6 +60258,7 @@
   - 02252167-n
   - 02252325-n
   partOfSpeech: n
+  wikidata: Q373290
 02252167-n:
   definition:
   - insect having a firm covering of wax especially in the female
@@ -58820,6 +60280,7 @@
   mero_member:
   - 02252461-n
   partOfSpeech: n
+  wikidata: Q1458247
 02252461-n:
   definition:
   - small east Asian insect naturalized in the United States that damages fruit trees
@@ -58842,6 +60303,7 @@
   mero_member:
   - 02252785-n
   partOfSpeech: n
+  wikidata: Q18549936
 02252785-n:
   definition:
   - type genus of the Dactylopiidae
@@ -58854,6 +60316,7 @@
   mero_member:
   - 02252932-n
   partOfSpeech: n
+  wikidata: Q677616
 02252932-n:
   definition:
   - Mexican red scale insect that feeds on cacti; the source of a red dye
@@ -58879,6 +60342,7 @@
   - 02253474-n
   - 02254104-n
   partOfSpeech: n
+  wikidata: Q143569
 02253305-n:
   definition:
   - type genus of the Pseudococcidae
@@ -58939,6 +60403,7 @@
   mero_member:
   - 02254245-n
   partOfSpeech: n
+  wikidata: Q10632934
 02254245-n:
   definition:
   - feeds on a wide variety of cultivated plants but especially destructive to citrus
@@ -59012,6 +60477,7 @@
   - 02255451-n
   - 02255624-n
   partOfSpeech: n
+  wikidata: Q2717643
 02255451-n:
   definition:
   - bright green aphid; feeds on and causes curling of apple leaves
@@ -59083,6 +60549,7 @@
   mero_member:
   - 02256565-n
   partOfSpeech: n
+  wikidata: Q10488197
 02256367-n:
   definition:
   - secretes a waxy substance like a mass of fine curly white cotton or woolly threads
@@ -59116,6 +60583,7 @@
   mero_member:
   - 02256898-n
   partOfSpeech: n
+  wikidata: Q7247417
 02256898-n:
   definition:
   - attacks alders
@@ -59198,6 +60666,7 @@
   mero_member:
   - 02257922-n
   partOfSpeech: n
+  wikidata: Q10631863
 02257922-n:
   definition:
   - a variety of adelgid which feeds on red, black, Engelmann, blue, and white spruce,
@@ -59231,6 +60700,7 @@
   mero_member:
   - 02258350-n
   partOfSpeech: n
+  wikidata: Q2671139
 02258350-n:
   definition:
   - 'type genus of the Phylloxeridae: plant lice'
@@ -59243,6 +60713,7 @@
   mero_member:
   - 02258507-n
   partOfSpeech: n
+  wikidata: Q18104594
 02258507-n:
   definition:
   - destructive to various grape plants
@@ -59296,6 +60767,7 @@
   - 02259534-n
   - 02259801-n
   partOfSpeech: n
+  wikidata: Q130778
 02259194-n:
   definition:
   - 'type genus of the Cicadidae: cicadas'
@@ -59305,6 +60777,7 @@
   members:
   - genus Cicada
   partOfSpeech: n
+  wikidata: Q18347690
 02259308-n:
   definition:
   - stout-bodied insect with large membranous wings; male has drum-like organs for
@@ -59328,6 +60801,7 @@
   mero_member:
   - 02259655-n
   partOfSpeech: n
+  wikidata: Q7800449
 02259655-n:
   definition:
   - its distinctive song is heard during July and August
@@ -59350,6 +60824,7 @@
   mero_member:
   - 02259936-n
   partOfSpeech: n
+  wikidata: Q49664
 02259936-n:
   definition:
   - North American cicada; appears in great numbers at infrequent intervals because
@@ -59410,6 +60885,7 @@
   mero_member:
   - 02260850-n
   partOfSpeech: n
+  wikidata: Q1949240
 02260850-n:
   definition:
   - North American insect that severely damages grasses
@@ -59466,6 +60942,7 @@
   mero_member:
   - 02261864-n
   partOfSpeech: n
+  wikidata: Q244452
 02261562-n:
   definition:
   - family of small leafhoppers coextensive with the Cicadellidae and not distinguished
@@ -59479,6 +60956,7 @@
   mero_member:
   - 02261864-n
   partOfSpeech: n
+  wikidata: Q33134010
 02261788-n:
   definition:
   - a variety of leafhopper
@@ -59519,6 +60997,7 @@
   mero_member:
   - 02262360-n
   partOfSpeech: n
+  wikidata: Q999560
 02262360-n:
   definition:
   - small leaping insect that sucks juices of branches and twigs
@@ -59568,6 +61047,7 @@
   - 02263275-n
   - 02263836-n
   partOfSpeech: n
+  wikidata: Q271623
 02263073-n:
   definition:
   - small soft-bodied insect with chewing mouthparts and either no wings or two pairs
@@ -59592,6 +61072,7 @@
   - 02263938-n
   - 02264282-n
   partOfSpeech: n
+  wikidata: Q3430220
 02263515-n:
   definition:
   - small winged insect living on the bark and leaves of trees and feeding on e.g.
@@ -59634,6 +61115,7 @@
   mero_member:
   - 02264071-n
   partOfSpeech: n
+  wikidata: Q10563111
 02264071-n:
   definition:
   - minute wingless psocopterous insects injurious to books and papers
@@ -59658,6 +61140,7 @@
   mero_member:
   - 02264409-n
   partOfSpeech: n
+  wikidata: Q17560372
 02264409-n:
   definition:
   - a variety of booklouse
@@ -59683,6 +61166,7 @@
   - 02264830-n
   - 02264976-n
   partOfSpeech: n
+  wikidata: Q174273
 02264714-n:
   definition:
   - 'in some former classifications: name for the Ephemeroptera'
@@ -59714,6 +61198,7 @@
   mero_member:
   - 02265101-n
   partOfSpeech: n
+  wikidata: Q1194030
 02265101-n:
   definition:
   - slender insect with delicate membranous wings having an aquatic larval stage and
@@ -59738,6 +61223,7 @@
   mero_member:
   - 02265455-n
   partOfSpeech: n
+  wikidata: Q203547
 02265455-n:
   definition:
   - primitive winged insect with a flattened body; used as bait by fishermen; aquatic
@@ -59793,6 +61279,7 @@
   mero_member:
   - 02266500-n
   partOfSpeech: n
+  wikidata: Q231439
 02266500-n:
   definition:
   - 'type genus of the Myrmeleontidae: antlions'
@@ -59806,6 +61293,7 @@
   - 02266673-n
   - 02266884-n
   partOfSpeech: n
+  wikidata: Q11787636
 02266673-n:
   definition:
   - winged insect resembling a dragonfly; the larvae (doodlebugs) dig conical pits
@@ -59898,6 +61386,7 @@
   - 02267243-n
   - 02267982-n
   partOfSpeech: n
+  wikidata: Q790667
 02267982-n:
   definition:
   - small dark-colored lacewing fly
@@ -59937,6 +61426,7 @@
   - 02268512-n
   - 02269073-n
   partOfSpeech: n
+  wikidata: Q1936061
 02268512-n:
   definition:
   - type genus of the Corydalidae
@@ -59952,6 +61442,7 @@
   - 02268702-n
   - 02268921-n
   partOfSpeech: n
+  wikidata: Q159568
 02268702-n:
   definition:
   - large soft-bodied insect having long slender mandibles in the male; aquatic larvae
@@ -59998,6 +61489,7 @@
   mero_member:
   - 02269384-n
   partOfSpeech: n
+  wikidata: Q899799
 02269384-n:
   definition:
   - type genus of the Sialidae
@@ -60035,6 +61527,7 @@
   mero_member:
   - 02269860-n
   partOfSpeech: n
+  wikidata: Q929599
 02269860-n:
   definition:
   - predatory insect of western North America having a long necklike prothorax
@@ -60104,6 +61597,7 @@
   - 02270986-n
   - 02271398-n
   partOfSpeech: n
+  wikidata: Q25375
 02270800-n:
   definition:
   - large primitive predatory aquatic insect having two pairs of membranous wings
@@ -60232,6 +61726,7 @@
   - 02272978-n
   - 02273739-n
   partOfSpeech: n
+  wikidata: Q226951
 02272663-n:
   definition:
   - 'primitive wingless insects: bristletail'
@@ -60264,6 +61759,7 @@
   - 02273125-n
   - 02273462-n
   partOfSpeech: n
+  wikidata: Q1066550
 02273125-n:
   definition:
   - 'type genus of the Lepismatidae: silverfish'
@@ -60276,6 +61772,7 @@
   mero_member:
   - 02273275-n
   partOfSpeech: n
+  wikidata: Q779558
 02273275-n:
   definition:
   - silver-grey wingless insect found in houses feeding on book bindings and starched
@@ -60299,6 +61796,7 @@
   mero_member:
   - 02273597-n
   partOfSpeech: n
+  wikidata: Q7783129
 02273597-n:
   definition:
   - lives in warm moist areas e.g. around furnaces
@@ -60321,6 +61819,7 @@
   mero_member:
   - 02273874-n
   partOfSpeech: n
+  wikidata: Q134098
 02273874-n:
   definition:
   - wingless insect living in dark moist places as under dead tree trunks; they make
@@ -60345,6 +61844,7 @@
   - 02274222-n
   - 02274392-n
   partOfSpeech: n
+  wikidata: Q185628
 02274222-n:
   definition:
   - an insect of the order Thysanoptera
@@ -60396,6 +61896,7 @@
   mero_member:
   - 02274938-n
   partOfSpeech: n
+  wikidata: Q3752044
 02274938-n:
   definition:
   - injurious to growing tobacco and peanuts
@@ -60417,6 +61918,7 @@
   mero_member:
   - 02275204-n
   partOfSpeech: n
+  wikidata: Q7798266
 02275204-n:
   definition:
   - injurious to onion plants and sometimes tobacco
@@ -60464,6 +61966,7 @@
   mero_member:
   - 02275906-n
   partOfSpeech: n
+  wikidata: Q1931619
 02275906-n:
   definition:
   - type genus of Forficulidae
@@ -60476,6 +61979,7 @@
   mero_member:
   - 02276044-n
   partOfSpeech: n
+  wikidata: Q3024850
 02276044-n:
   definition:
   - sometimes destructive to cultivated bulbs
@@ -60516,6 +62020,7 @@
   - 02308811-n
   - 02311989-n
   partOfSpeech: n
+  wikidata: Q28319
 02276676-n:
   definition:
   - insect that in the adult state has four wings more or less covered with tiny scales
@@ -60557,6 +62062,7 @@
   - 02281356-n
   - 02281779-n
   partOfSpeech: n
+  wikidata: Q156449
 02277474-n:
   definition:
   - medium to large butterflies found worldwide typically having brightly colored
@@ -60583,6 +62089,7 @@
   - 02278212-n
   - 02278425-n
   partOfSpeech: n
+  wikidata: Q32440
 02278212-n:
   definition:
   - of temperate regions; having dark purple wings with yellow borders
@@ -60618,6 +62125,7 @@
   - 02278730-n
   - 02279007-n
   partOfSpeech: n
+  wikidata: Q311218
 02278730-n:
   definition:
   - American butterfly having dark brown wings with white and golden orange spots
@@ -60662,6 +62170,7 @@
   - 02279746-n
   - 02279920-n
   partOfSpeech: n
+  wikidata: Q1064168
 02279401-n:
   definition:
   - Eurasian butterfly with brown wings and white markings
@@ -60725,6 +62234,7 @@
   mero_member:
   - 02280394-n
   partOfSpeech: n
+  wikidata: Q612468
 02280394-n:
   definition:
   - any of various butterflies belonging to the family Satyridae
@@ -60781,6 +62291,7 @@
   mero_member:
   - 02281115-n
   partOfSpeech: n
+  wikidata: Q2716199
 02281115-n:
   definition:
   - butterfly with silver spots on the underside of the hind wings
@@ -60800,6 +62311,7 @@
   - Argynnis
   - genus Argynnis
   partOfSpeech: n
+  wikidata: Q286622
 02281356-n:
   definition:
   - large Old World butterflies
@@ -60812,6 +62324,7 @@
   mero_member:
   - 02281491-n
   partOfSpeech: n
+  wikidata: Q1083863
 02281491-n:
   definition:
   - large richly colored butterfly
@@ -60845,6 +62358,7 @@
   mero_member:
   - 02281909-n
   partOfSpeech: n
+  wikidata: Q13135251
 02281909-n:
   definition:
   - European butterfly having reddish-brown wings each marked with a purple eyespot
@@ -60869,6 +62383,7 @@
   - 02282289-n
   - 02282471-n
   partOfSpeech: n
+  wikidata: Q3013286
 02282289-n:
   definition:
   - large tropical butterfly with degenerate forelegs and an unpleasant taste
@@ -60891,6 +62406,7 @@
   mero_member:
   - 02282624-n
   partOfSpeech: n
+  wikidata: Q662991
 02282624-n:
   definition:
   - large migratory American butterfly having deep orange wings with black and white
@@ -60919,6 +62435,7 @@
   - 02283497-n
   - 02284058-n
   partOfSpeech: n
+  wikidata: Q41559
 02283110-n:
   definition:
   - any of numerous pale-colored butterflies having three pairs of well-developed
@@ -60953,6 +62470,7 @@
   - 02283788-n
   - 02313237-n
   partOfSpeech: n
+  wikidata: Q997547
 02283667-n:
   definition:
   - small widely distributed form
@@ -61007,6 +62525,7 @@
   - 02284639-n
   - 02285368-n
   partOfSpeech: n
+  wikidata: Q158717
 02284439-n:
   definition:
   - any of various butterflies of the family Lycaenidae
@@ -61032,6 +62551,7 @@
   - 02285037-n
   - 02285205-n
   partOfSpeech: n
+  wikidata: Q258719
 02284909-n:
   definition:
   - any of numerous small butterflies of the family Lycaenidae
@@ -61073,6 +62593,7 @@
   - 02285555-n
   - 02285729-n
   partOfSpeech: n
+  wikidata: Q1354777
 02285555-n:
   definition:
   - small butterflies having striped markings under the wings
@@ -61128,6 +62649,7 @@
   - 02287423-n
   - 02287704-n
   partOfSpeech: n
+  wikidata: Q28953
 02286603-n:
   definition:
   - any of numerous small moths having lightly fringed wings; larvae are leaf rollers
@@ -61161,6 +62683,7 @@
   - 02287263-n
   - 02287536-n
   partOfSpeech: n
+  wikidata: Q1311036
 02287165-n:
   definition:
   - tea tortrix
@@ -61171,6 +62694,7 @@
   - Homona
   - genus Homona
   partOfSpeech: n
+  wikidata: Q10768136
 02287263-n:
   definition:
   - small Indian moth infesting e.g. tea and coffee plants
@@ -61217,6 +62741,7 @@
   mero_member:
   - 02287831-n
   partOfSpeech: n
+  wikidata: Q23072903
 02287831-n:
   definition:
   - a small grey moth whose larvae live in apples and English walnuts
@@ -61243,6 +62768,7 @@
   - 02288561-n
   - 02288923-n
   partOfSpeech: n
+  wikidata: Q162734
 02288200-n:
   definition:
   - dull-colored moth whose larvae have tufts of hair on the body and feed on the
@@ -61275,6 +62801,7 @@
   mero_member:
   - 02288741-n
   partOfSpeech: n
+  wikidata: Q1315974
 02288741-n:
   definition:
   - European moth introduced into North America; a serious pest of shade trees
@@ -61299,6 +62826,7 @@
   - 02289077-n
   - 02289306-n
   partOfSpeech: n
+  wikidata: Q5410920
 02289077-n:
   definition:
   - small brown and white European moth introduced into eastern United States; pest
@@ -61384,6 +62912,7 @@
   - 02290274-n
   - 02290774-n
   partOfSpeech: n
+  wikidata: Q140563
 02290274-n:
   definition:
   - North American moth with grey-winged males and wingless females; larvae are fall
@@ -61454,6 +62983,7 @@
   - 02293173-n
   - 02312493-n
   partOfSpeech: n
+  wikidata: Q248425
 02291441-n:
   definition:
   - usually tropical slender-bodied long-legged moth whose larvae are crop pests
@@ -61487,6 +63017,7 @@
   mero_member:
   - 02291959-n
   partOfSpeech: n
+  wikidata: Q14867415
 02291959-n:
   definition:
   - moth whose larvae live in and feed on bee honeycombs
@@ -61510,6 +63041,7 @@
   mero_member:
   - 02292262-n
   partOfSpeech: n
+  wikidata: Q149486
 02292262-n:
   definition:
   - native to Europe; in America the larvae bore into the stem and crown of corn and
@@ -61535,6 +63067,7 @@
   mero_member:
   - 02292640-n
   partOfSpeech: n
+  wikidata: Q14846366
 02292640-n:
   definition:
   - small moth whose larvae damage stored grain and flour
@@ -61647,6 +63180,7 @@
   - 02294924-n
   - 02295216-n
   partOfSpeech: n
+  wikidata: Q2473551
 02294224-n:
   definition:
   - small yellowish moths whose larvae feed on wool or fur
@@ -61679,6 +63213,7 @@
   mero_member:
   - 02294737-n
   partOfSpeech: n
+  wikidata: Q1955436
 02294737-n:
   definition:
   - the larvae live in tubes of its food material fastened with silk that it spins
@@ -61702,6 +63237,7 @@
   mero_member:
   - 02295053-n
   partOfSpeech: n
+  wikidata: Q7808096
 02295053-n:
   definition:
   - moth that forms a web in which it lives
@@ -61749,6 +63285,7 @@
   - Gracillariidae
   - family Gracilariidae
   partOfSpeech: n
+  wikidata: Q721100
 02295632-n:
   definition:
   - small dull or metallic-colored tineoid moths whose larvae mine in plant leaves
@@ -61775,6 +63312,7 @@
   - 02296931-n
   - 02312801-n
   partOfSpeech: n
+  wikidata: Q778491
 02296004-n:
   definition:
   - small slender-winged moths whose larvae are agricultural pests
@@ -61797,6 +63335,7 @@
   mero_member:
   - 02296367-n
   partOfSpeech: n
+  wikidata: Q5121983
 02296367-n:
   definition:
   - small brown moth whose larvae bore into flowers and bolls of cotton
@@ -61895,6 +63434,7 @@
   - 02300287-n
   - 02312986-n
   partOfSpeech: n
+  wikidata: Q459180
 02297716-n:
   definition:
   - usually dull-colored medium-sized nocturnal moth; the usually smooth-bodied larvae
@@ -61927,6 +63467,7 @@
   - Noctua
   - genus Noctua
   partOfSpeech: n
+  wikidata: Q1062824
 02298369-n:
   definition:
   - 'moths whose larvae are cutworms: underwings'
@@ -61939,6 +63480,7 @@
   mero_member:
   - 02298522-n
   partOfSpeech: n
+  wikidata: Q2450100
 02298522-n:
   definition:
   - moth having dull forewings and brightly colored hind wings
@@ -61994,6 +63536,7 @@
   mero_member:
   - 02299264-n
   partOfSpeech: n
+  wikidata: Q587379
 02299264-n:
   definition:
   - medium-sized moth whose larvae are corn earworms
@@ -62016,6 +63559,7 @@
   mero_member:
   - 02299564-n
   partOfSpeech: n
+  wikidata: Q5105108
 02299564-n:
   definition:
   - larvae (of a noctuid moth) that travel in large groups and destroy grains and
@@ -62040,6 +63584,7 @@
   - 02299946-n
   - 02300094-n
   partOfSpeech: n
+  wikidata: Q15647093
 02299946-n:
   definition:
   - moth whose destructive larvae travel in multitudes
@@ -62076,6 +63621,7 @@
   - 02300590-n
   - 02300747-n
   partOfSpeech: n
+  wikidata: Q2492887
 02300471-n:
   definition:
   - moth whose larvae are beet armyworms
@@ -62129,6 +63675,7 @@
   - 02301485-n
   - 02302367-n
   partOfSpeech: n
+  wikidata: Q157683
 02301193-n:
   definition:
   - any of various moths with long narrow forewings capable of powerful flight and
@@ -62157,6 +63704,7 @@
   - 02301809-n
   - 02302030-n
   partOfSpeech: n
+  wikidata: Q134774
 02301691-n:
   definition:
   - moth whose larvae are tobacco hornworms
@@ -62211,6 +63759,7 @@
   mero_member:
   - 02302498-n
   partOfSpeech: n
+  wikidata: Q312009
 02302498-n:
   definition:
   - European hawkmoth with markings on the back resembling a human skull
@@ -62259,6 +63808,7 @@
   - 02303206-n
   - 02303449-n
   partOfSpeech: n
+  wikidata: Q1314183
 02303206-n:
   definition:
   - stocky creamy-white Asiatic moth found almost entirely under human care; the source
@@ -62306,6 +63856,7 @@
   - 02306881-n
   - 02307619-n
   partOfSpeech: n
+  wikidata: Q843104
 02304104-n:
   definition:
   - large brightly colored and usually tropical moth; larvae spin silken cocoons
@@ -62328,6 +63879,7 @@
   mero_member:
   - 02304587-n
   partOfSpeech: n
+  wikidata: Q1325847
 02304587-n:
   definition:
   - large moth of temperate forests of Eurasia having heavily scaled transparent wings
@@ -62351,6 +63903,7 @@
   mero_member:
   - 02304896-n
   partOfSpeech: n
+  wikidata: Q27868
 02304896-n:
   definition:
   - large American moth having yellow wings with purplish or brownish markings; larvae
@@ -62398,6 +63951,7 @@
   mero_member:
   - 02305621-n
   partOfSpeech: n
+  wikidata: Q134540
 02305621-n:
   definition:
   - large pale-green American moth with long-tailed hind wings and a yellow crescent-shaped
@@ -62419,6 +63973,7 @@
   - Hyalophora
   - genus Hyalophora
   partOfSpeech: n
+  wikidata: Q310032
 02305936-n:
   definition:
   - North American silkworm moth; larvae feed on the leaves of forest trees
@@ -62443,6 +63998,7 @@
   - 02306237-n
   - 02306429-n
   partOfSpeech: n
+  wikidata: Q1759132
 02306237-n:
   definition:
   - large Asiatic moth introduced into the United States; larvae feed on the ailanthus
@@ -62476,6 +64032,7 @@
   mero_member:
   - 02306688-n
   partOfSpeech: n
+  wikidata: Q44776
 02306688-n:
   definition:
   - large yellow American moth having a large eyelike spot on each hind wing; the
@@ -62501,6 +64058,7 @@
   - 02307309-n
   - 02307449-n
   partOfSpeech: n
+  wikidata: Q135431
 02307084-n:
   definition:
   - very large yellowish-brown American silkworm moth with large eyespots on hind
@@ -62548,6 +64106,7 @@
   mero_member:
   - 02307737-n
   partOfSpeech: n
+  wikidata: Q26260766
 02307737-n:
   definition:
   - giant saturniid moth widespread in Asia; sometimes cultured for silk
@@ -62572,6 +64131,7 @@
   - 02308451-n
   - 02313593-n
   partOfSpeech: n
+  wikidata: Q15043775
 02308059-n:
   definition:
   - stout-bodied broad-winged moth with conspicuously striped or spotted wings; larvae
@@ -62605,6 +64165,7 @@
   mero_member:
   - 02308581-n
   partOfSpeech: n
+  wikidata: Q2934200
 02308581-n:
   definition:
   - large red-and-black European moth; larvae feed on leaves of ragwort; introduced
@@ -62659,6 +64220,7 @@
   mero_member:
   - 02309477-n
   partOfSpeech: n
+  wikidata: Q3218309
 02309477-n:
   definition:
   - moth having nonfunctional mouthparts as adults; larvae feed on tree foliage and
@@ -62684,6 +64246,7 @@
   - 02309977-n
   - 02310167-n
   partOfSpeech: n
+  wikidata: Q10790185
 02309828-n:
   definition:
   - moth whose larvae are tent caterpillars
@@ -63048,6 +64611,7 @@
   mero_member:
   - 02316012-n
   partOfSpeech: n
+  wikidata: Q162907
 02316012-n:
   definition:
   - hermaphrodite wormlike animal living in mud of the sea bottom
@@ -63072,6 +64636,7 @@
   - 02316653-n
   - 02316973-n
   partOfSpeech: n
+  wikidata: Q148134
 02316361-n:
   definition:
   - sessile aquatic animal forming mossy colonies of small polyps each having a curved
@@ -63122,6 +64687,7 @@
   mero_member:
   - 02317144-n
   partOfSpeech: n
+  wikidata: Q208580
 02317144-n:
   definition:
   - any of various moss-like aquatic animals usually forming branching colonies; each
@@ -63171,6 +64737,7 @@
   mero_member:
   - 02318139-n
   partOfSpeech: n
+  wikidata: Q178272
 02318139-n:
   definition:
   - marine animal with bivalve shell having a pair of arms bearing tentacles for capturing
@@ -63195,6 +64762,7 @@
   mero_member:
   - 02318473-n
   partOfSpeech: n
+  wikidata: Q205712
 02318473-n:
   definition:
   - small unsegmented marine worm that when disturbed retracts its anterior portion
@@ -63242,6 +64810,7 @@
   - 02322619-n
   - 02323994-n
   partOfSpeech: n
+  wikidata: Q44631
 02319359-n:
   definition:
   - marine invertebrates with tube feet and five-part radially symmetrical bodies
@@ -63277,6 +64846,7 @@
   mero_member:
   - 02319987-n
   partOfSpeech: n
+  wikidata: Q25349
 02319987-n:
   definition:
   - echinoderms characterized by five arms extending from a central disk
@@ -63300,6 +64870,7 @@
   - 02320305-n
   - 02320635-n
   partOfSpeech: n
+  wikidata: Q59256
 02320305-n:
   definition:
   - brittle stars
@@ -63360,6 +64931,7 @@
   - Euryale
   - genus Euryale
   partOfSpeech: n
+  wikidata: Q21444553
 02321190-n:
   definition:
   - includes many of the basket stars
@@ -63372,6 +64944,7 @@
   mero_member:
   - 02321339-n
   partOfSpeech: n
+  wikidata: Q2868606
 02321339-n:
   definition:
   - a variety of basket star
@@ -63407,6 +64980,7 @@
   - 02322075-n
   - 02322341-n
   partOfSpeech: n
+  wikidata: Q83483
 02321747-n:
   definition:
   - shallow-water echinoderms having soft bodies enclosed in thin spiny globular shells
@@ -63438,6 +65012,7 @@
   mero_member:
   - 02322207-n
   partOfSpeech: n
+  wikidata: Q1071960
 02322207-n:
   definition:
   - flattened disklike sea urchins that live on sandy bottoms
@@ -63459,6 +65034,7 @@
   mero_member:
   - 02322481-n
   partOfSpeech: n
+  wikidata: Q631141
 02322481-n:
   definition:
   - sea urchin having a heart-shaped body in a rigid spiny shell
@@ -63482,6 +65058,7 @@
   - 02322991-n
   - 02323273-n
   partOfSpeech: n
+  wikidata: Q33666
 02322779-n:
   definition:
   - primitive echinoderms having five or more feathery arms radiating from a central
@@ -63504,6 +65081,7 @@
   mero_member:
   - 02323117-n
   partOfSpeech: n
+  wikidata: Q18606085
 02323117-n:
   definition:
   - crinoid with delicate radiating arms and a stalked body attached to a hard surface
@@ -63525,6 +65103,7 @@
   mero_member:
   - 02323540-n
   partOfSpeech: n
+  wikidata: Q2852646
 02323421-n:
   definition:
   - former usage synonymous with Antedonidae
@@ -63535,6 +65114,7 @@
   - Comatulidae
   - family Comatulidae
   partOfSpeech: n
+  wikidata: Q19819363
 02323540-n:
   definition:
   - a genus of echinoderms of the family Antedonidae
@@ -63547,6 +65127,7 @@
   mero_member:
   - 02323822-n
   partOfSpeech: n
+  wikidata: Q2852647
 02323714-n:
   definition:
   - former usage synonymous with Antedon
@@ -63557,6 +65138,7 @@
   - Comatula
   - genus Comatula
   partOfSpeech: n
+  wikidata: Q18602072
 02323822-n:
   definition:
   - free-swimming stalkless crinoid with ten feathery arms; found on muddy sea bottoms
@@ -63580,6 +65162,7 @@
   - 02324181-n
   - 02324411-n
   partOfSpeech: n
+  wikidata: Q127470
 02324181-n:
   definition:
   - echinoderm having a flexible sausage-shaped body, tentacles surrounding the mouth
@@ -63603,6 +65186,7 @@
   mero_member:
   - 02324555-n
   partOfSpeech: n
+  wikidata: Q2490529
 02324555-n:
   definition:
   - type genus of the Holothuridae
@@ -63615,6 +65199,7 @@
   mero_member:
   - 02324699-n
   partOfSpeech: n
+  wikidata: Q1408044
 02324699-n:
   definition:
   - of warm coasts from Australia to Asia; used as food especially by Chinese
@@ -63699,6 +65284,7 @@
   - 02326367-n
   - 02330922-n
   partOfSpeech: n
+  wikidata: Q25401
 02326101-n:
   definition:
   - relative large gnawing animals; distinguished from rodents by having two pairs
@@ -63792,6 +65378,7 @@
   mero_member:
   - 02327502-n
   partOfSpeech: n
+  wikidata: Q10803279
 02327502-n:
   definition:
   - common greyish-brown burrowing animal native to southern Europe and northern Africa
@@ -63820,6 +65407,7 @@
   - 02328018-n
   - 02328536-n
   partOfSpeech: n
+  wikidata: Q748448
 02328018-n:
   definition:
   - common small rabbit of North America having greyish or brownish fur and a tail
@@ -63883,6 +65471,7 @@
   - 02329680-n
   - 02330308-n
   partOfSpeech: n
+  wikidata: Q46076
 02329084-n:
   definition:
   - swift timid long-eared mammal larger than a rabbit having a divided upper lip
@@ -64003,6 +65592,7 @@
   - 02331081-n
   - 02331314-n
   partOfSpeech: n
+  wikidata: Q4364126
 02331081-n:
   definition:
   - small short-eared burrowing mammal of rocky uplands of Asia and western North
@@ -64030,6 +65620,7 @@
   - 02331472-n
   - 02331594-n
   partOfSpeech: n
+  wikidata: Q184067
 02331472-n:
   definition:
   - North American pika
@@ -64158,6 +65749,7 @@
   - 02337261-n
   - 02337501-n
   partOfSpeech: n
+  wikidata: Q25916
 02334494-n:
   definition:
   - a rodent that is a member of the family Muridae
@@ -64180,6 +65772,7 @@
   mero_member:
   - 02334808-n
   partOfSpeech: n
+  wikidata: Q39275
 02334808-n:
   definition:
   - brownish-grey Old World mouse now a common household pest worldwide
@@ -64202,6 +65795,7 @@
   mero_member:
   - 02335099-n
   partOfSpeech: n
+  wikidata: Q2895175
 02335099-n:
   definition:
   - small reddish-brown Eurasian mouse inhabiting e.g. cornfields
@@ -64225,6 +65819,7 @@
   - 02335407-n
   - 02335842-n
   partOfSpeech: n
+  wikidata: Q739059
 02335407-n:
   definition:
   - any nocturnal Old World mouse of the genus Apodemus inhabiting woods and fields
@@ -64270,6 +65865,7 @@
   - 02336198-n
   - 02336561-n
   partOfSpeech: n
+  wikidata: Q36396
 02336198-n:
   definition:
   - common domestic rat; serious pest worldwide
@@ -64326,6 +65922,7 @@
   mero_member:
   - 02336853-n
   partOfSpeech: n
+  wikidata: Q930095
 02336853-n:
   definition:
   - burrowing scaly-tailed rat of India and Ceylon
@@ -64348,6 +65945,7 @@
   mero_member:
   - 02337112-n
   partOfSpeech: n
+  wikidata: Q738245
 02337112-n:
   definition:
   - large Australian rat with hind legs adapted for leaping
@@ -64369,6 +65967,7 @@
   mero_member:
   - 02337380-n
   partOfSpeech: n
+  wikidata: Q782974
 02337380-n:
   definition:
   - leaping rodent of Australian desert areas
@@ -64458,6 +66057,7 @@
   - 02348123-n
   - 02348542-n
   partOfSpeech: n
+  wikidata: Q193061
 02338663-n:
   definition:
   - a variety of rodent
@@ -64570,6 +66170,7 @@
   mero_member:
   - 02340250-n
   partOfSpeech: n
+  wikidata: Q469583
 02340250-n:
   definition:
   - very small dark greyish brown mouse resembling a house mouse; of Texas and Mexico
@@ -64592,6 +66193,7 @@
   mero_member:
   - 02340554-n
   partOfSpeech: n
+  wikidata: Q369761
 02340554-n:
   definition:
   - insectivorous mouse of western North America
@@ -64614,6 +66216,7 @@
   mero_member:
   - 02340797-n
   partOfSpeech: n
+  wikidata: Q12829163
 02340797-n:
   definition:
   - beaver-like aquatic rodent of North America with dark glossy brown fur
@@ -64637,6 +66240,7 @@
   mero_member:
   - 02341101-n
   partOfSpeech: n
+  wikidata: Q10797614
 02341101-n:
   definition:
   - of Florida wetlands
@@ -64661,6 +66265,7 @@
   mero_member:
   - 02341374-n
   partOfSpeech: n
+  wikidata: Q609460
 02341374-n:
   definition:
   - destructive long-haired burrowing rat of southern North America and Central America
@@ -64788,6 +66393,7 @@
   mero_member:
   - 02343582-n
   partOfSpeech: n
+  wikidata: Q50577682
 02343582-n:
   definition:
   - short-tailed glossy-furred burrowing vole of the eastern United States
@@ -64859,6 +66465,7 @@
   mero_member:
   - 02344626-n
   partOfSpeech: n
+  wikidata: Q539670
 02344626-n:
   definition:
   - common large Eurasian vole
@@ -64882,6 +66489,7 @@
   mero_member:
   - 02344902-n
   partOfSpeech: n
+  wikidata: Q11842375
 02344902-n:
   definition:
   - any of several voles of mountainous regions of Eurasia and America
@@ -64903,6 +66511,7 @@
   mero_member:
   - 02345186-n
   partOfSpeech: n
+  wikidata: Q847196
 02345186-n:
   definition:
   - any of several vole-like terrestrial or arboreal rodents of cold forested regions
@@ -64925,6 +66534,7 @@
   mero_member:
   - 02345537-n
   partOfSpeech: n
+  wikidata: Q10750831
 02345537-n:
   definition:
   - short-tailed Old World burrowing rodent with large cheek pouches
@@ -64956,6 +66566,7 @@
   mero_member:
   - 02345972-n
   partOfSpeech: n
+  wikidata: Q389919
 02345972-n:
   definition:
   - small light-colored hamster often kept as a pet
@@ -64991,6 +66602,7 @@
   - Gerbillus
   - genus Gerbillus
   partOfSpeech: n
+  wikidata: Q517079
 02346424-n:
   definition:
   - small Old World burrowing desert rodent with long soft pale fur and hind legs
@@ -65016,6 +66628,7 @@
   - 02346922-n
   - 02347060-n
   partOfSpeech: n
+  wikidata: Q941160
 02346827-n:
   definition:
   - gerbil of northern Africa
@@ -65067,6 +66680,7 @@
   - 02347570-n
   - 02347730-n
   partOfSpeech: n
+  wikidata: Q525589
 02347570-n:
   definition:
   - notable for mass migrations even into the sea where many drown
@@ -65099,6 +66713,7 @@
   mero_member:
   - 02347992-n
   partOfSpeech: n
+  wikidata: Q12263990
 02347992-n:
   definition:
   - Old World lemming
@@ -65122,6 +66737,7 @@
   mero_member:
   - 02348252-n
   partOfSpeech: n
+  wikidata: Q370070
 02348252-n:
   definition:
   - North American lemming having a white winter coat and some claws much enlarged
@@ -65151,6 +66767,7 @@
   - Synaptomys
   - genus Synaptomys
   partOfSpeech: n
+  wikidata: Q339937
 02348649-n:
   definition:
   - of low bogs and meadows of northeastern and central United States and southern
@@ -65216,6 +66833,7 @@
   - 02349792-n
   - 02350095-n
   partOfSpeech: n
+  wikidata: Q302006
 02349650-n:
   definition:
   - terrestrial porcupine
@@ -65237,6 +66855,7 @@
   mero_member:
   - 02349926-n
   partOfSpeech: n
+  wikidata: Q780143
 02349926-n:
   definition:
   - porcupine with a tuft of large beaded bristles on the tail
@@ -65259,6 +66878,7 @@
   mero_member:
   - 02350225-n
   partOfSpeech: n
+  wikidata: Q10827991
 02350225-n:
   definition:
   - porcupine of Borneo and Sumatra having short spines and a long tail
@@ -65292,6 +66912,7 @@
   - 02350396-n
   - 02350688-n
   partOfSpeech: n
+  wikidata: Q811633
 02350688-n:
   definition:
   - a genus of Erethizontidae
@@ -65304,6 +66925,7 @@
   mero_member:
   - 02350825-n
   partOfSpeech: n
+  wikidata: Q732499
 02350825-n:
   definition:
   - porcupine of northeastern North America with barbed spines concealed in the coarse
@@ -65333,6 +66955,7 @@
   - 02352632-n
   - 02353189-n
   partOfSpeech: n
+  wikidata: Q607610
 02351440-n:
   definition:
   - any of various small nocturnal burrowing desert rodents with cheek pouches and
@@ -65407,6 +67030,7 @@
   mero_member:
   - 02352499-n
   partOfSpeech: n
+  wikidata: Q912104
 02352499-n:
   definition:
   - large pocket mouse of Mexico
@@ -65429,6 +67053,7 @@
   mero_member:
   - 02352757-n
   partOfSpeech: n
+  wikidata: Q120094
 02352757-n:
   definition:
   - any of various leaping rodents of desert regions of North America and Mexico;
@@ -65464,6 +67089,7 @@
   mero_member:
   - 02353322-n
   partOfSpeech: n
+  wikidata: Q922132
 02353322-n:
   definition:
   - small silky-haired pouched rodent; similar to but smaller than kangaroo rats
@@ -65487,6 +67113,7 @@
   - 02353641-n
   - 02353864-n
   partOfSpeech: n
+  wikidata: Q13174621
 02353641-n:
   definition:
   - any of several primitive mouselike rodents with long hind legs and no cheek pouches;
@@ -65509,6 +67136,7 @@
   mero_member:
   - 02353995-n
   partOfSpeech: n
+  wikidata: Q524430
 02353995-n:
   definition:
   - widely distributed in northeastern and central United States and Canada
@@ -65546,6 +67174,7 @@
   mero_member:
   - 02354654-n
   partOfSpeech: n
+  wikidata: Q12256276
 02354522-n:
   definition:
   - mouselike jumping rodent
@@ -65577,6 +67206,7 @@
   mero_member:
   - 02354942-n
   partOfSpeech: n
+  wikidata: Q1072121
 02354942-n:
   definition:
   - a variety of jerboa
@@ -65624,6 +67254,7 @@
   mero_member:
   - 02355584-n
   partOfSpeech: n
+  wikidata: Q15102590
 02355584-n:
   definition:
   - large European dormouse
@@ -65646,6 +67277,7 @@
   mero_member:
   - 02355824-n
   partOfSpeech: n
+  wikidata: Q12263932
 02355824-n:
   definition:
   - a variety of dormouse
@@ -65692,6 +67324,7 @@
   - 02356513-n
   - 02357122-n
   partOfSpeech: n
+  wikidata: Q756901
 02356361-n:
   definition:
   - type genus of the Geomyidae
@@ -65752,6 +67385,7 @@
   - 02357273-n
   - 02357433-n
   partOfSpeech: n
+  wikidata: Q1094704
 02357273-n:
   definition:
   - of valleys and mountain meadows of western United States
@@ -65846,6 +67480,7 @@
   - 02359629-n
   - 02359763-n
   partOfSpeech: n
+  wikidata: Q281124
 02359033-n:
   definition:
   - common medium-large squirrel of eastern North America; now introduced into England
@@ -65911,6 +67546,7 @@
   - Tamiasciurus
   - genus Tamiasciurus
   partOfSpeech: n
+  wikidata: Q935907
 02360053-n:
   definition:
   - of northern United States and Canada
@@ -65950,6 +67586,7 @@
   mero_member:
   - 02360743-n
   partOfSpeech: n
+  wikidata: Q199251
 02360563-n:
   definition:
   - small ground squirrel of western United States
@@ -66041,6 +67678,7 @@
   mero_member:
   - 02361976-n
   partOfSpeech: n
+  wikidata: Q30359
 02361976-n:
   definition:
   - any of several rodents of North American prairies living in large complex burrows
@@ -66084,6 +67722,7 @@
   mero_member:
   - 02362567-n
   partOfSpeech: n
+  wikidata: Q22364
 02362567-n:
   definition:
   - small striped semiterrestrial eastern American squirrel with cheek pouches
@@ -66109,6 +67748,7 @@
   mero_member:
   - 02362934-n
   partOfSpeech: n
+  wikidata: Q5414381
 02362934-n:
   definition:
   - a burrowing ground squirrel of western America and Asia; has cheek pouches and
@@ -66146,6 +67786,7 @@
   mero_member:
   - 02363433-n
   partOfSpeech: n
+  wikidata: Q1010970
 02363433-n:
   definition:
   - a name used to describe both the northern and southern flying squirrels
@@ -66187,6 +67828,7 @@
   mero_member:
   - 02363989-n
   partOfSpeech: n
+  wikidata: Q131567
 02363989-n:
   definition:
   - stocky coarse-furred burrowing rodent with a short bushy tail found throughout
@@ -66267,6 +67909,7 @@
   mero_member:
   - 02365221-n
   partOfSpeech: n
+  wikidata: Q1080535
 02365221-n:
   definition:
   - East Indian flying squirrel
@@ -66306,6 +67949,7 @@
   mero_member:
   - 02365657-n
   partOfSpeech: n
+  wikidata: Q47542
 02365657-n:
   definition:
   - large semiaquatic rodent with webbed hind feet and a broad flat tail; construct
@@ -66359,6 +68003,7 @@
   mero_member:
   - 02366470-n
   partOfSpeech: n
+  wikidata: Q1887673
 02366470-n:
   definition:
   - 'type genus of the Aplodontiidae: comprising the mountain beavers'
@@ -66371,6 +68016,7 @@
   mero_member:
   - 02366648-n
   partOfSpeech: n
+  wikidata: Q10734562
 02366648-n:
   definition:
   - bulky nocturnal burrowing rodent of uplands of the Pacific coast of North America;
@@ -66396,6 +68042,7 @@
   - 02367029-n
   - 02367641-n
   partOfSpeech: n
+  wikidata: Q685772
 02367029-n:
   definition:
   - 'type genus of the Caviidae: guinea pigs'
@@ -66408,6 +68055,7 @@
   mero_member:
   - 02367172-n
   partOfSpeech: n
+  wikidata: Q286088
 02367172-n:
   definition:
   - short-tailed rough-haired South American rodent
@@ -66475,6 +68123,7 @@
   mero_member:
   - 02368008-n
   partOfSpeech: n
+  wikidata: Q24188433
 02368008-n:
   definition:
   - a genus of Hydrochoeridae
@@ -66485,6 +68134,7 @@
   - Hydrochoerus
   - genus Hydrochoerus
   partOfSpeech: n
+  wikidata: Q902454
 02368132-n:
   definition:
   - pig-sized tailless South American amphibious rodent with partly webbed feet; largest
@@ -66524,6 +68174,7 @@
   mero_member:
   - 02368654-n
   partOfSpeech: n
+  wikidata: Q193966
 02368654-n:
   definition:
   - agile long-legged rabbit-sized rodent of Central America and South America and
@@ -66545,6 +68196,7 @@
   - Cuniculus
   - genus Cuniculus
   partOfSpeech: n
+  wikidata: Q202697
 02368953-n:
   definition:
   - large burrowing rodent of South America and Central America; highly esteemed as
@@ -66589,6 +68241,7 @@
   mero_member:
   - 02369477-n
   partOfSpeech: n
+  wikidata: Q651787
 02369477-n:
   definition:
   - a genus of Capromyidae
@@ -66601,6 +68254,7 @@
   mero_member:
   - 02369611-n
   partOfSpeech: n
+  wikidata: Q10795801
 02369611-n:
   definition:
   - aquatic South American rodent resembling a small beaver; bred for its fur
@@ -66627,6 +68281,7 @@
   - 02370645-n
   - 02370932-n
   partOfSpeech: n
+  wikidata: Q650915
 02370012-n:
   definition:
   - type genus of the Chinchillidae
@@ -66638,6 +68293,7 @@
   mero_member:
   - 02370144-n
   partOfSpeech: n
+  wikidata: Q192930
 02370144-n:
   definition:
   - small rodent with soft pearly grey fur; native to the Andes but bred in captivity
@@ -66661,6 +68317,7 @@
   mero_member:
   - 02370464-n
   partOfSpeech: n
+  wikidata: Q1195501
 02370464-n:
   definition:
   - a rodent native to the mountains of Chile and Peru and now bred in captivity
@@ -66707,6 +68364,7 @@
   mero_member:
   - 02371051-n
   partOfSpeech: n
+  wikidata: Q480789
 02371051-n:
   definition:
   - ratlike rodent with soft fur and large ears of the Andes
@@ -66744,6 +68402,7 @@
   mero_member:
   - 02371473-n
   partOfSpeech: n
+  wikidata: Q951670
 02371473-n:
   definition:
   - furry short-limbed tailless rodent resembling a true mole in habits and appearance;
@@ -66767,6 +68426,7 @@
   - 02371822-n
   - 02372076-n
   partOfSpeech: n
+  wikidata: Q750383
 02371822-n:
   definition:
   - the genus of dune mole-rats, containing the Namaqua dune mole-rat and the Cape
@@ -66780,6 +68440,7 @@
   mero_member:
   - 02371945-n
   partOfSpeech: n
+  wikidata: Q791322
 02371945-n:
   definition:
   - African rodent resembling a mole in habits and appearance
@@ -66801,6 +68462,7 @@
   mero_member:
   - 02372207-n
   partOfSpeech: n
+  wikidata: Q12259103
 02372207-n:
   definition:
   - small nearly naked African mole rat of desert areas
@@ -66920,6 +68582,7 @@
   mero_member:
   - 02374299-n
   partOfSpeech: n
+  wikidata: Q132815
 02374299-n:
   definition:
   - an extinct family of Dinocerata
@@ -66932,6 +68595,7 @@
   mero_member:
   - 02374453-n
   partOfSpeech: n
+  wikidata: Q2663297
 02374453-n:
   definition:
   - type genus of the Uintatheriidae; extinct large herbivorous ungulates somewhat
@@ -66977,6 +68641,7 @@
   mero_member:
   - 02375049-n
   partOfSpeech: n
+  wikidata: Q53099
 02375049-n:
   definition:
   - includes all recent members of the order Hyracoidea
@@ -67044,6 +68709,7 @@
   - 02394434-n
   - 02395952-n
   partOfSpeech: n
+  wikidata: Q25374
 02375988-n:
   definition:
   - placental mammals having hooves with an odd number of toes on each foot
@@ -67072,6 +68738,7 @@
   - 02378955-n
   - 02380132-n
   partOfSpeech: n
+  wikidata: Q165115
 02376495-n:
   definition:
   - 'type genus of the Equidae: only surviving genus of the family Equidae'
@@ -67091,6 +68758,7 @@
   - 02393701-n
   - 02394269-n
   partOfSpeech: n
+  wikidata: Q27022
 02376801-n:
   definition:
   - hoofed mammals having slender legs and a flat coat with a narrow mane along the
@@ -67184,6 +68852,7 @@
   mero_member:
   - 02378787-n
   partOfSpeech: n
+  wikidata: Q132597
 02378787-n:
   definition:
   - North American three-toed Oligocene animal; probably not directly ancestral to
@@ -67205,6 +68874,7 @@
   mero_member:
   - 02379075-n
   partOfSpeech: n
+  wikidata: Q3408120
 02379075-n:
   definition:
   - Pliocene horse approaching donkeys in size
@@ -68374,6 +70044,7 @@
   - 02395362-n
   - 02395676-n
   partOfSpeech: n
+  wikidata: Q34718
 02394646-n:
   definition:
   - massive powerful herbivorous odd-toed ungulate of southeast Asia and Africa having
@@ -68397,6 +70068,7 @@
   - 02395086-n
   - 02395207-n
   partOfSpeech: n
+  wikidata: Q134657
 02395086-n:
   definition:
   - having one horn
@@ -68428,6 +70100,7 @@
   - Ceratotherium
   - genus Ceratotherium
   partOfSpeech: n
+  wikidata: Q5762446
 02395476-n:
   definition:
   - large light-grey African rhinoceros having two horns; endangered; sometimes placed
@@ -68452,6 +70125,7 @@
   mero_member:
   - 02395813-n
   partOfSpeech: n
+  wikidata: Q18511101
 02395813-n:
   definition:
   - African rhino; in danger of extinction
@@ -68474,6 +70148,7 @@
   mero_member:
   - 02396097-n
   partOfSpeech: n
+  wikidata: Q3745367
 02396097-n:
   definition:
   - type genus of the Tapiridae
@@ -68486,6 +70161,7 @@
   mero_member:
   - 02396232-n
   partOfSpeech: n
+  wikidata: Q128001
 02396232-n:
   definition:
   - large inoffensive chiefly nocturnal ungulate of tropical America and southeast
@@ -68565,6 +70241,7 @@
   - 02399319-n
   - 02399622-n
   partOfSpeech: n
+  wikidata: Q166898
 02397655-n:
   definition:
   - stout-bodied short-legged omnivorous animals
@@ -68588,6 +70265,7 @@
   - 02398346-n
   - 02399079-n
   partOfSpeech: n
+  wikidata: Q10798
 02398058-n:
   definition:
   - domestic swine
@@ -68692,6 +70370,7 @@
   mero_member:
   - 02399448-n
   partOfSpeech: n
+  wikidata: Q232558
 02399448-n:
   definition:
   - Indonesian wild pig with enormous curved canine teeth
@@ -68716,6 +70395,7 @@
   mero_member:
   - 02399748-n
   partOfSpeech: n
+  wikidata: Q3645260
 02399748-n:
   definition:
   - African wild swine with warty protuberances on the face and large protruding tusks
@@ -68737,6 +70417,7 @@
   mero_member:
   - 02400029-n
   partOfSpeech: n
+  wikidata: Q232866
 02400029-n:
   definition:
   - type genus of the Tayassuidae
@@ -68750,6 +70431,7 @@
   mero_member:
   - 02400181-n
   partOfSpeech: n
+  wikidata: Q10824139
 02400181-n:
   definition:
   - nocturnal gregarious pig-like wild animals of North America and South America
@@ -68806,6 +70488,7 @@
   mero_member:
   - 02401038-n
   partOfSpeech: n
+  wikidata: Q213336
 02401038-n:
   definition:
   - type genus of the Hippopotamidae
@@ -68817,6 +70500,7 @@
   mero_member:
   - 02401173-n
   partOfSpeech: n
+  wikidata: Q629680
 02401173-n:
   definition:
   - massive thick-skinned herbivorous animal living in or around rivers of tropical
@@ -68957,6 +70641,7 @@
   - 02430875-n
   - 02431299-n
   partOfSpeech: n
+  wikidata: Q25497
 02403683-n:
   definition:
   - hollow-horned ruminants
@@ -69008,6 +70693,7 @@
   - 02407954-n
   - 02408092-n
   partOfSpeech: n
+  wikidata: Q237993
 02404662-n:
   definition:
   - any of various members of the genus Bos
@@ -69447,6 +71133,7 @@
   - 02411075-n
   - 02411848-n
   partOfSpeech: n
+  wikidata: Q83521
 02411075-n:
   definition:
   - an Asian buffalo that is often domesticated for use as a draft animal
@@ -69489,6 +71176,7 @@
   mero_member:
   - 02411684-n
   partOfSpeech: n
+  wikidata: Q122848966
 02411684-n:
   definition:
   - small buffalo of the Celebes having small straight horns
@@ -69525,6 +71213,7 @@
   mero_member:
   - 02412154-n
   partOfSpeech: n
+  wikidata: Q10822466
 02412154-n:
   definition:
   - large often savage buffalo of southern Africa having upward-curving horns; mostly
@@ -69551,6 +71240,7 @@
   - 02412657-n
   - 02412787-n
   partOfSpeech: n
+  wikidata: Q21441827
 02412516-n:
   definition:
   - genus of Asiatic wild oxen
@@ -69594,6 +71284,7 @@
   - 02413348-n
   - 02413546-n
   partOfSpeech: n
+  wikidata: Q18099
 02413155-n:
   definition:
   - any of several large humped bovids having shaggy manes and large heads and short
@@ -69641,6 +71332,7 @@
   mero_member:
   - 02413852-n
   partOfSpeech: n
+  wikidata: Q19817365
 02413852-n:
   definition:
   - large shaggy-coated bovid mammal of Canada and Greenland; intermediate in size
@@ -69674,6 +71366,7 @@
   - 02418223-n
   - 02418475-n
   partOfSpeech: n
+  wikidata: Q22724
 02414351-n:
   definition:
   - woolly usually horned ruminant mammal related to the goat
@@ -69996,6 +71689,7 @@
   mero_member:
   - 02418750-n
   partOfSpeech: n
+  wikidata: Q10732899
 02418750-n:
   definition:
   - wild sheep of northern Africa
@@ -70031,6 +71725,7 @@
   mero_member:
   - 02419165-n
   partOfSpeech: n
+  wikidata: Q172923
 02419165-n:
   definition:
   - any of numerous agile ruminants related to sheep but having a beard and straight
@@ -70197,6 +71892,7 @@
   mero_member:
   - 02421416-n
   partOfSpeech: n
+  wikidata: Q1370188
 02421416-n:
   definition:
   - small goat antelope with small conical horns; of southern Asian mountains
@@ -70219,6 +71915,7 @@
   mero_member:
   - 02421702-n
   partOfSpeech: n
+  wikidata: Q1140380
 02421702-n:
   definition:
   - short-horned dark-coated goat antelope of mountain areas of southern and southeastern
@@ -70241,6 +71938,7 @@
   mero_member:
   - 02421982-n
   partOfSpeech: n
+  wikidata: Q912026
 02421982-n:
   definition:
   - hoofed mammal of mountains of Eurasia having upright horns with backward-hooked
@@ -70264,6 +71962,7 @@
   mero_member:
   - 02422280-n
   partOfSpeech: n
+  wikidata: Q10741556
 02422280-n:
   definition:
   - large heavily built goat antelope of eastern Himalayan area
@@ -70297,6 +71996,7 @@
   mero_member:
   - 02423155-n
   partOfSpeech: n
+  wikidata: Q1416078
 02423155-n:
   definition:
   - common Indian antelope with a dark back and spiral horns
@@ -70321,6 +72021,7 @@
   mero_member:
   - 02423474-n
   partOfSpeech: n
+  wikidata: Q19817358
 02423474-n:
   definition:
   - slender East African antelope with slim neck and backward-curving horns
@@ -70343,6 +72044,7 @@
   mero_member:
   - 02423782-n
   partOfSpeech: n
+  wikidata: Q10730701
 02423782-n:
   definition:
   - large antelope with lightly spiraled horns of desert regions of northern Africa
@@ -70365,6 +72067,7 @@
   mero_member:
   - 02424095-n
   partOfSpeech: n
+  wikidata: Q7609
 02424095-n:
   definition:
   - large African antelope having a head with horns like an ox and a long tufted tail
@@ -70387,6 +72090,7 @@
   mero_member:
   - 02424438-n
   partOfSpeech: n
+  wikidata: Q216263
 02424438-n:
   definition:
   - any of several small antelopes of eastern Africa of the genus Madoqua; the size
@@ -70431,6 +72135,7 @@
   mero_member:
   - 02425037-n
   partOfSpeech: n
+  wikidata: Q2086371
 02425037-n:
   definition:
   - a large South African antelope; considered the swiftest hoofed mammal
@@ -70454,6 +72159,7 @@
   mero_member:
   - 02425345-n
   partOfSpeech: n
+  wikidata: Q10730799
 02425345-n:
   definition:
   - African antelope with ridged curved horns; moves with enormous leaps
@@ -70478,6 +72184,7 @@
   - 02425864-n
   - 02426008-n
   partOfSpeech: n
+  wikidata: Q190858
 02425668-n:
   definition:
   - small swift graceful antelope of Africa and Asia having lustrous eyes
@@ -70518,6 +72225,7 @@
   mero_member:
   - 02426235-n
   partOfSpeech: n
+  wikidata: Q10734306
 02426235-n:
   definition:
   - a South African gazelle noted for springing lightly into the air
@@ -70549,6 +72257,7 @@
   - 02427732-n
   - 02427874-n
   partOfSpeech: n
+  wikidata: Q311375
 02426731-n:
   definition:
   - large forest antelope of central Africa having a reddish-brown coat with white
@@ -70648,6 +72357,7 @@
   mero_member:
   - 02428178-n
   partOfSpeech: n
+  wikidata: Q10740872
 02428178-n:
   definition:
   - large Indian antelope; male is blue-grey with white markings; female is brownish
@@ -70674,6 +72384,7 @@
   mero_member:
   - 02428533-n
   partOfSpeech: n
+  wikidata: Q516624
 02428533-n:
   definition:
   - large black East African antelope with sharp backward-curving horns
@@ -70695,6 +72406,7 @@
   mero_member:
   - 02428822-n
   partOfSpeech: n
+  wikidata: Q3016753
 02428822-n:
   definition:
   - goat-like antelope of central Eurasia having a stubby nose like a proboscis
@@ -70717,6 +72429,7 @@
   mero_member:
   - 02429127-n
   partOfSpeech: n
+  wikidata: Q2345033
 02429127-n:
   definition:
   - small plains antelope of southeastern Africa
@@ -70785,6 +72498,7 @@
   mero_member:
   - 02430370-n
   partOfSpeech: n
+  wikidata: Q550036
 02430116-n:
   definition:
   - an orange-brown antelope of southeast Africa
@@ -70849,6 +72563,7 @@
   mero_member:
   - 02430995-n
   partOfSpeech: n
+  wikidata: Q658179
 02430995-n:
   definition:
   - large African antelope with long straight nearly upright horns
@@ -70883,6 +72598,7 @@
   mero_member:
   - 02431488-n
   partOfSpeech: n
+  wikidata: Q11830630
 02431488-n:
   definition:
   - cow-like creature with the glossy coat of a horse and the agility of a goat and
@@ -70908,6 +72624,7 @@
   mero_member:
   - 02431922-n
   partOfSpeech: n
+  wikidata: Q3581369
 02431922-n:
   definition:
   - type and sole genus of the Antilocapridae comprising one species
@@ -70920,6 +72637,7 @@
   mero_member:
   - 02432102-n
   partOfSpeech: n
+  wikidata: Q19817351
 02432102-n:
   definition:
   - fleet antelope-like ruminant of western North American plains with small branched
@@ -71166,6 +72884,7 @@
   mero_member:
   - 02435629-n
   partOfSpeech: n
+  wikidata: Q10731891
 02435629-n:
   definition:
   - large northern deer with enormous flattened antlers in the male; called ‘elk’
@@ -71190,6 +72909,7 @@
   mero_member:
   - 02435949-n
   partOfSpeech: n
+  wikidata: Q912336
 02435949-n:
   definition:
   - small Eurasian deer
@@ -71212,6 +72932,7 @@
   mero_member:
   - 02436177-n
   partOfSpeech: n
+  wikidata: Q1043583
 02436177-n:
   definition:
   - small graceful deer of Eurasian woodlands having small forked antlers
@@ -71243,6 +72964,7 @@
   mero_member:
   - 02436556-n
   partOfSpeech: n
+  wikidata: Q15303567
 02436556-n:
   definition:
   - Arctic deer with large antlers in both sexes; called ‘reindeer’ in Eurasia and
@@ -71290,6 +73012,7 @@
   mero_member:
   - 02437343-n
   partOfSpeech: n
+  wikidata: Q911770
 02437343-n:
   definition:
   - small South American deer with unbranched antlers
@@ -71311,6 +73034,7 @@
   mero_member:
   - 02437585-n
   partOfSpeech: n
+  wikidata: Q234121
 02437585-n:
   definition:
   - small Asian deer with small antlers and a cry like a bark
@@ -71333,6 +73057,7 @@
   mero_member:
   - 02437847-n
   partOfSpeech: n
+  wikidata: Q3866060
 02437847-n:
   definition:
   - small heavy-limbed upland deer of central Asia; male secretes valued musk
@@ -71355,6 +73080,7 @@
   mero_member:
   - 02438148-n
   partOfSpeech: n
+  wikidata: Q10758204
 02438148-n:
   definition:
   - large Chinese deer surviving only in domesticated herds
@@ -71380,6 +73106,7 @@
   - 02438698-n
   - 02439145-n
   partOfSpeech: n
+  wikidata: Q8535351
 02438484-n:
   definition:
   - very small hornless deer-like ruminant of tropical Asia and west Africa
@@ -71403,6 +73130,7 @@
   - 02438855-n
   - 02438984-n
   partOfSpeech: n
+  wikidata: Q1987747
 02438855-n:
   definition:
   - small chevrotain of southeastern Asia
@@ -71435,6 +73163,7 @@
   mero_member:
   - 02439276-n
   partOfSpeech: n
+  wikidata: Q19817324
 02439276-n:
   definition:
   - largest chevrotain; of marshy areas of west Africa
@@ -71460,6 +73189,7 @@
   - 02440456-n
   - 02441083-n
   partOfSpeech: n
+  wikidata: Q135022
 02439624-n:
   definition:
   - 'type genus of the Camelidae: camels'
@@ -71472,6 +73202,7 @@
   mero_member:
   - 02439767-n
   partOfSpeech: n
+  wikidata: Q7375
 02439767-n:
   definition:
   - cud-chewing mammal used as a draft or saddle animal in desert regions
@@ -71527,6 +73258,7 @@
   - 02440804-n
   - 02440903-n
   partOfSpeech: n
+  wikidata: Q753853
 02440602-n:
   definition:
   - used in the Andes as a beast of burden and source of wool; considered a domesticated
@@ -71571,6 +73303,7 @@
   mero_member:
   - 02441211-n
   partOfSpeech: n
+  wikidata: Q2703941
 02441211-n:
   definition:
   - small wild cud-chewing Andean animal similar to the guanaco but smaller; valued
@@ -71596,6 +73329,7 @@
   - 02441528-n
   - 02441917-n
   partOfSpeech: n
+  wikidata: Q186154
 02441528-n:
   definition:
   - type genus of the Giraffidae
@@ -71608,6 +73342,7 @@
   mero_member:
   - 02441664-n
   partOfSpeech: n
+  wikidata: Q862089
 02441664-n:
   definition:
   - tallest living quadruped; having a spotted coat and small horns and very long
@@ -71632,6 +73367,7 @@
   mero_member:
   - 02442029-n
   partOfSpeech: n
+  wikidata: Q1872039
 02442029-n:
   definition:
   - similar to the giraffe but smaller with much shorter neck and stripe on the legs
@@ -71773,6 +73509,7 @@
   - 02445745-n
   - 02446115-n
   partOfSpeech: n
+  wikidata: Q28521
 02444573-n:
   definition:
   - small carnivorous mammal with short legs and elongated body and neck
@@ -71900,6 +73637,7 @@
   mero_member:
   - 02446439-n
   partOfSpeech: n
+  wikidata: Q10808040
 02446439-n:
   definition:
   - southern African weasel
@@ -71976,6 +73714,7 @@
   mero_member:
   - 02447450-n
   partOfSpeech: n
+  wikidata: Q446882
 02447450-n:
   definition:
   - freshwater carnivorous mammal having webbed and clawed feet and dark brown fur
@@ -72018,6 +73757,7 @@
   mero_member:
   - 02448025-n
   partOfSpeech: n
+  wikidata: Q5832825
 02448025-n:
   definition:
   - large marine otter of northern Pacific coasts having very thick dark brown fur
@@ -72063,6 +73803,7 @@
   - 02448837-n
   - 02448983-n
   partOfSpeech: n
+  wikidata: Q1207714
 02448837-n:
   definition:
   - most common and widespread North American skunk
@@ -72167,6 +73908,7 @@
   mero_member:
   - 02450393-n
   partOfSpeech: n
+  wikidata: Q11950979
 02450393-n:
   definition:
   - a variety of badger native to America
@@ -72190,6 +73932,7 @@
   mero_member:
   - 02450691-n
   partOfSpeech: n
+  wikidata: Q1345042
 02450691-n:
   definition:
   - a variety of badger native to Europe and Asia
@@ -72212,6 +73955,7 @@
   mero_member:
   - 02450949-n
   partOfSpeech: n
+  wikidata: Q13564654
 02450949-n:
   definition:
   - nocturnal badger-like carnivore of wooded regions of Africa and southern Asia
@@ -72235,6 +73979,7 @@
   mero_member:
   - 02451264-n
   partOfSpeech: n
+  wikidata: Q1366503
 02451264-n:
   definition:
   - small ferret-like badger of southeast Asia
@@ -72256,6 +74001,7 @@
   mero_member:
   - 02451516-n
   partOfSpeech: n
+  wikidata: Q11906411
 02451516-n:
   definition:
   - southeast Asian badger with a snout like a pig
@@ -72281,6 +74027,7 @@
   mero_member:
   - 02451814-n
   partOfSpeech: n
+  wikidata: Q16894566
 02451814-n:
   definition:
   - stocky shaggy-coated North American carnivorous mammal
@@ -72315,6 +74062,7 @@
   mero_member:
   - 02452330-n
   partOfSpeech: n
+  wikidata: Q25606482
 02452213-n:
   definition:
   - alternative name for the genus Grison
@@ -72324,6 +74072,7 @@
   members:
   - genus Galictis
   partOfSpeech: n
+  wikidata: Q756008
 02452330-n:
   definition:
   - carnivore of Central America and South America resembling a weasel with a greyish-white
@@ -72348,6 +74097,7 @@
   mero_member:
   - 02452665-n
   partOfSpeech: n
+  wikidata: Q26533
 02452665-n:
   definition:
   - agile slender-bodied arboreal mustelids somewhat larger than weasels
@@ -72448,6 +74198,7 @@
   mero_member:
   - 02454046-n
   partOfSpeech: n
+  wikidata: Q15631638
 02454046-n:
   definition:
   - long-tailed arboreal mustelid of Central America and South America
@@ -72643,6 +74394,7 @@
   - 02458778-n
   - 02459136-n
   partOfSpeech: n
+  wikidata: Q47867
 02457010-n:
   definition:
   - burrowing chiefly nocturnal mammal with body covered with strong horny plates
@@ -72664,6 +74416,7 @@
   mero_member:
   - 02457425-n
   partOfSpeech: n
+  wikidata: Q902499
 02457425-n:
   definition:
   - having nine hinged bands of bony plates; ranges from Texas to Paraguay
@@ -72689,6 +74442,7 @@
   mero_member:
   - 02457766-n
   partOfSpeech: n
+  wikidata: Q1080942
 02457766-n:
   definition:
   - South American armadillo with three bands of bony plates
@@ -72711,6 +74465,7 @@
   mero_member:
   - 02458059-n
   partOfSpeech: n
+  wikidata: Q856879
 02458059-n:
   definition:
   - naked-tailed armadillo of tropical South America
@@ -72735,6 +74490,7 @@
   mero_member:
   - 02458351-n
   partOfSpeech: n
+  wikidata: Q10759617
 02458351-n:
   definition:
   - Argentine armadillo with six movable bands and hairy underparts
@@ -72756,6 +74512,7 @@
   - Priodontes
   - genus Priodontes
   partOfSpeech: n
+  wikidata: Q10808428
 02458639-n:
   definition:
   - about three feet long exclusive of tail
@@ -72780,6 +74537,7 @@
   mero_member:
   - 02458906-n
   partOfSpeech: n
+  wikidata: Q19816366
 02458906-n:
   definition:
   - very small Argentine armadillo with pale silky hair and pink plates on head and
@@ -72806,6 +74564,7 @@
   mero_member:
   - 02459276-n
   partOfSpeech: n
+  wikidata: Q4999415
 02459276-n:
   definition:
   - of southern South America
@@ -72829,6 +74588,7 @@
   - 02459593-n
   - 02459880-n
   partOfSpeech: n
+  wikidata: Q15407789
 02459593-n:
   definition:
   - any of several slow-moving arboreal mammals of South America and Central America;
@@ -72852,6 +74612,7 @@
   mero_member:
   - 02460039-n
   partOfSpeech: n
+  wikidata: Q185167
 02460039-n:
   definition:
   - a sloth that has three long claws on each forefoot and each hindfoot
@@ -72876,6 +74637,7 @@
   mero_member:
   - 02460387-n
   partOfSpeech: n
+  wikidata: Q3259942
 02460387-n:
   definition:
   - a genus of Megalonychidae consisting of the two-toed sloth
@@ -72889,6 +74651,7 @@
   - 02460576-n
   - 02460766-n
   partOfSpeech: n
+  wikidata: Q511079
 02460576-n:
   definition:
   - relatively small fast-moving sloth with two long claws on each front foot
@@ -72927,6 +74690,7 @@
   - 02461148-n
   - 02461306-n
   partOfSpeech: n
+  wikidata: Q784732
 02461148-n:
   definition:
   - a large extinct ground sloth
@@ -72950,6 +74714,7 @@
   mero_member:
   - 02461453-n
   partOfSpeech: n
+  wikidata: Q310387
 02461453-n:
   definition:
   - gigantic extinct terrestrial sloth-like mammal of the Pliocene and Pleistocene
@@ -72976,6 +74741,7 @@
   - 02461944-n
   - 02462267-n
   partOfSpeech: n
+  wikidata: Q1749282
 02461821-n:
   definition:
   - a variety of extinct edentate
@@ -72996,6 +74762,7 @@
   mero_member:
   - 02462116-n
   partOfSpeech: n
+  wikidata: Q310869
 02462116-n:
   definition:
   - large (bear-sized) extinct edentate mammal of the Pleistocene in South America
@@ -73031,6 +74798,7 @@
   - 02463315-n
   - 02463645-n
   partOfSpeech: n
+  wikidata: Q206538
 02462640-n:
   definition:
   - any of several tropical American mammals of the family Myrmecophagidae which lack
@@ -73054,6 +74822,7 @@
   mero_member:
   - 02463082-n
   partOfSpeech: n
+  wikidata: Q10795875
 02463082-n:
   definition:
   - large shaggy-haired toothless anteater with long tongue and powerful claws; of
@@ -73081,6 +74850,7 @@
   mero_member:
   - 02463448-n
   partOfSpeech: n
+  wikidata: Q19816375
 02463448-n:
   definition:
   - squirrel-sized South American toothless anteater with long silky golden fur
@@ -73103,6 +74873,7 @@
   mero_member:
   - 02463759-n
   partOfSpeech: n
+  wikidata: Q428197
 02463759-n:
   definition:
   - small toothless anteater with prehensile tail and four-clawed forelimbs; of tropical
@@ -73128,6 +74899,7 @@
   mero_member:
   - 02464187-n
   partOfSpeech: n
+  wikidata: Q2191516
 02464187-n:
   definition:
   - coextensive with the order Pholidota
@@ -73140,6 +74912,7 @@
   mero_member:
   - 02464332-n
   partOfSpeech: n
+  wikidata: Q9027425
 02464332-n:
   definition:
   - type genus of the Manidae
@@ -73152,6 +74925,7 @@
   mero_member:
   - 02464461-n
   partOfSpeech: n
+  wikidata: Q25397
 02464461-n:
   definition:
   - toothless mammal of southern Africa and Asia having a body covered with horny
@@ -73665,6 +75439,7 @@
   - 02503380-n
   - 02503732-n
   partOfSpeech: n
+  wikidata: Q7380
 02472545-n:
   definition:
   - any placental mammal of the order Primates; has good eyesight and flexible hands
@@ -73773,6 +75548,7 @@
   - 02481047-n
   - 02481170-n
   partOfSpeech: n
+  wikidata: Q635162
 02474393-n:
   definition:
   - a primate of the family Hominidae
@@ -73801,6 +75577,7 @@
   - 02478109-n
   - 02478300-n
   partOfSpeech: n
+  wikidata: Q171283
 02474924-n:
   definition:
   - any living or extinct member of the family Hominidae characterized by superior
@@ -73868,6 +75645,7 @@
   - Pithecanthropus erectus
   - genus Pithecanthropus
   partOfSpeech: n
+  wikidata: Q21446423
 02476351-n:
   definition:
   - fossil remains found in Java; formerly called Pithecanthropus erectus
@@ -73898,6 +75676,7 @@
   - Sinanthropus
   - genus Sinanthropus
   partOfSpeech: n
+  wikidata: Q21447470
 02476741-n:
   definition:
   - extinct primitive hominid of late Pleistocene; Java; formerly Javanthropus
@@ -73917,6 +75696,7 @@
   - Javanthropus
   - genus Javanthropus
   partOfSpeech: n
+  wikidata: Q21446703
 02477062-n:
   definition:
   - early man of late Pleistocene; skull resembles that of Neanderthal man but with
@@ -74020,6 +75800,7 @@
   - Plesianthropus
   - genus Plesianthropus
   partOfSpeech: n
+  wikidata: Q56425569
 02478850-n:
   definition:
   - any of several extinct humanlike bipedal primates with relatively small brains
@@ -74079,6 +75860,7 @@
   - Zinjanthropus
   - genus Zinjanthropus
   partOfSpeech: n
+  wikidata: Q21448049
 02479960-n:
   definition:
   - large-toothed hominid of southern Africa; from 1.5 to 2 million years ago; formerly
@@ -74111,6 +75893,7 @@
   mero_member:
   - 02480413-n
   partOfSpeech: n
+  wikidata: Q132950
 02480413-n:
   definition:
   - fossil primates found in India
@@ -74134,6 +75917,7 @@
   - 02480708-n
   - 02480870-n
   partOfSpeech: n
+  wikidata: Q131637
 02480708-n:
   definition:
   - considered a possible ancestor to both anthropoid apes and humans
@@ -74164,6 +75948,7 @@
   - Ouranopithecus
   - genus Ouranopithecus
   partOfSpeech: n
+  wikidata: Q14516253
 02481170-n:
   definition:
   - a genus of Hominidae containing three species, L. lufengensis, L. hudienensis
@@ -74175,6 +75960,7 @@
   - Lufengpithecus
   - genus Lufengpithecus
   partOfSpeech: n
+  wikidata: Q138078
 02481293-n:
   definition:
   - genus of extinct primitive African primates of the Miocene epoch; sometimes considered
@@ -74187,6 +75973,7 @@
   mero_member:
   - 02481506-n
   partOfSpeech: n
+  wikidata: Q131791
 02481506-n:
   definition:
   - an anthropoid ape of the genus Proconsul
@@ -74219,6 +76006,7 @@
   mero_member:
   - 02481963-n
   partOfSpeech: n
+  wikidata: Q18604603
 02481963-n:
   definition:
   - extinct primate of about 38 million years ago; fossils found in Egypt
@@ -74268,6 +76056,7 @@
   - 02483304-n
   - 02484260-n
   partOfSpeech: n
+  wikidata: Q3396223
 02482784-n:
   definition:
   - any of the large anthropoid apes of the family Pongidae
@@ -74290,6 +76079,7 @@
   mero_member:
   - 02483126-n
   partOfSpeech: n
+  wikidata: Q41050
 02483126-n:
   definition:
   - large long-armed ape of Borneo and Sumatra having arboreal habits
@@ -74317,6 +76107,7 @@
   - 02483997-n
   - 02484131-n
   partOfSpeech: n
+  wikidata: Q36611
 02483486-n:
   definition:
   - largest anthropoid ape; terrestrial and vegetarian; of forests of central west
@@ -74383,6 +76174,7 @@
   - 02484454-n
   - 02485281-n
   partOfSpeech: n
+  wikidata: Q80174
 02484454-n:
   definition:
   - intelligent somewhat arboreal ape of equatorial African forests
@@ -74454,6 +76246,7 @@
   - 02485855-n
   - 02486195-n
   partOfSpeech: n
+  wikidata: Q185939
 02485723-n:
   definition:
   - gibbons and siamangs
@@ -74476,6 +76269,7 @@
   - 02485993-n
   - 02486339-n
   partOfSpeech: n
+  wikidata: Q878467
 02485993-n:
   definition:
   - smallest and most perfectly anthropoid arboreal ape having long arms and no tail;
@@ -74497,6 +76291,7 @@
   - Symphalangus
   - genus Symphalangus
   partOfSpeech: n
+  wikidata: Q1962797
 02486339-n:
   definition:
   - large black gibbon of Sumatra having the 2nd and 3rd toes partially united by
@@ -74531,6 +76326,7 @@
   - 02491209-n
   - 02491691-n
   partOfSpeech: n
+  wikidata: Q182968
 02486953-n:
   definition:
   - any of various long-tailed primates (excluding the prosimians)
@@ -74562,6 +76358,7 @@
   mero_member:
   - 02487606-n
   partOfSpeech: n
+  wikidata: Q255571
 02487606-n:
   definition:
   - small slender African monkey having long hind limbs and tail and long hair around
@@ -74629,6 +76426,7 @@
   mero_member:
   - 02488619-n
   partOfSpeech: n
+  wikidata: Q1070855
 02488619-n:
   definition:
   - large agile arboreal monkey with long limbs and tail and white upper eyelids
@@ -74650,6 +76448,7 @@
   mero_member:
   - 02488892-n
   partOfSpeech: n
+  wikidata: Q10758998
 02488892-n:
   definition:
   - reddish long-tailed monkey of west Africa
@@ -74680,6 +76479,7 @@
   - Papio
   - genus Papio
   partOfSpeech: n
+  wikidata: Q159429
 02489288-n:
   definition:
   - greyish baboon of southern and eastern Africa
@@ -74703,6 +76503,7 @@
   mero_member:
   - 02489539-n
   partOfSpeech: n
+  wikidata: Q798426
 02489539-n:
   definition:
   - baboon of west Africa with a bright red and blue muzzle and blue hindquarters
@@ -74735,6 +76536,7 @@
   mero_member:
   - 02489978-n
   partOfSpeech: n
+  wikidata: Q177601
 02489978-n:
   definition:
   - short-tailed monkey of rocky regions of Asia and Africa
@@ -74803,6 +76605,7 @@
   mero_member:
   - 02490922-n
   partOfSpeech: n
+  wikidata: Q857471
 02490922-n:
   definition:
   - slender long-tailed monkey of Asia
@@ -74836,6 +76639,7 @@
   mero_member:
   - 02491333-n
   partOfSpeech: n
+  wikidata: Q358813
 02491333-n:
   definition:
   - arboreal monkey of western and central Africa with long silky fur and reduced
@@ -74868,6 +76672,7 @@
   - Nasalis
   - genus Nasalis
   partOfSpeech: n
+  wikidata: Q3336165
 02491797-n:
   definition:
   - Borneo monkey having a long bulbous nose
@@ -74920,6 +76725,7 @@
   - 02493317-n
   - 02493595-n
   partOfSpeech: n
+  wikidata: Q574338
 02492850-n:
   definition:
   - small soft-furred South American and Central American monkey with claws instead
@@ -74942,6 +76748,7 @@
   mero_member:
   - 02493228-n
   partOfSpeech: n
+  wikidata: Q1064620
 02493228-n:
   definition:
   - a marmoset
@@ -74963,6 +76770,7 @@
   mero_member:
   - 02493442-n
   partOfSpeech: n
+  wikidata: Q19826010
 02493442-n:
   definition:
   - the smallest monkey; of tropical forests of the Amazon
@@ -74987,6 +76795,7 @@
   mero_member:
   - 02493738-n
   partOfSpeech: n
+  wikidata: Q25384537
 02493738-n:
   definition:
   - small South American marmoset with silky fur and long nonprehensile tail
@@ -75039,6 +76848,7 @@
   - 02496605-n
   - 02496888-n
   partOfSpeech: n
+  wikidata: Q425707
 02494537-n:
   definition:
   - type genus of the Cebidae
@@ -75051,6 +76861,7 @@
   mero_member:
   - 02494666-n
   partOfSpeech: n
+  wikidata: Q8447051
 02494666-n:
   definition:
   - monkey of Central America and South America having thick hair on the head that
@@ -75075,6 +76886,7 @@
   mero_member:
   - 02494987-n
   partOfSpeech: n
+  wikidata: Q469636
 02494987-n:
   definition:
   - nocturnal monkey of Central America and South America with large eyes and thick
@@ -75098,6 +76910,7 @@
   mero_member:
   - 02495291-n
   partOfSpeech: n
+  wikidata: Q504247
 02495291-n:
   definition:
   - monkey of tropical South American forests having a loud howling cry
@@ -75120,6 +76933,7 @@
   mero_member:
   - 02495579-n
   partOfSpeech: n
+  wikidata: Q841159
 02495579-n:
   definition:
   - small arboreal monkey of tropical South America with long hair and bushy nonprehensile
@@ -75142,6 +76956,7 @@
   mero_member:
   - 02495855-n
   partOfSpeech: n
+  wikidata: Q1048171
 02495855-n:
   definition:
   - medium-sized tree-dwelling monkey of the Amazon basin; only New World monkey with
@@ -75164,6 +76979,7 @@
   mero_member:
   - 02496140-n
   partOfSpeech: n
+  wikidata: Q203649
 02496140-n:
   definition:
   - small South American monkeys with long beautiful fur and long nonprehensile tail
@@ -75186,6 +77002,7 @@
   mero_member:
   - 02496424-n
   partOfSpeech: n
+  wikidata: Q258244
 02496424-n:
   definition:
   - arboreal monkey of tropical America with long slender legs and long prehensile
@@ -75207,6 +77024,7 @@
   - Saimiri
   - genus Saimiri
   partOfSpeech: n
+  wikidata: Q309200
 02496710-n:
   definition:
   - small long-tailed monkey of Central American and South America with greenish fur
@@ -75231,6 +77049,7 @@
   mero_member:
   - 02497014-n
   partOfSpeech: n
+  wikidata: Q1061113
 02497014-n:
   definition:
   - large monkeys with dark skin and woolly fur of the Amazon and Orinoco basins
@@ -75254,6 +77073,7 @@
   mero_member:
   - 02497497-n
   partOfSpeech: n
+  wikidata: Q231550
 02497497-n:
   definition:
   - tree shrews; in some classifications tree shrews are considered prosimian primates
@@ -75279,6 +77099,7 @@
   - Tupaia
   - genus Tupaia
   partOfSpeech: n
+  wikidata: Q258827
 02497873-n:
   definition:
   - insectivorous arboreal mammal of southeast Asia that resembles a squirrel with
@@ -75301,6 +77122,7 @@
   mero_member:
   - 02498201-n
   partOfSpeech: n
+  wikidata: Q10809520
 02498201-n:
   definition:
   - brown tree shrew having a naked tail bilaterally fringed with long stiff hairs
@@ -75408,6 +77230,7 @@
   mero_member:
   - 02500304-n
   partOfSpeech: n
+  wikidata: Q2340126
 02500304-n:
   definition:
   - small lemur having its tail barred with black
@@ -75432,6 +77255,7 @@
   mero_member:
   - 02500614-n
   partOfSpeech: n
+  wikidata: Q12358399
 02500614-n:
   definition:
   - type genus; coextensive with the family Daubentoniidae
@@ -75472,6 +77296,7 @@
   - 02502065-n
   - 02502331-n
   partOfSpeech: n
+  wikidata: Q368623
 02501251-n:
   definition:
   - type genus of the Lorisidae
@@ -75483,6 +77308,7 @@
   mero_member:
   - 02501374-n
   partOfSpeech: n
+  wikidata: Q3259581
 02501374-n:
   definition:
   - slim-bodied lemur of southern India and Sri Lanka
@@ -75505,6 +77331,7 @@
   mero_member:
   - 02501653-n
   partOfSpeech: n
+  wikidata: Q74941
 02501653-n:
   definition:
   - stocky lemur of southeastern Asia
@@ -75528,6 +77355,7 @@
   mero_member:
   - 02501947-n
   partOfSpeech: n
+  wikidata: Q19816393
 02501947-n:
   definition:
   - a kind of gray-brown lemur (Perodicticus potto)
@@ -75551,6 +77379,7 @@
   mero_member:
   - 02502199-n
   partOfSpeech: n
+  wikidata: Q1019157
 02502199-n:
   definition:
   - a kind of yellow or golden lemur (Arctocebus calabarensis)
@@ -75573,6 +77402,7 @@
   mero_member:
   - 02502439-n
   partOfSpeech: n
+  wikidata: Q285214
 02502439-n:
   definition:
   - agile long-tailed nocturnal African lemur with dense woolly fur and large eyes
@@ -75598,6 +77428,7 @@
   - 02502775-n
   - 02503103-n
   partOfSpeech: n
+  wikidata: Q175626
 02502775-n:
   definition:
   - type genus of the Indriidae
@@ -75609,6 +77440,7 @@
   mero_member:
   - 02502898-n
   partOfSpeech: n
+  wikidata: Q19816385
 02502898-n:
   definition:
   - large short-tailed lemur of Madagascar having thick silky fur in black and white
@@ -75634,6 +77466,7 @@
   mero_member:
   - 02503227-n
   partOfSpeech: n
+  wikidata: Q1064408
 02503227-n:
   definition:
   - nocturnal indris with thick grey-brown fur and a long tail
@@ -75681,6 +77514,7 @@
   mero_member:
   - 02504063-n
   partOfSpeech: n
+  wikidata: Q1114471
 02504063-n:
   definition:
   - type and sole genus of the family Tarsiidae
@@ -75693,6 +77527,7 @@
   mero_member:
   - 02504214-n
   partOfSpeech: n
+  wikidata: Q60205
 02504214-n:
   definition:
   - nocturnal arboreal primate of Indonesia and the Philippines having huge eyes and
@@ -75734,6 +77569,7 @@
   mero_member:
   - 02504843-n
   partOfSpeech: n
+  wikidata: Q183383
 02504843-n:
   definition:
   - a family of Dermoptera
@@ -75746,6 +77582,7 @@
   mero_member:
   - 02504988-n
   partOfSpeech: n
+  wikidata: Q11762767
 02504988-n:
   definition:
   - type genus of the family Cynocephalidae
@@ -75758,6 +77595,7 @@
   mero_member:
   - 02505145-n
   partOfSpeech: n
+  wikidata: Q10751360
 02505145-n:
   definition:
   - arboreal nocturnal mammal of southeast Asia and the Philippines resembling a lemur
@@ -75795,6 +77633,7 @@
   - 02508277-n
   - 02509097-n
   partOfSpeech: n
+  wikidata: Q26308
 02505758-n:
   definition:
   - massive herbivorous mammals having tusks and a long trunk
@@ -75821,6 +77660,7 @@
   - 02507266-n
   - 02507973-n
   partOfSpeech: n
+  wikidata: Q2372824
 02506148-n:
   definition:
   - five-toed pachyderm
@@ -75855,6 +77695,7 @@
   mero_member:
   - 02506644-n
   partOfSpeech: n
+  wikidata: Q310746
 02506644-n:
   definition:
   - Asian elephant having smaller ears and tusks primarily in the male
@@ -75887,6 +77728,7 @@
   mero_member:
   - 02507089-n
   partOfSpeech: n
+  wikidata: Q185038
 02507089-n:
   definition:
   - an elephant native to Africa having enormous flapping ears and ivory tusks
@@ -75909,6 +77751,7 @@
   mero_member:
   - 02507401-n
   partOfSpeech: n
+  wikidata: Q36715
 02507401-n:
   definition:
   - any of numerous extinct elephants widely distributed in the Pleistocene; extremely
@@ -75954,6 +77797,7 @@
   mero_member:
   - 02508116-n
   partOfSpeech: n
+  wikidata: Q2701841
 02508116-n:
   definition:
   - largest known mammoth; of America
@@ -75978,6 +77822,7 @@
   mero_member:
   - 02508440-n
   partOfSpeech: n
+  wikidata: Q13424536
 02508440-n:
   definition:
   - 'extinct type genus of the Mammutidae: mastodons'
@@ -75992,6 +77837,7 @@
   - 02508629-n
   - 02508879-n
   partOfSpeech: n
+  wikidata: Q192272
 02508629-n:
   definition:
   - extinct elephant-like mammal that flourished worldwide from Miocene through Pleistocene
@@ -76027,6 +77873,7 @@
   mero_member:
   - 02509261-n
   partOfSpeech: n
+  wikidata: Q387585
 02509261-n:
   definition:
   - type genus of the Gomphotheriidae
@@ -76039,6 +77886,7 @@
   mero_member:
   - 02509414-n
   partOfSpeech: n
+  wikidata: Q132604
 02509414-n:
   definition:
   - extinct elephants of Central American and South America; of the Miocene and Pleistocene
@@ -76089,6 +77937,7 @@
   - 02512325-n
   - 02512871-n
   partOfSpeech: n
+  wikidata: Q147114
 02510280-n:
   definition:
   - plantigrade carnivorous mammals
@@ -76110,6 +77959,7 @@
   mero_member:
   - 02510652-n
   partOfSpeech: n
+  wikidata: Q148856
 02510652-n:
   definition:
   - an omnivorous nocturnal mammal native to North America and Central America
@@ -76197,6 +78047,7 @@
   mero_member:
   - 02511828-n
   partOfSpeech: n
+  wikidata: Q10808340
 02511828-n:
   definition:
   - arboreal fruit-eating mammal of tropical America with a long prehensile tail
@@ -76222,6 +78073,7 @@
   mero_member:
   - 02512146-n
   partOfSpeech: n
+  wikidata: Q148628
 02512146-n:
   definition:
   - omnivorous mammal of Central America and South America
@@ -76247,6 +78099,7 @@
   mero_member:
   - 02512446-n
   partOfSpeech: n
+  wikidata: Q19817309
 02512446-n:
   definition:
   - reddish-brown Old World raccoon-like carnivore; in some classifications considered
@@ -76272,6 +78125,7 @@
   - Ailuropodidae
   - family Ailuropodidae
   partOfSpeech: n
+  wikidata: Q104468335
 02512871-n:
   definition:
   - 'only the giant panda: in some classifications considered a genus of the separate
@@ -76285,6 +78139,7 @@
   mero_member:
   - 02513086-n
   partOfSpeech: n
+  wikidata: Q535979
 02513086-n:
   definition:
   - large black-and-white herbivorous mammal of bamboo forests of China and Tibet;
@@ -76512,6 +78367,7 @@
   mero_member:
   - 02516951-n
   partOfSpeech: n
+  wikidata: Q503788
 02516951-n:
   definition:
   - a voracious freshwater fish that is native to northeastern China; can use fin
@@ -76584,6 +78440,7 @@
   mero_member:
   - 02518191-n
   partOfSpeech: n
+  wikidata: Q3218487
 02518191-n:
   definition:
   - 'type genus of the Latimeridae: coelacanth'
@@ -76596,6 +78453,7 @@
   mero_member:
   - 02518344-n
   partOfSpeech: n
+  wikidata: Q133019
 02518344-n:
   definition:
   - fish thought to have been extinct since the Cretaceous period but found in 1938
@@ -76645,6 +78503,7 @@
   - 02519246-n
   - 02519498-n
   partOfSpeech: n
+  wikidata: Q3544436
 02519246-n:
   definition:
   - 'type genus of the Ceratodontidae: extinct genus of lungfishes'
@@ -76656,6 +78515,7 @@
   mero_member:
   - 02519407-n
   partOfSpeech: n
+  wikidata: Q1027599
 02519407-n:
   definition:
   - extinct lungfish
@@ -76703,6 +78563,7 @@
   - 02523022-n
   - 02523300-n
   partOfSpeech: n
+  wikidata: Q59576
 02520073-n:
   definition:
   - any of numerous mostly freshwater bottom-living fishes of Eurasia and North America
@@ -76752,6 +78613,7 @@
   mero_member:
   - 02520955-n
   partOfSpeech: n
+  wikidata: Q150645
 02520955-n:
   definition:
   - large elongated catfish of central and eastern Europe
@@ -76776,6 +78638,7 @@
   mero_member:
   - 02521253-n
   partOfSpeech: n
+  wikidata: Q1883238
 02521253-n:
   definition:
   - freshwater catfish of the Nile and tropical central Africa having an electric
@@ -76802,6 +78665,7 @@
   - 02522207-n
   - 02522646-n
   partOfSpeech: n
+  wikidata: Q578666
 02521621-n:
   definition:
   - 'type genus of the Ameiuridae: bullhead catfishes'
@@ -76814,6 +78678,7 @@
   mero_member:
   - 02521779-n
   partOfSpeech: n
+  wikidata: Q601085
 02521779-n:
   definition:
   - any of several common freshwater catfishes of the United States
@@ -76892,6 +78757,7 @@
   mero_member:
   - 02522778-n
   partOfSpeech: n
+  wikidata: Q18677545
 02522778-n:
   definition:
   - large catfish of central United States having a flattened head and projecting
@@ -76920,6 +78786,7 @@
   mero_member:
   - 02523156-n
   partOfSpeech: n
+  wikidata: Q663380
 02523156-n:
   definition:
   - South American catfish having the body covered with bony plates
@@ -76964,6 +78831,7 @@
   mero_member:
   - 02523760-n
   partOfSpeech: n
+  wikidata: Q2141569
 02523760-n:
   definition:
   - sea catfish of the Caribbean area
@@ -77029,6 +78897,7 @@
   - 02527643-n
   - 02527918-n
   partOfSpeech: n
+  wikidata: Q208028
 02524878-n:
   definition:
   - 'type genus of the Gadidae: the typical codfishes'
@@ -77041,6 +78910,7 @@
   mero_member:
   - 02525030-n
   partOfSpeech: n
+  wikidata: Q248924
 02525030-n:
   definition:
   - major food fish of Arctic and cold-temperate waters
@@ -77096,6 +78966,7 @@
   mero_member:
   - 02525741-n
   partOfSpeech: n
+  wikidata: Q11777489
 02525741-n:
   definition:
   - a food fish of the Atlantic waters of Europe resembling the cod; sometimes placed
@@ -77120,6 +78991,7 @@
   - Lota
   - genus Lota
   partOfSpeech: n
+  wikidata: Q15278263
 02526058-n:
   definition:
   - elongate freshwater cod of northern Europe and Asia and North America having barbels
@@ -77157,6 +79029,7 @@
   mero_member:
   - 02526508-n
   partOfSpeech: n
+  wikidata: Q17379593
 02526508-n:
   definition:
   - important food fish on both sides of the Atlantic; related to cod but usually
@@ -77182,6 +79055,7 @@
   mero_member:
   - 02526833-n
   partOfSpeech: n
+  wikidata: Q5123445
 02526833-n:
   definition:
   - important food and game fish of northern seas (especially the northern Atlantic);
@@ -77206,6 +79080,7 @@
   - Merluccius
   - genus Merluccius
   partOfSpeech: n
+  wikidata: Q733110
 02527155-n:
   definition:
   - any of several marine food fishes related to cod
@@ -77240,6 +79115,7 @@
   mero_member:
   - 02527559-n
   partOfSpeech: n
+  wikidata: Q2067751
 02527559-n:
   definition:
   - American hakes
@@ -77261,6 +79137,7 @@
   mero_member:
   - 02527751-n
   partOfSpeech: n
+  wikidata: Q1042112
 02527751-n:
   definition:
   - elongated marine food fish of Greenland and northern Europe; often salted and
@@ -77282,6 +79159,7 @@
   - Brosmius
   - genus Browmius
   partOfSpeech: n
+  wikidata: Q13171457
 02528013-n:
   definition:
   - large edible marine fish of northern coastal waters; related to cod
@@ -77309,6 +79187,7 @@
   mero_member:
   - 02528334-n
   partOfSpeech: n
+  wikidata: Q766678
 02528334-n:
   definition:
   - deep-sea fish with a large head and body and long tapering tail
@@ -77336,6 +79215,7 @@
   - 02529776-n
   - 02530129-n
   partOfSpeech: n
+  wikidata: Q128685
 02528752-n:
   definition:
   - voracious snakelike marine or freshwater fishes with smooth slimy usually scaleless
@@ -77367,6 +79247,7 @@
   mero_member:
   - 02529304-n
   partOfSpeech: n
+  wikidata: Q212239
 02529304-n:
   definition:
   - 'type genus of the Anguillidae: eels'
@@ -77379,6 +79260,7 @@
   mero_member:
   - 02529449-n
   partOfSpeech: n
+  wikidata: Q9154612
 02529449-n:
   definition:
   - eels that live in fresh water as adults but return to sea to spawn; found in Europe
@@ -77505,6 +79387,7 @@
   - 02545229-n
   - 02545724-n
   partOfSpeech: n
+  wikidata: Q126476679
 02531580-n:
   definition:
   - coextensive with the genus Gonorhynchus
@@ -77517,6 +79400,7 @@
   mero_member:
   - 02531742-n
   partOfSpeech: n
+  wikidata: Q14266423
 02531742-n:
   definition:
   - slender cylindrical marine fishes lacking air bladders and teeth
@@ -77529,6 +79413,7 @@
   mero_member:
   - 02531924-n
   partOfSpeech: n
+  wikidata: Q22106396
 02531924-n:
   definition:
   - fish of sandy areas of western Pacific and Indian oceans having an angular snout
@@ -77560,6 +79445,7 @@
   - 02535706-n
   - 02536055-n
   partOfSpeech: n
+  wikidata: Q27141
 02532403-n:
   definition:
   - any of numerous soft-finned schooling food fishes of shallow waters of northern
@@ -77603,6 +79489,7 @@
   - 02533052-n
   - 02533745-n
   partOfSpeech: n
+  wikidata: Q344999
 02533052-n:
   definition:
   - herring-like food fishes that migrate from the sea to fresh water to spawn
@@ -77675,6 +79562,7 @@
   - Pomolobus
   - genus Pomolobus
   partOfSpeech: n
+  wikidata: Q107268960
 02534134-n:
   definition:
   - menhaden
@@ -77687,6 +79575,7 @@
   mero_member:
   - 02534256-n
   partOfSpeech: n
+  wikidata: Q4844347
 02534256-n:
   definition:
   - shad-like North American marine fishes used for fish meal and oil and fertilizer
@@ -77714,6 +79603,7 @@
   - 02535082-n
   - 02535549-n
   partOfSpeech: n
+  wikidata: Q209907
 02534659-n:
   definition:
   - commercially important food fish of northern waters of both Atlantic and Pacific
@@ -77792,6 +79682,7 @@
   mero_member:
   - 02535840-n
   partOfSpeech: n
+  wikidata: Q15694866
 02535840-n:
   definition:
   - small fishes found in great schools along coasts of Europe; smaller and rounder
@@ -77817,6 +79708,7 @@
   mero_member:
   - 02536176-n
   partOfSpeech: n
+  wikidata: Q13403032
 02536176-n:
   definition:
   - small pilchards common off the pacific coast of North America
@@ -77839,6 +79731,7 @@
   mero_member:
   - 02536465-n
   partOfSpeech: n
+  wikidata: Q192662
 02536465-n:
   definition:
   - small herring-like plankton-eating fishes often canned whole or as paste; abundant
@@ -77861,6 +79754,7 @@
   mero_member:
   - 02536796-n
   partOfSpeech: n
+  wikidata: Q281043
 02536796-n:
   definition:
   - esteemed for its flavor; usually preserved or used for sauces and relishes
@@ -77951,6 +79845,7 @@
   - 02539950-n
   - 02540156-n
   partOfSpeech: n
+  wikidata: Q310436
 02538168-n:
   definition:
   - found in northern coastal Atlantic waters or tributaries; adults do not die after
@@ -78171,6 +80066,7 @@
   - 02541882-n
   - 02542383-n
   partOfSpeech: n
+  wikidata: Q782971
 02541616-n:
   definition:
   - silvery herring-like freshwater food fish of cold lakes of the Northern Hemisphere
@@ -78196,6 +80092,7 @@
   - 02542055-n
   - 02542204-n
   partOfSpeech: n
+  wikidata: Q311392
 02542055-n:
   definition:
   - found in the Great Lakes and north to Alaska
@@ -78295,6 +80192,7 @@
   - 02543422-n
   - 02543614-n
   partOfSpeech: n
+  wikidata: Q2701013
 02543422-n:
   definition:
   - important marine and landlocked food fish of eastern North America and Alaska
@@ -78332,6 +80230,7 @@
   mero_member:
   - 02543888-n
   partOfSpeech: n
+  wikidata: Q18748434
 02543888-n:
   definition:
   - very small northern fish; forage for sea birds and marine mammals and other fishes
@@ -78356,6 +80255,7 @@
   - 02544214-n
   - 02544506-n
   partOfSpeech: n
+  wikidata: Q15220778
 02544214-n:
   definition:
   - tarpons
@@ -78367,6 +80267,7 @@
   mero_member:
   - 02544318-n
   partOfSpeech: n
+  wikidata: Q1759766
 02544318-n:
   definition:
   - large silvery game fish of warm Atlantic coastal waters especially off Florida
@@ -78414,6 +80315,7 @@
   mero_member:
   - 02544914-n
   partOfSpeech: n
+  wikidata: Q3279738
 02544914-n:
   definition:
   - type and sole genus of the family Albulidae
@@ -78426,6 +80328,7 @@
   mero_member:
   - 02545063-n
   partOfSpeech: n
+  wikidata: Q2669163
 02545063-n:
   definition:
   - slender silvery marine fish found in tropical mud flats and mangrove lagoons
@@ -78450,6 +80353,7 @@
   mero_member:
   - 02545435-n
   partOfSpeech: n
+  wikidata: Q998876
 02545435-n:
   definition:
   - 'type genus of the Argentinidae: argentines'
@@ -78462,6 +80366,7 @@
   mero_member:
   - 02545589-n
   partOfSpeech: n
+  wikidata: Q2183754
 02545589-n:
   definition:
   - any of various small silver-scaled salmon-like marine fishes
@@ -78483,6 +80388,7 @@
   mero_member:
   - 02545886-n
   partOfSpeech: n
+  wikidata: Q1975704
 02545886-n:
   definition:
   - small fish having rows of luminous organs along each side; some surface at night
@@ -78504,6 +80410,7 @@
   mero_member:
   - 02546196-n
   partOfSpeech: n
+  wikidata: Q854803
 02546196-n:
   definition:
   - tropical fishes with large mouths in lizard-like heads; found worldwide
@@ -78527,6 +80434,7 @@
   mero_member:
   - 02546583-n
   partOfSpeech: n
+  wikidata: Q548754
 02546583-n:
   definition:
   - bottom-dwellers having large eyes with metallic green luster
@@ -78549,6 +80457,7 @@
   - 02546905-n
   - 02547106-n
   partOfSpeech: n
+  wikidata: Q12782074
 02546905-n:
   definition:
   - large elongate scaleless oceanic fishes with sharp teeth and a long dorsal fin
@@ -78595,6 +80504,7 @@
   mero_member:
   - 02547591-n
   partOfSpeech: n
+  wikidata: Q546243
 02547591-n:
   definition:
   - a genus of large freshwater fishes of Australia and Borneo
@@ -78608,6 +80518,7 @@
   - 02547784-n
   - 02548018-n
   partOfSpeech: n
+  wikidata: Q1766674
 02547784-n:
   definition:
   - a species of large fish found in Australian rivers, it has a red or pink spot
@@ -78648,6 +80559,7 @@
   mero_member:
   - 02548318-n
   partOfSpeech: n
+  wikidata: Q16607623
 02548318-n:
   definition:
   - type genus of the Lampridae
@@ -78661,6 +80573,7 @@
   - 02548472-n
   - 02548659-n
   partOfSpeech: n
+  wikidata: Q220801
 02548472-n:
   definition:
   - large elliptical brightly colored deep-sea fish of Atlantic and Pacific and Mediterranean
@@ -78696,6 +80609,7 @@
   - 02548962-n
   - 02549108-n
   partOfSpeech: n
+  wikidata: Q1057454
 02548962-n:
   definition:
   - marine fish having a long compressed ribbonlike body
@@ -78741,6 +80655,7 @@
   mero_member:
   - 02549504-n
   partOfSpeech: n
+  wikidata: Q1078201
 02549504-n:
   definition:
   - type genus of the Regalecidae
@@ -78753,6 +80668,7 @@
   mero_member:
   - 02549645-n
   partOfSpeech: n
+  wikidata: Q2697754
 02549645-n:
   definition:
   - thin deep-water tropical fish 20 to 30 feet long having a red dorsal fin
@@ -78782,6 +80698,7 @@
   - 02551153-n
   - 02551621-n
   partOfSpeech: n
+  wikidata: Q206948
 02550193-n:
   definition:
   - 'batfishes: sluggish bottom-dwelling spiny fishes'
@@ -78794,6 +80711,7 @@
   mero_member:
   - 02550364-n
   partOfSpeech: n
+  wikidata: Q917267
 02550364-n:
   definition:
   - bottom-dweller of warm western Atlantic coastal waters having a flattened scaleless
@@ -78828,6 +80746,7 @@
   - Lophius
   - genus Lophius
   partOfSpeech: n
+  wikidata: Q643135
 02550878-n:
   definition:
   - fishes having large mouths with a wormlike filament attached for luring prey
@@ -78859,6 +80778,7 @@
   mero_member:
   - 02551320-n
   partOfSpeech: n
+  wikidata: Q867549
 02551320-n:
   definition:
   - bottom-dwelling fish having scaleless slimy skin and a broad thick head with a
@@ -78895,6 +80815,7 @@
   - 02551879-n
   - 02552007-n
   partOfSpeech: n
+  wikidata: Q540454
 02551879-n:
   definition:
   - fish having a frog-like mouth with a lure on the snout
@@ -78928,6 +80849,7 @@
   - 02553546-n
   - 02553947-n
   partOfSpeech: n
+  wikidata: Q329667
 02552427-n:
   definition:
   - ferocious fishes of warm regions resembling but unrelated to the freshwater gars
@@ -78940,6 +80862,7 @@
   mero_member:
   - 02552620-n
   partOfSpeech: n
+  wikidata: Q1079148
 02552620-n:
   definition:
   - elongate European surface-dwelling predacious fishes with long toothed jaws; abundant
@@ -78973,6 +80896,7 @@
   mero_member:
   - 02553091-n
   partOfSpeech: n
+  wikidata: Q183686
 02553091-n:
   definition:
   - tropical marine fishes having enlarged winglike fins used for brief gliding flight
@@ -79015,6 +80939,7 @@
   mero_member:
   - 02553765-n
   partOfSpeech: n
+  wikidata: Q127749
 02553765-n:
   definition:
   - tropical and subtropical marine and freshwater fishes having an elongated body
@@ -79040,6 +80965,7 @@
   mero_member:
   - 02554125-n
   partOfSpeech: n
+  wikidata: Q1342872
 02554125-n:
   definition:
   - a genus of Scomberesocidae
@@ -79054,6 +80980,7 @@
   mero_member:
   - 02554299-n
   partOfSpeech: n
+  wikidata: Q3475985
 02554299-n:
   definition:
   - slender long-beaked fish of temperate Atlantic waters
@@ -79109,6 +81036,7 @@
   mero_member:
   - 02555525-n
   partOfSpeech: n
+  wikidata: Q61882741
 02555525-n:
   definition:
   - a genus of Ophiodontidae
@@ -79121,6 +81049,7 @@
   mero_member:
   - 02555659-n
   partOfSpeech: n
+  wikidata: Q19917281
 02555659-n:
   definition:
   - food fish of the northern Pacific related to greenlings
@@ -79250,6 +81179,7 @@
   mero_member:
   - 02558826-n
   partOfSpeech: n
+  wikidata: Q797543
 02558826-n:
   definition:
   - the type genus of the family Anabantidae; small fish that resemble perch
@@ -79262,6 +81192,7 @@
   mero_member:
   - 02559004-n
   partOfSpeech: n
+  wikidata: Q2372331
 02559004-n:
   definition:
   - a small perch of India whose gills are modified to allow it to breathe air; has
@@ -79289,6 +81220,7 @@
   - 02560092-n
   - 02560710-n
   partOfSpeech: n
+  wikidata: Q746136
 02559477-n:
   definition:
   - spiny-finned freshwater food and game fishes
@@ -79311,6 +81243,7 @@
   - 02559813-n
   - 02559949-n
   partOfSpeech: n
+  wikidata: Q600262
 02559813-n:
   definition:
   - North American perch
@@ -79347,6 +81280,7 @@
   mero_member:
   - 02560222-n
   partOfSpeech: n
+  wikidata: Q107270743
 02560222-n:
   definition:
   - any of several pike-like fishes of the perch family
@@ -79395,6 +81329,7 @@
   mero_member:
   - 02560837-n
   partOfSpeech: n
+  wikidata: Q2195856
 02560837-n:
   definition:
   - a small snail-eating perch of the Tennessee River
@@ -79419,6 +81354,7 @@
   mero_member:
   - 02561191-n
   partOfSpeech: n
+  wikidata: Q134421
 02561191-n:
   definition:
   - either of two small silvery scaleless fishes of the northern Pacific that burrow
@@ -79463,6 +81399,7 @@
   mero_member:
   - 02561775-n
   partOfSpeech: n
+  wikidata: Q35079527
 02561775-n:
   definition:
   - deep-sea fishes
@@ -79484,6 +81421,7 @@
   mero_member:
   - 02562014-n
   partOfSpeech: n
+  wikidata: Q1307559
 02562014-n:
   definition:
   - found living within the alimentary canals of e.g. sea cucumbers or between the
@@ -79512,6 +81450,7 @@
   - 02562902-n
   - 02563014-n
   partOfSpeech: n
+  wikidata: Q3332482
 02562493-n:
   definition:
   - a kind of percoid fish
@@ -79531,6 +81470,7 @@
   - Centropomus
   - genus Centropomus
   partOfSpeech: n
+  wikidata: Q2140510
 02562741-n:
   definition:
   - large tropical American food and game fishes of coastal and brackish waters; resemble
@@ -79562,6 +81502,7 @@
   mero_member:
   - 02563177-n
   partOfSpeech: n
+  wikidata: Q787185
 02563177-n:
   definition:
   - a species of large perch noted for its sporting and eating qualities; lives in
@@ -79590,6 +81531,7 @@
   mero_member:
   - 02563595-n
   partOfSpeech: n
+  wikidata: Q1987393
 02563595-n:
   definition:
   - type and only genus of the family Esocidae
@@ -79685,6 +81627,7 @@
   - 02566901-n
   - 02567203-n
   partOfSpeech: n
+  wikidata: Q647004
 02564946-n:
   definition:
   - 'small carnivorous freshwater percoid fishes of North America usually having a
@@ -79711,6 +81654,7 @@
   mero_member:
   - 02565427-n
   partOfSpeech: n
+  wikidata: Q1063438
 02565427-n:
   definition:
   - small sunfishes of central United States rivers
@@ -79769,6 +81713,7 @@
   - 02566423-n
   - 02566580-n
   partOfSpeech: n
+  wikidata: Q251730
 02566279-n:
   definition:
   - small brilliantly colored North American sunfish
@@ -79937,6 +81882,7 @@
   - 02572669-n
   - 02572943-n
   partOfSpeech: n
+  wikidata: Q207941
 02568740-n:
   definition:
   - marine food sport fishes mainly of warm coastal waters
@@ -79960,6 +81906,7 @@
   - 02569120-n
   - 02569296-n
   partOfSpeech: n
+  wikidata: Q605688
 02569120-n:
   definition:
   - small silvery food and game fish of eastern United States streams
@@ -80031,6 +81978,7 @@
   - 02570264-n
   - 02570403-n
   partOfSpeech: n
+  wikidata: Q2494913
 02570264-n:
   definition:
   - a kind of sea bass
@@ -80091,6 +82039,7 @@
   mero_member:
   - 02571078-n
   partOfSpeech: n
+  wikidata: Q281106
 02571078-n:
   definition:
   - brown fish of the Atlantic and Mediterranean found around rocks and shipwrecks
@@ -80115,6 +82064,7 @@
   mero_member:
   - 02571438-n
   partOfSpeech: n
+  wikidata: Q1071020
 02571438-n:
   definition:
   - found in warm shallow waters of western Atlantic
@@ -80150,6 +82100,7 @@
   - 02572115-n
   - 02572262-n
   partOfSpeech: n
+  wikidata: Q284420
 02571965-n:
   definition:
   - black-spotted usually dusky-colored fish with reddish fins
@@ -80215,6 +82166,7 @@
   mero_member:
   - 02572795-n
   partOfSpeech: n
+  wikidata: Q2286852
 02572795-n:
   definition:
   - large dark grouper with a thick head and rough scales
@@ -80237,6 +82189,7 @@
   mero_member:
   - 02573115-n
   partOfSpeech: n
+  wikidata: Q1970835
 02573115-n:
   definition:
   - fishes with slimy mucus-covered skin; found in the warm Atlantic coastal waters
@@ -80284,6 +82237,7 @@
   mero_member:
   - 02573798-n
   partOfSpeech: n
+  wikidata: Q2479995
 02573798-n:
   definition:
   - Pacific coast fish
@@ -80307,6 +82261,7 @@
   mero_member:
   - 02574117-n
   partOfSpeech: n
+  wikidata: Q578926
 02574117-n:
   definition:
   - type genus of the Priacanthidae
@@ -80320,6 +82275,7 @@
   - 02574283-n
   - 02574441-n
   partOfSpeech: n
+  wikidata: Q2964100
 02574283-n:
   definition:
   - red fishes of American coastal tropical waters having very large eyes and rough
@@ -80355,6 +82311,7 @@
   - 02575000-n
   - 02575259-n
   partOfSpeech: n
+  wikidata: Q728422
 02574827-n:
   definition:
   - small red fishes of coral reefs and inshore tropical waters
@@ -80374,6 +82331,7 @@
   - Apogon
   - genus Apogon
   partOfSpeech: n
+  wikidata: Q773694
 02575115-n:
   definition:
   - a cardinalfish found in tropical Atlantic coastal waters
@@ -80395,6 +82353,7 @@
   - Astropogon
   - genus Astropogon
   partOfSpeech: n
+  wikidata: Q779231
 02575394-n:
   definition:
   - found in West Indies; lives in mantle cavity of a living conch
@@ -80417,6 +82376,7 @@
   mero_member:
   - 02575706-n
   partOfSpeech: n
+  wikidata: Q1782772
 02575706-n:
   definition:
   - large brightly colored food fish of deep Atlantic waters
@@ -80429,6 +82389,7 @@
   mero_member:
   - 02575880-n
   partOfSpeech: n
+  wikidata: Q2534510
 02575880-n:
   definition:
   - yellow-spotted violet food fish of warm deep waters
@@ -80451,6 +82412,7 @@
   mero_member:
   - 02576194-n
   partOfSpeech: n
+  wikidata: Q12809595
 02576194-n:
   definition:
   - type genus of the Pomatomidae
@@ -80463,6 +82425,7 @@
   mero_member:
   - 02576335-n
   partOfSpeech: n
+  wikidata: Q10351126
 02576335-n:
   definition:
   - bluish warm-water marine food and game fish that follow schools of small fishes
@@ -80488,6 +82451,7 @@
   mero_member:
   - 02576724-n
   partOfSpeech: n
+  wikidata: Q13035888
 02576724-n:
   definition:
   - genus and family are coextensive and comprise only the cobia
@@ -80500,6 +82464,7 @@
   mero_member:
   - 02576902-n
   partOfSpeech: n
+  wikidata: Q14250612
 02576902-n:
   definition:
   - large dark-striped tropical food and game fish related to remoras; found worldwide
@@ -80539,6 +82504,7 @@
   - 02577799-n
   - 02578086-n
   partOfSpeech: n
+  wikidata: Q239771
 02577541-n:
   definition:
   - marine fishes with a flattened elongated body and a sucking disk on the head for
@@ -80563,6 +82529,7 @@
   mero_member:
   - 02577956-n
   partOfSpeech: n
+  wikidata: Q2709145
 02577956-n:
   definition:
   - remoras found attached to sharks
@@ -80585,6 +82552,7 @@
   mero_member:
   - 02578221-n
   partOfSpeech: n
+  wikidata: Q107270439
 02578221-n:
   definition:
   - large blue Pacific remora that attaches to whales and dolphins
@@ -80644,6 +82612,7 @@
   - Caranx
   - genus Caranx
   partOfSpeech: n
+  wikidata: Q139783
 02579206-n:
   definition:
   - any of several fast-swimming predacious fishes of tropical to warm temperate seas
@@ -80698,6 +82667,7 @@
   - Elagatis
   - genus Elagatis
   partOfSpeech: n
+  wikidata: Q15240873
 02580034-n:
   definition:
   - streamlined cigar-shaped jack; good game fish
@@ -80743,6 +82713,7 @@
   mero_member:
   - 02580583-n
   partOfSpeech: n
+  wikidata: Q2963482
 02580583-n:
   definition:
   - fish having greatly elongated front rays on dorsal and anal fins
@@ -80764,6 +82735,7 @@
   - Selene
   - genus Selene
   partOfSpeech: n
+  wikidata: Q671979
 02580864-n:
   definition:
   - any of several silvery marine fishes with very flat bodies
@@ -80804,6 +82776,7 @@
   - 02581559-n
   - 02581722-n
   partOfSpeech: n
+  wikidata: Q1093514
 02581402-n:
   definition:
   - any of several amber to coppery fork-tailed warm-water carangid fishes
@@ -80859,6 +82832,7 @@
   mero_member:
   - 02582188-n
   partOfSpeech: n
+  wikidata: Q133930
 02582188-n:
   definition:
   - any of several deep-bodied food fishes of western Atlantic and Gulf of Mexico
@@ -80902,6 +82876,7 @@
   mero_member:
   - 02582819-n
   partOfSpeech: n
+  wikidata: Q17141301
 02582819-n:
   definition:
   - small pelagic fish often accompanying sharks or mantas
@@ -80968,6 +82943,7 @@
   mero_member:
   - 02583739-n
   partOfSpeech: n
+  wikidata: Q745504
 02583739-n:
   definition:
   - of Atlantic coastal waters; commonly used for bait
@@ -80994,6 +82970,7 @@
   - 02584113-n
   - 02584273-n
   partOfSpeech: n
+  wikidata: Q903235
 02584113-n:
   definition:
   - small silvery fish; Nova Scotia to Brazil
@@ -81030,6 +83007,7 @@
   mero_member:
   - 02584588-n
   partOfSpeech: n
+  wikidata: Q13170001
 02584588-n:
   definition:
   - large slender food and game fish widely distributed in warm seas (especially around
@@ -81089,6 +83067,7 @@
   mero_member:
   - 02585352-n
   partOfSpeech: n
+  wikidata: Q1053062
 02585352-n:
   definition:
   - deep-bodied sooty-black pelagic spiny-finned fish of the northern Atlantic and
@@ -81112,6 +83091,7 @@
   mero_member:
   - 02585727-n
   partOfSpeech: n
+  wikidata: Q33135518
 02585727-n:
   definition:
   - important marine food fishes
@@ -81171,6 +83151,7 @@
   mero_member:
   - 02586521-n
   partOfSpeech: n
+  wikidata: Q134548
 02586521-n:
   definition:
   - brightly colored tropical freshwater fishes
@@ -81192,6 +83173,7 @@
   mero_member:
   - 02586776-n
   partOfSpeech: n
+  wikidata: Q132910
 02586776-n:
   definition:
   - small bright red and blue aquarium fish from streams in Brazil and Colombia
@@ -81214,6 +83196,7 @@
   mero_member:
   - 02587080-n
   partOfSpeech: n
+  wikidata: Q972721
 02587080-n:
   definition:
   - small voraciously carnivorous freshwater fishes of South America that attack and
@@ -81290,6 +83273,7 @@
   - 02588503-n
   - 02588760-n
   partOfSpeech: n
+  wikidata: Q3406
 02588503-n:
   definition:
   - freshwater fishes of tropical America and Africa and Asia similar to American
@@ -81311,6 +83295,7 @@
   - Tilapia
   - genus Tilapia
   partOfSpeech: n
+  wikidata: Q1770703
 02588869-n:
   definition:
   - important food fish of the Nile and other rivers of Africa and Asia Minor
@@ -81335,6 +83320,7 @@
   - 02589496-n
   - 02590391-n
   partOfSpeech: n
+  wikidata: Q849160
 02589174-n:
   definition:
   - any of several large sharp-toothed marine food and sport fishes of the family
@@ -81362,6 +83348,7 @@
   - 02589931-n
   - 02590248-n
   partOfSpeech: n
+  wikidata: Q139141
 02589682-n:
   definition:
   - an esteemed food fish with pinkish red head and body; common in the Atlantic coastal
@@ -81422,6 +83409,7 @@
   mero_member:
   - 02590507-n
   partOfSpeech: n
+  wikidata: Q2212925
 02590507-n:
   definition:
   - superior food fish of the tropical Atlantic and Caribbean with broad yellow stripe
@@ -81449,6 +83437,7 @@
   - 02592116-n
   - 02592585-n
   partOfSpeech: n
+  wikidata: Q517736
 02590916-n:
   definition:
   - medium-sized tropical marine food fishes that utter grunting sounds when caught
@@ -81474,6 +83463,7 @@
   - 02591826-n
   - 02591946-n
   partOfSpeech: n
+  wikidata: Q772044
 02591424-n:
   definition:
   - a grunt with a red mouth that is found from Florida to Brazil
@@ -81655,6 +83645,7 @@
   mero_member:
   - 02593960-n
   partOfSpeech: n
+  wikidata: Q432412
 02593960-n:
   definition:
   - food fish of the Mediterranean and Atlantic coasts of Europe and America
@@ -81678,6 +83669,7 @@
   mero_member:
   - 02594243-n
   partOfSpeech: n
+  wikidata: Q1654733
 02594243-n:
   definition:
   - food fish of European coastal waters
@@ -81701,6 +83693,7 @@
   - 02594541-n
   - 02594685-n
   partOfSpeech: n
+  wikidata: Q2623566
 02594541-n:
   definition:
   - sea bream of warm Atlantic waters
@@ -81733,6 +83726,7 @@
   mero_member:
   - 02595001-n
   partOfSpeech: n
+  wikidata: Q13217680
 02595001-n:
   definition:
   - similar to sea bream; small spiny-finned fish found in bays along the southeastern
@@ -81758,6 +83752,7 @@
   mero_member:
   - 02595364-n
   partOfSpeech: n
+  wikidata: Q2729463
 02595364-n:
   definition:
   - from Florida and Bahamas to Brazil
@@ -81781,6 +83776,7 @@
   - 02595649-n
   - 02595821-n
   partOfSpeech: n
+  wikidata: Q19851071
 02595649-n:
   definition:
   - Australian food fish having a pinkish body with blue spots
@@ -81813,6 +83809,7 @@
   - Stenotomus
   - genus Stenotomus
   partOfSpeech: n
+  wikidata: Q1980894
 02596083-n:
   definition:
   - found in Atlantic coastal waters of North America from South Carolina to Maine;
@@ -81864,6 +83861,7 @@
   - 02601377-n
   - 02601837-n
   partOfSpeech: n
+  wikidata: Q216634
 02596880-n:
   definition:
   - widely distributed family of carnivorous percoid fishes having a large air bladder
@@ -81934,6 +83932,7 @@
   mero_member:
   - 02597969-n
   partOfSpeech: n
+  wikidata: Q145353
 02597969-n:
   definition:
   - small silvery drumfish often mistaken for white perch; found along coasts of United
@@ -81959,6 +83958,7 @@
   mero_member:
   - 02598332-n
   partOfSpeech: n
+  wikidata: Q14718316
 02598332-n:
   definition:
   - large edible fish found off coast of United States from Massachusetts to Mexico
@@ -81984,6 +83984,7 @@
   - 02598697-n
   - 02598882-n
   partOfSpeech: n
+  wikidata: Q2260146
 02598697-n:
   definition:
   - large important food fish of Australia; almost indistinguishable from the maigre
@@ -82029,6 +84030,7 @@
   mero_member:
   - 02599350-n
   partOfSpeech: n
+  wikidata: Q2705026
 02599350-n:
   definition:
   - a silvery-bodied croaker with dark markings and tiny barbels
@@ -82052,6 +84054,7 @@
   mero_member:
   - 02599634-n
   partOfSpeech: n
+  wikidata: Q2478227
 02599634-n:
   definition:
   - a fish of the Pacific coast of North America
@@ -82080,6 +84083,7 @@
   - 02600448-n
   - 02600882-n
   partOfSpeech: n
+  wikidata: Q135256
 02599997-n:
   definition:
   - any of several food fishes of North American coastal waters
@@ -82157,6 +84161,7 @@
   mero_member:
   - 02601203-n
   partOfSpeech: n
+  wikidata: Q17152657
 02601203-n:
   definition:
   - small silvery marine food fish found off California
@@ -82182,6 +84187,7 @@
   mero_member:
   - 02601508-n
   partOfSpeech: n
+  wikidata: Q14721204
 02601508-n:
   definition:
   - silvery and bluish drumfish of shallow California coastal waters
@@ -82259,6 +84265,7 @@
   - 02602765-n
   - 02603287-n
   partOfSpeech: n
+  wikidata: Q470850
 02602588-n:
   definition:
   - bottom dwelling marine warm water fishes with two barbels on the chin
@@ -82282,6 +84289,7 @@
   - 02602928-n
   - 02603133-n
   partOfSpeech: n
+  wikidata: Q1289177
 02602928-n:
   definition:
   - brightly colored tropical fishes with chin barbels
@@ -82317,6 +84325,7 @@
   mero_member:
   - 02603428-n
   partOfSpeech: n
+  wikidata: Q2265003
 02603428-n:
   definition:
   - schooling goatfish; greyish with yellow stripe
@@ -82427,6 +84436,7 @@
   - 02605035-n
   - 02605250-n
   partOfSpeech: n
+  wikidata: Q446802
 02605035-n:
   definition:
   - small fishes having a silver stripe along each side; abundant along the Atlantic
@@ -82450,6 +84460,7 @@
   mero_member:
   - 02605390-n
   partOfSpeech: n
+  wikidata: Q2636021
 02605390-n:
   definition:
   - a relatively large silversides of the Pacific coast of North America (known to
@@ -82473,6 +84484,7 @@
   mero_member:
   - 02605804-n
   partOfSpeech: n
+  wikidata: Q13166704
 02605804-n:
   definition:
   - 'type and sole genus of the Sphyraenidae: barracuda'
@@ -82483,6 +84495,7 @@
   - Sphyraena
   - genus Sphyraena
   partOfSpeech: n
+  wikidata: Q193921
 02605947-n:
   definition:
   - any voracious marine fish of the genus Sphyraena having an elongated cylindrical
@@ -82516,6 +84529,7 @@
   mero_member:
   - 02606492-n
   partOfSpeech: n
+  wikidata: Q1362711
 02606492-n:
   definition:
   - little-known nocturnal fish of warm shallow seas with an oblong compressed body
@@ -82538,6 +84552,7 @@
   - 02606787-n
   - 02606972-n
   partOfSpeech: n
+  wikidata: Q1130631
 02606787-n:
   definition:
   - schooling fishes mostly of Indian and western Pacific oceans; two species in western
@@ -82585,6 +84600,7 @@
   mero_member:
   - 02607441-n
   partOfSpeech: n
+  wikidata: Q637670
 02607441-n:
   definition:
   - a genus of Ephippidae
@@ -82597,6 +84613,7 @@
   mero_member:
   - 02607584-n
   partOfSpeech: n
+  wikidata: Q596898
 02607584-n:
   definition:
   - deep-bodied disk-shaped food fish of warmer western Atlantic coastal waters
@@ -82622,6 +84639,7 @@
   - 02608201-n
   - 02608439-n
   partOfSpeech: n
+  wikidata: Q271004
 02607946-n:
   definition:
   - small usually brilliantly colored tropical marine fishes having narrow deep bodies
@@ -82643,6 +84661,7 @@
   mero_member:
   - 02608333-n
   partOfSpeech: n
+  wikidata: Q133259
 02608333-n:
   definition:
   - any fish of the genus Chaetodon
@@ -82665,6 +84684,7 @@
   mero_member:
   - 02608566-n
   partOfSpeech: n
+  wikidata: Q762409
 02608566-n:
   definition:
   - a butterfly fish of the genus Pomacanthus
@@ -82700,6 +84720,7 @@
   - 02609556-n
   - 02609975-n
   partOfSpeech: n
+  wikidata: Q501720
 02609014-n:
   definition:
   - small brilliantly colored tropical marine fishes of coral reefs
@@ -82722,6 +84743,7 @@
   mero_member:
   - 02609381-n
   partOfSpeech: n
+  wikidata: Q934789
 02609381-n:
   definition:
   - a blue and yellow damselfish of Bermuda and Florida and the West Indies
@@ -82745,6 +84767,7 @@
   - 02609702-n
   - 02609831-n
   partOfSpeech: n
+  wikidata: Q6193348
 02609702-n:
   definition:
   - live associated with sea anemones
@@ -82776,6 +84799,7 @@
   mero_member:
   - 02610100-n
   partOfSpeech: n
+  wikidata: Q132841
 02610100-n:
   definition:
   - large blue-grey black-striped damselfish; nearly worldwide
@@ -82827,6 +84851,7 @@
   mero_member:
   - 02610914-n
   partOfSpeech: n
+  wikidata: Q370454
 02610914-n:
   definition:
   - found around the Great Barrier Reef
@@ -82873,6 +84898,7 @@
   - 02611490-n
   - 02611626-n
   partOfSpeech: n
+  wikidata: Q134935
 02611490-n:
   definition:
   - small wrasse of tropical Atlantic
@@ -82906,6 +84932,7 @@
   mero_member:
   - 02611932-n
   partOfSpeech: n
+  wikidata: Q137133
 02611932-n:
   definition:
   - small Atlantic wrasse the male of which has a brilliant blue head
@@ -82929,6 +84956,7 @@
   - 02612247-n
   - 02612453-n
   partOfSpeech: n
+  wikidata: Q50376969
 02612247-n:
   definition:
   - any of several small wrasses with compressed sharp-edged heads of the West Indies
@@ -83035,6 +85063,7 @@
   - 02613610-n
   - 02613784-n
   partOfSpeech: n
+  wikidata: Q924957
 02613610-n:
   definition:
   - mullet-like tropical marine fishes having pectoral fins with long threadlike rays
@@ -83103,6 +85132,7 @@
   mero_member:
   - 02614528-n
   partOfSpeech: n
+  wikidata: Q183280
 02614528-n:
   definition:
   - heavy-bodied marine bottom-lurkers with eyes on flattened top of the head
@@ -83124,6 +85154,7 @@
   mero_member:
   - 02614797-n
   partOfSpeech: n
+  wikidata: Q2166073
 02614797-n:
   definition:
   - small pallid fishes of shoal tropical waters of North America and South America
@@ -83202,6 +85233,7 @@
   mero_member:
   - 02616202-n
   partOfSpeech: n
+  wikidata: Q1928709
 02616202-n:
   definition:
   - European scaleless blenny
@@ -83224,6 +85256,7 @@
   mero_member:
   - 02616450-n
   partOfSpeech: n
+  wikidata: Q3951720
 02616450-n:
   definition:
   - inhabits both coasts of tropical Atlantic
@@ -83248,6 +85281,7 @@
   - 02616770-n
   - 02616918-n
   partOfSpeech: n
+  wikidata: Q658930
 02616770-n:
   definition:
   - mostly small blennioid fishes of coral reefs and seagrass beds
@@ -83271,6 +85305,7 @@
   - 02617112-n
   - 02617283-n
   partOfSpeech: n
+  wikidata: Q2371271
 02617112-n:
   definition:
   - tropical American fishes; males are aggressively defensive of their territory
@@ -83328,6 +85363,7 @@
   mero_member:
   - 02617928-n
   partOfSpeech: n
+  wikidata: Q2704983
 02617928-n:
   definition:
   - slippery scaleless food fish of the northern Atlantic coastal waters
@@ -83354,6 +85390,7 @@
   - 02618459-n
   - 02618881-n
   partOfSpeech: n
+  wikidata: Q1542021
 02618272-n:
   definition:
   - small elongate fishes of shallow northern seas; a long dorsal fin consists entirely
@@ -83434,6 +85471,7 @@
   mero_member:
   - 02619335-n
   partOfSpeech: n
+  wikidata: Q604663
 02619335-n:
   definition:
   - type genus of the Anarhichadidae
@@ -83474,6 +85512,7 @@
   - 02620319-n
   - 02620586-n
   partOfSpeech: n
+  wikidata: Q300929
 02619837-n:
   definition:
   - marine eellike mostly bottom-dwelling fishes of northern seas
@@ -83520,6 +85559,7 @@
   mero_member:
   - 02620449-n
   partOfSpeech: n
+  wikidata: Q620717
 02620449-n:
   definition:
   - brightly colored scaleless Arctic eelpout
@@ -83542,6 +85582,7 @@
   mero_member:
   - 02620724-n
   partOfSpeech: n
+  wikidata: Q107271202
 02620724-n:
   definition:
   - common along northeastern coast of North America
@@ -83565,6 +85606,7 @@
   mero_member:
   - 02621002-n
   partOfSpeech: n
+  wikidata: Q695712
 02621002-n:
   definition:
   - type genus of the Ammodytidae
@@ -83577,6 +85619,7 @@
   mero_member:
   - 02621143-n
   partOfSpeech: n
+  wikidata: Q2624613
 02621143-n:
   definition:
   - very small silvery eellike schooling fishes that burrow into sandy beaches
@@ -83649,6 +85692,7 @@
   mero_member:
   - 02622180-n
   partOfSpeech: n
+  wikidata: Q662601
 02622180-n:
   definition:
   - found in tropical coastal regions of Africa and Asia; able to move on land on
@@ -83697,6 +85741,7 @@
   mero_member:
   - 02622797-n
   partOfSpeech: n
+  wikidata: Q1651138
 02622797-n:
   definition:
   - pallid bottom-dwelling flat-headed fish with large eyes and a duck-like snout
@@ -83718,6 +85763,7 @@
   mero_member:
   - 02623073-n
   partOfSpeech: n
+  wikidata: Q15207743
 02623073-n:
   definition:
   - type genus of the Toxotidae
@@ -83730,6 +85776,7 @@
   mero_member:
   - 02623208-n
   partOfSpeech: n
+  wikidata: Q732534
 02623208-n:
   definition:
   - any of several small freshwater fishes that catch insects by squirting water at
@@ -83754,6 +85801,7 @@
   mero_member:
   - 02623586-n
   partOfSpeech: n
+  wikidata: Q1093168
 02623586-n:
   definition:
   - poorly known family of small tropical shallow-water fishes related to gobies
@@ -83798,6 +85846,7 @@
   mero_member:
   - 02624207-n
   partOfSpeech: n
+  wikidata: Q648200
 02624207-n:
   definition:
   - surgeon fish of the West Indies
@@ -83824,6 +85873,7 @@
   - 02624879-n
   - 02625038-n
   partOfSpeech: n
+  wikidata: Q1136229
 02624538-n:
   definition:
   - snake mackerels; elongated marine fishes with oily flesh; resembles mackerels;
@@ -83844,6 +85894,7 @@
   - Gempylus
   - genus Gempylus
   partOfSpeech: n
+  wikidata: Q14265654
 02624879-n:
   definition:
   - predatory tropical fishes with jutting jaws and strong teeth
@@ -83866,6 +85917,7 @@
   mero_member:
   - 02625177-n
   partOfSpeech: n
+  wikidata: Q12816990
 02625177-n:
   definition:
   - large snake mackerel with rings like spectacles around its eyes
@@ -83959,6 +86011,7 @@
   - 02631097-n
   - 02631486-n
   partOfSpeech: n
+  wikidata: Q215185
 02626797-n:
   definition:
   - any of various fishes of the family Scombridae
@@ -83982,6 +86035,7 @@
   - 02627437-n
   - 02627617-n
   partOfSpeech: n
+  wikidata: Q3593412
 02627181-n:
   definition:
   - important food fish of the northern Atlantic and Mediterranean; its body is greenish-blue
@@ -84031,6 +86085,7 @@
   mero_member:
   - 02627888-n
   partOfSpeech: n
+  wikidata: Q17152321
 02627888-n:
   definition:
   - large fast-moving predacious food and game fish; found worldwide
@@ -84131,6 +86186,7 @@
   - 02629922-n
   - 02630162-n
   partOfSpeech: n
+  wikidata: Q2346039
 02629392-n:
   definition:
   - any very large marine food and game fish of the genus Thunnus; related to mackerel;
@@ -84199,6 +86255,7 @@
   - 02630692-n
   - 02630889-n
   partOfSpeech: n
+  wikidata: Q1191675
 02630465-n:
   definition:
   - any of various scombroid fishes intermediate in size and characteristics between
@@ -84247,6 +86304,7 @@
   mero_member:
   - 02631230-n
   partOfSpeech: n
+  wikidata: Q250377
 02631230-n:
   definition:
   - oceanic schooling tuna of considerable value in Pacific but less in Atlantic;
@@ -84272,6 +86330,7 @@
   mero_member:
   - 02631860-n
   partOfSpeech: n
+  wikidata: Q17152354
 02631678-n:
   definition:
   - in some classifications considered a separate family comprising the oceanic bonitos
@@ -84306,6 +86365,7 @@
   mero_member:
   - 02632211-n
   partOfSpeech: n
+  wikidata: Q567749
 02632211-n:
   definition:
   - type genus of the Xiphiidae
@@ -84318,6 +86378,7 @@
   mero_member:
   - 02632346-n
   partOfSpeech: n
+  wikidata: Q14182864
 02632346-n:
   definition:
   - 'large toothless marine food fish with a long swordlike upper jaw; not completely
@@ -84348,6 +86409,7 @@
   - 02633556-n
   - 02634529-n
   partOfSpeech: n
+  wikidata: Q30961
 02632911-n:
   definition:
   - large pelagic game fish having an elongated upper jaw and long dorsal fin that
@@ -84370,6 +86432,7 @@
   mero_member:
   - 02633245-n
   partOfSpeech: n
+  wikidata: Q127497
 02633245-n:
   definition:
   - a kind of sailfish
@@ -84465,6 +86528,7 @@
   mero_member:
   - 02634669-n
   partOfSpeech: n
+  wikidata: Q517091
 02634669-n:
   definition:
   - any of several large vigorous pelagic fishes resembling sailfishes but with first
@@ -84487,6 +86551,7 @@
   mero_member:
   - 02634989-n
   partOfSpeech: n
+  wikidata: Q1817202
 02634989-n:
   definition:
   - type genus of the Luvaridae
@@ -84499,6 +86564,7 @@
   mero_member:
   - 02635124-n
   partOfSpeech: n
+  wikidata: Q16573319
 02635124-n:
   definition:
   - large silvery fish found worldwide in warm seas but nowhere common; resembles
@@ -84576,6 +86642,7 @@
   - 02636052-n
   - 02636307-n
   partOfSpeech: n
+  wikidata: Q2714710
 02636607-n:
   definition:
   - butterfish up to a foot long of Atlantic waters from Chesapeake Bay to Argentina
@@ -84598,6 +86665,7 @@
   mero_member:
   - 02636915-n
   partOfSpeech: n
+  wikidata: Q1887029
 02636915-n:
   definition:
   - small (6 inches) tropical butterfishes found worldwide
@@ -84642,6 +86710,7 @@
   mero_member:
   - 02637488-n
   partOfSpeech: n
+  wikidata: Q2116400
 02637488-n:
   definition:
   - sluggish square-tailed fish armored with tough bony scales; of deep warm waters
@@ -84688,6 +86757,7 @@
   - 02638089-n
   - 02638210-n
   partOfSpeech: n
+  wikidata: Q559345
 02638089-n:
   definition:
   - type genus of the Gobiesocidae
@@ -84698,6 +86768,7 @@
   - Gobiesox
   - genus Gobiesox
   partOfSpeech: n
+  wikidata: Q1989044
 02638210-n:
   definition:
   - very small (to 3 inches) flattened marine fish with a sucking disc on the abdomen
@@ -84745,6 +86816,7 @@
   mero_member:
   - 02638800-n
   partOfSpeech: n
+  wikidata: Q1258113
 02638800-n:
   definition:
   - large food fish of warm waters worldwide having long anal and dorsal fins that
@@ -84791,7 +86863,7 @@
   - 02639676-n
   - 02639967-n
   partOfSpeech: n
-  wikidata: Q1140406
+  wikidata: Q270322
 02639484-n:
   definition:
   - small silvery schooling fishes with protrusible mouths found in warm coastal waters
@@ -84837,6 +86909,7 @@
   mero_member:
   - 02640105-n
   partOfSpeech: n
+  wikidata: Q2029813
 02640105-n:
   definition:
   - silvery mojarra found along sandy shores of the western Atlantic
@@ -84873,6 +86946,7 @@
   mero_member:
   - 02640607-n
   partOfSpeech: n
+  wikidata: Q2252483
 02640607-n:
   definition:
   - a small fish of the genus Sillago; excellent food fish
@@ -84932,6 +87006,7 @@
   mero_member:
   - 02641590-n
   partOfSpeech: n
+  wikidata: Q141948
 02641590-n:
   definition:
   - type genus of the Amiidae
@@ -84944,6 +87019,7 @@
   mero_member:
   - 02641717-n
   partOfSpeech: n
+  wikidata: Q4064288
 02641717-n:
   definition:
   - primitive long-bodied carnivorous freshwater fish with a very long dorsal fin;
@@ -84971,6 +87047,7 @@
   - 02642094-n
   - 02642416-n
   partOfSpeech: n
+  wikidata: Q858011
 02642094-n:
   definition:
   - type genus of the Polyodontidae
@@ -85008,6 +87085,7 @@
   mero_member:
   - 02642552-n
   partOfSpeech: n
+  wikidata: Q18521053
 02642552-n:
   definition:
   - fish of larger rivers of China similar to the Mississippi paddlefish
@@ -85032,6 +87110,7 @@
   - 02642872-n
   - 02643083-n
   partOfSpeech: n
+  wikidata: Q181871
 02642872-n:
   definition:
   - large primitive fishes valued for their flesh and roe; widely distributed in the
@@ -85055,6 +87134,7 @@
   - 02643256-n
   - 02643487-n
   partOfSpeech: n
+  wikidata: Q174020
 02643256-n:
   definition:
   - food and game fish of marine and fresh waters of northwestern coast of North America
@@ -85093,6 +87173,7 @@
   mero_member:
   - 02643845-n
   partOfSpeech: n
+  wikidata: Q506144
 02643845-n:
   definition:
   - 'type genus of the Lepisosteidae: freshwater gars'
@@ -85134,6 +87215,7 @@
   - 02651086-n
   - 02654476-n
   partOfSpeech: n
+  wikidata: Q208777
 02644455-n:
   definition:
   - 'mail-cheeked fishes: scorpionfishes; gurnards'
@@ -85178,6 +87260,7 @@
   - 02646343-n
   - 02646619-n
   partOfSpeech: n
+  wikidata: Q386535
 02645274-n:
   definition:
   - any of numerous carnivorous usually bottom-dwelling warm-water marine fishes found
@@ -85258,6 +87341,7 @@
   mero_member:
   - 02646466-n
   partOfSpeech: n
+  wikidata: Q13396094
 02646466-n:
   definition:
   - venomous tropical marine fish resembling a piece of rock
@@ -85280,6 +87364,7 @@
   mero_member:
   - 02646743-n
   partOfSpeech: n
+  wikidata: Q149077
 02646743-n:
   definition:
   - marine food fish found among rocks along the northern coasts of Europe and America
@@ -85352,6 +87437,7 @@
   - 02648453-n
   - 02648747-n
   partOfSpeech: n
+  wikidata: Q513998
 02647773-n:
   definition:
   - 'type genus of the Cottidae: sculpins'
@@ -85365,6 +87451,7 @@
   - 02648168-n
   - 02648321-n
   partOfSpeech: n
+  wikidata: Q134913
 02647934-n:
   definition:
   - any of numerous spiny large-headed usually scaleless scorpaenoid fishes with broad
@@ -85429,6 +87516,7 @@
   mero_member:
   - 02648871-n
   partOfSpeech: n
+  wikidata: Q107269468
 02648871-n:
   definition:
   - small sculpin of the coast of New England
@@ -85451,6 +87539,7 @@
   mero_member:
   - 02649138-n
   partOfSpeech: n
+  wikidata: Q4057200
 02649138-n:
   definition:
   - 'type genus of the Cyclopteridae: lumpfishes'
@@ -85463,6 +87552,7 @@
   mero_member:
   - 02649297-n
   partOfSpeech: n
+  wikidata: Q18001776
 02649297-n:
   definition:
   - clumsy soft thick-bodied northern Atlantic fish with pelvic fins fused into a
@@ -85497,6 +87587,7 @@
   mero_member:
   - 02649774-n
   partOfSpeech: n
+  wikidata: Q670598
 02649774-n:
   definition:
   - 'type genus of the Liparididae: snailfishes'
@@ -85509,6 +87600,7 @@
   mero_member:
   - 02649924-n
   partOfSpeech: n
+  wikidata: Q162097
 02649924-n:
   definition:
   - small tadpole-shaped cold-water fishes with pelvic fins forming a sucker; related
@@ -85536,6 +87628,7 @@
   - 02650533-n
   - 02650804-n
   partOfSpeech: n
+  wikidata: Q1030003
 02650290-n:
   definition:
   - small slender fish (to 8 inches) with body covered by bony plates; chiefly of
@@ -85584,6 +87677,7 @@
   mero_member:
   - 02650943-n
   partOfSpeech: n
+  wikidata: Q1449104
 02650943-n:
   definition:
   - small very elongate sea poachers
@@ -85655,6 +87749,7 @@
   mero_member:
   - 02651848-n
   partOfSpeech: n
+  wikidata: Q2183433
 02651848-n:
   definition:
   - greenling with whitish body marked with black bands
@@ -85680,6 +87775,7 @@
   mero_member:
   - 02652176-n
   partOfSpeech: n
+  wikidata: Q1072599
 02652176-n:
   definition:
   - food fish of the Indonesian region of the Pacific; resembles gurnards
@@ -85707,6 +87803,7 @@
   - 02653845-n
   - 02654042-n
   partOfSpeech: n
+  wikidata: Q250699
 02652680-n:
   definition:
   - bottom-dwelling coastal fishes with spiny armored heads and fingerlike pectoral
@@ -85729,6 +87826,7 @@
   mero_member:
   - 02653043-n
   partOfSpeech: n
+  wikidata: Q14506504
 02653043-n:
   definition:
   - a kind of gurnard
@@ -85809,6 +87907,7 @@
   mero_member:
   - 02654247-n
   partOfSpeech: n
+  wikidata: Q1951787
 02654247-n:
   definition:
   - sea robins having bony scutes on the body and barbels on the chin; found mostly
@@ -85846,6 +87945,7 @@
   - Dactylopterus
   - genus Dactylopterus
   partOfSpeech: n
+  wikidata: Q16538599
 02654762-n:
   definition:
   - tropical fish with huge fanlike pectoral fins for underwater gliding; unrelated
@@ -85878,6 +87978,7 @@
   - 02657985-n
   - 02659056-n
   partOfSpeech: n
+  wikidata: Q211837
 02655298-n:
   definition:
   - tropical marine fishes having the teeth fused into a beak and thick skin covered
@@ -85903,6 +88004,7 @@
   - 02655989-n
   - 02656416-n
   partOfSpeech: n
+  wikidata: Q504796
 02655775-n:
   definition:
   - any of numerous compressed deep-bodied tropical fishes with sandpapery skin and
@@ -85925,6 +88027,7 @@
   mero_member:
   - 02656127-n
   partOfSpeech: n
+  wikidata: Q35016
 02656127-n:
   definition:
   - tropical Atlantic fish
@@ -85950,6 +88053,7 @@
   mero_member:
   - 02656595-n
   partOfSpeech: n
+  wikidata: Q948098
 02656416-n:
   definition:
   - narrow flattened warm-water fishes with leathery skin and a long file-like dorsal
@@ -85972,6 +88076,7 @@
   mero_member:
   - 02656742-n
   partOfSpeech: n
+  wikidata: Q56847
 02656742-n:
   definition:
   - any of several brightly colored tropical filefishes
@@ -85996,6 +88101,7 @@
   - 02657055-n
   - 02657239-n
   partOfSpeech: n
+  wikidata: Q755011
 02657055-n:
   definition:
   - any of numerous small tropical fishes having body and head encased in bony plates
@@ -86018,6 +88124,7 @@
   mero_member:
   - 02657375-n
   partOfSpeech: n
+  wikidata: Q82855
 02657375-n:
   definition:
   - trunkfish having hornlike spines over the eyes
@@ -86040,6 +88147,7 @@
   mero_member:
   - 02657650-n
   partOfSpeech: n
+  wikidata: Q201701
 02657650-n:
   definition:
   - any of numerous marine fishes whose elongated spiny body can inflate itself with
@@ -86070,6 +88178,7 @@
   - 02658324-n
   - 02658801-n
   partOfSpeech: n
+  wikidata: Q329334
 02658153-n:
   definition:
   - puffers having rigid or erectile spines
@@ -86092,6 +88201,7 @@
   - 02658478-n
   - 02658662-n
   partOfSpeech: n
+  wikidata: Q1809104
 02658478-n:
   definition:
   - spines become erect when the body is inflated; worldwide in warm waters
@@ -86126,6 +88236,7 @@
   mero_member:
   - 02658931-n
   partOfSpeech: n
+  wikidata: Q2690499
 02658931-n:
   definition:
   - any of several fishes having rigid flattened spines
@@ -86159,6 +88270,7 @@
   mero_member:
   - 02659300-n
   partOfSpeech: n
+  wikidata: Q1178471
 02659300-n:
   definition:
   - among the largest bony fish; pelagic fish having an oval compressed body with
@@ -86201,6 +88313,7 @@
   - 02665982-n
   - 02666287-n
   partOfSpeech: n
+  wikidata: Q59577
 02659998-n:
   definition:
   - any of several families of fishes having flattened bodies that swim along the
@@ -86262,6 +88375,7 @@
   mero_member:
   - 02661161-n
   partOfSpeech: n
+  wikidata: Q572495
 02661161-n:
   definition:
   - large European food fish
@@ -86286,6 +88400,7 @@
   mero_member:
   - 02661441-n
   partOfSpeech: n
+  wikidata: Q849396
 02661441-n:
   definition:
   - important food fish of Europe
@@ -86362,6 +88477,7 @@
   mero_member:
   - 02662438-n
   partOfSpeech: n
+  wikidata: Q549006
 02662438-n:
   definition:
   - European flatfish highly valued as food
@@ -86420,6 +88536,7 @@
   - Hippoglossus
   - genus Hippoglossus
   partOfSpeech: n
+  wikidata: Q2697230
 02663149-n:
   definition:
   - largest United States flatfish
@@ -86459,6 +88576,7 @@
   - 02665318-n
   - 02665716-n
   partOfSpeech: n
+  wikidata: Q838524
 02663647-n:
   definition:
   - flatfishes with both eyes on the left side of the head
@@ -86516,6 +88634,7 @@
   mero_member:
   - 02664522-n
   partOfSpeech: n
+  wikidata: Q5404893
 02664522-n:
   definition:
   - flounder found from North Carolina to Florida and the eastern Gulf of Mexico
@@ -86541,6 +88660,7 @@
   - 02664869-n
   - 02665189-n
   partOfSpeech: n
+  wikidata: Q2491501
 02664869-n:
   definition:
   - a lefteye flounder found in coastal waters from New England to Brazil
@@ -86581,6 +88701,7 @@
   mero_member:
   - 02665455-n
   partOfSpeech: n
+  wikidata: Q2705790
 02665455-n:
   definition:
   - very thin translucent flounder of the Atlantic coast of North America
@@ -86613,6 +88734,7 @@
   mero_member:
   - 02665841-n
   partOfSpeech: n
+  wikidata: Q2499212
 02665841-n:
   definition:
   - a large brownish European flatfish
@@ -86637,6 +88759,7 @@
   mero_member:
   - 02666115-n
   partOfSpeech: n
+  wikidata: Q1136219
 02666115-n:
   definition:
   - left-eyed marine flatfish whose tail tapers to a point; of little commercial value
@@ -86691,6 +88814,7 @@
   - 02666915-n
   - 02667029-n
   partOfSpeech: n
+  wikidata: Q531725
 02666915-n:
   definition:
   - highly valued as food
@@ -86723,6 +88847,7 @@
   mero_member:
   - 02667272-n
   partOfSpeech: n
+  wikidata: Q3014512
 02667272-n:
   definition:
   - popular pale brown food flatfish of the Pacific coast of North America
@@ -86746,6 +88871,7 @@
   mero_member:
   - 02667590-n
   partOfSpeech: n
+  wikidata: Q14672291
 02667590-n:
   definition:
   - a common flatfish of the Pacific coast of North America
@@ -86768,6 +88894,7 @@
   mero_member:
   - 02667880-n
   partOfSpeech: n
+  wikidata: Q224890
 02667880-n:
   definition:
   - useless as food; in coastal streams from Maine to Texas and Panama

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -24,6 +24,7 @@
   - 11765328-n
   - 13242141-n
   partOfSpeech: n
+  wikidata: Q756
 11550459-n:
   definition:
   - microscopic plants; bacteria are often considered to be microflora
@@ -451,6 +452,7 @@
   mero_member:
   - 11559271-n
   partOfSpeech: n
+  wikidata: Q5696912
 11559033-n:
   definition:
   - the family of hornworts (Anthocerotaceae)
@@ -463,6 +465,7 @@
   mero_member:
   - 11559167-n
   partOfSpeech: n
+  wikidata: Q1050205
 11559167-n:
   definition:
   - the genus of hornworts (Anthoceros)
@@ -502,6 +505,7 @@
   - 11561198-n
   - 11562164-n
   partOfSpeech: n
+  wikidata: Q831482
 11559740-n:
   definition:
   - a moss in which the main axis is terminated by the archegonium (and hence the
@@ -536,6 +540,7 @@
   mero_member:
   - 11560276-n
   partOfSpeech: n
+  wikidata: Q2846441
 11560276-n:
   definition:
   - brown or blackish Alpine mosses having a dehiscent capsule with 4 longitudinal
@@ -559,6 +564,7 @@
   - Bryales
   - order Bryales
   partOfSpeech: n
+  wikidata: Q140344
 11560681-n:
   definition:
   - widely distributed order of mosses with erect gametophores and sporophytes at
@@ -572,6 +578,7 @@
   mero_member:
   - 11560890-n
   partOfSpeech: n
+  wikidata: Q141514
 11560890-n:
   definition:
   - mosses having costate leaves and long-stalked capsules with cleft peristome
@@ -610,6 +617,7 @@
   - 11561421-n
   - 11561773-n
   partOfSpeech: n
+  wikidata: Q17277039
 11561421-n:
   definition:
   - a family of acrocarpous mosses
@@ -622,6 +630,7 @@
   mero_member:
   - 11561562-n
   partOfSpeech: n
+  wikidata: Q140324
 11561562-n:
   definition:
   - 'type genus of the Bryaceae: mosses distinguished by mostly erect and tufted gametophytes
@@ -633,6 +642,7 @@
   - Bryum
   - genus Bryum
   partOfSpeech: n
+  wikidata: Q146228
 11561773-n:
   definition:
   - family of erect mosses with club-shaped paraphyses and the hexagonal cells of
@@ -671,6 +681,7 @@
   mero_member:
   - 11562370-n
   partOfSpeech: n
+  wikidata: Q1138673
 11562370-n:
   definition:
   - 'a large genus constituting the order Sphagnales: atypical mosses of temperate
@@ -683,6 +694,7 @@
   mero_member:
   - 11562588-n
   partOfSpeech: n
+  wikidata: Q30019
 11562588-n:
   definition:
   - any of various pale or ashy mosses of the genus Sphagnum whose decomposed remains
@@ -714,6 +726,7 @@
   - 11563880-n
   - 11564582-n
   partOfSpeech: n
+  wikidata: Q16111747
 11563091-n:
   definition:
   - any of numerous small green nonvascular plants of the class Hepaticopsida growing
@@ -772,6 +785,7 @@
   mero_member:
   - 11564053-n
   partOfSpeech: n
+  wikidata: Q139099
 11564053-n:
   definition:
   - liverworts with prostrate and usually dichotomously branched thalli
@@ -784,6 +798,7 @@
   mero_member:
   - 11564243-n
   partOfSpeech: n
+  wikidata: Q138798
 11564243-n:
   definition:
   - type genus of Marchantiaceae; liverworts that reproduce asexually by gemmae and
@@ -820,6 +835,7 @@
   mero_member:
   - 11564765-n
   partOfSpeech: n
+  wikidata: Q147918
 11564765-n:
   definition:
   - liverworts with bilaterally symmetrical gametophytes; sometimes placed in the
@@ -881,6 +897,7 @@
   mero_member:
   - 11565801-n
   partOfSpeech: n
+  wikidata: Q144285
 11565801-n:
   definition:
   - Carboniferous fossil fern characterized by a regular arrangement of the leaflets
@@ -1519,7 +1536,7 @@
   - 11683900-n
   - 13129421-n
   partOfSpeech: n
-  wikidata: Q133712
+  wikidata: Q5625083
 11616559-n:
   definition:
   - plants of the class Gymnospermae having seeds not enclosed in an ovary
@@ -1555,7 +1572,7 @@
   mero_member:
   - 11617296-n
   partOfSpeech: n
-  wikidata: Q309147
+  wikidata: Q1011212
 11617296-n:
   definition:
   - chiefly tropical or xerophytic woody plants; practically unknown as fossils but
@@ -1571,6 +1588,7 @@
   - 11618375-n
   - 11619442-n
   partOfSpeech: n
+  wikidata: Q2705562
 11617577-n:
   definition:
   - 'plants having small unisexual flowers and fleshy or winged fruit: in some classifications
@@ -1584,6 +1602,7 @@
   mero_member:
   - 11617847-n
   partOfSpeech: n
+  wikidata: Q2056554
 11617847-n:
   definition:
   - type genus of the Gnetaceae; small trees or shrubs usually with climbing jointed
@@ -1597,6 +1616,7 @@
   mero_member:
   - 11618108-n
   partOfSpeech: n
+  wikidata: Q131550
 11618108-n:
   definition:
   - small tropical tree with tiered branches and divaricate branchlets having broad
@@ -1622,6 +1642,7 @@
   mero_member:
   - 11618903-n
   partOfSpeech: n
+  wikidata: Q10376735
 11618551-n:
   definition:
   - a genus of African evergreen shrubs characterized by thick leaves and white flowers
@@ -1634,6 +1655,7 @@
   mero_member:
   - 11618738-n
   partOfSpeech: n
+  wikidata: Q8342894
 11618738-n:
   definition:
   - a shrub that is cultivated by Arabs for its leaves which are chewed or used to
@@ -1657,6 +1679,7 @@
   mero_member:
   - 11619137-n
   partOfSpeech: n
+  wikidata: Q838000
 11619137-n:
   definition:
   - jointed and nearly leafless desert shrub having reduced scalelike leaves and reddish
@@ -1691,6 +1714,7 @@
   mero_member:
   - 11619616-n
   partOfSpeech: n
+  wikidata: Q10780833
 11619616-n:
   definition:
   - type and sole genus of Welwitschiaceae
@@ -1703,6 +1727,7 @@
   mero_member:
   - 11619775-n
   partOfSpeech: n
+  wikidata: Q15044266
 11619775-n:
   definition:
   - curious plant of arid regions of southwestern Africa having a yard-high and yard-wide
@@ -1735,7 +1760,7 @@
   - 11620590-n
   - 11624676-n
   partOfSpeech: n
-  wikidata: Q1089795
+  wikidata: Q5605610
 11620590-n:
   definition:
   - primitive tropical gymnosperms abundant in the Mesozoic, now reduced to a few
@@ -1775,6 +1800,7 @@
   mero_member:
   - 11621351-n
   partOfSpeech: n
+  wikidata: Q11773804
 11621351-n:
   definition:
   - 'type genus of Cycadaceae: genus of widely distributed Old World evergreen tropical
@@ -1832,6 +1858,7 @@
   - 11623496-n
   - 11624081-n
   partOfSpeech: n
+  wikidata: Q133329
 11622208-n:
   definition:
   - genus of small evergreen tropical and subtropical American cycads
@@ -1843,6 +1870,7 @@
   mero_member:
   - 11622369-n
   partOfSpeech: n
+  wikidata: Q134842
 11622369-n:
   definition:
   - any of various cycads of the genus Zamia; among the smallest and most verdant
@@ -1878,6 +1906,7 @@
   mero_member:
   - 11622929-n
   partOfSpeech: n
+  wikidata: Q135250
 11622929-n:
   definition:
   - a small cycad of the genus Ceratozamia having a short scaly woody trunk and fernlike
@@ -1900,6 +1929,7 @@
   mero_member:
   - 11623324-n
   partOfSpeech: n
+  wikidata: Q135605
 11623324-n:
   definition:
   - any cycad of the genus Dioon; handsome palmlike cycads with robust crowns of leaves
@@ -1922,6 +1952,7 @@
   - 11623697-n
   - 11623913-n
   partOfSpeech: n
+  wikidata: Q947957
 11623697-n:
   definition:
   - any of numerous cycads of the genus Encephalartos having stout cylindrical trunks
@@ -1954,6 +1985,7 @@
   - 11624286-n
   - 11624497-n
   partOfSpeech: n
+  wikidata: Q138789
 11624286-n:
   definition:
   - any treelike cycad of the genus Macrozamia having erect trunks and pinnate leaves
@@ -1991,6 +2023,7 @@
   mero_member:
   - 11624844-n
   partOfSpeech: n
+  wikidata: Q132823
 11624844-n:
   definition:
   - a family of fossil gymnospermous plants of the Carboniferous
@@ -2003,6 +2036,7 @@
   mero_member:
   - 11625027-n
   partOfSpeech: n
+  wikidata: Q15050378
 11625027-n:
   definition:
   - type of the Bennettitales
@@ -2025,6 +2059,7 @@
   mero_member:
   - 11625355-n
   partOfSpeech: n
+  wikidata: Q15617175
 11625355-n:
   definition:
   - 'fossil gymnospermous trees or climbing plants from the Devonian: seed ferns'
@@ -2039,6 +2074,7 @@
   mero_member:
   - 11625847-n
   partOfSpeech: n
+  wikidata: Q573940
 11625598-n:
   definition:
   - 'used in some classification systems: a group of extinct fossil gymnosperms coextensive
@@ -2062,6 +2098,7 @@
   - Lyginopteris
   - genus Lyginopteris
   partOfSpeech: n
+  wikidata: Q3840994
 11625993-n:
   definition:
   - an extinct seed-producing fernlike plant of the order Cycadofilicales (or group
@@ -2096,6 +2133,7 @@
   - 11680988-n
   - 11681299-n
   partOfSpeech: n
+  wikidata: Q16050271
 11626830-n:
   definition:
   - extinct plants having tall arborescent trunks comparable to or more advanced than
@@ -2150,6 +2188,7 @@
   - Pinophytina
   - subdivision Pinophytina
   partOfSpeech: n
+  wikidata: Q1329304
 11627843-n:
   definition:
   - profusely branching and chiefly evergreen trees and some shrubs having narrow
@@ -2170,6 +2209,7 @@
   - 11680360-n
   - 11681430-n
   partOfSpeech: n
+  wikidata: Q14107023
 11628190-n:
   definition:
   - a family of Pinaceae
@@ -2192,6 +2232,7 @@
   - 11649662-n
   - 11665492-n
   partOfSpeech: n
+  wikidata: Q101680
 11628506-n:
   definition:
   - 'type genus of the Pinaceae: large genus of true pines'
@@ -2206,6 +2247,7 @@
   - 11629926-n
   - 11630313-n
   partOfSpeech: n
+  wikidata: Q12024
 11628701-n:
   definition:
   - a coniferous tree
@@ -2808,6 +2850,7 @@
   mero_member:
   - 11639312-n
   partOfSpeech: n
+  wikidata: Q25618
 11639312-n:
   definition:
   - any of numerous conifers of the genus Larix all having deciduous needlelike leaves
@@ -2923,6 +2966,7 @@
   mero_member:
   - 11641124-n
   partOfSpeech: n
+  wikidata: Q25350
 11641124-n:
   definition:
   - any of various evergreen trees of the genus Abies; chiefly of upland areas
@@ -3078,6 +3122,7 @@
   mero_member:
   - 11643556-n
   partOfSpeech: n
+  wikidata: Q128550
 11643556-n:
   definition:
   - any cedar of the genus Cedrus
@@ -3167,6 +3212,7 @@
   mero_member:
   - 11644982-n
   partOfSpeech: n
+  wikidata: Q26782
 11644982-n:
   definition:
   - any coniferous tree of the genus Picea
@@ -3320,6 +3366,7 @@
   mero_member:
   - 11647619-n
   partOfSpeech: n
+  wikidata: Q739430
 11647619-n:
   definition:
   - an evergreen tree, could refer to any one of a genus of conifers named Tsuga
@@ -3402,6 +3449,7 @@
   mero_member:
   - 11648907-n
   partOfSpeech: n
+  wikidata: Q158771
 11648907-n:
   definition:
   - tall evergreen timber tree of western North America having resinous wood and short
@@ -3461,6 +3509,7 @@
   mero_member:
   - 11649805-n
   partOfSpeech: n
+  wikidata: Q1543178
 11649805-n:
   definition:
   - Chinese evergreen conifer discovered in 1955; not yet cultivated elsewhere
@@ -3501,6 +3550,7 @@
   - 11664135-n
   - 11665163-n
   partOfSpeech: n
+  wikidata: Q146037
 11650468-n:
   definition:
   - any of numerous trees of the family Cupressaceae that resemble cedars
@@ -3525,6 +3575,7 @@
   mero_member:
   - 11650940-n
   partOfSpeech: n
+  wikidata: Q146911
 11650940-n:
   definition:
   - any of numerous evergreen conifers of the genus Cupressus of north temperate regions
@@ -3655,6 +3706,7 @@
   mero_member:
   - 11653380-n
   partOfSpeech: n
+  wikidata: Q1368777
 11653380-n:
   definition:
   - evergreen of Tasmanian mountains having sharp-pointed leaves that curve inward
@@ -3678,6 +3730,7 @@
   mero_member:
   - 11653735-n
   partOfSpeech: n
+  wikidata: Q1072934
 11653735-n:
   definition:
   - a small South American evergreen having coppery bark and pretty foliage
@@ -3758,6 +3811,7 @@
   mero_member:
   - 11655187-n
   partOfSpeech: n
+  wikidata: Q765246
 11655187-n:
   definition:
   - tall tree of the Pacific coast of North America having foliage like cypress and
@@ -3851,6 +3905,7 @@
   mero_member:
   - 11656655-n
   partOfSpeech: n
+  wikidata: Q12323064
 11656655-n:
   definition:
   - tall evergreen of Japan and China yielding valuable soft wood
@@ -4019,6 +4074,7 @@
   - 11659757-n
   - 11659896-n
   partOfSpeech: n
+  wikidata: Q2340419
 11659535-n:
   definition:
   - any of several attractive trees of southwestern South America and New Zealand
@@ -4078,6 +4134,7 @@
   mero_member:
   - 11660583-n
   partOfSpeech: n
+  wikidata: Q1825748
 11660583-n:
   definition:
   - large fast-growing Chinese monoecious tree having flat bright-green deciduous
@@ -4102,6 +4159,7 @@
   mero_member:
   - 11661485-n
   partOfSpeech: n
+  wikidata: Q1975652
 11661349-n:
   definition:
   - the soft reddish wood of either of two species of sequoia trees
@@ -4136,6 +4194,7 @@
   mero_member:
   - 11661945-n
   partOfSpeech: n
+  wikidata: Q14707792
 11661945-n:
   definition:
   - extremely lofty evergreen of southern end of western foothills of Sierra Nevada
@@ -4166,6 +4225,7 @@
   - 80820791-n
   - 85319713-n
   partOfSpeech: n
+  wikidata: Q147392
 11663073-n:
   definition:
   - Mexico's most famous tree; a giant specimen of Montezuma cypress more than 2,000
@@ -4189,6 +4249,7 @@
   - Tetraclinis
   - genus Tetraclinis
   partOfSpeech: n
+  wikidata: Q13091238
 11663473-n:
   definition:
   - large coniferous evergreen tree of North Africa and Spain having flattened branches
@@ -4302,6 +4363,7 @@
   mero_member:
   - 11665323-n
   partOfSpeech: n
+  wikidata: Q12317810
 11665323-n:
   definition:
   - slow-growing medium-large Japanese evergreen used as an ornamental
@@ -4323,6 +4385,7 @@
   mero_member:
   - 11665614-n
   partOfSpeech: n
+  wikidata: Q132109
 11665614-n:
   definition:
   - Asiatic conifers resembling firs
@@ -4348,6 +4411,7 @@
   - 11666234-n
   - 11667582-n
   partOfSpeech: n
+  wikidata: Q217697
 11666041-n:
   definition:
   - newly discovered (1994) pine thought to have been long extinct; Australia; genus
@@ -4369,6 +4433,7 @@
   mero_member:
   - 11666365-n
   partOfSpeech: n
+  wikidata: Q157214
 11666365-n:
   definition:
   - any of several tall South American or Australian trees with large cones and edible
@@ -4454,6 +4519,7 @@
   - 11668490-n
   - 11668719-n
   partOfSpeech: n
+  wikidata: Q216113
 11667757-n:
   definition:
   - any of various trees of the genus Agathis; yield dammar resin
@@ -4550,6 +4616,7 @@
   mero_member:
   - 11669227-n
   partOfSpeech: n
+  wikidata: Q933520
 11669227-n:
   definition:
   - any of several evergreen trees and shrubs of eastern Asia resembling yew and having
@@ -4573,6 +4640,7 @@
   - 11669601-n
   - 11669810-n
   partOfSpeech: n
+  wikidata: Q429944
 11669601-n:
   definition:
   - California evergreen having a fruit resembling a nutmeg but with a strong turpentine
@@ -4611,6 +4679,7 @@
   mero_member:
   - 11670200-n
   partOfSpeech: n
+  wikidata: Q33138051
 11670200-n:
   definition:
   - celery pine
@@ -4623,6 +4692,7 @@
   mero_member:
   - 11670329-n
   partOfSpeech: n
+  wikidata: Q134249
 11670329-n:
   definition:
   - Australasian evergreen conifer having a graceful head of foliage resembling celery
@@ -4749,6 +4819,7 @@
   - 11673417-n
   - 11673577-n
   partOfSpeech: n
+  wikidata: Q157524
 11672490-n:
   definition:
   - any evergreen in the Southern Hemisphere of the genus Podocarpus having a pulpy
@@ -4887,6 +4958,7 @@
   - 11674744-n
   - 11674889-n
   partOfSpeech: n
+  wikidata: Q1482244
 11674744-n:
   definition:
   - tall New Zealand timber tree
@@ -4927,6 +4999,7 @@
   - 11675435-n
   - 11675603-n
   partOfSpeech: n
+  wikidata: Q133717
 11675435-n:
   definition:
   - small tropical rain forest tree of Indonesia and Malaysia
@@ -4988,6 +5061,7 @@
   mero_member:
   - 11676574-n
   partOfSpeech: n
+  wikidata: Q3216153
 11676425-n:
   definition:
   - timber tree of New Zealand having shiny white wood
@@ -5061,6 +5135,7 @@
   mero_member:
   - 11677604-n
   partOfSpeech: n
+  wikidata: Q135762
 11677604-n:
   definition:
   - small shrub or Tasmania having short stiff branches
@@ -5110,6 +5185,7 @@
   mero_member:
   - 11678355-n
   partOfSpeech: n
+  wikidata: Q13077228
 11678355-n:
   definition:
   - rare and endangered monoecious parasitic conifer of New Caledonia; parasitic on
@@ -5182,6 +5258,7 @@
   - Retrophyllum
   - genus Retrophyllum
   partOfSpeech: n
+  wikidata: Q138257
 11679519-n:
   definition:
   - 'one species: Prince Albert''s yew'
@@ -5196,6 +5273,7 @@
   mero_member:
   - 11679699-n
   partOfSpeech: n
+  wikidata: Q13080853
 11679699-n:
   definition:
   - small yew having attractive foliage and partially weeping branches cultivated
@@ -5220,6 +5298,7 @@
   mero_member:
   - 11680078-n
   partOfSpeech: n
+  wikidata: Q13080891
 11680078-n:
   definition:
   - a large fast-growing monoecious tropical evergreen tree having large glossy lanceolate
@@ -5244,6 +5323,7 @@
   mero_member:
   - 11680572-n
   partOfSpeech: n
+  wikidata: Q520165
 11680572-n:
   definition:
   - type and sole genus of Sciadopityaceae; Japanese umbrella pines
@@ -5256,6 +5336,7 @@
   mero_member:
   - 11680751-n
   partOfSpeech: n
+  wikidata: Q3065538
 11680751-n:
   definition:
   - tall evergreen having a symmetrical spreading crown and needles growing in whorls
@@ -5280,6 +5361,7 @@
   - Taxophytina
   - subdivision Taxophytina
   partOfSpeech: n
+  wikidata: Q99048207
 11681299-n:
   definition:
   - 'coextensive with the family Taxaceae: yews'
@@ -5290,6 +5372,7 @@
   - Taxales
   - order Taxales
   partOfSpeech: n
+  wikidata: Q2697797
 11681430-n:
   definition:
   - sometimes classified as member of order Taxales
@@ -5322,6 +5405,7 @@
   - 11682822-n
   - 11683036-n
   partOfSpeech: n
+  wikidata: Q27355
 11681823-n:
   definition:
   - any of numerous evergreen trees or shrubs having red cup-shaped berries and flattened
@@ -5405,6 +5489,7 @@
   mero_member:
   - 11683388-n
   partOfSpeech: n
+  wikidata: Q13052844
 11683388-n:
   definition:
   - large yew native to New Caledonia; cultivated in eastern Australia and New Zealand
@@ -5429,6 +5514,7 @@
   mero_member:
   - 11683714-n
   partOfSpeech: n
+  wikidata: Q13080832
 11683714-n:
   definition:
   - yew of southeastern China, differing from the Old World yew in having white berries
@@ -5456,6 +5542,7 @@
   mero_member:
   - 11684264-n
   partOfSpeech: n
+  wikidata: Q10788836
 11684264-n:
   definition:
   - 'coextensive with the family Ginkgoaceae: plants that first appeared in the Permian
@@ -5469,6 +5556,7 @@
   mero_member:
   - 11684541-n
   partOfSpeech: n
+  wikidata: Q835097
 11684541-n:
   definition:
   - constituting the order Ginkgoales; includes the genus Ginkgo and extinct forms
@@ -5492,6 +5580,7 @@
   members:
   - genus Ginkgo
   partOfSpeech: n
+  wikidata: Q149461
 11684869-n:
   definition:
   - deciduous dioecious Chinese tree having fan-shaped leaves and fleshy yellow seeds;
@@ -5537,6 +5626,7 @@
   - 13130492-n
   - 13140762-n
   partOfSpeech: n
+  wikidata: Q25314
 11685823-n:
   definition:
   - plants having seeds in a closed ovary
@@ -7021,6 +7111,7 @@
   - 11716807-n
   - 11717245-n
   partOfSpeech: n
+  wikidata: Q220025
 11714281-n:
   definition:
   - type genus of the Annonaceae; tropical American trees or shrubs
@@ -7033,6 +7124,7 @@
   mero_member:
   - 11714450-n
   partOfSpeech: n
+  wikidata: Q275737
 11714450-n:
   definition:
   - any of several tropical American trees bearing fruit with soft edible pulp
@@ -7173,6 +7265,7 @@
   mero_member:
   - 11716443-n
   partOfSpeech: n
+  wikidata: Q3264724
 11716443-n:
   definition:
   - evergreen Asian tree with aromatic greenish-yellow flowers yielding a volatile
@@ -7204,6 +7297,7 @@
   - Oxandra
   - genus Oxandra
   partOfSpeech: n
+  wikidata: Q1331220
 11716919-n:
   definition:
   - source of most of the lancewood of commerce
@@ -7239,6 +7333,7 @@
   mero_member:
   - 11717404-n
   partOfSpeech: n
+  wikidata: Q2234889
 11717404-n:
   definition:
   - tropical west African evergreen tree bearing pungent aromatic seeds used as a
@@ -7269,6 +7364,7 @@
   - 11719752-n
   - 11720384-n
   partOfSpeech: n
+  wikidata: Q155949
 11717857-n:
   definition:
   - large genus of shrubs of temperate zones of New and Old Worlds
@@ -7281,6 +7377,7 @@
   mero_member:
   - 11718029-n
   partOfSpeech: n
+  wikidata: Q158503
 11718029-n:
   definition:
   - any of numerous plants of the genus Berberis having prickly stems and yellow flowers
@@ -7337,6 +7434,7 @@
   mero_member:
   - 11719031-n
   partOfSpeech: n
+  wikidata: Q2671028
 11719031-n:
   definition:
   - tall herb of eastern North America and Asia having blue berrylike fruit and a
@@ -7367,6 +7465,7 @@
   mero_member:
   - 11719540-n
   partOfSpeech: n
+  wikidata: Q157746
 11719540-n:
   definition:
   - slow-growing creeping plant with semi-evergreen leaves on erect wiry stems; used
@@ -7389,6 +7488,7 @@
   - Mahonia
   - genus Mahonia
   partOfSpeech: n
+  wikidata: Q157379
 11719911-n:
   definition:
   - ornamental evergreen shrub of Pacific coast of North America having dark green
@@ -7427,6 +7527,7 @@
   mero_member:
   - 11720527-n
   partOfSpeech: n
+  wikidata: Q732308
 11720527-n:
   definition:
   - North American herb with poisonous root stock and edible though insipid fruit
@@ -7466,6 +7567,7 @@
   - 11721145-n
   - 11721961-n
   partOfSpeech: n
+  wikidata: Q867622
 11721145-n:
   definition:
   - 'a magnoliid dicot genus of the family Calycanthaceae including: allspice'
@@ -7478,6 +7580,7 @@
   mero_member:
   - 11721333-n
   partOfSpeech: n
+  wikidata: Q158029
 11721333-n:
   definition:
   - deciduous shrubs having aromatic bark; eastern China; southwestern and eastern
@@ -7553,6 +7656,7 @@
   mero_member:
   - 11722550-n
   partOfSpeech: n
+  wikidata: Q12012524
 11722550-n:
   definition:
   - 'constituting the family Ceratophyllaceae: hornworts'
@@ -7601,6 +7705,7 @@
   mero_member:
   - 11723182-n
   partOfSpeech: n
+  wikidata: Q858028
 11723182-n:
   definition:
   - rapidly growing deciduous tree of low mountainsides of China and Japan; grown
@@ -7627,6 +7732,7 @@
   mero_member:
   - 11723674-n
   partOfSpeech: n
+  wikidata: Q840758
 11723674-n:
   definition:
   - evergreen monoecious climbers of South America having dark mauve-blue edible berries
@@ -7637,6 +7743,7 @@
   - Lardizabala
   - genus Lardizabala
   partOfSpeech: n
+  wikidata: Q2603764
 11723855-n:
   definition:
   - a family of Lauraceae
@@ -7657,6 +7764,7 @@
   - 11727578-n
   - 11728137-n
   partOfSpeech: n
+  wikidata: Q26538
 11724138-n:
   definition:
   - any of various aromatic trees of the laurel family
@@ -7678,6 +7786,7 @@
   mero_member:
   - 11724562-n
   partOfSpeech: n
+  wikidata: Q21188
 11724562-n:
   definition:
   - small Mediterranean evergreen tree with small blackish berries and glossy aromatic
@@ -7709,6 +7818,7 @@
   - 11725640-n
   - 11726042-n
   partOfSpeech: n
+  wikidata: Q27282
 11725089-n:
   definition:
   - large evergreen tree of warm regions whose aromatic wood yields camphor
@@ -7803,6 +7913,7 @@
   mero_member:
   - 11726794-n
   partOfSpeech: n
+  wikidata: Q311790
 11726589-n:
   definition:
   - used in some classifications for the American spicebush and certain other plants
@@ -7814,6 +7925,7 @@
   - Benzoin
   - genus Benzoin
   partOfSpeech: n
+  wikidata: Q18337957
 11726794-n:
   definition:
   - deciduous shrub of the eastern United States having highly aromatic leaves and
@@ -7842,6 +7954,7 @@
   - 11727230-n
   - 11727411-n
   partOfSpeech: n
+  wikidata: Q132039
 11727230-n:
   definition:
   - tropical American tree bearing large pulpy green fruits
@@ -7877,6 +7990,7 @@
   mero_member:
   - 11727698-n
   partOfSpeech: n
+  wikidata: Q131532
 11727698-n:
   definition:
   - yellowwood tree with brittle wood and aromatic leaves and bark; source of sassafras
@@ -7914,6 +8028,7 @@
   mero_member:
   - 11728296-n
   partOfSpeech: n
+  wikidata: Q15933047
 11728296-n:
   definition:
   - Pacific coast tree having aromatic foliage and small umbellate flowers followed
@@ -7949,6 +8064,7 @@
   - 11732440-n
   - 11732622-n
   partOfSpeech: n
+  wikidata: Q120228
 11728911-n:
   definition:
   - 'anise trees: evergreen trees with aromatic leaves'
@@ -7964,6 +8080,7 @@
   - 11729514-n
   - 11729674-n
   partOfSpeech: n
+  wikidata: Q5492045
 11729127-n:
   definition:
   - any of several evergreen shrubs and small trees of the genus Illicium
@@ -8023,6 +8140,7 @@
   mero_member:
   - 11730143-n
   partOfSpeech: n
+  wikidata: Q157017
 11730143-n:
   definition:
   - any shrub or tree of the genus Magnolia; valued for their longevity and exquisite
@@ -8154,6 +8272,7 @@
   - manglietia
   - genus Manglietia
   partOfSpeech: n
+  wikidata: Q2213494
 11732622-n:
   definition:
   - tulip trees
@@ -8166,6 +8285,7 @@
   mero_member:
   - 11732751-n
   partOfSpeech: n
+  wikidata: Q157236
 11732751-n:
   definition:
   - tall North American deciduous timber tree having large tulip-shaped greenish yellow
@@ -8211,6 +8331,7 @@
   - 11733633-n
   - 11734097-n
   partOfSpeech: n
+  wikidata: Q855116
 11733503-n:
   definition:
   - climbing herbs
@@ -8260,6 +8381,7 @@
   mero_member:
   - 11734232-n
   partOfSpeech: n
+  wikidata: Q1152946
 11734232-n:
   definition:
   - woody vine of southeastern United States resembling the common moonseed but having
@@ -8284,6 +8406,7 @@
   mero_member:
   - 11734619-n
   partOfSpeech: n
+  wikidata: Q161214
 11734619-n:
   definition:
   - type genus of Myristicaceae; tropical Asian evergreen trees with small white or
@@ -8329,6 +8452,7 @@
   - 11737476-n
   - 11738289-n
   partOfSpeech: n
+  wikidata: Q148650
 11735322-n:
   definition:
   - an aquatic plant of the family Nymphaeaceae
@@ -8354,6 +8478,7 @@
   - 11736147-n
   - 11736279-n
   partOfSpeech: n
+  wikidata: Q146628
 11735899-n:
   definition:
   - a water lily having large leaves and showy fragrant flowers that float on the
@@ -8486,6 +8611,7 @@
   mero_member:
   - 11738046-n
   partOfSpeech: n
+  wikidata: Q207427
 11737868-n:
   definition:
   - native to eastern Asia; widely cultivated for its large pink or white flowers
@@ -8567,6 +8693,7 @@
   mero_member:
   - 11739150-n
   partOfSpeech: n
+  wikidata: Q4095708
 11739150-n:
   definition:
   - aquatic plant with floating oval leaves and purple flowers; in lakes and slow-moving
@@ -8592,6 +8719,7 @@
   mero_member:
   - 11739589-n
   partOfSpeech: n
+  wikidata: Q3360397
 11739589-n:
   definition:
   - 'peonies: herbaceous or shrubby plants having showy flowers'
@@ -8604,6 +8732,7 @@
   mero_member:
   - 11739755-n
   partOfSpeech: n
+  wikidata: Q147105
 11739755-n:
   definition:
   - any of numerous plants widely cultivated for their showy single or double red
@@ -8652,6 +8781,7 @@
   - 11759301-n
   - 11759668-n
   partOfSpeech: n
+  wikidata: Q145869
 11740557-n:
   definition:
   - 'annual, biennial or perennial herbs: buttercup; crowfoot'
@@ -8669,6 +8799,7 @@
   - 11742313-n
   - 11742505-n
   partOfSpeech: n
+  wikidata: Q146130
 11740822-n:
   definition:
   - any of various plants of the genus Ranunculus
@@ -8824,6 +8955,7 @@
   mero_member:
   - 11743451-n
   partOfSpeech: n
+  wikidata: Q155904
 11743451-n:
   definition:
   - any of various usually poisonous plants of the genus Aconitum having tuberous
@@ -8872,6 +9004,7 @@
   mero_member:
   - 11744239-n
   partOfSpeech: n
+  wikidata: Q158086
 11744239-n:
   definition:
   - a plant of the genus Actaea having acrid poisonous berries
@@ -8934,6 +9067,7 @@
   mero_member:
   - 11745129-n
   partOfSpeech: n
+  wikidata: Q147534
 11745129-n:
   definition:
   - Eurasian herb cultivated for its deep red flowers with dark centers
@@ -8956,6 +9090,7 @@
   mero_member:
   - 11745484-n
   partOfSpeech: n
+  wikidata: Q158286
 11745484-n:
   definition:
   - any woodland plant of the genus Anemone grown for its beautiful flowers and whorls
@@ -9064,6 +9199,7 @@
   mero_member:
   - 11747176-n
   partOfSpeech: n
+  wikidata: Q15976207
 11747176-n:
   definition:
   - woodland flower native to eastern North America having cup-shaped flowers reminiscent
@@ -9089,6 +9225,7 @@
   - 11748009-n
   - 11748207-n
   partOfSpeech: n
+  wikidata: Q147641
 11747560-n:
   definition:
   - a plant of the genus Aquilegia having irregular showy spurred flowers; north temperate
@@ -9146,6 +9283,7 @@
   mero_member:
   - 11748568-n
   partOfSpeech: n
+  wikidata: Q148547
 11748568-n:
   definition:
   - swamp plant of Europe and North America having bright yellow flowers resembling
@@ -9231,6 +9369,7 @@
   mero_member:
   - 11749947-n
   partOfSpeech: n
+  wikidata: Q157634
 11749947-n:
   definition:
   - any of various ornamental climbing plants of the genus Clematis usually having
@@ -9383,6 +9522,7 @@
   mero_member:
   - 11752521-n
   partOfSpeech: n
+  wikidata: Q135562
 11752521-n:
   definition:
   - low-growing perennial of North America woodlands having trifoliate leaves and
@@ -9409,6 +9549,7 @@
   mero_member:
   - 11753036-n
   partOfSpeech: n
+  wikidata: Q157591
 11753036-n:
   definition:
   - commonly cultivated larkspur of southern Europe having unbranched spikelike racemes
@@ -9433,6 +9574,7 @@
   mero_member:
   - 11753523-n
   partOfSpeech: n
+  wikidata: Q160107
 11753523-n:
   definition:
   - any plant of the genus Delphinium having palmately divided leaves and showy spikes
@@ -9464,6 +9606,7 @@
   mero_member:
   - 11754017-n
   partOfSpeech: n
+  wikidata: Q157775
 11754017-n:
   definition:
   - small Old World perennial herb grown for its bright yellow flowers which appear
@@ -9559,6 +9702,7 @@
   mero_member:
   - 11755522-n
   partOfSpeech: n
+  wikidata: Q157505
 11755522-n:
   definition:
   - any of several plants of the genus Hepatica having three-lobed leaves and white
@@ -9584,6 +9728,7 @@
   mero_member:
   - 11756039-n
   partOfSpeech: n
+  wikidata: Q9005595
 11756039-n:
   definition:
   - perennial herb of northeastern United States having a thick knotted yellow rootstock
@@ -9610,6 +9755,7 @@
   mero_member:
   - 11756446-n
   partOfSpeech: n
+  wikidata: Q1007528
 11756446-n:
   definition:
   - slender erect perennial of eastern North America having tuberous roots and pink-tinged
@@ -9634,6 +9780,7 @@
   mero_member:
   - 11756831-n
   partOfSpeech: n
+  wikidata: Q5968671
 11756831-n:
   definition:
   - spectacular perennial native of wet montane grasslands of Peru; formerly included
@@ -9656,6 +9803,7 @@
   mero_member:
   - 11757163-n
   partOfSpeech: n
+  wikidata: Q161065
 11757163-n:
   definition:
   - any plant of the genus Nigella
@@ -9710,6 +9858,7 @@
   mero_member:
   - 11758003-n
   partOfSpeech: n
+  wikidata: Q147764
 11758003-n:
   definition:
   - any plant of the genus Pulsatilla; sometimes included in genus Anemone
@@ -9797,6 +9946,7 @@
   mero_member:
   - 11759466-n
   partOfSpeech: n
+  wikidata: Q7835851
 11759466-n:
   definition:
   - tall perennial of the eastern United States having large basal leaves and white
@@ -9820,6 +9970,7 @@
   mero_member:
   - 11759834-n
   partOfSpeech: n
+  wikidata: Q161588
 11759834-n:
   definition:
   - any of several plants of the genus Trollius having globose yellow flowers
@@ -9858,6 +10009,7 @@
   mero_member:
   - 11760447-n
   partOfSpeech: n
+  wikidata: Q749412
 11760447-n:
   definition:
   - South American evergreen tree yielding winter's bark and a light soft wood similar
@@ -9912,6 +10064,7 @@
   - 11761293-n
   - 11763000-n
   partOfSpeech: n
+  wikidata: Q2106238
 11761293-n:
   definition:
   - constituting the order Myricales
@@ -9926,6 +10079,7 @@
   - 11761479-n
   - 11762644-n
   partOfSpeech: n
+  wikidata: Q843892
 11761479-n:
   definition:
   - deciduous aromatic shrubs or small trees
@@ -9939,6 +10093,7 @@
   - 11761644-n
   - 11761819-n
   partOfSpeech: n
+  wikidata: Q133287
 11761644-n:
   definition:
   - bog shrub of north temperate zone having bitter-tasting fragrant leaves
@@ -10009,6 +10164,7 @@
   mero_member:
   - 11762779-n
   partOfSpeech: n
+  wikidata: Q16879998
 11762779-n:
   definition:
   - deciduous shrub of eastern North America with sweet scented fernlike leaves and
@@ -10035,6 +10191,7 @@
   mero_member:
   - 11763214-n
   partOfSpeech: n
+  wikidata: Q13107376
 11763214-n:
   definition:
   - 'one species: corkwood'
@@ -10047,6 +10204,7 @@
   mero_member:
   - 11763347-n
   partOfSpeech: n
+  wikidata: Q13070310
 11763347-n:
   definition:
   - very small deciduous dioecious tree or shrub of damp habitats in southeastern
@@ -10074,6 +10232,7 @@
   - 11763763-n
   - 11764039-n
   partOfSpeech: n
+  wikidata: Q156169
 11763763-n:
   definition:
   - grasslike plants growing in wet places and having cylindrical often hollow stems
@@ -10213,6 +10372,7 @@
   - family Connaraceae
   - zebrawood family
   partOfSpeech: n
+  wikidata: Q131661
 11766888-n:
   definition:
   - large genus of tropical trees and shrubs; type genus of the Connaraceae
@@ -10272,6 +10432,7 @@
   - 12559811-n
   - 12576812-n
   partOfSpeech: n
+  wikidata: Q44448
 11767937-n:
   definition:
   - an erect or climbing bean or pea plant of the family Leguminosae
@@ -10308,6 +10469,7 @@
   mero_member:
   - 11768970-n
   partOfSpeech: n
+  wikidata: Q636425
 11768970-n:
   definition:
   - widely cultivated American plant cultivated in tropical and warm regions; showy
@@ -10345,6 +10507,7 @@
   - Brya
   - genus Brya
   partOfSpeech: n
+  wikidata: Q4979921
 11769581-n:
   definition:
   - West Indian tree yielding a fine grade of green ebony
@@ -10381,6 +10544,7 @@
   mero_member:
   - 11770072-n
   partOfSpeech: n
+  wikidata: Q5062982
 11770072-n:
   definition:
   - Brazilian tree with handsomely marked wood
@@ -10477,6 +10641,7 @@
   mero_member:
   - 11771458-n
   partOfSpeech: n
+  wikidata: Q161142
 11771458-n:
   definition:
   - erect annual or biennial plant grown extensively especially for hay and soil improvement
@@ -10570,6 +10735,7 @@
   mero_member:
   - 11773047-n
   partOfSpeech: n
+  wikidata: Q101538
 11773047-n:
   definition:
   - a plant of the genus Trifolium
@@ -10664,6 +10830,7 @@
   - Mimosaceae
   - family Mimosaceae
   partOfSpeech: n
+  wikidata: Q3061312
 11774657-n:
   definition:
   - alternative name used in some classification systems for the family Mimosaceae
@@ -10703,6 +10870,7 @@
   - 11775579-n
   - 11775788-n
   partOfSpeech: n
+  wikidata: Q160110
 11775362-n:
   definition:
   - any of various tropical shrubs or trees of the genus Mimosa having usually yellow
@@ -10762,6 +10930,7 @@
   - 11778745-n
   - 11778952-n
   partOfSpeech: n
+  wikidata: Q81666
 11776561-n:
   definition:
   - any of various spiny trees or shrubs of the genus Acacia
@@ -10950,6 +11119,7 @@
   mero_member:
   - 11779693-n
   partOfSpeech: n
+  wikidata: Q664945
 11779693-n:
   definition:
   - any of numerous trees of the genus Albizia
@@ -11039,6 +11209,7 @@
   mero_member:
   - 11781254-n
   partOfSpeech: n
+  wikidata: Q164454
 11781254-n:
   definition:
   - any of various shrubs and small trees valued for their fine foliage and attractive
@@ -11088,6 +11259,7 @@
   - 11782305-n
   - 11782487-n
   partOfSpeech: n
+  wikidata: Q290354
 11782119-n:
   definition:
   - any tree or shrub of the genus Inga having pinnate leaves and showy usually white
@@ -11133,6 +11305,7 @@
   mero_member:
   - 11782902-n
   partOfSpeech: n
+  wikidata: Q311423
 11782902-n:
   definition:
   - low scrubby tree of tropical and subtropical North America having white flowers
@@ -11160,6 +11333,7 @@
   - 11783396-n
   - 11783611-n
   partOfSpeech: n
+  wikidata: Q6710182
 11783396-n:
   definition:
   - a tree of the West Indies and Florida and Mexico; resembles tamarind and has long
@@ -11207,6 +11381,7 @@
   mero_member:
   - 11784094-n
   partOfSpeech: n
+  wikidata: Q135404
 11784094-n:
   definition:
   - any of several Old World tropical trees of the genus Parkia having heads of red
@@ -11254,6 +11429,7 @@
   - 11784947-n
   - 11785283-n
   partOfSpeech: n
+  wikidata: Q2717810
 11784947-n:
   definition:
   - common thorny tropical American tree having terminal racemes of yellow flowers
@@ -11294,6 +11470,7 @@
   mero_member:
   - 11785746-n
   partOfSpeech: n
+  wikidata: Q133422
 11785746-n:
   definition:
   - any of several small spiny trees or shrubs of the genus Prosopis having small
@@ -11403,6 +11580,7 @@
   - 11797834-n
   - 11798248-n
   partOfSpeech: n
+  wikidata: Q173756
 11787665-n:
   definition:
   - perennial herbs with small pink or white flowers
@@ -11415,6 +11593,7 @@
   mero_member:
   - 11787823-n
   partOfSpeech: n
+  wikidata: Q133242
 11787823-n:
   definition:
   - any of several poisonous perennial plants of the genus Apocynum having acrid milky
@@ -11478,6 +11657,7 @@
   - 11788974-n
   - 11789285-n
   partOfSpeech: n
+  wikidata: Q1822458
 11788974-n:
   definition:
   - medium-sized shrubby tree of South Africa having thick leathery evergreen leaves
@@ -11515,6 +11695,7 @@
   mero_member:
   - 11789645-n
   partOfSpeech: n
+  wikidata: Q913594
 11789645-n:
   definition:
   - South African shrub having a swollen succulent stem and bearing showy pink and
@@ -11541,6 +11722,7 @@
   mero_member:
   - 11790090-n
   partOfSpeech: n
+  wikidata: Q1262196
 11790090-n:
   definition:
   - a plant of the genus Allamanda having large showy funnel-shaped flowers in terminal
@@ -11577,6 +11759,7 @@
   mero_member:
   - 11790725-n
   partOfSpeech: n
+  wikidata: Q2475725
 11790725-n:
   definition:
   - evergreen tree of eastern Asia and Philippines having large leathery leaves and
@@ -11603,6 +11786,7 @@
   mero_member:
   - 11791222-n
   partOfSpeech: n
+  wikidata: Q478077
 11791222-n:
   definition:
   - subshrubs of southeastern United States forming slow-growing clumps and having
@@ -11627,6 +11811,7 @@
   mero_member:
   - 11791616-n
   partOfSpeech: n
+  wikidata: Q3311674
 11791616-n:
   definition:
   - evergreen woody twiner with large glossy leaves and showy corymbs of fragrant
@@ -11650,6 +11835,7 @@
   mero_member:
   - 11792008-n
   partOfSpeech: n
+  wikidata: Q1470978
 11792008-n:
   definition:
   - a shrub of the genus Carissa having fragrant white flowers and plumlike red to
@@ -11701,6 +11887,7 @@
   mero_member:
   - 11792877-n
   partOfSpeech: n
+  wikidata: Q1050790
 11792877-n:
   definition:
   - commonly cultivated Old World woody herb having large pinkish to red flowers
@@ -11730,6 +11917,7 @@
   mero_member:
   - 11793348-n
   partOfSpeech: n
+  wikidata: Q15972122
 11793348-n:
   definition:
   - tropical Asian tree with hard white wood and bark formerly used as a remedy for
@@ -11797,6 +11985,7 @@
   mero_member:
   - 11794456-n
   partOfSpeech: n
+  wikidata: Q3874774
 11794456-n:
   definition:
   - 'an ornamental but poisonous flowering shrub having narrow evergreen leaves and
@@ -11824,6 +12013,7 @@
   mero_member:
   - 11794982-n
   partOfSpeech: n
+  wikidata: Q218123
 11794982-n:
   definition:
   - any of various tropical American deciduous shrubs or trees of the genus Plumeria
@@ -11871,6 +12061,7 @@
   mero_member:
   - 11795809-n
   partOfSpeech: n
+  wikidata: Q1145247
 11795809-n:
   definition:
   - any shrub or small tree of the genus Rauwolfia having leaves in whorls and cymose
@@ -11904,6 +12095,7 @@
   mero_member:
   - 11796428-n
   partOfSpeech: n
+  wikidata: Q133997
 11796428-n:
   definition:
   - any of various shrubs or small trees of the genus Strophanthus having whorled
@@ -11936,6 +12128,7 @@
   mero_member:
   - 11796980-n
   partOfSpeech: n
+  wikidata: Q310915
 11796980-n:
   definition:
   - tropical shrub having glossy foliage and fragrant nocturnal flowers with crimped
@@ -11992,6 +12185,7 @@
   mero_member:
   - 11798021-n
   partOfSpeech: n
+  wikidata: Q1549062
 11798021-n:
   definition:
   - evergreen Chinese woody climber with shiny dark green leaves and intensely fragrant
@@ -12017,6 +12211,7 @@
   mero_member:
   - 11798398-n
   partOfSpeech: n
+  wikidata: Q220925
 11798398-n:
   definition:
   - chiefly trailing poisonous plants with blue flowers
@@ -12104,6 +12299,7 @@
   - 11813721-n
   - 11814120-n
   partOfSpeech: n
+  wikidata: Q48227
 11799769-n:
   definition:
   - any plant of the family Araceae; have small flowers massed on a spadix surrounded
@@ -12128,6 +12324,7 @@
   - 11800617-n
   - 11800893-n
   partOfSpeech: n
+  wikidata: Q161121
 11800487-n:
   definition:
   - starch resembling sago that is obtained from cuckoopint root
@@ -12175,6 +12372,7 @@
   mero_member:
   - 11801399-n
   partOfSpeech: n
+  wikidata: Q160087
 11801216-n:
   definition:
   - used in some classifications for the genus Acorus which is usually assigned to
@@ -12259,6 +12457,7 @@
   mero_member:
   - 11802505-n
   partOfSpeech: n
+  wikidata: Q644312
 11802505-n:
   definition:
   - any plant of the genus Alocasia having large showy basal leaves and boat-shaped
@@ -12298,6 +12497,7 @@
   - 11803631-n
   - 11803957-n
   partOfSpeech: n
+  wikidata: Q132651
 11803230-n:
   definition:
   - any plant of the genus Amorphophallus
@@ -12361,6 +12561,7 @@
   mero_member:
   - 11804389-n
   partOfSpeech: n
+  wikidata: Q239835
 11804389-n:
   definition:
   - any of various tropical American plants cultivated for their showy foliage and
@@ -12399,6 +12600,7 @@
   - 11804966-n
   - 11805294-n
   partOfSpeech: n
+  wikidata: Q133284
 11804966-n:
   definition:
   - common American spring-flowering woodland herb having sheathing leaves and an
@@ -12437,6 +12639,7 @@
   mero_member:
   - 11805745-n
   partOfSpeech: n
+  wikidata: Q2447519
 11805745-n:
   definition:
   - 'tuberous perennial having a cowl-shaped maroon or violet-black spathe: native
@@ -12460,6 +12663,7 @@
   mero_member:
   - 11806137-n
   partOfSpeech: n
+  wikidata: Q1521382
 11806137-n:
   definition:
   - any plant of the genus Caladium cultivated for their ornamental foliage variously
@@ -12491,6 +12695,7 @@
   mero_member:
   - 11806600-n
   partOfSpeech: n
+  wikidata: Q1945962
 11806600-n:
   definition:
   - plant of wetlands and bogs of temperate regions having small greenish flowers
@@ -12516,6 +12721,7 @@
   mero_member:
   - 11807008-n
   partOfSpeech: n
+  wikidata: Q310882
 11807008-n:
   definition:
   - herb of the Pacific islands grown throughout the tropics for its edible root and
@@ -12557,6 +12763,7 @@
   mero_member:
   - 11807659-n
   partOfSpeech: n
+  wikidata: Q1423091
 11807659-n:
   definition:
   - any plant of the genus Cryptocoryne; evergreen perennials growing in fresh or
@@ -12582,6 +12789,7 @@
   mero_member:
   - 11808094-n
   partOfSpeech: n
+  wikidata: Q738915
 11808094-n:
   definition:
   - an evergreen plant with large showy dark green leaves; contains a poison that
@@ -12606,6 +12814,7 @@
   mero_member:
   - 11808508-n
   partOfSpeech: n
+  wikidata: Q2703377
 11808508-n:
   definition:
   - any plant of the genus Dracontium; strongly malodorous tropical American plants
@@ -12652,6 +12861,7 @@
   mero_member:
   - 11809196-n
   partOfSpeech: n
+  wikidata: Q1295844
 11809196-n:
   definition:
   - evergreen liana widely cultivated for its variegated foliage
@@ -12677,6 +12887,7 @@
   - Lysichitum
   - genus Lysichitum
   partOfSpeech: n
+  wikidata: Q1784347
 11809535-n:
   definition:
   - clump-forming deciduous perennial swamp plant of western North America similar
@@ -12699,6 +12910,7 @@
   mero_member:
   - 11809907-n
   partOfSpeech: n
+  wikidata: Q159216
 11809907-n:
   definition:
   - any plant of the genus Monstera; often grown as houseplants
@@ -12732,6 +12944,7 @@
   mero_member:
   - 11810431-n
   partOfSpeech: n
+  wikidata: Q5223526
 11810431-n:
   definition:
   - any plant of the genus Nephthytis
@@ -12763,6 +12976,7 @@
   mero_member:
   - 11810859-n
   partOfSpeech: n
+  wikidata: Q11799321
 11810859-n:
   definition:
   - aquatic plant of the southeastern United States having blue-green leaves and a
@@ -12786,6 +13000,7 @@
   mero_member:
   - 11811257-n
   partOfSpeech: n
+  wikidata: Q578875
 11811257-n:
   definition:
   - an aquatic plant of the genus Peltandra; North America
@@ -12818,6 +13033,7 @@
   mero_member:
   - 11811810-n
   partOfSpeech: n
+  wikidata: Q131880
 11811810-n:
   definition:
   - often grown as a houseplant
@@ -12838,6 +13054,7 @@
   mero_member:
   - 11812038-n
   partOfSpeech: n
+  wikidata: Q13077266
 11812038-n:
   definition:
   - pantropical floating plant forming a rosette of wedge-shaped leaves; a widespread
@@ -12866,6 +13083,7 @@
   mero_member:
   - 11812498-n
   partOfSpeech: n
+  wikidata: Q2624761
 11812498-n:
   definition:
   - any of various tropical lianas of the genus Scindapsus
@@ -12886,6 +13104,7 @@
   mero_member:
   - 11812810-n
   partOfSpeech: n
+  wikidata: Q132632
 11812810-n:
   definition:
   - any of various plants of the genus Spathiphyllum having a white or green spathe
@@ -12910,6 +13129,7 @@
   mero_member:
   - 11813211-n
   partOfSpeech: n
+  wikidata: Q7233044
 11813211-n:
   definition:
   - deciduous perennial low-growing fetid swamp plant of eastern North America having
@@ -12934,6 +13154,7 @@
   - Syngonium
   - genus Syngonium
   partOfSpeech: n
+  wikidata: Q2448411
 11813721-n:
   definition:
   - tropical American tuberous perennials
@@ -13025,6 +13246,7 @@
   - 11816243-n
   - 11816787-n
   partOfSpeech: n
+  wikidata: Q14293890
 11814988-n:
   definition:
   - any small or minute aquatic plant of the family Lemnaceae that float on or near
@@ -13049,6 +13271,7 @@
   - 11815518-n
   - 11815685-n
   partOfSpeech: n
+  wikidata: Q161207
 11815518-n:
   definition:
   - of temperate regions except eastern Asia and Australia
@@ -13083,6 +13306,7 @@
   mero_member:
   - 11816049-n
   partOfSpeech: n
+  wikidata: Q161458
 11816049-n:
   definition:
   - cosmopolitan except South America and New Zealand and some oceanic islands
@@ -13107,6 +13331,7 @@
   mero_member:
   - 11816474-n
   partOfSpeech: n
+  wikidata: Q163015
 11816474-n:
   definition:
   - any of various aquatic plants of the genus Wolffia; throughout warmer regions
@@ -13140,6 +13365,7 @@
   mero_member:
   - 11817042-n
   partOfSpeech: n
+  wikidata: Q9377653
 11817042-n:
   definition:
   - having narrow flat sickle-shaped submerged fronds; North America
@@ -13168,6 +13394,7 @@
   - 11819989-n
   - 11820828-n
   partOfSpeech: n
+  wikidata: Q193335
 11817485-n:
   definition:
   - 'type genus of Araliaceae; large widely distributed genus of shrubs and trees
@@ -13185,6 +13412,7 @@
   - 11818739-n
   - 11818965-n
   partOfSpeech: n
+  wikidata: Q132636
 11817790-n:
   definition:
   - any of various plants of the genus Aralia; often aromatic plants having compound
@@ -13282,6 +13510,7 @@
   mero_member:
   - 11819447-n
   partOfSpeech: n
+  wikidata: Q26771
 11819447-n:
   definition:
   - Old World vine with lobed evergreen leaves and black berrylike fruits
@@ -13332,6 +13561,7 @@
   - 11820201-n
   - 11820489-n
   partOfSpeech: n
+  wikidata: Q7213683
 11820201-n:
   definition:
   - Chinese herb with palmately compound leaves and small greenish flowers and forked
@@ -13411,6 +13641,7 @@
   - 11823587-n
   - 11823746-n
   partOfSpeech: n
+  wikidata: Q1973300
 11821507-n:
   definition:
   - family of birthworts (including wild ginger)
@@ -13425,6 +13656,7 @@
   - 11821716-n
   - 11822545-n
   partOfSpeech: n
+  wikidata: Q156446
 11821716-n:
   definition:
   - birthworts; Dutchman's-pipe
@@ -13437,6 +13669,7 @@
   mero_member:
   - 11821861-n
   partOfSpeech: n
+  wikidata: Q156212
 11821861-n:
   definition:
   - creeping plant having curving flowers thought to resemble fetuses; native to Europe;
@@ -13486,6 +13719,7 @@
   - 11822681-n
   - 11823269-n
   partOfSpeech: n
+  wikidata: Q157718
 11822681-n:
   definition:
   - low-growing perennial herb with pungent gingery leaves and rhizomes
@@ -13551,6 +13785,7 @@
   - Rafflesiaceae
   - family Rafflesiaceae
   partOfSpeech: n
+  wikidata: Q157019
 11823746-n:
   definition:
   - a family of flowering plants in Africa and Argentina that are parasitic on the
@@ -13562,6 +13797,7 @@
   - Hydnoraceae
   - family Hydnoraceae
   partOfSpeech: n
+  wikidata: Q132628
 11823944-n:
   definition:
   - 'a group of families of mostly flowers having basal or central placentation and
@@ -13601,6 +13837,7 @@
   - 11875229-n
   - 11877450-n
   partOfSpeech: n
+  wikidata: Q21808
 11824902-n:
   definition:
   - used in former classification systems; approximately synonymous with order Caryophyllales
@@ -13647,6 +13884,7 @@
   - 11838243-n
   - 11838984-n
   partOfSpeech: n
+  wikidata: Q25995
 11825724-n:
   definition:
   - a plant of the family Caryophyllaceae
@@ -13668,6 +13906,7 @@
   mero_member:
   - 11826013-n
   partOfSpeech: n
+  wikidata: Q148897
 11826013-n:
   definition:
   - European annual having large trumpet-shaped reddish-purple flowers and poisonous
@@ -13828,6 +14067,7 @@
   mero_member:
   - 11828448-n
   partOfSpeech: n
+  wikidata: Q156099
 11828448-n:
   definition:
   - any of various flowers of plants of the genus Dianthus cultivated for their fragrant
@@ -13952,6 +14192,7 @@
   mero_member:
   - 11830499-n
   partOfSpeech: n
+  wikidata: Q5309794
 11830499-n:
   definition:
   - spiny-leaved perennial herb of southern Europe having terminal clusters of small
@@ -13975,6 +14216,7 @@
   mero_member:
   - 11830827-n
   partOfSpeech: n
+  wikidata: Q161948
 11830827-n:
   definition:
   - tall plant with small lance-shaped leaves and numerous tiny white or pink flowers
@@ -13998,6 +14240,7 @@
   mero_member:
   - 11831197-n
   partOfSpeech: n
+  wikidata: Q164172
 11831197-n:
   definition:
   - common prostrate Old World herb often used as a ground cover; formerly reputed
@@ -14043,6 +14286,7 @@
   mero_member:
   - 11831942-n
   partOfSpeech: n
+  wikidata: Q158863
 11831942-n:
   definition:
   - mostly perennial herbs with sticky stems that catch insects; widespread in north
@@ -14103,6 +14347,7 @@
   - Minuartia
   - genus Minuartia
   partOfSpeech: n
+  wikidata: Q163073
 11833042-n:
   definition:
   - 'low-growing herbs widely distributed in temperate and Arctic Northern Hemisphere:
@@ -14152,6 +14397,7 @@
   mero_member:
   - 11833959-n
   partOfSpeech: n
+  wikidata: Q3365995
 11833959-n:
   definition:
   - any of various low-growing tufted plants of the genus Paronychia having tiny greenish
@@ -14175,6 +14421,7 @@
   - Petrocoptis
   - genus Petrocoptis
   partOfSpeech: n
+  wikidata: Q10348998
 11834528-n:
   definition:
   - small low-growing annual or perennial herbs of temperate and cool regions
@@ -14187,6 +14434,7 @@
   mero_member:
   - 11834707-n
   partOfSpeech: n
+  wikidata: Q163066
 11834707-n:
   definition:
   - any of various low-growing plants of the genus Sagina having small spherical flowers
@@ -14211,6 +14459,7 @@
   mero_member:
   - 11835053-n
   partOfSpeech: n
+  wikidata: Q157500
 11835053-n:
   definition:
   - plant of European origin having pink or white flowers and leaves yielding a detergent
@@ -14237,6 +14486,7 @@
   mero_member:
   - 11835465-n
   partOfSpeech: n
+  wikidata: Q158561
 11835465-n:
   definition:
   - widely distributed low-growing Eurasian herb having narrow leaves and inconspicuous
@@ -14266,6 +14516,7 @@
   - 11836805-n
   - 11837118-n
   partOfSpeech: n
+  wikidata: Q116209
 11835960-n:
   definition:
   - any plant of the genus Silene
@@ -14386,6 +14637,7 @@
   mero_member:
   - 11837970-n
   partOfSpeech: n
+  wikidata: Q163048
 11837970-n:
   definition:
   - prostrate weedy herb with tiny pink flowers; widespread throughout Europe and
@@ -14411,6 +14663,7 @@
   mero_member:
   - 11838383-n
   partOfSpeech: n
+  wikidata: Q156694
 11838383-n:
   definition:
   - any of various plants of the genus Stellaria
@@ -14458,6 +14711,7 @@
   mero_member:
   - 11839105-n
   partOfSpeech: n
+  wikidata: Q161470
 11839105-n:
   definition:
   - European annual with pale rose-colored flowers; cultivated flower or self-sown
@@ -14494,6 +14748,7 @@
   - 11842246-n
   - 11842636-n
   partOfSpeech: n
+  wikidata: Q156219
 11839823-n:
   definition:
   - a caryophyllaceous genus of Carpobrotus
@@ -14533,6 +14788,7 @@
   mero_member:
   - 11840381-n
   partOfSpeech: n
+  wikidata: Q143939
 11840381-n:
   definition:
   - low-growing showy succulent annual of South Africa having white or pink or red
@@ -14567,6 +14823,7 @@
   mero_member:
   - 11840932-n
   partOfSpeech: n
+  wikidata: Q133283
 11840932-n:
   definition:
   - any plant of the genus Lithops native to Africa having solitary yellow or white
@@ -14632,6 +14889,7 @@
   mero_member:
   - 11842003-n
   partOfSpeech: n
+  wikidata: Q2639601
 11842003-n:
   definition:
   - annual prostrate mat-forming weed having whorled leaves and small greenish-white
@@ -14681,6 +14939,7 @@
   mero_member:
   - 11842769-n
   partOfSpeech: n
+  wikidata: Q133932
 11842769-n:
   definition:
   - coarse sprawling Australasian plant with red or yellow flowers; cultivated for
@@ -14712,6 +14971,7 @@
   - 11846885-n
   - 11847468-n
   partOfSpeech: n
+  wikidata: Q155931
 11843318-n:
   definition:
   - large widely distributed genus of chiefly coarse annual herbs
@@ -14725,6 +14985,7 @@
   - 11843512-n
   - 11844813-n
   partOfSpeech: n
+  wikidata: Q156344
 11843512-n:
   definition:
   - any of various plants of the genus Amaranthus having dense plumes of green or
@@ -14848,6 +15109,7 @@
   mero_member:
   - 11845680-n
   partOfSpeech: n
+  wikidata: Q159223
 11845680-n:
   definition:
   - weedy annual with spikes of silver-white flowers
@@ -14884,6 +15146,7 @@
   mero_member:
   - 11846218-n
   partOfSpeech: n
+  wikidata: Q5505160
 11846218-n:
   definition:
   - any of various plants of the genus Froelichia found in sandy soils and on rocky
@@ -14907,6 +15170,7 @@
   mero_member:
   - 11846667-n
   partOfSpeech: n
+  wikidata: Q1446121
 11846667-n:
   definition:
   - tropical American herb having rose to red or purple flowers that can be dried
@@ -14931,6 +15195,7 @@
   mero_member:
   - 11847038-n
   partOfSpeech: n
+  wikidata: Q1672624
 11847038-n:
   definition:
   - any plant of the genus Iresine having colored foliage
@@ -14964,6 +15229,7 @@
   - Telanthera
   - genus Telanthera
   partOfSpeech: n
+  wikidata: Q17377912
 11847638-n:
   definition:
   - 'family coextensive with genus Batis: saltworts'
@@ -14977,6 +15243,7 @@
   mero_member:
   - 11847817-n
   partOfSpeech: n
+  wikidata: Q2094045
 11847817-n:
   definition:
   - 'small genus of plants constituting the family Batidaceae: low straggling dioecious
@@ -14990,6 +15257,7 @@
   mero_member:
   - 11848010-n
   partOfSpeech: n
+  wikidata: Q134459
 11848010-n:
   definition:
   - low-growing strong-smelling coastal shrub of warm parts of the New World having
@@ -15022,6 +15290,7 @@
   - 11855583-n
   - 11855920-n
   partOfSpeech: n
+  wikidata: Q157881
 11848582-n:
   definition:
   - goosefoot; pigweed
@@ -15034,6 +15303,7 @@
   mero_member:
   - 11848716-n
   partOfSpeech: n
+  wikidata: Q158094
 11848716-n:
   definition:
   - any of various weeds of the genus Chenopodium having small greenish flowers
@@ -15258,6 +15528,7 @@
   mero_member:
   - 11852343-n
   partOfSpeech: n
+  wikidata: Q158343
 11852343-n:
   definition:
   - densely branched Eurasian plant; foliage turns purple-red in autumn
@@ -15287,6 +15558,7 @@
   mero_member:
   - 11852683-n
   partOfSpeech: n
+  wikidata: Q3761162
 11852683-n:
   definition:
   - biennial Eurasian plant usually having a swollen edible root; widely cultivated
@@ -15364,6 +15636,7 @@
   mero_member:
   - 11853842-n
   partOfSpeech: n
+  wikidata: Q8352821
 11853842-n:
   definition:
   - bushy annual weed of central North America having greenish flowers and winged
@@ -15389,6 +15662,7 @@
   - 11854218-n
   - 11854468-n
   partOfSpeech: n
+  wikidata: Q1024025
 11854218-n:
   definition:
   - a coarse annual herb introduced into North America from Siberia; dangerous to
@@ -15423,6 +15697,7 @@
   mero_member:
   - 11854741-n
   partOfSpeech: n
+  wikidata: Q159525
 11854741-n:
   definition:
   - fleshy maritime plant having fleshy stems with rudimentary scalelike leaves and
@@ -15445,6 +15720,7 @@
   - Salsola
   - genus Salsola
   partOfSpeech: n
+  wikidata: Q159544
 11855123-n:
   definition:
   - bushy plant of Old World salt marshes and sea beaches having prickly leaves; burned
@@ -15549,6 +15825,7 @@
   - 11859766-n
   - 11861530-n
   partOfSpeech: n
+  wikidata: Q156227
 11856606-n:
   definition:
   - a caryophyllaceous genus of the family Nyctaginaceae having only one species
@@ -15561,6 +15838,7 @@
   mero_member:
   - 11856796-n
   partOfSpeech: n
+  wikidata: Q10338319
 11856796-n:
   definition:
   - viscid branched perennial of the southwestern United States and northern Mexico
@@ -15584,6 +15862,7 @@
   mero_member:
   - 11857191-n
   partOfSpeech: n
+  wikidata: Q312349
 11857191-n:
   definition:
   - any of various plants of the genus Abronia of western North America and Mexico
@@ -15675,6 +15954,7 @@
   mero_member:
   - 11858882-n
   partOfSpeech: n
+  wikidata: Q950253
 11858882-n:
   definition:
   - trailing plant having crowded clusters of 3 brilliant deep pink flowers resembling
@@ -15701,6 +15981,7 @@
   mero_member:
   - 11859385-n
   partOfSpeech: n
+  wikidata: Q156996
 11859385-n:
   definition:
   - any of several South American ornamental woody vines of the genus Bougainvillea
@@ -15735,6 +16016,7 @@
   - 11860037-n
   - 11860536-n
   partOfSpeech: n
+  wikidata: Q158323
 11859929-n:
   definition:
   - a plant of the genus Mirabilis
@@ -15830,6 +16112,7 @@
   mero_member:
   - 11861716-n
   partOfSpeech: n
+  wikidata: Q135334
 11861716-n:
   definition:
   - small spiny West Indian tree
@@ -15852,6 +16135,7 @@
   mero_member:
   - 11861998-n
   partOfSpeech: n
+  wikidata: Q14915568
 11861998-n:
   definition:
   - constituting the order Opuntiales
@@ -15892,6 +16176,7 @@
   - 11874113-n
   - 11874701-n
   partOfSpeech: n
+  wikidata: Q14560
 11862673-n:
   definition:
   - any succulent plant of the family Cactaceae native chiefly to arid regions of
@@ -15967,6 +16252,7 @@
   mero_member:
   - 11864365-n
   partOfSpeech: n
+  wikidata: Q131642
 11864365-n:
   definition:
   - usually unbranched usually spineless cactus covered with warty tubercles and having
@@ -15992,6 +16278,7 @@
   mero_member:
   - 11864840-n
   partOfSpeech: n
+  wikidata: Q8175886
 11864840-n:
   definition:
   - extremely large treelike cactus of desert regions of southwestern United States
@@ -16018,6 +16305,7 @@
   mero_member:
   - 11865361-n
   partOfSpeech: n
+  wikidata: Q5317148
 11865361-n:
   definition:
   - any of several cacti of the genus Cereus
@@ -16039,6 +16327,7 @@
   mero_member:
   - 11865746-n
   partOfSpeech: n
+  wikidata: Q133876
 11865746-n:
   definition:
   - a cactus of the genus Coryphantha
@@ -16060,6 +16349,7 @@
   mero_member:
   - 11866026-n
   partOfSpeech: n
+  wikidata: Q133014
 11866026-n:
   definition:
   - any cactus of the genus Echinocactus; strongly ribbed and very spiny; southwestern
@@ -16136,6 +16426,7 @@
   mero_member:
   - 11867234-n
   partOfSpeech: n
+  wikidata: Q310964
 11867234-n:
   definition:
   - any cactus of the genus Epiphyllum having flattened jointed irregularly branching
@@ -16183,6 +16474,7 @@
   - Gymnocalycium
   - genus Gymnocalycium
   partOfSpeech: n
+  wikidata: Q131641
 11868084-n:
   definition:
   - genus of slender often treelike spiny cacti with solitary showy nocturnal white
@@ -16194,6 +16486,7 @@
   - Harrisia
   - genus Harrisia
   partOfSpeech: n
+  wikidata: Q133985
 11868310-n:
   definition:
   - small genus of South American epiphytic or lithophytic cacti
@@ -16206,6 +16499,7 @@
   mero_member:
   - 11868478-n
   partOfSpeech: n
+  wikidata: Q133297
 11868478-n:
   definition:
   - spring-blooming South American cactus with oblong joints and coral-red flowers;
@@ -16232,6 +16526,7 @@
   mero_member:
   - 11868948-n
   partOfSpeech: n
+  wikidata: Q133960
 11868948-n:
   definition:
   - any of several cacti of the genus Hylocereus
@@ -16254,6 +16549,7 @@
   mero_member:
   - 11869336-n
   partOfSpeech: n
+  wikidata: Q14931532
 11869336-n:
   definition:
   - tall treelike Mexican cactus with edible red fruit
@@ -16277,6 +16573,7 @@
   mero_member:
   - 11869740-n
   partOfSpeech: n
+  wikidata: Q132102
 11869740-n:
   definition:
   - a small spineless globe-shaped cactus; source of mescal buttons
@@ -16317,6 +16614,7 @@
   mero_member:
   - 11870340-n
   partOfSpeech: n
+  wikidata: Q311120
 11870340-n:
   definition:
   - any cactus of the genus Mammillaria
@@ -16386,6 +16684,7 @@
   mero_member:
   - 11871387-n
   partOfSpeech: n
+  wikidata: Q133563
 11871387-n:
   definition:
   - small clustering cactus of southwestern United States; a threatened species
@@ -16409,6 +16708,7 @@
   mero_member:
   - 11871727-n
   partOfSpeech: n
+  wikidata: Q10859058
 11871727-n:
   definition:
   - any of several cacti of the genus Nopalea resembling prickly pears
@@ -16431,6 +16731,7 @@
   - 11872047-n
   - 11872308-n
   partOfSpeech: n
+  wikidata: Q158991
 11872047-n:
   definition:
   - cacti having spiny flat joints and oval fruit that is edible in some species;
@@ -16491,6 +16792,7 @@
   mero_member:
   - 11873000-n
   partOfSpeech: n
+  wikidata: Q131724
 11873000-n:
   definition:
   - West Indian woody climber with spiny stems and numerous fragrant white flowers
@@ -16565,6 +16867,7 @@
   mero_member:
   - 11874282-n
   partOfSpeech: n
+  wikidata: Q132870
 11874282-n:
   definition:
   - any of several night-blooming cacti of the genus Selenicereus
@@ -16598,6 +16901,7 @@
   mero_member:
   - 11874948-n
   partOfSpeech: n
+  wikidata: Q15710811
 11874948-n:
   definition:
   - South American jointed cactus with usually red flowers; often cultivated as a
@@ -16704,6 +17008,7 @@
   - Agdestis
   - genus Agdestis
   partOfSpeech: n
+  wikidata: Q5390212
 11876740-n:
   definition:
   - a genus of evergreen climbers
@@ -16714,6 +17019,7 @@
   - Ercilla
   - genus Ercilla
   partOfSpeech: n
+  wikidata: Q1348619
 11876858-n:
   definition:
   - small genus of erect perennial shrubby herbs; tropical and subtropical America
@@ -16751,6 +17057,7 @@
   - Trichostigma
   - genus Trichostigma
   partOfSpeech: n
+  wikidata: Q3004024
 11877450-n:
   definition:
   - family of usually succulent herbs; cosmopolitan in distribution especially in
@@ -16794,6 +17101,7 @@
   - 11878165-n
   - 11878546-n
   partOfSpeech: n
+  wikidata: Q159554
 11878165-n:
   definition:
   - a plant of the genus Portulaca having pink or red or purple or white ephemeral
@@ -16884,6 +17192,7 @@
   - 11879941-n
   - 11880206-n
   partOfSpeech: n
+  wikidata: Q164192
 11879744-n:
   definition:
   - similar to Claytonia virginica but having usually pink flowers; eastern North
@@ -16932,6 +17241,7 @@
   - 11880677-n
   - 11881024-n
   partOfSpeech: n
+  wikidata: Q879036
 11880677-n:
   definition:
   - evergreen perennial having a dense basal rosette of long spatula-shaped leaves
@@ -16969,6 +17279,7 @@
   mero_member:
   - 11881490-n
   partOfSpeech: n
+  wikidata: Q160046
 11881490-n:
   definition:
   - a plant of the genus Montia having edible pleasant-tasting leaves
@@ -17038,6 +17349,7 @@
   mero_member:
   - 11882769-n
   partOfSpeech: n
+  wikidata: Q10373941
 11882769-n:
   definition:
   - pink clusters of densely packed flowers on prostrate stems resemble upturned pads
@@ -17068,6 +17380,7 @@
   - 11884186-n
   - 11884583-n
   partOfSpeech: n
+  wikidata: Q138395
 11883304-n:
   definition:
   - plant with fleshy roots and erect stems with narrow succulent leaves and one reddish-orange
@@ -17155,6 +17468,7 @@
   - 11920527-n
   - 11929517-n
   partOfSpeech: n
+  wikidata: Q2206636
 11885071-n:
   definition:
   - 'a dilleniid dicot family of the order Rhoeadales that includes: genera Capparis,
@@ -17172,6 +17486,7 @@
   - 11887411-n
   - 11887539-n
   partOfSpeech: n
+  wikidata: Q35146354
 11885375-n:
   definition:
   - tropical or subtropical evergreen shrubs or small trees
@@ -17184,6 +17499,7 @@
   mero_member:
   - 11885540-n
   partOfSpeech: n
+  wikidata: Q157866
 11885540-n:
   definition:
   - any of numerous plants of the genus Capparis
@@ -17261,6 +17577,7 @@
   mero_member:
   - 11886717-n
   partOfSpeech: n
+  wikidata: Q2086565
 11886717-n:
   definition:
   - any of various often strong-smelling plants of the genus Cleome having showy spider-shaped
@@ -17321,6 +17638,7 @@
   mero_member:
   - 11887780-n
   partOfSpeech: n
+  wikidata: Q2277970
 11887780-n:
   definition:
   - strong-scented herb common in southern United States covered with intermixed gland
@@ -17498,6 +17816,7 @@
   mero_member:
   - 11891216-n
   partOfSpeech: n
+  wikidata: Q161063
 11891216-n:
   definition:
   - any garden plant of the genus Alyssum having clusters of small yellow or white
@@ -17521,6 +17840,7 @@
   mero_member:
   - 11891528-n
   partOfSpeech: n
+  wikidata: Q14559266
 11891528-n:
   definition:
   - small grey Asiatic desert plant bearing minute white flowers that rolls up when
@@ -17545,6 +17865,7 @@
   - Arabidopsis
   - genus Arabidopsis
   partOfSpeech: n
+  wikidata: Q157892
 11891965-n:
   definition:
   - a small invasive self-pollinating weed with small white flowers; much studied
@@ -17583,6 +17904,7 @@
   - 11892793-n
   - 11892942-n
   partOfSpeech: n
+  wikidata: Q157396
 11892615-n:
   definition:
   - any of several rock-loving cresses of the genus Arabis
@@ -17683,6 +18005,7 @@
   - 11894314-n
   - 11894550-n
   partOfSpeech: n
+  wikidata: Q157614
 11894081-n:
   definition:
   - 'any plant of the genus Barbarea: yellow-flowered Eurasian cresses; widely cultivated
@@ -17762,6 +18085,7 @@
   mero_member:
   - 11895347-n
   partOfSpeech: n
+  wikidata: Q599498
 11895347-n:
   definition:
   - plant of southeastern Europe having yellow flowers like those of mustard and pods
@@ -17799,6 +18123,7 @@
   - 11899974-n
   - 11900191-n
   partOfSpeech: n
+  wikidata: Q58677
 11895992-n:
   definition:
   - wild original of cultivated cabbages; common in western coastal Europe
@@ -18115,6 +18440,7 @@
   mero_member:
   - 11900880-n
   partOfSpeech: n
+  wikidata: Q158349
 11900880-n:
   definition:
   - salt-tolerant seashore annual grown for its fragrant rose or violet flowers and
@@ -18139,6 +18465,7 @@
   mero_member:
   - 11901260-n
   partOfSpeech: n
+  wikidata: Q163520
 11901260-n:
   definition:
   - annual European false flax having small white flowers; cultivated since Neolithic
@@ -18163,6 +18490,7 @@
   mero_member:
   - 11901658-n
   partOfSpeech: n
+  wikidata: Q157786
 11901658-n:
   definition:
   - white-flowered annual European herb bearing triangular notched pods; nearly cosmopolitan
@@ -18199,6 +18527,7 @@
   - Dentaria
   - genus Dentaria
   partOfSpeech: n
+  wikidata: Q9397832
 11902211-n:
   definition:
   - any of various herbs of the genus Cardamine, having usually pinnate leaves and
@@ -18296,6 +18625,7 @@
   - 11903797-n
   - 11904097-n
   partOfSpeech: n
+  wikidata: Q11913648
 11903797-n:
   definition:
   - perennial of southern Europe having clusters of fragrant flowers of all colors
@@ -18358,6 +18688,7 @@
   mero_member:
   - 11904853-n
   partOfSpeech: n
+  wikidata: Q162902
 11904853-n:
   definition:
   - perennial of coastal sands and shingles of northern Europe and Baltic and Black
@@ -18385,6 +18716,7 @@
   mero_member:
   - 11905436-n
   partOfSpeech: n
+  wikidata: Q162770
 11905436-n:
   definition:
   - North American herb with bitter-tasting pinnate leaves resembling those of tansy
@@ -18408,6 +18740,7 @@
   - 11905761-n
   - 11905993-n
   partOfSpeech: n
+  wikidata: Q158032
 11905761-n:
   definition:
   - yellow-flowered European plant that grows on old walls and in waste places; an
@@ -18441,6 +18774,7 @@
   mero_member:
   - 11906325-n
   partOfSpeech: n
+  wikidata: Q157381
 11906325-n:
   definition:
   - any of numerous low-growing cushion-forming plants of the genus Draba having rosette-forming
@@ -18477,6 +18811,7 @@
   mero_member:
   - 11907006-n
   partOfSpeech: n
+  wikidata: Q162865
 11907006-n:
   definition:
   - erect European annual often grown as a salad crop to be harvested when young and
@@ -18510,6 +18845,7 @@
   - 11908219-n
   - 11908530-n
   partOfSpeech: n
+  wikidata: Q165206
 11907588-n:
   definition:
   - any of numerous plants of the genus Erysimum having fragrant yellow or orange
@@ -18578,6 +18914,7 @@
   mero_member:
   - 11908893-n
   partOfSpeech: n
+  wikidata: Q955407
 11908893-n:
   definition:
   - any of various South African herbs and subshrubs cultivated for long showy racemes
@@ -18600,6 +18937,7 @@
   mero_member:
   - 11909269-n
   partOfSpeech: n
+  wikidata: Q3303714
 11909269-n:
   definition:
   - long cultivated herb having flowers whose scent is more pronounced in the evening;
@@ -18625,6 +18963,7 @@
   mero_member:
   - 11909674-n
   partOfSpeech: n
+  wikidata: Q3767758
 11909674-n:
   definition:
   - perennial stellate and hairy herb with small yellow flowers of mountains of southern
@@ -18673,6 +19012,7 @@
   - 11910491-n
   - 11910619-n
   partOfSpeech: n
+  wikidata: Q157382
 11910491-n:
   definition:
   - any of several herbs of the genus Isatis
@@ -18705,6 +19045,7 @@
   mero_member:
   - 11910976-n
   partOfSpeech: n
+  wikidata: Q146217
 11910976-n:
   definition:
   - annual herb used as salad green and garnish
@@ -18732,6 +19073,7 @@
   mero_member:
   - 11911353-n
   partOfSpeech: n
+  wikidata: Q2713145
 11911353-n:
   definition:
   - any of several hairy North American herbs having yellow racemose flowers and inflated
@@ -18754,6 +19096,7 @@
   mero_member:
   - 11911644-n
   partOfSpeech: n
+  wikidata: Q2593152
 11911644-n:
   definition:
   - perennial European plant having clusters of small fragrant usually white flowers;
@@ -18779,6 +19122,7 @@
   mero_member:
   - 11912010-n
   partOfSpeech: n
+  wikidata: Q842030
 11912010-n:
   definition:
   - southeastern European plant cultivated for its fragrant purplish flowers and round
@@ -18806,6 +19150,7 @@
   mero_member:
   - 11912498-n
   partOfSpeech: n
+  wikidata: Q2914608
 11912498-n:
   definition:
   - any of various ornamental flowering plants of the genus Malcolmia
@@ -18877,6 +19222,7 @@
   mero_member:
   - 11913600-n
   partOfSpeech: n
+  wikidata: Q161068
 11913600-n:
   definition:
   - perennial Eurasian cress growing chiefly in springs or running water having fleshy
@@ -18902,6 +19248,7 @@
   mero_member:
   - 11914109-n
   partOfSpeech: n
+  wikidata: Q945619
 11914109-n:
   definition:
   - any of several plants of the genus Physaria having racemose yellow flowers and
@@ -19059,6 +19406,7 @@
   mero_member:
   - 11916610-n
   partOfSpeech: n
+  wikidata: Q7431603
 11916610-n:
   definition:
   - a dainty South American annual having deeply pinnatifid leaves and racemes of
@@ -19080,6 +19428,7 @@
   - Sinapis
   - genus Sinapis
   partOfSpeech: n
+  wikidata: Q150072
 11916988-n:
   definition:
   - Eurasian mustard cultivated for its pungent seeds; a source of table mustard and
@@ -19121,6 +19470,7 @@
   mero_member:
   - 11917585-n
   partOfSpeech: n
+  wikidata: Q158183
 11917585-n:
   definition:
   - stiffly branching Old World annual with pale yellow flowers; widely naturalized
@@ -19145,6 +19495,7 @@
   mero_member:
   - 11917935-n
   partOfSpeech: n
+  wikidata: Q2708462
 11917935-n:
   definition:
   - perennial of southwestern United States having leathery blue-green pinnatifid
@@ -19172,6 +19523,7 @@
   mero_member:
   - 11918369-n
   partOfSpeech: n
+  wikidata: Q5392954
 11918369-n:
   definition:
   - a small plant of Oregon resembling mustard; a threatened species
@@ -19195,6 +19547,7 @@
   mero_member:
   - 11918740-n
   partOfSpeech: n
+  wikidata: Q159790
 11918740-n:
   definition:
   - small aquatic plant having tufted awl-shaped leaves in a basal rosette and minute
@@ -19281,6 +19634,7 @@
   mero_member:
   - 11893127-n
   partOfSpeech: n
+  wikidata: Q5734076
 11920064-n:
   definition:
   - 'small genus of chiefly Mediterranean herbs: bladderpods'
@@ -19293,6 +19647,7 @@
   mero_member:
   - 11920231-n
   partOfSpeech: n
+  wikidata: Q15985041
 11920231-n:
   definition:
   - annual or perennial herbs with inflated seed pods; some placed in genus Lesquerella
@@ -19369,6 +19724,7 @@
   - 11922669-n
   - 11922858-n
   partOfSpeech: n
+  wikidata: Q146391
 11921763-n:
   definition:
   - Old World alpine poppy with white or yellow to orange flowers
@@ -19461,6 +19817,7 @@
   mero_member:
   - 11923178-n
   partOfSpeech: n
+  wikidata: Q1783190
 11923178-n:
   definition:
   - any plant of the genus Argemone having large white or yellow flowers and prickly
@@ -19498,6 +19855,7 @@
   mero_member:
   - 11923802-n
   partOfSpeech: n
+  wikidata: Q1974044
 11923802-n:
   definition:
   - small Central American tree having loose racemes of purple-tinted green flowers
@@ -19521,6 +19879,7 @@
   mero_member:
   - 11924140-n
   partOfSpeech: n
+  wikidata: Q12723971
 11924140-n:
   definition:
   - perennial herb with branched woody stock and bright yellow flowers
@@ -19629,6 +19988,7 @@
   mero_member:
   - 11925861-n
   partOfSpeech: n
+  wikidata: Q18603090
 11925861-n:
   definition:
   - of Pacific coast of North America; widely cultivated for its yellow to red flowers
@@ -19651,6 +20011,7 @@
   mero_member:
   - 11926218-n
   partOfSpeech: n
+  wikidata: Q158826
 11926218-n:
   definition:
   - yellow-flowered Eurasian glaucous herb naturalized in along sandy shores in eastern
@@ -19677,6 +20038,7 @@
   mero_member:
   - 11926596-n
   partOfSpeech: n
+  wikidata: Q16325285
 11926596-n:
   definition:
   - native of Mexican highlands grown for its glossy clear yellow flowers and blue-grey
@@ -19701,6 +20063,7 @@
   mero_member:
   - 11926983-n
   partOfSpeech: n
+  wikidata: Q2697922
 11926983-n:
   definition:
   - herb of China and Japan widely cultivated for its plumelike panicles of creamy
@@ -19762,6 +20125,7 @@
   mero_member:
   - 11927874-n
   partOfSpeech: n
+  wikidata: Q1029455
 11927874-n:
   definition:
   - California plant with small pale yellow flowers
@@ -19809,6 +20173,7 @@
   mero_member:
   - 11928546-n
   partOfSpeech: n
+  wikidata: Q14566105
 11928546-n:
   definition:
   - perennial woodland native of North America having a red root and red sap and bearing
@@ -19834,6 +20199,7 @@
   - Stylomecon
   - genus Stylomecon
   partOfSpeech: n
+  wikidata: Q18335946
 11929018-n:
   definition:
   - California wild poppy with bright red flowers
@@ -19887,6 +20253,7 @@
   - 11930214-n
   - 11930539-n
   partOfSpeech: n
+  wikidata: Q156610
 11929822-n:
   definition:
   - annual herbs whose flowers have only one petal spurred at the base
@@ -19899,6 +20266,7 @@
   mero_member:
   - 11929996-n
   partOfSpeech: n
+  wikidata: Q157496
 11929996-n:
   definition:
   - delicate European herb with greyish leaves and spikes of purplish flowers; formerly
@@ -20215,6 +20583,7 @@
   - 12053779-n
   - 12054408-n
   partOfSpeech: n
+  wikidata: Q25400
 11935683-n:
   definition:
   - considered the most highly evolved dicotyledonous plants, characterized by florets
@@ -20260,6 +20629,7 @@
   mero_member:
   - 11936936-n
   partOfSpeech: n
+  wikidata: Q146617
 11936936-n:
   definition:
   - any of several plants of the genus Achillea native to Europe and having small
@@ -20308,6 +20678,7 @@
   mero_member:
   - 11937876-n
   partOfSpeech: n
+  wikidata: Q87140572
 11937876-n:
   definition:
   - flower of southwestern Australia having bright pink daisylike papery flowers;
@@ -20359,6 +20730,7 @@
   mero_member:
   - 11938755-n
   partOfSpeech: n
+  wikidata: Q132653
 11938755-n:
   definition:
   - any plant of the genus Ageratum having opposite leaves and small heads of blue
@@ -20417,6 +20789,7 @@
   mero_member:
   - 11939916-n
   partOfSpeech: n
+  wikidata: Q844270
 11939701-n:
   definition:
   - in some classifications considered a separate family comprising a subgroup of
@@ -20428,6 +20801,7 @@
   - Ambrosiaceae
   - family Ambrosiaceae
   partOfSpeech: n
+  wikidata: Q65707888
 11939916-n:
   definition:
   - any of numerous chiefly North American weedy plants constituting the genus Ambrosia
@@ -20487,6 +20861,7 @@
   mero_member:
   - 11940967-n
   partOfSpeech: n
+  wikidata: Q15886464
 11940967-n:
   definition:
   - any plant of the genus Ammobium having yellow flowers and silvery foliage
@@ -20519,6 +20894,7 @@
   mero_member:
   - 11941467-n
   partOfSpeech: n
+  wikidata: Q828427
 11941467-n:
   definition:
   - a small Mediterranean plant containing a volatile oil once used to relieve toothache
@@ -20567,6 +20943,7 @@
   mero_member:
   - 11942261-n
   partOfSpeech: n
+  wikidata: Q2704518
 11942261-n:
   definition:
   - any plant of the genus Andryala having milky sap and heads of bright yellow flowers
@@ -20591,6 +20968,7 @@
   - 11942661-n
   - 11942843-n
   partOfSpeech: n
+  wikidata: Q602788
 11942661-n:
   definition:
   - North American perennial propagated by means of runners
@@ -20665,6 +21043,7 @@
   - 11943866-n
   - 11944106-n
   partOfSpeech: n
+  wikidata: Q847930
 11943643-n:
   definition:
   - widespread rank-smelling weed having white-rayed flower heads with yellow discs
@@ -20715,6 +21094,7 @@
   mero_member:
   - 11944483-n
   partOfSpeech: n
+  wikidata: Q2714312
 11944483-n:
   definition:
   - tiny grey woolly tufted annual with small golden-yellow flower heads; southeastern
@@ -20741,6 +21121,7 @@
   mero_member:
   - 11944914-n
   partOfSpeech: n
+  wikidata: Q27257
 11944914-n:
   definition:
   - any of several erect biennial herbs of temperate Eurasia having stout taproots
@@ -20793,6 +21174,7 @@
   - 11945772-n
   - 11945919-n
   partOfSpeech: n
+  wikidata: Q2290011
 11945772-n:
   definition:
   - any of several plants of the genus Arctotis having daisylike flowers
@@ -20827,6 +21209,7 @@
   mero_member:
   - 11946367-n
   partOfSpeech: n
+  wikidata: Q133909
 11946367-n:
   definition:
   - perennial subshrub of the Canary Islands having usually pale yellow daisylike
@@ -20881,6 +21264,7 @@
   - 11947445-n
   - 11947684-n
   partOfSpeech: n
+  wikidata: Q693908
 11947302-n:
   definition:
   - any of various rhizomatous usually perennial plants of the genus Arnica
@@ -20936,6 +21320,7 @@
   mero_member:
   - 11948209-n
   partOfSpeech: n
+  wikidata: Q15985096
 11948209-n:
   definition:
   - small European herb with small yellow flowers
@@ -20970,6 +21355,7 @@
   - 11951604-n
   - 11951781-n
   partOfSpeech: n
+  wikidata: Q156421
 11948821-n:
   definition:
   - any of various composite shrubs or herbs of the genus Artemisia having aromatic
@@ -21175,6 +21561,7 @@
   mero_member:
   - 11952387-n
   partOfSpeech: n
+  wikidata: Q517130
 11952387-n:
   definition:
   - any of various chiefly fall-blooming herbs of the genus Aster with showy daisylike
@@ -21587,6 +21974,7 @@
   mero_member:
   - 11958161-n
   partOfSpeech: n
+  wikidata: Q2713599
 11958161-n:
   definition:
   - low spreading tropical American shrub with long slender leaves used to make a
@@ -21615,6 +22003,7 @@
   - 11959025-n
   - 11959201-n
   partOfSpeech: n
+  wikidata: Q133834
 11958730-n:
   definition:
   - a shrub of salt marshes of eastern and south central North America and West Indies;
@@ -21691,6 +22080,7 @@
   mero_member:
   - 11959960-n
   partOfSpeech: n
+  wikidata: Q27583
 11959960-n:
   definition:
   - any of numerous composite plants having flower heads with well-developed ray flowers
@@ -21829,6 +22219,7 @@
   mero_member:
   - 11961947-n
   partOfSpeech: n
+  wikidata: Q4940265
 11961947-n:
   definition:
   - any of various autumn-flowering perennials having white or pink to purple flowers
@@ -21852,6 +22243,7 @@
   mero_member:
   - 11962393-n
   partOfSpeech: n
+  wikidata: Q87176002
 11962393-n:
   definition:
   - western Australian annual much cultivated for its flower heads with white or bluish
@@ -21874,6 +22266,7 @@
   - Brickellia
   - genus Brickelia
   partOfSpeech: n
+  wikidata: Q4965994
 11962835-n:
   definition:
   - a genus of flowering plants in the aster family containing two or three species
@@ -21921,6 +22314,7 @@
   mero_member:
   - 11963602-n
   partOfSpeech: n
+  wikidata: Q1445138
 11963602-n:
   definition:
   - any of various plants of the genus Cacalia having leaves resembling those of plantain
@@ -21941,6 +22335,7 @@
   mero_member:
   - 11963876-n
   partOfSpeech: n
+  wikidata: Q147281
 11963876-n:
   definition:
   - any of numerous chiefly annual herbs of the genus Calendula widely cultivated
@@ -21976,6 +22371,7 @@
   mero_member:
   - 11964461-n
   partOfSpeech: n
+  wikidata: Q12358274
 11964461-n:
   definition:
   - valued for their beautiful flowers in a wide range of clear bright colors; grown
@@ -22010,6 +22406,7 @@
   - 11965220-n
   - 11965423-n
   partOfSpeech: n
+  wikidata: Q254502
 11965220-n:
   definition:
   - European biennial introduced in North America having flower heads in crowded clusters
@@ -22046,6 +22443,7 @@
   mero_member:
   - 11965836-n
   partOfSpeech: n
+  wikidata: Q1136447
 11965836-n:
   definition:
   - a thistle of the genus Carlina
@@ -22139,6 +22537,7 @@
   mero_member:
   - 11967196-n
   partOfSpeech: n
+  wikidata: Q2520391
 11967196-n:
   definition:
   - any of several plants of the genus Catananche having long-stalked heads of blue
@@ -22174,6 +22573,7 @@
   - 11968271-n
   - 11968938-n
   partOfSpeech: n
+  wikidata: Q156414
 11967720-n:
   definition:
   - any plant of the genus Centaurea
@@ -22299,6 +22699,7 @@
   mero_member:
   - 11969871-n
   partOfSpeech: n
+  wikidata: Q1427205
 11969871-n:
   definition:
   - Eurasian plant with apple-scented foliage and white-rayed flowers and feathery
@@ -22323,6 +22724,7 @@
   mero_member:
   - 11970326-n
   partOfSpeech: n
+  wikidata: Q2708653
 11970326-n:
   definition:
   - any of several United States plants having long stalks of funnel-shaped white
@@ -22349,6 +22751,7 @@
   - 11971346-n
   - 11971521-n
   partOfSpeech: n
+  wikidata: Q59882
 11970814-n:
   definition:
   - any of numerous perennial Old World herbs having showy brightly colored flower
@@ -22418,6 +22821,7 @@
   mero_member:
   - 11971980-n
   partOfSpeech: n
+  wikidata: Q5580003
 11971980-n:
   definition:
   - any of several shrubby herbs or subshrubs of the genus Chrysopsis having bright
@@ -22507,6 +22911,7 @@
   - 11973507-n
   - 11973808-n
   partOfSpeech: n
+  wikidata: Q158514
 11973507-n:
   definition:
   - perennial Old World herb having rayed flower heads with blue florets cultivated
@@ -22560,6 +22965,7 @@
   mero_member:
   - 11974353-n
   partOfSpeech: n
+  wikidata: Q1638558
 11974353-n:
   definition:
   - any of numerous biennial to perennial herbs with handsome purple or yellow or
@@ -22687,6 +23093,7 @@
   mero_member:
   - 11976365-n
   partOfSpeech: n
+  wikidata: Q5162107
 11976365-n:
   definition:
   - rhizomatous plant of central and southeastern United States and West Indies having
@@ -22713,6 +23120,7 @@
   mero_member:
   - 11976817-n
   partOfSpeech: n
+  wikidata: Q828737
 11976817-n:
   definition:
   - common North American weed with linear leaves and small discoid heads of yellowish
@@ -22741,6 +23149,7 @@
   - 11977319-n
   - 11977631-n
   partOfSpeech: n
+  wikidata: Q1362995
 11977319-n:
   definition:
   - any of numerous plants of the genus Coreopsis having a profusion of showy usually
@@ -22807,6 +23216,7 @@
   mero_member:
   - 11978549-n
   partOfSpeech: n
+  wikidata: Q476937
 11978549-n:
   definition:
   - any of various mostly Mexican herbs of the genus Cosmos having radiate heads of
@@ -22830,6 +23240,7 @@
   mero_member:
   - 11978968-n
   partOfSpeech: n
+  wikidata: Q1807600
 11978968-n:
   definition:
   - South African herb with golden-yellow globose flower heads; naturalized in moist
@@ -22853,6 +23264,7 @@
   mero_member:
   - 11979357-n
   partOfSpeech: n
+  wikidata: Q5182455
 11979357-n:
   definition:
   - any of various plants of the genus Craspedia grown for their downy foliage and
@@ -22875,6 +23287,7 @@
   mero_member:
   - 11979728-n
   partOfSpeech: n
+  wikidata: Q727610
 11979728-n:
   definition:
   - any of various plants of the genus Crepis having loose heads of yellow flowers
@@ -22899,6 +23312,7 @@
   - 11980101-n
   - 11980331-n
   partOfSpeech: n
+  wikidata: Q19070
 11980101-n:
   definition:
   - Mediterranean thistlelike plant widely cultivated for its large edible flower
@@ -22963,6 +23377,7 @@
   mero_member:
   - 11981142-n
   partOfSpeech: n
+  wikidata: Q16029211
 11981142-n:
   definition:
   - South African succulent evergreen twining climber with yellow flowers grown primarily
@@ -22986,6 +23401,7 @@
   - Dendranthema
   - genus Dendranthema
   partOfSpeech: n
+  wikidata: Q4157859
 11981569-n:
   definition:
   - of China
@@ -23011,6 +23427,7 @@
   mero_member:
   - 11981915-n
   partOfSpeech: n
+  wikidata: Q2698290
 11981915-n:
   definition:
   - any of several South African plants grown for the profusion of usually yellow
@@ -23059,6 +23476,7 @@
   mero_member:
   - 11982741-n
   partOfSpeech: n
+  wikidata: Q1642983
 11982741-n:
   definition:
   - any of various perennials of the eastern United States having thick rough leaves
@@ -23081,6 +23499,7 @@
   mero_member:
   - 11983136-n
   partOfSpeech: n
+  wikidata: Q650106
 11983136-n:
   definition:
   - any of various plants of the genus Echinops having prickly leaves and dense globose
@@ -23103,6 +23522,7 @@
   mero_member:
   - 11983463-n
   partOfSpeech: n
+  wikidata: Q5359423
 11983463-n:
   definition:
   - any plant of the genus Elephantopus having heads of blue or purple flowers; America
@@ -23125,6 +23545,7 @@
   - 11983774-n
   - 11984041-n
   partOfSpeech: n
+  wikidata: Q5371629
 11983774-n:
   definition:
   - tropical African annual having scarlet tassel-shaped flower heads; sometimes placed
@@ -23214,6 +23635,7 @@
   mero_member:
   - 11985317-n
   partOfSpeech: n
+  wikidata: Q8775911
 11985317-n:
   definition:
   - common erect hairy perennial of plains and prairies of southern and central United
@@ -23235,6 +23657,7 @@
   mero_member:
   - 11985687-n
   partOfSpeech: n
+  wikidata: Q3232518
 11985687-n:
   definition:
   - an American weedy plant with small white or greenish flowers
@@ -23258,6 +23681,7 @@
   mero_member:
   - 11986096-n
   partOfSpeech: n
+  wikidata: Q745253
 11986096-n:
   definition:
   - any of several North American plants of the genus Erigeron having daisylike flowers;
@@ -23409,6 +23833,7 @@
   - 11989400-n
   - 11989635-n
   partOfSpeech: n
+  wikidata: Q1123970
 11988804-n:
   definition:
   - coarse European herb with palmately divided leaves and clusters of small reddish-purple
@@ -23486,6 +23911,7 @@
   - 11990076-n
   - 11990275-n
   partOfSpeech: n
+  wikidata: Q338143
 11990076-n:
   definition:
   - hairy South African or Australian subshrub that has daisylike flowers with blue
@@ -23519,6 +23945,7 @@
   mero_member:
   - 11990570-n
   partOfSpeech: n
+  wikidata: Q1415764
 11990570-n:
   definition:
   - any plant of the genus Filago having capitate clusters of small woolly flower
@@ -23552,6 +23979,7 @@
   mero_member:
   - 11991055-n
   partOfSpeech: n
+  wikidata: Q732510
 11991055-n:
   definition:
   - any plant of western America of the genus Gaillardia having hairy leaves and long-stalked
@@ -23587,6 +24015,7 @@
   mero_member:
   - 11991717-n
   partOfSpeech: n
+  wikidata: Q858999
 11991717-n:
   definition:
   - any plant of the genus Gazania valued for their showy daisy flowers
@@ -23621,6 +24050,7 @@
   - 11992252-n
   - 11992396-n
   partOfSpeech: n
+  wikidata: Q310654
 11992252-n:
   definition:
   - African or Asiatic herbs with daisylike flowers
@@ -23655,6 +24085,7 @@
   mero_member:
   - 11992760-n
   partOfSpeech: n
+  wikidata: Q2711348
 11992760-n:
   definition:
   - slender hairy plant with few leaves and golden-yellow flower heads; sandy desert
@@ -23679,6 +24110,7 @@
   mero_member:
   - 11993228-n
   partOfSpeech: n
+  wikidata: Q41552
 11993228-n:
   definition:
   - any of numerous plants of the genus Gnaphalium having flowers that can be dried
@@ -23714,6 +24146,7 @@
   mero_member:
   - 11993810-n
   partOfSpeech: n
+  wikidata: Q2702875
 11993810-n:
   definition:
   - any of various western American plants of the genus Grindelia having resinous
@@ -23877,6 +24310,7 @@
   - 11996783-n
   - 11996980-n
   partOfSpeech: n
+  wikidata: Q2392615
 11996639-n:
   definition:
   - a plant of the genus Haplopappus
@@ -23921,6 +24355,7 @@
   mero_member:
   - 11997402-n
   partOfSpeech: n
+  wikidata: Q5687694
 11997402-n:
   definition:
   - western American shrubs having white felted foliage and yellow flowers that become
@@ -24000,6 +24435,7 @@
   mero_member:
   - 11998702-n
   partOfSpeech: n
+  wikidata: Q26949
 11998702-n:
   definition:
   - any plant of the genus Helianthus having large flower heads with dark disk florets
@@ -24116,6 +24552,7 @@
   - Helichrysum
   - genus Helichrysum
   partOfSpeech: n
+  wikidata: Q28195
 12000787-n:
   definition:
   - Australian plant naturalized in Spain having flowers of lemon yellow to deep gold;
@@ -24140,6 +24577,7 @@
   mero_member:
   - 12001151-n
   partOfSpeech: n
+  wikidata: Q2065883
 12001151-n:
   definition:
   - any North American shrubby perennial herb of the genus Heliopsis having large
@@ -24165,6 +24603,7 @@
   mero_member:
   - 12001661-n
   partOfSpeech: n
+  wikidata: Q5221176
 12001661-n:
   definition:
   - any of various plants of the genus Helipterum
@@ -24186,6 +24625,7 @@
   mero_member:
   - 12001944-n
   partOfSpeech: n
+  wikidata: Q970748
 12001944-n:
   definition:
   - hairy perennial with yellow flower heads in branched clusters; found almost everywhere
@@ -24215,6 +24655,7 @@
   - 12002584-n
   - 12002811-n
   partOfSpeech: n
+  wikidata: Q16526
 12002584-n:
   definition:
   - any of numerous often hairy plants of the genus Hieracium having yellow or orange
@@ -24262,6 +24703,7 @@
   mero_member:
   - 12003408-n
   partOfSpeech: n
+  wikidata: Q2605211
 12003408-n:
   definition:
   - rhizomatous herb with purple-red flowers suitable for groundcover; sometimes placed
@@ -24288,6 +24730,7 @@
   - 12003844-n
   - 12004075-n
   partOfSpeech: n
+  wikidata: Q2464876
 12003844-n:
   definition:
   - low tufted plant having hairy stems each topped by a flower head with short narrow
@@ -24321,6 +24764,7 @@
   - Hyalosperma
   - genus Hyalosperma
   partOfSpeech: n
+  wikidata: Q9005567
 12004379-n:
   definition:
   - widely distributed genus of herbs with milky juice; includes some cosmopolitan
@@ -24362,6 +24806,7 @@
   mero_member:
   - 12005011-n
   partOfSpeech: n
+  wikidata: Q338207
 12005011-n:
   definition:
   - any plant of the genus Inula
@@ -24394,6 +24839,7 @@
   mero_member:
   - 12005522-n
   partOfSpeech: n
+  wikidata: Q4338415
 12005522-n:
   definition:
   - any of various coarse shrubby plants of the genus Iva with small greenish flowers;
@@ -24429,6 +24875,7 @@
   mero_member:
   - 12006208-n
   partOfSpeech: n
+  wikidata: Q6437019
 12006208-n:
   definition:
   - any small branched yellow-flowered North American herb of the genus Krigia
@@ -24565,6 +25012,7 @@
   - Lagenophera
   - genus Lagenophera
   partOfSpeech: n
+  wikidata: Q5220402
 12008425-n:
   definition:
   - small genus of herbs of Pacific coast of North and South America
@@ -24577,6 +25025,7 @@
   mero_member:
   - 12008601-n
   partOfSpeech: n
+  wikidata: Q614059
 12008601-n:
   definition:
   - small slender woolly annual with very narrow opposite leaves and branches bearing
@@ -24625,6 +25074,7 @@
   mero_member:
   - 12009362-n
   partOfSpeech: n
+  wikidata: Q27909
 12009362-n:
   definition:
   - any of various common wildflowers of the genus Leontodon; of temperate Eurasia
@@ -24748,6 +25198,7 @@
   - Leucogenes
   - genus Leucogenes
   partOfSpeech: n
+  wikidata: Q10317683
 12011389-n:
   definition:
   - perennial herb closely resembling European edelweiss; New Zealand
@@ -24770,6 +25221,7 @@
   mero_member:
   - 12011732-n
   partOfSpeech: n
+  wikidata: Q1580155
 12011732-n:
   definition:
   - any of various North American plants of the genus Liatris having racemes or panicles
@@ -24818,6 +25270,7 @@
   mero_member:
   - 12012635-n
   partOfSpeech: n
+  wikidata: Q1156814
 12012635-n:
   definition:
   - any of various plants of temperate Eurasia; grown for their yellow flowers and
@@ -24840,6 +25293,7 @@
   mero_member:
   - 12012948-n
   partOfSpeech: n
+  wikidata: Q3132945
 12012948-n:
   definition:
   - Texas annual with coarsely pinnatifid leaves; cultivated for its showy radiate
@@ -24864,6 +25318,7 @@
   mero_member:
   - 12013275-n
   partOfSpeech: n
+  wikidata: Q254419
 12013275-n:
   definition:
   - shrub of southwestern Mediterranean region having yellow daisylike flowers
@@ -24891,6 +25346,7 @@
   - 12013913-n
   - 12014144-n
   partOfSpeech: n
+  wikidata: Q547333
 12013672-n:
   definition:
   - wild aster with fernlike leaves and flower heads with very narrow bright purple
@@ -24940,6 +25396,7 @@
   - 12014619-n
   - 12014805-n
   partOfSpeech: n
+  wikidata: Q267953
 12014619-n:
   definition:
   - any of various resinous glandular plants of the genus Madia; of western North
@@ -24999,6 +25456,7 @@
   - 12015561-n
   - 12015865-n
   partOfSpeech: n
+  wikidata: Q27618
 12015561-n:
   definition:
   - annual Eurasian herb similar in fragrance and medicinal uses to chamomile though
@@ -25067,6 +25525,7 @@
   mero_member:
   - 12016720-n
   partOfSpeech: n
+  wikidata: Q2698264
 12016720-n:
   definition:
   - herb of tropical America having vanilla-scented flowers; climbs up trees
@@ -25093,6 +25552,7 @@
   mero_member:
   - 12017146-n
   partOfSpeech: n
+  wikidata: Q2511051
 12017146-n:
   definition:
   - any of various plants of the genus Mutisia
@@ -25118,6 +25578,7 @@
   - 12017629-n
   - 12017878-n
   partOfSpeech: n
+  wikidata: Q5487724
 12017501-n:
   definition:
   - a plant of the genus Nabalus
@@ -25167,6 +25628,7 @@
   mero_member:
   - 12018438-n
   partOfSpeech: n
+  wikidata: Q291873
 12018438-n:
   definition:
   - any of various mostly Australian attractively shaped shrubs of the genus Olearia
@@ -25216,6 +25678,7 @@
   mero_member:
   - 12019357-n
   partOfSpeech: n
+  wikidata: Q28104
 12019357-n:
   definition:
   - biennial Eurasian white hairy thistle having pale purple flowers; naturalized
@@ -25241,6 +25704,7 @@
   mero_member:
   - 12019747-n
   partOfSpeech: n
+  wikidata: Q5230439
 12019747-n:
   definition:
   - a South African plant of the genus Othonna having smooth often fleshy leaves and
@@ -25264,6 +25728,7 @@
   mero_member:
   - 12020125-n
   partOfSpeech: n
+  wikidata: Q2713153
 12020125-n:
   definition:
   - shrub with white woolly branches and woolly leaves having fragrant flowers forming
@@ -25289,6 +25754,7 @@
   mero_member:
   - 12020660-n
   partOfSpeech: n
+  wikidata: Q3004070
 12020660-n:
   definition:
   - any of several yellow-flowered plants of the genus Packera; often placed in genus
@@ -25328,6 +25794,7 @@
   - 12021546-n
   - 12021763-n
   partOfSpeech: n
+  wikidata: Q3236767
 12021320-n:
   definition:
   - much-branched subshrub with silvery leaves and small white flowers of Texas and
@@ -25377,6 +25844,7 @@
   - 12022176-n
   - 12022393-n
   partOfSpeech: n
+  wikidata: Q2709984
 12022176-n:
   definition:
   - herb of Canary Islands widely cultivated for its blue or purple or red or variegated
@@ -25540,6 +26008,7 @@
   mero_member:
   - 12025016-n
   partOfSpeech: n
+  wikidata: Q5230471
 12025016-n:
   definition:
   - any plant of the genus Piqueria or the closely related genus Stevia
@@ -25585,6 +26054,7 @@
   mero_member:
   - 12025798-n
   partOfSpeech: n
+  wikidata: Q87178995
 12025798-n:
   definition:
   - southern Australian plant having feathery hairs surrounding the fruit
@@ -25607,6 +26077,7 @@
   mero_member:
   - 12026125-n
   partOfSpeech: n
+  wikidata: Q671075
 12026125-n:
   definition:
   - hairy perennial Eurasian herb with yellow daisylike flowers reputed to destroy
@@ -25630,6 +26101,7 @@
   - Pyrethrum
   - genus Pyrethrum
   partOfSpeech: n
+  wikidata: Q16269373
 12026550-n:
   definition:
   - genus of low-growing mat-forming New Zealand plants; in some classifications includes
@@ -25643,6 +26115,7 @@
   mero_member:
   - 12026775-n
   partOfSpeech: n
+  wikidata: Q310366
 12026775-n:
   definition:
   - perennial prostrate mat-forming herb with hoary woolly foliage
@@ -25725,6 +26198,7 @@
   mero_member:
   - 12028235-n
   partOfSpeech: n
+  wikidata: Q2704490
 12028235-n:
   definition:
   - Australian annual everlasting having light pink nodding flower heads; sometimes
@@ -25754,6 +26228,7 @@
   - 12029218-n
   - 12029516-n
   partOfSpeech: n
+  wikidata: Q320510
 12028721-n:
   definition:
   - any of various plants of the genus Rudbeckia cultivated for their large usually
@@ -25837,6 +26312,7 @@
   mero_member:
   - 12030261-n
   partOfSpeech: n
+  wikidata: Q1638845
 12030261-n:
   definition:
   - low-branching leafy annual with flower heads resembling zinnias; found in southwestern
@@ -25886,6 +26362,7 @@
   mero_member:
   - 12031097-n
   partOfSpeech: n
+  wikidata: Q2530127
 12031097-n:
   definition:
   - any of several spiny Mediterranean herbs of the genus Scolymus having yellow flower
@@ -25926,6 +26403,7 @@
   - 12032722-n
   - 12033224-n
   partOfSpeech: n
+  wikidata: Q209596
 12031839-n:
   definition:
   - plant with erect leafy stems bearing clusters of rayless yellow flower heads on
@@ -26017,6 +26495,7 @@
   mero_member:
   - 12033504-n
   partOfSpeech: n
+  wikidata: Q1140322
 12033504-n:
   definition:
   - perennial south European herb having narrow entire leaves and solitary yellow
@@ -26079,6 +26558,7 @@
   - 12034824-n
   - 12034993-n
   partOfSpeech: n
+  wikidata: Q7454921
 12034554-n:
   definition:
   - low much-branched perennial of western United States having silvery leaves; an
@@ -26156,6 +26636,7 @@
   mero_member:
   - 12035690-n
   partOfSpeech: n
+  wikidata: Q729352
 12035690-n:
   definition:
   - North American perennial having a resinous odor and yellow flowers
@@ -26178,6 +26659,7 @@
   mero_member:
   - 12035994-n
   partOfSpeech: n
+  wikidata: Q1521997
 12035994-n:
   definition:
   - tall Old World biennial thistle with large clasping white-blotched leaves and
@@ -26427,6 +26909,7 @@
   mero_member:
   - 12039844-n
   partOfSpeech: n
+  wikidata: Q2711319
 12039844-n:
   definition:
   - dark green erect herb of northwestern United States and southwestern Canada having
@@ -26452,6 +26935,7 @@
   mero_member:
   - 12040296-n
   partOfSpeech: n
+  wikidata: Q312246
 12040296-n:
   definition:
   - any plant of the genus Stevia or the closely related genus Piqueria having glutinous
@@ -26474,6 +26958,7 @@
   mero_member:
   - 12040653-n
   partOfSpeech: n
+  wikidata: Q16269591
 12040653-n:
   definition:
   - erect perennial of southeastern United States having large heads of usually blue
@@ -26498,6 +26983,7 @@
   mero_member:
   - 12040976-n
   partOfSpeech: n
+  wikidata: Q147552
 12040976-n:
   definition:
   - any of various tropical American plants of the genus Tagetes widely cultivated
@@ -26553,6 +27039,7 @@
   - 12043876-n
   - 12044195-n
   partOfSpeech: n
+  wikidata: Q54016
 12041968-n:
   definition:
   - tansy-scented Eurasian perennial herb with buttonlike yellow flowers; used as
@@ -26685,6 +27172,7 @@
   mero_member:
   - 12044645-n
   partOfSpeech: n
+  wikidata: Q30024
 12044645-n:
   definition:
   - any of several herbs of the genus Taraxacum having long tap roots and deeply notched
@@ -26747,6 +27235,7 @@
   - 12045689-n
   - 12045976-n
   partOfSpeech: n
+  wikidata: Q5234663
 12045689-n:
   definition:
   - perennial having tufted basal leaves and short leafless stalks each bearing a
@@ -26784,6 +27273,7 @@
   mero_member:
   - 12046487-n
   partOfSpeech: n
+  wikidata: Q136941
 12046487-n:
   definition:
   - any plant of the genus Tithonia; tall coarse herbs or shrubs of Mexico to Panama
@@ -26808,6 +27298,7 @@
   mero_member:
   - 12046945-n
   partOfSpeech: n
+  wikidata: Q2708411
 12046945-n:
   definition:
   - dwarf tufted nearly stemless herb having a rosette of woolly leaves and large
@@ -26836,6 +27327,7 @@
   - 12047691-n
   - 12048127-n
   partOfSpeech: n
+  wikidata: Q889257
 12047450-n:
   definition:
   - European perennial naturalized throughout United States having hollow stems with
@@ -26897,6 +27389,7 @@
   mero_member:
   - 12048481-n
   partOfSpeech: n
+  wikidata: Q7842001
 12048481-n:
   definition:
   - perennial of southeastern United States with leaves having the fragrance of vanilla
@@ -26976,6 +27469,7 @@
   mero_member:
   - 12050104-n
   partOfSpeech: n
+  wikidata: Q2297615
 12050104-n:
   definition:
   - perennial herb with large rounded leaves resembling a colt's foot and yellow flowers
@@ -27000,6 +27494,7 @@
   mero_member:
   - 12050561-n
   partOfSpeech: n
+  wikidata: Q4006525
 12050561-n:
   definition:
   - any of various plants of the genus Ursinia grown for their yellow- or orange-
@@ -27035,6 +27530,7 @@
   - Actinomeris
   - genus Actinomeris
   partOfSpeech: n
+  wikidata: Q87140608
 12051123-n:
   definition:
   - any plant of the genus Verbesina having clustered white or yellow flower heads
@@ -27110,6 +27606,7 @@
   mero_member:
   - 12052396-n
   partOfSpeech: n
+  wikidata: Q1411311
 12052396-n:
   definition:
   - any of various plants of the genus Vernonia of tropical and warm regions of especially
@@ -27135,6 +27632,7 @@
   - 12052898-n
   - 12053155-n
   partOfSpeech: n
+  wikidata: Q5221410
 12052898-n:
   definition:
   - balsamic-resinous herb with clumps of lanceolate leaves and stout leafy stems
@@ -27195,6 +27693,7 @@
   - 12053973-n
   - 12054178-n
   partOfSpeech: n
+  wikidata: Q2306080
 12053973-n:
   definition:
   - any plant of the genus Xeranthemum native to southern Europe having chaffy or
@@ -27228,6 +27727,7 @@
   mero_member:
   - 12054610-n
   partOfSpeech: n
+  wikidata: Q205106
 12054610-n:
   definition:
   - any of various plants of the genus Zinnia cultivated for their variously and brightly
@@ -27277,6 +27777,7 @@
   - 12055533-n
   - 12055892-n
   partOfSpeech: n
+  wikidata: Q599518
 12055533-n:
   definition:
   - genus of tropical American prickly herbs or subshrubs
@@ -27288,6 +27789,7 @@
   mero_member:
   - 12055682-n
   partOfSpeech: n
+  wikidata: Q150242
 12055682-n:
   definition:
   - any of various perennial South American plants of the genus Loasa having stinging
@@ -27380,6 +27882,7 @@
   - 12057250-n
   - 12188902-n
   partOfSpeech: n
+  wikidata: Q155802
 12057250-n:
   definition:
   - 'large genus of herbs grown for their blossoms: bellflowers'
@@ -27391,6 +27894,7 @@
   mero_member:
   - 12057408-n
   partOfSpeech: n
+  wikidata: Q157069
 12057408-n:
   definition:
   - any of various plants of the genus Campanula having blue or white bell-shaped
@@ -27555,6 +28059,7 @@
   - 12060212-n
   - 12107724-n
   partOfSpeech: n
+  wikidata: Q1771937
 12060212-n:
   definition:
   - enormous cosmopolitan family of perennial terrestrial or epiphytic plants with
@@ -27645,6 +28150,7 @@
   - 12106357-n
   - 12106879-n
   partOfSpeech: n
+  wikidata: Q25308
 12061915-n:
   definition:
   - any of numerous plants of the orchid family usually having flowers of unusual
@@ -27671,6 +28177,7 @@
   mero_member:
   - 12063913-n
   partOfSpeech: n
+  wikidata: Q161714
 12063913-n:
   definition:
   - any of various deciduous terrestrial orchids having fleshy tubers and flowers
@@ -27730,6 +28237,7 @@
   mero_member:
   - 12064936-n
   partOfSpeech: n
+  wikidata: Q21107
 12064936-n:
   definition:
   - any orchid of the genus Aerides
@@ -27752,6 +28260,7 @@
   mero_member:
   - 12065253-n
   partOfSpeech: n
+  wikidata: Q21139
 12065253-n:
   definition:
   - any of various spectacular orchids of the genus Angraecum having dark green leathery
@@ -27774,6 +28283,7 @@
   mero_member:
   - 12065626-n
   partOfSpeech: n
+  wikidata: Q20846
 12065626-n:
   definition:
   - any of several delicate Asiatic orchids grown especially for their velvety leaves
@@ -27797,6 +28307,7 @@
   mero_member:
   - 12065983-n
   partOfSpeech: n
+  wikidata: Q20815
 12065983-n:
   definition:
   - North American orchid bearing a single leaf and yellowish-brown flowers
@@ -27821,6 +28332,7 @@
   - 12066329-n
   - 12066497-n
   partOfSpeech: n
+  wikidata: Q133789
 12066329-n:
   definition:
   - any of several bog orchids of the genus Arethusa having 1 or 2 showy flowers
@@ -27854,6 +28366,7 @@
   mero_member:
   - 12066897-n
   partOfSpeech: n
+  wikidata: Q311069
 12066897-n:
   definition:
   - any of various orchids of the genus Bletia having pseudobulbs and erect leafless
@@ -27877,6 +28390,7 @@
   mero_member:
   - 12067284-n
   partOfSpeech: n
+  wikidata: Q133743
 12067284-n:
   definition:
   - Japanese orchid with white-striped leaves and slender erect racemes of rose to
@@ -27909,6 +28423,7 @@
   mero_member:
   - 12067814-n
   partOfSpeech: n
+  wikidata: Q94815
 12067814-n:
   definition:
   - any of various tropical American orchids with usually solitary fleshy leaves and
@@ -27969,6 +28484,7 @@
   - 12068868-n
   - 12069006-n
   partOfSpeech: n
+  wikidata: Q2720020
 12068868-n:
   definition:
   - any of various orchids of the genus Caladenia
@@ -28001,6 +28517,7 @@
   mero_member:
   - 12069397-n
   partOfSpeech: n
+  wikidata: Q133768
 12069397-n:
   definition:
   - any of various showy orchids of the genus Calanthe having white or yellow or rose-colored
@@ -28044,6 +28561,7 @@
   members:
   - genus Calypso
   partOfSpeech: n
+  wikidata: Q13398625
 12070031-n:
   definition:
   - rare north temperate bog orchid bearing a solitary white to pink flower marked
@@ -28069,6 +28587,7 @@
   mero_member:
   - 12070483-n
   partOfSpeech: n
+  wikidata: Q133751
 12070483-n:
   definition:
   - orchid having both male and female flowers in the same raceme; when a sensitive
@@ -28093,6 +28612,7 @@
   mero_member:
   - 12071002-n
   partOfSpeech: n
+  wikidata: Q133733
 12071002-n:
   definition:
   - any orchid of the genus Cattleya characterized by a three-lobed lip enclosing
@@ -28116,6 +28636,7 @@
   - 12071428-n
   - 12071572-n
   partOfSpeech: n
+  wikidata: Q162001
 12071428-n:
   definition:
   - any of several orchids of the genus Cephalanthera
@@ -28149,6 +28670,7 @@
   - 12071983-n
   - 12072261-n
   partOfSpeech: n
+  wikidata: Q134020
 12071983-n:
   definition:
   - orchid of northeastern United States with magenta-pink flowers having funnel-shaped
@@ -28188,6 +28710,7 @@
   - 12072736-n
   - 12072916-n
   partOfSpeech: n
+  wikidata: Q161295
 12072736-n:
   definition:
   - orchid with broad ovate leaves and long-bracted green very irregular flowers
@@ -28220,6 +28743,7 @@
   mero_member:
   - 12073256-n
   partOfSpeech: n
+  wikidata: Q2206870
 12073256-n:
   definition:
   - 'any of various orchids of the genus Coelogyne with: clusters of fragrant lacy
@@ -28245,6 +28769,7 @@
   mero_member:
   - 12073874-n
   partOfSpeech: n
+  wikidata: Q163537
 12073874-n:
   definition:
   - a wildflower of the genus Corallorhiza growing from a hard mass of rhizomes associated
@@ -28303,6 +28828,7 @@
   mero_member:
   - 12075147-n
   partOfSpeech: n
+  wikidata: Q3484449
 12075147-n:
   definition:
   - any of several orchids of the genus Coryanthes having racemes of a few musky-scented
@@ -28353,6 +28879,7 @@
   mero_member:
   - 12075985-n
   partOfSpeech: n
+  wikidata: Q843914
 12075985-n:
   definition:
   - any of various plants of the genus Cymbidium having narrow leaves and a long drooping
@@ -28550,6 +29077,7 @@
   mero_member:
   - 12079815-n
   partOfSpeech: n
+  wikidata: Q133778
 12079815-n:
   definition:
   - a plant of the genus Dendrobium having stems like cane and usually showy racemose
@@ -28571,6 +29099,7 @@
   mero_member:
   - 12080126-n
   partOfSpeech: n
+  wikidata: Q599025
 12080126-n:
   definition:
   - any orchid of the genus Disa; beautiful orchids with dark green leaves and usually
@@ -28593,6 +29122,7 @@
   - Dracula
   - genus Dracula
   partOfSpeech: n
+  wikidata: Q133719
 12080619-n:
   definition:
   - 'comprises tropical American species usually placed in genus Masdevallia: very
@@ -28618,6 +29148,7 @@
   mero_member:
   - 12081047-n
   partOfSpeech: n
+  wikidata: Q87201444
 12081047-n:
   definition:
   - waxy white nearly leafless plant with stems in clusters and racemes of white flowers;
@@ -28645,6 +29176,7 @@
   - 12081881-n
   - 12082115-n
   partOfSpeech: n
+  wikidata: Q133786
 12081605-n:
   definition:
   - Mexican epiphytic orchid with glaucous grey-green leaves and lemon- to golden-yellow
@@ -28696,6 +29228,7 @@
   mero_member:
   - 12082606-n
   partOfSpeech: n
+  wikidata: Q133728
 12082606-n:
   definition:
   - any of various orchids of the genus Epidendrum
@@ -28764,6 +29297,7 @@
   mero_member:
   - 12083712-n
   partOfSpeech: n
+  wikidata: Q2670108
 12083712-n:
   definition:
   - orchid having blue to purple flowers with tongue-shaped or strap-shaped protuberances
@@ -28788,6 +29322,7 @@
   mero_member:
   - 12084140-n
   partOfSpeech: n
+  wikidata: Q163556
 12084140-n:
   definition:
   - any of several small temperate and tropical orchids having mottled or striped
@@ -28811,6 +29346,7 @@
   - Grammatophyllum
   - genus Grammatophyllum
   partOfSpeech: n
+  wikidata: Q2372901
 12084684-n:
   definition:
   - small genus of terrestrial orchids of North America and temperate Eurasia
@@ -28824,6 +29360,7 @@
   - 12084890-n
   - 12085092-n
   partOfSpeech: n
+  wikidata: Q162057
 12084890-n:
   definition:
   - European orchid having dense spikes of fragrant pink or lilac or red flowers with
@@ -28856,6 +29393,7 @@
   - Gymnadeniopsis
   - genus Gymnadeniopsis
   partOfSpeech: n
+  wikidata: Q3906361
 12085497-n:
   definition:
   - chiefly terrestrial orchids with tubers or fleshy roots often having long slender
@@ -29065,6 +29603,7 @@
   - 12089510-n
   - 12089718-n
   partOfSpeech: n
+  wikidata: Q3291967
 12089510-n:
   definition:
   - orchid with yellowish-brown flowers with dark veins; southeastern Arizona to the
@@ -29123,6 +29662,7 @@
   mero_member:
   - 12090517-n
   partOfSpeech: n
+  wikidata: Q133101
 12090517-n:
   definition:
   - any of various spectacular plants of the genus Laelia having showy flowers in
@@ -29266,6 +29806,7 @@
   mero_member:
   - 12093223-n
   partOfSpeech: n
+  wikidata: Q132700
 12093223-n:
   definition:
   - any of numerous orchids of the genus Masdevallia; tufted evergreen often diminutive
@@ -29289,6 +29830,7 @@
   mero_member:
   - 12093718-n
   partOfSpeech: n
+  wikidata: Q2719986
 12093718-n:
   definition:
   - any of numerous orchids of the genus Maxillaria often cultivated for their large
@@ -29335,6 +29877,7 @@
   mero_member:
   - 12094492-n
   partOfSpeech: n
+  wikidata: Q134034
 12094492-n:
   definition:
   - any of numerous and diverse orchids of the genus Odontoglossum having racemes
@@ -29357,6 +29900,7 @@
   mero_member:
   - 12094909-n
   partOfSpeech: n
+  wikidata: Q133754
 12094909-n:
   definition:
   - 'any orchid of the genus Oncidium: characterized by slender branching sprays of
@@ -29383,6 +29927,7 @@
   mero_member:
   - 12095652-n
   partOfSpeech: n
+  wikidata: Q157544
 12095368-n:
   definition:
   - European orchid whose flowers resemble bumble bees in shape and color
@@ -29463,6 +30008,7 @@
   mero_member:
   - 12096724-n
   partOfSpeech: n
+  wikidata: Q2719951
 12096724-n:
   definition:
   - an orchid of the genus Phaius having large plicate leaves and racemes of showy
@@ -29486,6 +30032,7 @@
   - 12097078-n
   - 12097353-n
   partOfSpeech: n
+  wikidata: Q133897
 12097078-n:
   definition:
   - any of various orchids of the genus Phalaenopsis having often drooping glossy
@@ -29522,6 +30069,7 @@
   mero_member:
   - 12097745-n
   partOfSpeech: n
+  wikidata: Q1300407
 12097745-n:
   definition:
   - any of various orchids of the genus Pholidota having numerous white to brown flowers
@@ -29544,6 +30092,7 @@
   - Phragmipedium
   - genus Phragmipedium
   partOfSpeech: n
+  wikidata: Q132709
 12098233-n:
   definition:
   - herbaceous terrestrial orchids of temperate northern and Southern Hemispheres
@@ -29557,6 +30106,7 @@
   - 12098445-n
   - 12098673-n
   partOfSpeech: n
+  wikidata: Q161849
 12098445-n:
   definition:
   - south European orchid having fragrant greenish-white flowers; sometimes placed
@@ -29627,6 +30177,7 @@
   mero_member:
   - 12099621-n
   partOfSpeech: n
+  wikidata: Q1989603
 12099621-n:
   definition:
   - any of several dwarf orchids of the genus Pleione bearing one or two solitary
@@ -29648,6 +30199,7 @@
   mero_member:
   - 12100024-n
   partOfSpeech: n
+  wikidata: Q29979
 12100024-n:
   definition:
   - any of numerous small tufted orchids of the genus Pleurothallis having leathery
@@ -29670,6 +30222,7 @@
   mero_member:
   - 12100464-n
   partOfSpeech: n
+  wikidata: Q134023
 12100464-n:
   definition:
   - 'any hardy bog orchid of the genus Pogonia: terrestrial orchids having slender
@@ -29693,6 +30246,7 @@
   mero_member:
   - 12100896-n
   partOfSpeech: n
+  wikidata: Q2673653
 12100896-n:
   definition:
   - 'any orchid of the genus Psychopsis: spectacular large tiger-striped orchids'
@@ -29738,6 +30292,7 @@
   mero_member:
   - 12101716-n
   partOfSpeech: n
+  wikidata: Q134246
 12101716-n:
   definition:
   - any of numerous orchids of the genus Pterostylis having leaves in a basal rosette
@@ -29762,6 +30317,7 @@
   mero_member:
   - 12102150-n
   partOfSpeech: n
+  wikidata: Q1300371
 12102150-n:
   definition:
   - any of various orchids of the genus Rhyncostylis having pink- to purple-marked
@@ -29810,6 +30366,7 @@
   - Scaphosepalum
   - genus Scaphosepalum
   partOfSpeech: n
+  wikidata: Q3308291
 12103094-n:
   definition:
   - genus of tropical American epiphytic orchids with showy racemose flowers
@@ -29832,6 +30389,7 @@
   - Selenipedium
   - genus Selenipedium
   partOfSpeech: n
+  wikidata: Q138016
 12103481-n:
   definition:
   - genus of about 125 tropical American orchids, and one of the two genera of the
@@ -29844,6 +30402,7 @@
   mero_member:
   - 12103614-n
   partOfSpeech: n
+  wikidata: Q133231
 12103614-n:
   definition:
   - any of various showy orchids of the genus Sobralia having leafy stems and bright-colored
@@ -29870,6 +30429,7 @@
   - 12104901-n
   - 12105072-n
   partOfSpeech: n
+  wikidata: Q163541
 12104092-n:
   definition:
   - an orchid of the genus Spiranthes having slender often twisted spikes of white
@@ -29937,6 +30497,7 @@
   mero_member:
   - 12105407-n
   partOfSpeech: n
+  wikidata: Q2719974
 12105407-n:
   definition:
   - any of various orchids of the genus Stanhopea having a single large leaf and loose
@@ -29959,6 +30520,7 @@
   mero_member:
   - 12105784-n
   partOfSpeech: n
+  wikidata: Q2720003
 12105784-n:
   definition:
   - any of various small tropical American orchids of the genus Stelis having long
@@ -29981,6 +30543,7 @@
   mero_member:
   - 12106181-n
   partOfSpeech: n
+  wikidata: Q7840728
 12106181-n:
   definition:
   - any of several dwarf creeping orchids with small bizarre insect-like hairy flowers
@@ -30003,6 +30566,7 @@
   - 12106529-n
   - 12106709-n
   partOfSpeech: n
+  wikidata: Q286061
 12106529-n:
   definition:
   - any of numerous showy orchids of the genus Vanda having many large flowers in
@@ -30035,6 +30599,7 @@
   - 12107056-n
   - 12107295-n
   partOfSpeech: n
+  wikidata: Q162044
 12107056-n:
   definition:
   - any of numerous climbing plants of the genus Vanilla having fleshy leaves and
@@ -30092,6 +30657,7 @@
   - Burmannia
   - genus Burmannia
   partOfSpeech: n
+  wikidata: Q141307
 12108167-n:
   definition:
   - the family of yams (Dioscoreaceae)
@@ -30106,6 +30672,7 @@
   - 12108324-n
   - 12110142-n
   partOfSpeech: n
+  wikidata: Q161220
 12108324-n:
   definition:
   - the genus of yams (Dioscorea)
@@ -30287,6 +30854,7 @@
   - 12115303-n
   - 12116740-n
   partOfSpeech: n
+  wikidata: Q157115
 12111219-n:
   definition:
   - very large and important genus of plants of temperate Europe and Asia having showy
@@ -30299,6 +30867,7 @@
   mero_member:
   - 12111407-n
   partOfSpeech: n
+  wikidata: Q158974
 12111407-n:
   definition:
   - any of numerous short-stemmed plants of the genus Primula having tufted basal
@@ -30389,6 +30958,7 @@
   mero_member:
   - 12112779-n
   partOfSpeech: n
+  wikidata: Q157732
 12112779-n:
   definition:
   - any of several plants of the genus Anagallis
@@ -30459,6 +31029,7 @@
   - 12113846-n
   - 12114117-n
   partOfSpeech: n
+  wikidata: Q147295
 12113846-n:
   definition:
   - Mediterranean plant widely cultivated as a houseplant for its showy dark green
@@ -30494,6 +31065,7 @@
   mero_member:
   - 12114402-n
   partOfSpeech: n
+  wikidata: Q14565146
 12114402-n:
   definition:
   - a small fleshy herb common along North American seashores and in brackish marshes
@@ -30566,6 +31138,7 @@
   mero_member:
   - 12115537-n
   partOfSpeech: n
+  wikidata: Q157761
 12115537-n:
   definition:
   - any of various herbs and subshrubs of the genus Lysimachia
@@ -30661,6 +31234,7 @@
   mero_member:
   - 12116912-n
   partOfSpeech: n
+  wikidata: Q121047
 12116912-n:
   definition:
   - a white-flowered aquatic plant of the genus Samolus
@@ -30705,6 +31279,7 @@
   - 12117530-n
   - 12117697-n
   partOfSpeech: n
+  wikidata: Q161260
 12117530-n:
   definition:
   - evergreen trees and shrubs having aromatic foliage; native to Africa; Asia (New
@@ -30716,6 +31291,7 @@
   - Myrsine
   - genus Myrsine
   partOfSpeech: n
+  wikidata: Q159796
 12117697-n:
   definition:
   - tropical evergreen subshrubs (some climbers) to trees of Asia and Australasia
@@ -30764,6 +31340,7 @@
   - Plumbaginales
   - order Plumbaginales
   partOfSpeech: n
+  wikidata: Q2059792
 12118444-n:
   definition:
   - perennial herbs and shrubs and lianas; cosmopolitan especially in saltwater areas
@@ -30780,6 +31357,7 @@
   - 12119182-n
   - 12119737-n
   partOfSpeech: n
+  wikidata: Q156141
 12118744-n:
   definition:
   - 'shrubs and herbs and woody vines of warm regions: leadwort'
@@ -30792,6 +31370,7 @@
   - 12118920-n
   - 12119041-n
   partOfSpeech: n
+  wikidata: Q2039140
 12118920-n:
   definition:
   - any plumbaginaceous plant of the genus Plumbago
@@ -30823,6 +31402,7 @@
   mero_member:
   - 12119344-n
   partOfSpeech: n
+  wikidata: Q158399
 12119344-n:
   definition:
   - any of numerous sun-loving low-growing evergreens of the genus Armeria having
@@ -30858,6 +31438,7 @@
   mero_member:
   - 12119859-n
   partOfSpeech: n
+  wikidata: Q157375
 12119859-n:
   definition:
   - any of various plants of the genus Limonium of temperate salt marshes having spikes
@@ -30883,6 +31464,7 @@
   mero_member:
   - 12120320-n
   partOfSpeech: n
+  wikidata: Q132048
 12120320-n:
   definition:
   - sometimes placed in family Myrsinaceae
@@ -30896,6 +31478,7 @@
   - 12120489-n
   - 12120704-n
   partOfSpeech: n
+  wikidata: Q309936
 12120489-n:
   definition:
   - small West Indian shrub or tree with hard glossy seeds patterned yellow and brown
@@ -30932,6 +31515,7 @@
   - 12121055-n
   - 12170268-n
   partOfSpeech: n
+  wikidata: Q28502
 12121055-n:
   definition:
   - 'the grasses: chiefly herbaceous but some woody plants including cereals, bamboo,
@@ -31004,6 +31588,7 @@
   - 12166617-n
   - 12167548-n
   partOfSpeech: n
+  wikidata: Q43238
 12122387-n:
   definition:
   - cosmopolitan herbaceous or woody plants with hollow jointed stems and long narrow
@@ -31117,6 +31702,7 @@
   mero_member:
   - 12125251-n
   partOfSpeech: n
+  wikidata: Q1764888
 12125251-n:
   definition:
   - European grass naturalized as a weed in North America; sharp-pointed seeds cause
@@ -31140,6 +31726,7 @@
   mero_member:
   - 12125642-n
   partOfSpeech: n
+  wikidata: Q162731
 12125642-n:
   definition:
   - a grass of the genus Agropyron
@@ -31238,6 +31825,7 @@
   mero_member:
   - 12127303-n
   partOfSpeech: n
+  wikidata: Q161137
 12127303-n:
   definition:
   - grass for pastures and lawns especially bowling and putting greens
@@ -31297,6 +31885,7 @@
   mero_member:
   - 12128227-n
   partOfSpeech: n
+  wikidata: Q158104
 12128227-n:
   definition:
   - stout erect perennial grass of northern parts of Old World having silky flowering
@@ -31392,6 +31981,7 @@
   mero_member:
   - 12130015-n
   partOfSpeech: n
+  wikidata: Q165263
 12129882-n:
   definition:
   - used by Maoris for thatching
@@ -31428,6 +32018,7 @@
   mero_member:
   - 12130344-n
   partOfSpeech: n
+  wikidata: Q146760
 12130344-n:
   definition:
   - 'annual grass of Europe and North Africa; grains used as food and fodder (referred
@@ -31497,6 +32088,7 @@
   mero_member:
   - 12131295-n
   partOfSpeech: n
+  wikidata: Q147621
 12131295-n:
   definition:
   - any of various woodland and meadow grasses of the genus Bromus; native to temperate
@@ -31624,6 +32216,7 @@
   mero_member:
   - 12133126-n
   partOfSpeech: n
+  wikidata: Q15102508
 12133126-n:
   definition:
   - short grass growing on dry plains of central United States (where buffalo roam)
@@ -31693,6 +32286,7 @@
   - 12134174-n
   - 12134307-n
   partOfSpeech: n
+  wikidata: Q430325
 12134174-n:
   definition:
   - a grass of the genus Cenchrus
@@ -31739,6 +32333,7 @@
   - Chloris
   - genus Chloris
   partOfSpeech: n
+  wikidata: Q2147082
 12134914-n:
   definition:
   - any grass of the genus Chloris; occurs in short grassland especially on waste
@@ -31787,6 +32382,7 @@
   mero_member:
   - 12135697-n
   partOfSpeech: n
+  wikidata: Q941632
 12135697-n:
   definition:
   - tall perennial grass of Pampas of South America having silvery plumes and growing
@@ -31824,6 +32420,7 @@
   - 12136265-n
   - 12136575-n
   partOfSpeech: n
+  wikidata: Q959222
 12136265-n:
   definition:
   - trailing grass native to Europe now cosmopolitan in warm regions; used for lawns
@@ -31862,6 +32459,7 @@
   - Dactylis
   - genus Dactylis
   partOfSpeech: n
+  wikidata: Q1047931
 12136946-n:
   definition:
   - widely grown stout Old World hay and pasture grass
@@ -31908,6 +32506,7 @@
   mero_member:
   - 12137534-n
   partOfSpeech: n
+  wikidata: Q163915
 12137534-n:
   definition:
   - grasses with creeping stems that root freely; a pest in lawns
@@ -31955,6 +32554,7 @@
   - 12138212-n
   - 12138429-n
   partOfSpeech: n
+  wikidata: Q163965
 12138212-n:
   definition:
   - a coarse annual panic grass; a cosmopolitan weed; occasionally used for hay or
@@ -32042,6 +32642,7 @@
   - 12139616-n
   - 12139755-n
   partOfSpeech: n
+  wikidata: Q1072892
 12139616-n:
   definition:
   - a grass of the genus Elymus
@@ -32115,6 +32716,7 @@
   mero_member:
   - 12140631-n
   partOfSpeech: n
+  wikidata: Q161088
 12140631-n:
   definition:
   - any of various grasses of the genus Eragrostis; specially useful for forage and
@@ -32165,6 +32767,7 @@
   - 12141550-n
   - 12141704-n
   partOfSpeech: n
+  wikidata: Q2731014
 12141550-n:
   definition:
   - a reedlike grass of the genus Erianthus having large plumes
@@ -32200,6 +32803,7 @@
   - 12142352-n
   - 12142535-n
   partOfSpeech: n
+  wikidata: Q157337
 12142127-n:
   definition:
   - grass with wide flat leaves cultivated in Europe and America for permanent pasture
@@ -32246,6 +32850,7 @@
   mero_member:
   - 12142762-n
   partOfSpeech: n
+  wikidata: Q157515
 12142762-n:
   definition:
   - any of several moisture-loving grasses of the genus Glyceria having sweet flavor
@@ -32314,6 +32919,7 @@
   mero_member:
   - 12143761-n
   partOfSpeech: n
+  wikidata: Q518044
 12143761-n:
   definition:
   - cultivated since prehistoric times; grown for forage and grain
@@ -32384,6 +32990,7 @@
   - Leymus
   - genus Leymus
   partOfSpeech: n
+  wikidata: Q1542804
 12145022-n:
   definition:
   - darnel; ryegrass
@@ -32481,6 +33088,7 @@
   mero_member:
   - 12146407-n
   partOfSpeech: n
+  wikidata: Q690633
 12146407-n:
   definition:
   - annual or perennial rhizomatous marsh grasses; seed used for food; straw used
@@ -32566,6 +33174,7 @@
   mero_member:
   - 12147547-n
   partOfSpeech: n
+  wikidata: Q934037
 12147547-n:
   definition:
   - any grass of the genus Panicum; grown for grain and fodder
@@ -32637,6 +33246,7 @@
   - 12148823-n
   - 12149007-n
   partOfSpeech: n
+  wikidata: Q2333069
 12148588-n:
   definition:
   - tall tufted perennial tropical American grass naturalized as pasture and forage
@@ -32740,6 +33350,7 @@
   - 12150503-n
   - 12150677-n
   partOfSpeech: n
+  wikidata: Q157573
 12150255-n:
   definition:
   - perennial grass of marshy meadows and ditches having broad leaves; Europe and
@@ -32792,6 +33403,7 @@
   mero_member:
   - 12151066-n
   partOfSpeech: n
+  wikidata: Q158502
 12151066-n:
   definition:
   - grass with long cylindrical spikes grown in northern United States and Europe
@@ -32818,6 +33430,7 @@
   mero_member:
   - 12151454-n
   partOfSpeech: n
+  wikidata: Q1976487
 12151454-n:
   definition:
   - tall North American reed having relative wide leaves and large plumelike panicles;
@@ -32845,6 +33458,7 @@
   - 12152284-n
   - 12152609-n
   partOfSpeech: n
+  wikidata: Q157656
 12151922-n:
   definition:
   - any of various grasses of the genus Poa
@@ -32906,6 +33520,7 @@
   - 12153019-n
   - 12153668-n
   partOfSpeech: n
+  wikidata: Q17136949
 12153019-n:
   definition:
   - tall tropical southeast Asian grass having stout fibrous jointed stalks; sap is
@@ -32964,6 +33579,7 @@
   - Schizachyrium
   - genus Schizachyrium
   partOfSpeech: n
+  wikidata: Q2708217
 12153979-n:
   definition:
   - handsome hardy North American grass with foliage turning pale bronze in autumn
@@ -33031,6 +33647,7 @@
   - 12155003-n
   - 12155787-n
   partOfSpeech: n
+  wikidata: Q157389
 12155003-n:
   definition:
   - grasses of grasslands and woodlands having large gracefully arching spikes with
@@ -33174,6 +33791,7 @@
   mero_member:
   - 12157637-n
   partOfSpeech: n
+  wikidata: Q12111
 12157637-n:
   definition:
   - economically important Old World tropical cereal grass
@@ -33325,6 +33943,7 @@
   mero_member:
   - 12160092-n
   partOfSpeech: n
+  wikidata: Q159038
 12160092-n:
   definition:
   - any of several perennial grasses of the genus Spartina; some important as coastal
@@ -33373,6 +33992,7 @@
   - 12161028-n
   - 12161420-n
   partOfSpeech: n
+  wikidata: Q2603825
 12160875-n:
   definition:
   - a grass of the genus Sporobolus
@@ -33477,6 +34097,7 @@
   mero_member:
   - 12162602-n
   partOfSpeech: n
+  wikidata: Q12106
 12162602-n:
   definition:
   - annual or biennial grass having erect flower spikes and light brown grains
@@ -33583,6 +34204,7 @@
   mero_member:
   - 12164193-n
   partOfSpeech: n
+  wikidata: Q542456
 12164193-n:
   definition:
   - 'tall annual cereal grass bearing kernels on large ears: widely cultivated in
@@ -33728,6 +34350,7 @@
   mero_member:
   - 12166436-n
   partOfSpeech: n
+  wikidata: Q831681
 12166436-n:
   definition:
   - perennial aquatic grass of North America bearing grain used for food
@@ -33754,6 +34377,7 @@
   mero_member:
   - 12166828-n
   partOfSpeech: n
+  wikidata: Q1205244
 12166828-n:
   definition:
   - any of several creeping grasses of the genus Zoysia
@@ -33875,6 +34499,7 @@
   - 12168770-n
   - 12168956-n
   partOfSpeech: n
+  wikidata: Q2700649
 12168770-n:
   definition:
   - tall grass of southern United States growing in thickets
@@ -33909,6 +34534,7 @@
   mero_member:
   - 12169274-n
   partOfSpeech: n
+  wikidata: Q2718894
 12169274-n:
   definition:
   - immense tropical southeast Asian bamboo with tough hollow culms that resemble
@@ -33991,6 +34617,7 @@
   - 12173386-n
   - 12173910-n
   partOfSpeech: n
+  wikidata: Q155843
 12170545-n:
   definition:
   - grasslike or rushlike plant growing in wet places having solid stems, narrow grasslike
@@ -34019,6 +34646,7 @@
   - 12171882-n
   - 12172132-n
   partOfSpeech: n
+  wikidata: Q161224
 12171239-n:
   definition:
   - African sedge widely cultivated as an ornamental water plant for its terminal
@@ -34102,6 +34730,7 @@
   - 12172548-n
   - 12172768-n
   partOfSpeech: n
+  wikidata: Q158501
 12172548-n:
   definition:
   - European maritime sedge naturalized along Atlantic coast of United States; rootstock
@@ -34171,6 +34800,7 @@
   - 12173550-n
   - 12173741-n
   partOfSpeech: n
+  wikidata: Q159220
 12173550-n:
   definition:
   - widely distributed North American sedge having rigid olive green stems
@@ -34205,6 +34835,7 @@
   mero_member:
   - 12174097-n
   partOfSpeech: n
+  wikidata: Q161871
 12174097-n:
   definition:
   - a sedge of the genus Eleocharis
@@ -34290,6 +34921,7 @@
   mero_member:
   - 12175290-n
   partOfSpeech: n
+  wikidata: Q471914
 12175290-n:
   definition:
   - any of various Old World tropical palmlike trees having huge prop roots and edible
@@ -34400,6 +35032,7 @@
   mero_member:
   - 12177001-n
   partOfSpeech: n
+  wikidata: Q157075
 12177001-n:
   definition:
   - type and sole genus of Sparganiaceae; marsh or aquatic herbs of temperate regions
@@ -34412,6 +35045,7 @@
   mero_member:
   - 12177196-n
   partOfSpeech: n
+  wikidata: Q1196275
 12177196-n:
   definition:
   - marsh plant having elongated linear leaves and round prickly fruit
@@ -34473,6 +35107,7 @@
   - 12186829-n
   - 12187799-n
   partOfSpeech: n
+  wikidata: Q8314
 12178194-n:
   definition:
   - any plant of the family Cucurbitaceae
@@ -34522,6 +35157,7 @@
   mero_part:
   - 12182698-n
   partOfSpeech: n
+  wikidata: Q5339301
 12178960-n:
   definition:
   - a coarse vine widely cultivated for its large pulpy round orange fruit with firm
@@ -34782,6 +35418,7 @@
   mero_member:
   - 12183552-n
   partOfSpeech: n
+  wikidata: Q149006
 12183552-n:
   definition:
   - a vine of the genus Bryonia having large leaves and small flowers and yielding
@@ -34829,6 +35466,7 @@
   mero_member:
   - 12184582-n
   partOfSpeech: n
+  wikidata: Q132239
 12184341-n:
   definition:
   - 'any of various fruit of cucurbitaceous vines including: muskmelons, watermelons,
@@ -34868,6 +35506,7 @@
   - 12184880-n
   - 12185901-n
   partOfSpeech: n
+  wikidata: Q148758
 12184880-n:
   definition:
   - any of several varieties of vine whose fruit has a netted rind and edible flesh
@@ -35004,6 +35643,7 @@
   mero_member:
   - 12186941-n
   partOfSpeech: n
+  wikidata: Q232909
 12186941-n:
   definition:
   - any of several tropical annual climbers having large yellow flowers and edible
@@ -35104,6 +35744,7 @@
   mero_member:
   - 12188472-n
   partOfSpeech: n
+  wikidata: Q547938
 12188472-n:
   definition:
   - a genus of shrubs and herbs that grow in Australia and New Guinea and Malaysia
@@ -35127,6 +35768,7 @@
   - family Lobeliaceae
   - lobelia family
   partOfSpeech: n
+  wikidata: Q10726796
 12188902-n:
   definition:
   - in some classifications considered the type genus of a separate family Lobeliaceae
@@ -35138,6 +35780,7 @@
   mero_member:
   - 12189082-n
   partOfSpeech: n
+  wikidata: Q158182
 12189082-n:
   definition:
   - any plant or flower of the genus Lobelia
@@ -35250,6 +35893,7 @@
   - 12207967-n
   - 12208637-n
   partOfSpeech: n
+  wikidata: Q156551
 12190932-n:
   definition:
   - 'herbs and subshrubs: mallows'
@@ -35264,6 +35908,7 @@
   - 12191833-n
   - 12192020-n
   partOfSpeech: n
+  wikidata: Q147325
 12191102-n:
   definition:
   - any of various plants of the family Malvaceae
@@ -35324,6 +35969,7 @@
   - 12192483-n
   - 12192998-n
   partOfSpeech: n
+  wikidata: Q866047
 12192483-n:
   definition:
   - tall coarse annual of Old World tropics widely cultivated in southern United States
@@ -35378,6 +36024,7 @@
   - 12193423-n
   - 12193586-n
   partOfSpeech: n
+  wikidata: Q132638
 12193423-n:
   definition:
   - an ornamental plant of the genus Abutilon having leaves that resemble maple leaves
@@ -35419,6 +36066,7 @@
   - 12194181-n
   - 12194429-n
   partOfSpeech: n
+  wikidata: Q1148371
 12194181-n:
   definition:
   - any of various tall plants of the genus Alcea; native to the Middle East but widely
@@ -35453,6 +36101,7 @@
   - 12194828-n
   - 12195038-n
   partOfSpeech: n
+  wikidata: Q157706
 12194828-n:
   definition:
   - any of various plants of the genus Althaea; similar to but having smaller flowers
@@ -35489,6 +36138,7 @@
   mero_member:
   - 12195443-n
   partOfSpeech: n
+  wikidata: Q3626558
 12195443-n:
   definition:
   - a plant of the genus Callirhoe having palmately cleft leaves and white to red
@@ -35544,6 +36194,7 @@
   mero_member:
   - 12196466-n
   partOfSpeech: n
+  wikidata: Q719312
 12196466-n:
   definition:
   - erect bushy mallow plant or small tree bearing bolls containing seeds with many
@@ -35647,6 +36298,7 @@
   mero_member:
   - 12198361-n
   partOfSpeech: n
+  wikidata: Q157124
 12198361-n:
   definition:
   - any plant of the genus Hibiscus
@@ -35851,6 +36503,7 @@
   - 12201869-n
   - 12202129-n
   partOfSpeech: n
+  wikidata: Q956342
 12201869-n:
   definition:
   - a rare mallow found only in Illinois resembling the common hollyhock and having
@@ -35887,6 +36540,7 @@
   mero_member:
   - 12202566-n
   partOfSpeech: n
+  wikidata: Q3773987
 12202566-n:
   definition:
   - any of various plants of the genus Kosteletzya predominantly of coastal habitats;
@@ -35920,6 +36574,7 @@
   mero_member:
   - 12203132-n
   partOfSpeech: n
+  wikidata: Q1415570
 12203132-n:
   definition:
   - arborescent perennial shrub having palmately lobed furry leaves and showy red-purple
@@ -35970,6 +36625,7 @@
   mero_member:
   - 12203969-n
   partOfSpeech: n
+  wikidata: Q3504689
 12203969-n:
   definition:
   - western Mediterranean annual having deep purple-red flowers subtended by 3 large
@@ -36039,6 +36695,7 @@
   mero_member:
   - 12204985-n
   partOfSpeech: n
+  wikidata: Q3335868
 12204985-n:
   definition:
   - tall coarse American herb having palmate leaves and numerous small white dioecious
@@ -36062,6 +36719,7 @@
   mero_member:
   - 12205429-n
   partOfSpeech: n
+  wikidata: Q3316083
 12205429-n:
   definition:
   - any of various evergreen plants of the genus Pavonia having white or yellow or
@@ -36084,6 +36742,7 @@
   mero_member:
   - 12205771-n
   partOfSpeech: n
+  wikidata: Q9060360
 12205771-n:
   definition:
   - deciduous New Zealand tree whose inner bark yields a strong fiber that resembles
@@ -36148,6 +36807,7 @@
   - 12207071-n
   - 12207356-n
   partOfSpeech: n
+  wikidata: Q311463
 12206869-n:
   definition:
   - tall handsome perennial herb of southeastern United States having maplelike leaves
@@ -36196,6 +36856,7 @@
   mero_member:
   - 12207764-n
   partOfSpeech: n
+  wikidata: Q5219981
 12207764-n:
   definition:
   - perennial purple-flowered wild mallow of western North America that is also cultivated
@@ -36257,6 +36918,7 @@
   mero_member:
   - 12209152-n
   partOfSpeech: n
+  wikidata: Q1149349
 12208806-n:
   definition:
   - any of various trees yielding variously colored woods similar to true tulipwood
@@ -36309,6 +36971,7 @@
   - 12211978-n
   - 12212482-n
   partOfSpeech: n
+  wikidata: Q2006755
 12209810-n:
   definition:
   - trees of chiefly South America
@@ -36321,6 +36984,7 @@
   mero_member:
   - 12209946-n
   partOfSpeech: n
+  wikidata: Q719028
 12209946-n:
   definition:
   - East Indian silk cotton tree yielding fibers inferior to kapok
@@ -36346,6 +37010,7 @@
   - 12210296-n
   - 12210504-n
   partOfSpeech: n
+  wikidata: Q157991
 12210296-n:
   definition:
   - Australian tree having an agreeably acid fruit that resembles a gourd
@@ -36385,6 +37050,7 @@
   - Ceiba
   - genus Ceiba
   partOfSpeech: n
+  wikidata: Q284019
 12210927-n:
   definition:
   - massive tropical tree with deep ridges on its massive trunk and bearing large
@@ -36414,6 +37080,7 @@
   mero_member:
   - 12211386-n
   partOfSpeech: n
+  wikidata: Q2309085
 12211386-n:
   definition:
   - tree of southeastern Asia having edible oval fruit with a hard spiny rind
@@ -36440,6 +37107,7 @@
   mero_member:
   - 12211757-n
   partOfSpeech: n
+  wikidata: Q6022764
 12211757-n:
   definition:
   - evergreen tree with large leathery leaves and large pink to orange flowers; considered
@@ -36462,6 +37130,7 @@
   mero_member:
   - 12212104-n
   partOfSpeech: n
+  wikidata: Q12302824
 12212104-n:
   definition:
   - forest tree of lowland Central America having a strong very light wood; used for
@@ -36497,6 +37166,7 @@
   mero_member:
   - 12212649-n
   partOfSpeech: n
+  wikidata: Q5221618
 12212649-n:
   definition:
   - tree of Mexico to Guatemala having densely hairy flowers with long narrow petals
@@ -36526,6 +37196,7 @@
   - 12214481-n
   - 12214983-n
   partOfSpeech: n
+  wikidata: Q131280
 12213239-n:
   definition:
   - type genus of the family Elaeocarpaceae
@@ -36538,6 +37209,7 @@
   mero_member:
   - 12213394-n
   partOfSpeech: n
+  wikidata: Q29128
 12213394-n:
   definition:
   - Australian tree having hard white timber and glossy green leaves with white flowers
@@ -36588,6 +37260,7 @@
   mero_member:
   - 12214182-n
   partOfSpeech: n
+  wikidata: Q2372406
 12214182-n:
   definition:
   - graceful deciduous shrub or small tree having attractive foliage and small red
@@ -36615,6 +37288,7 @@
   mero_member:
   - 12214664-n
   partOfSpeech: n
+  wikidata: Q10333250
 12214664-n:
   definition:
   - a fast-growing tropical American evergreen having white flowers and fleshy edible
@@ -36680,6 +37354,7 @@
   - 12221973-n
   - 12222278-n
   partOfSpeech: n
+  wikidata: Q1071125
 12215703-n:
   definition:
   - 'type genus of the Sterculiaceae: deciduous or evergreen trees of Old and New
@@ -36692,6 +37367,7 @@
   mero_member:
   - 12215908-n
   partOfSpeech: n
+  wikidata: Q1478297
 12215908-n:
   definition:
   - any tree of the genus Sterculia
@@ -36812,6 +37488,7 @@
   mero_member:
   - 12217876-n
   partOfSpeech: n
+  wikidata: Q114264
 12217876-n:
   definition:
   - tree bearing large brown nuts containing e.g. caffeine; source of cola extract
@@ -36851,6 +37528,7 @@
   mero_member:
   - 12218418-n
   partOfSpeech: n
+  wikidata: Q908118
 12218418-n:
   definition:
   - any of various shrubs or small trees of the genus Dombeya grown for their rounded
@@ -36875,6 +37553,7 @@
   mero_member:
   - 12218803-n
   partOfSpeech: n
+  wikidata: Q427914
 12218803-n:
   definition:
   - deciduous tree widely grown in southern United States as an ornamental for its
@@ -36905,6 +37584,7 @@
   mero_member:
   - 12219310-n
   partOfSpeech: n
+  wikidata: Q2703645
 12219310-n:
   definition:
   - any of several handsome evergreen shrubs of California and northern Mexico having
@@ -36930,6 +37610,7 @@
   mero_member:
   - 12219783-n
   partOfSpeech: n
+  wikidata: Q3312735
 12219783-n:
   definition:
   - a tree or shrub of the genus Helicteres
@@ -36962,6 +37643,7 @@
   - Terrietia
   - genus Terrietia
   partOfSpeech: n
+  wikidata: Q148716
 12220307-n:
   definition:
   - large tree of Australasia
@@ -37010,6 +37692,7 @@
   mero_member:
   - 12221021-n
   partOfSpeech: n
+  wikidata: Q368955
 12221021-n:
   definition:
   - African shrub having decumbent stems and slender yellow honey-scented flowers
@@ -37035,6 +37718,7 @@
   mero_member:
   - 12221422-n
   partOfSpeech: n
+  wikidata: Q2702537
 12221422-n:
   definition:
   - Indian tree having fragrant nocturnal white flowers and yielding a reddish wood
@@ -37059,6 +37743,7 @@
   mero_member:
   - 12221848-n
   partOfSpeech: n
+  wikidata: Q15814211
 12221848-n:
   definition:
   - Australian timber tree
@@ -37081,6 +37766,7 @@
   mero_member:
   - 12222097-n
   partOfSpeech: n
+  wikidata: Q162078
 12222097-n:
   definition:
   - tropical American tree producing cacao beans
@@ -37162,6 +37848,7 @@
   mero_member:
   - 12223453-n
   partOfSpeech: n
+  wikidata: Q127849
 12223453-n:
   definition:
   - any of various deciduous trees of the genus Tilia with heart-shaped leaves and
@@ -37261,6 +37948,7 @@
   - Entelea
   - genus Entelea
   partOfSpeech: n
+  wikidata: Q15813022
 12225063-n:
   definition:
   - widely distributed genus of tropical herbs or subshrubs; especially Asia
@@ -37273,6 +37961,7 @@
   mero_member:
   - 12225247-n
   partOfSpeech: n
+  wikidata: Q161489
 12225247-n:
   definition:
   - any of various plants of the genus Corchorus having large leaves and cymose clusters
@@ -37295,6 +37984,7 @@
   mero_member:
   - 12225621-n
   partOfSpeech: n
+  wikidata: Q80212
 12225621-n:
   definition:
   - drought-resistant Asiatic treelike shrub bearing pleasantly acid small red edible
@@ -37318,6 +38008,7 @@
   mero_member:
   - 12225977-n
   partOfSpeech: n
+  wikidata: Q87302332
 12225977-n:
   definition:
   - large shrub of South Africa having many conspicuously hairy branches with large
@@ -37399,6 +38090,7 @@
   - 12950804-n
   - 12966848-n
   partOfSpeech: n
+  wikidata: Q14856870
 12234002-n:
   definition:
   - coextensive with the family Proteaceae
@@ -37443,6 +38135,7 @@
   - 12243922-n
   - 12244467-n
   partOfSpeech: n
+  wikidata: Q157228
 12234762-n:
   definition:
   - a living fossil or so-called ‘green dinosaur’; genus or subfamily of primitive
@@ -37456,6 +38149,7 @@
   - genus Bartle-Frere
   - green dinosaur
   partOfSpeech: n
+  wikidata: Q2711732
 12235122-n:
   definition:
   - type genus of Proteaceae; tropical African shrubs
@@ -37469,6 +38163,7 @@
   - 12235539-n
   - 12235727-n
   partOfSpeech: n
+  wikidata: Q227822
 12235306-n:
   definition:
   - any tropical African shrub of the genus Protea having alternate rigid leaves and
@@ -37514,6 +38209,7 @@
   mero_member:
   - 12236096-n
   partOfSpeech: n
+  wikidata: Q131258
 12236096-n:
   definition:
   - any shrub or tree of the genus Banksia having alternate leathery leaves apetalous
@@ -37548,6 +38244,7 @@
   mero_member:
   - 12236732-n
   partOfSpeech: n
+  wikidata: Q2705208
 12236732-n:
   definition:
   - any of various shrubs of the genus Conospermum with panicles of mostly white woolly
@@ -37571,6 +38268,7 @@
   mero_member:
   - 12237145-n
   partOfSpeech: n
+  wikidata: Q3355974
 12237145-n:
   definition:
   - grown for outstanding display of brilliant usually scarlet-crimson flowers; Andes
@@ -37595,6 +38293,7 @@
   mero_member:
   - 12237485-n
   partOfSpeech: n
+  wikidata: Q3104697
 12237485-n:
   definition:
   - Chilean shrub bearing coral-red fruit with an edible seed resembling a hazelnut
@@ -37624,6 +38323,7 @@
   - 12238571-n
   - 12238791-n
   partOfSpeech: n
+  wikidata: Q1545761
 12237970-n:
   definition:
   - any shrub or tree of the genus Grevillea
@@ -37704,6 +38404,7 @@
   - 12239582-n
   - 12239806-n
   partOfSpeech: n
+  wikidata: Q141826
 12239385-n:
   definition:
   - tall straggling shrub with large globose crimson-yellow flowers; western Australia
@@ -37752,6 +38453,7 @@
   mero_member:
   - 12240185-n
   partOfSpeech: n
+  wikidata: Q9017763
 12240185-n:
   definition:
   - slender elegant tree of New Zealand having racemes of red flowers and yielding
@@ -37775,6 +38477,7 @@
   mero_member:
   - 12240536-n
   partOfSpeech: n
+  wikidata: Q2712665
 12240536-n:
   definition:
   - erect bushy shrub of eastern Australia having terminal clusters of red flowers
@@ -37802,6 +38505,7 @@
   mero_member:
   - 12241013-n
   partOfSpeech: n
+  wikidata: Q159466
 12241013-n:
   definition:
   - small South African tree with long silvery silky foliage
@@ -37848,6 +38552,7 @@
   - 12242039-n
   - 12242318-n
   partOfSpeech: n
+  wikidata: Q310041
 12241708-n:
   definition:
   - any tree of the genus Macadamia
@@ -37930,6 +38635,7 @@
   mero_member:
   - 12243010-n
   partOfSpeech: n
+  wikidata: Q138331
 12243010-n:
   definition:
   - any of numerous shrubs and small trees having hard narrow leaves and long-lasting
@@ -37995,6 +38701,7 @@
   - 12244086-n
   - 12244281-n
   partOfSpeech: n
+  wikidata: Q136760
 12244086-n:
   definition:
   - tall shrub of eastern Australia having oblanceolate to obovate leaves and red
@@ -38055,6 +38762,7 @@
   mero_member:
   - 12245039-n
   partOfSpeech: n
+  wikidata: Q2261590
 12245039-n:
   definition:
   - 'one genus: genus Casuarina'
@@ -38067,6 +38775,7 @@
   mero_member:
   - 12245186-n
   partOfSpeech: n
+  wikidata: Q474620
 12245186-n:
   definition:
   - genus of trees and shrubs widely naturalized in southern United States and West
@@ -38082,6 +38791,7 @@
   - 12245866-n
   - 12246080-n
   partOfSpeech: n
+  wikidata: Q756005
 12245495-n:
   definition:
   - any of various trees and shrubs of the genus Casuarina having jointed stems and
@@ -38151,6 +38861,7 @@
   - 12276176-n
   - 12278897-n
   partOfSpeech: n
+  wikidata: Q21737
 12246839-n:
   definition:
   - heathers
@@ -38190,6 +38901,7 @@
   - 12264444-n
   - 12265989-n
   partOfSpeech: n
+  wikidata: Q975872
 12247449-n:
   definition:
   - a low evergreen shrub of the family Ericaceae; has small bell-shaped pink or purple
@@ -38212,6 +38924,7 @@
   mero_member:
   - 12247937-n
   partOfSpeech: n
+  wikidata: Q206998
 12247937-n:
   definition:
   - any plant of the genus Erica
@@ -38343,6 +39056,7 @@
   mero_member:
   - 12249960-n
   partOfSpeech: n
+  wikidata: Q2846938
 12249960-n:
   definition:
   - any of several shrubs of the genus Andromeda having leathery leaves and clusters
@@ -38389,6 +39103,7 @@
   mero_member:
   - 12250864-n
   partOfSpeech: n
+  wikidata: Q430057
 12250864-n:
   definition:
   - any of several evergreen shrubs of the genus Arbutus of temperate Europe and America
@@ -38436,6 +39151,7 @@
   - 12251709-n
   - 12252435-n
   partOfSpeech: n
+  wikidata: Q280566
 12251709-n:
   definition:
   - chiefly evergreen subshrubs of northern to Arctic areas
@@ -38532,6 +39248,7 @@
   mero_member:
   - 12253368-n
   partOfSpeech: n
+  wikidata: Q19888183
 12253368-n:
   definition:
   - small evergreen mat-forming shrub of southern Europe and Asia Minor having stiff
@@ -38554,6 +39271,7 @@
   mero_member:
   - 12253766-n
   partOfSpeech: n
+  wikidata: Q866655
 12253766-n:
   definition:
   - procumbent Old World mat-forming evergreen shrub with racemes of pinkish-white
@@ -38576,6 +39294,7 @@
   mero_member:
   - 12254046-n
   partOfSpeech: n
+  wikidata: Q6983007
 12254046-n:
   definition:
   - common Old World heath represented by many varieties; low evergreen grown widely
@@ -38603,6 +39322,7 @@
   mero_member:
   - 12254515-n
   partOfSpeech: n
+  wikidata: Q574564
 12254515-n:
   definition:
   - heath of mountains of western United States having bell-shaped white flowers
@@ -38625,6 +39345,7 @@
   mero_member:
   - 12254835-n
   partOfSpeech: n
+  wikidata: Q3502448
 12254835-n:
   definition:
   - north temperate bog shrub with evergreen leathery leaves and small white cylindrical
@@ -38649,6 +39370,7 @@
   mero_member:
   - 12255186-n
   partOfSpeech: n
+  wikidata: Q24156
 12255186-n:
   definition:
   - low straggling evergreen shrub of western Europe represented by several varieties
@@ -38698,6 +39420,7 @@
   - 12256282-n
   - 12256677-n
   partOfSpeech: n
+  wikidata: Q1626776
 12255996-n:
   definition:
   - slow-growing procumbent evergreen shrublet of northern North America and Japan
@@ -38817,6 +39540,7 @@
   mero_member:
   - 12258003-n
   partOfSpeech: n
+  wikidata: Q1427635
 12258003-n:
   definition:
   - any plant of the genus Kalmia
@@ -38881,6 +39605,7 @@
   - 12259273-n
   - 12259430-n
   partOfSpeech: n
+  wikidata: Q2001352
 12259008-n:
   definition:
   - evergreen shrub of eastern North America having white or creamy bell-shaped flowers
@@ -38926,6 +39651,7 @@
   mero_member:
   - 12259757-n
   partOfSpeech: n
+  wikidata: Q3502252
 12259757-n:
   definition:
   - low-growing evergreen shrub of New Jersey to Florida grown for its many white
@@ -38950,6 +39676,7 @@
   - 12260397-n
   - 12260667-n
   partOfSpeech: n
+  wikidata: Q1506945
 12260164-n:
   definition:
   - any plant of the genus Leucothoe; grown for their beautiful white flowers; glossy
@@ -38997,6 +39724,7 @@
   mero_member:
   - 12260994-n
   partOfSpeech: n
+  wikidata: Q6980968
 12260994-n:
   definition:
   - creeping mat-forming evergreen shrub of high mountain regions of Northern Hemisphere
@@ -39024,6 +39752,7 @@
   - 12261709-n
   - 12261943-n
   partOfSpeech: n
+  wikidata: Q2664959
 12261482-n:
   definition:
   - deciduous shrub of coastal plain of the eastern United States having nodding pinkish-white
@@ -39078,6 +39807,7 @@
   - 12262397-n
   - 12262640-n
   partOfSpeech: n
+  wikidata: Q32269
 12262397-n:
   definition:
   - straggling shrub of northwestern North America having foliage with a bluish tinge
@@ -39114,6 +39844,7 @@
   mero_member:
   - 12262926-n
   partOfSpeech: n
+  wikidata: Q15940594
 12262926-n:
   definition:
   - deciduous shrubby tree of eastern North America having deeply fissured bark and
@@ -39141,6 +39872,7 @@
   - 12263367-n
   - 12263626-n
   partOfSpeech: n
+  wikidata: Q2417381
 12263367-n:
   definition:
   - small shrub with tiny evergreen leaves and pink or purple flowers; Alpine summits
@@ -39179,6 +39911,7 @@
   - 12263976-n
   - 12264210-n
   partOfSpeech: n
+  wikidata: Q132967
 12263976-n:
   definition:
   - broad-leaved evergreen Asiatic shrub with glossy leaves and drooping clusters
@@ -39219,6 +39952,7 @@
   - 12264670-n
   - 12265584-n
   partOfSpeech: n
+  wikidata: Q189393
 12264670-n:
   definition:
   - 'any shrub of the genus Rhododendron: evergreen shrubs or small shrubby trees
@@ -39301,6 +40035,7 @@
   - 12266212-n
   - 12266749-n
   partOfSpeech: n
+  wikidata: Q5079636
 12266212-n:
   definition:
   - any of numerous shrubs of genus Vaccinium bearing cranberries
@@ -39550,6 +40285,7 @@
   mero_member:
   - 12270510-n
   partOfSpeech: n
+  wikidata: Q157454
 12270510-n:
   definition:
   - 'type and sole genus of the Clethraceae; deciduous shrubs or small trees: white
@@ -39616,6 +40352,7 @@
   mero_member:
   - 12271518-n
   partOfSpeech: n
+  wikidata: Q7179462
 12271518-n:
   definition:
   - any boreal low-growing evergreen plant of the genus Diapensia
@@ -39636,6 +40373,7 @@
   mero_member:
   - 12271795-n
   partOfSpeech: n
+  wikidata: Q14565066
 12271795-n:
   definition:
   - tufted evergreen perennial herb having spikes of tiny white flowers and glossy
@@ -39665,6 +40403,7 @@
   mero_member:
   - 12272257-n
   partOfSpeech: n
+  wikidata: Q9064979
 12272257-n:
   definition:
   - creeping evergreen shrub having narrow overlapping leaves and early white star-shaped
@@ -39690,6 +40429,7 @@
   mero_member:
   - 12272685-n
   partOfSpeech: n
+  wikidata: Q1681735
 12272685-n:
   definition:
   - any plant of the genus Shortia; evergreen perennial herbs with smooth leathery
@@ -39728,6 +40468,7 @@
   - 12274995-n
   - 12275603-n
   partOfSpeech: n
+  wikidata: Q2333338
 12273383-n:
   definition:
   - any heathlike plant of the family Epacridaceae; most are of the Australian region
@@ -39748,6 +40489,7 @@
   mero_member:
   - 12273746-n
   partOfSpeech: n
+  wikidata: Q2589976
 12273746-n:
   definition:
   - any heathlike evergreen shrub of the genus Epacris grown for their showy and crowded
@@ -39806,6 +40548,7 @@
   mero_member:
   - 12274685-n
   partOfSpeech: n
+  wikidata: Q218908
 12274685-n:
   definition:
   - small prostrate or ascending shrub having scarlet flowers and succulent fruit
@@ -39834,6 +40577,7 @@
   - 12275184-n
   - 12275408-n
   partOfSpeech: n
+  wikidata: Q2593020
 12275184-n:
   definition:
   - stout Australian shrub with narrow leaves crowded at ends of branches and terminal
@@ -39870,6 +40614,7 @@
   mero_member:
   - 12275742-n
   partOfSpeech: n
+  wikidata: Q73917
 12275742-n:
   definition:
   - heathlike shrub of southwestern Australia grown for its sharply scented foliage
@@ -39892,6 +40637,7 @@
   - Lennoaceae
   - family Lennoaceae
   partOfSpeech: n
+  wikidata: Q14302093
 12276176-n:
   definition:
   - 'evergreen herbs of temperate regions: genera Pyrola, Chimaphila, Moneses, Orthilia'
@@ -39908,6 +40654,7 @@
   - 12277860-n
   - 12278437-n
   partOfSpeech: n
+  wikidata: Q49733
 12276451-n:
   definition:
   - 'short-stemmed perennial herbs of cool or temperate regions: wintergreen; shinleaf'
@@ -39919,6 +40666,7 @@
   mero_member:
   - 12276629-n
   partOfSpeech: n
+  wikidata: Q157528
 12276629-n:
   definition:
   - any of several evergreen perennials of the genus Pyrola
@@ -39985,6 +40733,7 @@
   - Orthilia
   - genus Orthilia
   partOfSpeech: n
+  wikidata: Q1552593
 12277860-n:
   definition:
   - small genus of evergreen herbs with long creeping rootstocks and shining leaves;
@@ -39998,6 +40747,7 @@
   mero_member:
   - 12278087-n
   partOfSpeech: n
+  wikidata: Q157932
 12278087-n:
   definition:
   - any of several plants of the genus Chimaphila
@@ -40032,6 +40782,7 @@
   mero_member:
   - 12278618-n
   partOfSpeech: n
+  wikidata: Q159496
 12278618-n:
   definition:
   - delicate evergreen dwarf herb of north temperate regions having a solitary white
@@ -40061,6 +40812,7 @@
   - 12279639-n
   - 12280132-n
   partOfSpeech: n
+  wikidata: Q1411022
 12279180-n:
   definition:
   - leafless fleshy saprophytic plants; in some classifications placed in the family
@@ -40075,6 +40827,7 @@
   - 12279402-n
   - 12279833-n
   partOfSpeech: n
+  wikidata: Q133288
 12279402-n:
   definition:
   - small waxy white or pinkish-white saprophytic woodland plant having scalelike
@@ -40099,6 +40852,7 @@
   - Hypopitys
   - genus Hypopitys
   partOfSpeech: n
+  wikidata: Q15940528
 12279833-n:
   definition:
   - fleshy tawny or reddish saprophytic herb resembling the Indian pipe and growing
@@ -40124,6 +40878,7 @@
   mero_member:
   - 12280305-n
   partOfSpeech: n
+  wikidata: Q15940650
 12280305-n:
   definition:
   - a fleshy bright red saprophytic plant of the mountains of western North America
@@ -40148,6 +40903,7 @@
   - 12280725-n
   - 12301004-n
   partOfSpeech: n
+  wikidata: Q21881
 12280725-n:
   definition:
   - 'chiefly monoecious trees and shrubs: beeches, chestnuts, oaks; genera Castanea,
@@ -40168,6 +40924,7 @@
   - 12286417-n
   - 12288613-n
   partOfSpeech: n
+  wikidata: Q145977
 12281110-n:
   definition:
   - beeches
@@ -40185,6 +40942,7 @@
   - 12282535-n
   - 12282702-n
   partOfSpeech: n
+  wikidata: Q25403
 12281316-n:
   definition:
   - any of several large deciduous trees with rounded spreading crowns and smooth
@@ -40289,6 +41047,7 @@
   - 12284255-n
   - 12284504-n
   partOfSpeech: n
+  wikidata: Q129324
 12283070-n:
   definition:
   - any of several attractive deciduous trees yellow-brown in autumn; yield a hard
@@ -40425,6 +41184,7 @@
   - 12285303-n
   - 12285600-n
   partOfSpeech: n
+  wikidata: Q137054
 12285303-n:
   definition:
   - small ornamental evergreen tree of Pacific Coast whose glossy yellow-green leaves
@@ -40515,6 +41275,7 @@
   - 12287928-n
   - 12288051-n
   partOfSpeech: n
+  wikidata: Q218274
 12286734-n:
   definition:
   - any of various beeches of the Southern Hemisphere having small usually evergreen
@@ -40651,6 +41412,7 @@
   - 12295834-n
   - 12299577-n
   partOfSpeech: n
+  wikidata: Q12004
 12288763-n:
   definition:
   - a deciduous tree of the genus Quercus; has acorns and lobed leaves
@@ -41343,6 +42105,7 @@
   - 12304059-n
   - 12304307-n
   partOfSpeech: n
+  wikidata: Q25243
 12301758-n:
   definition:
   - any betulaceous tree or shrub of the genus Betula having a thin peeling bark
@@ -41514,6 +42277,7 @@
   - 12306585-n
   - 12306714-n
   partOfSpeech: n
+  wikidata: Q25239
 12304779-n:
   definition:
   - north temperate shrubs or trees having toothed leaves and conelike fruit; bark
@@ -41650,6 +42414,7 @@
   - subfamily Carpinaceae
   - family Carpinaceae
   partOfSpeech: n
+  wikidata: Q85332884
 12307098-n:
   definition:
   - 'mostly deciduous monoecious trees or shrubs: hornbeams; sometimes placed in subfamily
@@ -41665,6 +42430,7 @@
   - 12307505-n
   - 12307712-n
   partOfSpeech: n
+  wikidata: Q158513
 12307343-n:
   definition:
   - any of several trees or shrubs of the genus Carpinus
@@ -41754,6 +42520,7 @@
   - Ostryopsis
   - genus Ostryopsis
   partOfSpeech: n
+  wikidata: Q311254
 12308939-n:
   definition:
   - used in some classification systems for the genus Corylus
@@ -41765,6 +42532,7 @@
   - subfamily Corylaceae
   - family Corylaceae
   partOfSpeech: n
+  wikidata: Q2008610
 12309115-n:
   definition:
   - 'deciduous monoecious nut-bearing shrubs of small trees: hazel; sometimes placed
@@ -41778,6 +42546,7 @@
   mero_member:
   - 12309340-n
   partOfSpeech: n
+  wikidata: Q145889
 12309340-n:
   definition:
   - any of several shrubs or small trees of the genus Corylus bearing edible nuts
@@ -41856,6 +42625,7 @@
   - 12505627-n
   - 13253910-n
   partOfSpeech: n
+  wikidata: Q21754
 12310633-n:
   definition:
   - chiefly herbaceous plants with showy flowers; some are cultivated as ornamentals
@@ -41879,6 +42649,7 @@
   - 12318520-n
   - 12319300-n
   partOfSpeech: n
+  wikidata: Q157216
 12311039-n:
   definition:
   - genus of low-growing herbs mostly of Northern Hemisphere having flowers with protruding
@@ -41892,6 +42663,7 @@
   mero_member:
   - 12311265-n
   partOfSpeech: n
+  wikidata: Q157703
 12311265-n:
   definition:
   - any of various plants of the genus Centaurium
@@ -42000,6 +42772,7 @@
   mero_member:
   - 12312980-n
   partOfSpeech: n
+  wikidata: Q3314768
 12312980-n:
   definition:
   - perennial cultivated especially as a houseplant for its fragrant bluish to dark
@@ -42026,6 +42799,7 @@
   - 12313394-n
   - 12313697-n
   partOfSpeech: n
+  wikidata: Q8962722
 12313394-n:
   definition:
   - any of various tall perennial herbs constituting the genus Frasera; widely distributed
@@ -42068,6 +42842,7 @@
   - 12315388-n
   - 12315550-n
   partOfSpeech: n
+  wikidata: Q144682
 12314240-n:
   definition:
   - any of various plants of the family Gentianaceae especially the genera Gentiana
@@ -42182,6 +42957,7 @@
   - 12316313-n
   - 12316562-n
   partOfSpeech: n
+  wikidata: Q162809
 12316313-n:
   definition:
   - gentian of eastern North America having clusters of bristly blue flowers
@@ -42297,6 +43073,7 @@
   mero_member:
   - 12318363-n
   partOfSpeech: n
+  wikidata: Q2984595
 12318363-n:
   definition:
   - any of various plants of the genus Halenia having flowers with spurred lobes
@@ -42317,6 +43094,7 @@
   mero_member:
   - 12318682-n
   partOfSpeech: n
+  wikidata: Q6801770
 12318682-n:
   definition:
   - any of various plants of the genus Sabbatia having usually pink cymose flowers;
@@ -42365,6 +43143,7 @@
   mero_member:
   - 12319475-n
   partOfSpeech: n
+  wikidata: Q163970
 12319475-n:
   definition:
   - perennial of damp places in mountains of Eurasia and North America having dull-colored
@@ -42390,6 +43169,7 @@
   mero_member:
   - 12319942-n
   partOfSpeech: n
+  wikidata: Q1068569
 12319942-n:
   definition:
   - genus of evergreen trees or shrubs; fruit is a drupe; grows in Africa through
@@ -42403,6 +43183,7 @@
   mero_member:
   - 12320157-n
   partOfSpeech: n
+  wikidata: Q2616418
 12320157-n:
   definition:
   - glabrous or pubescent evergreen shrub or tree of the genus Salvadora; twigs are
@@ -42439,6 +43220,7 @@
   - 12330367-n
   - 12330670-n
   partOfSpeech: n
+  wikidata: Q155966
 12320958-n:
   definition:
   - coextensive with the family Oleaceae; in some classifications included in the
@@ -42450,6 +43232,7 @@
   - Oleales
   - order Oleales
   partOfSpeech: n
+  wikidata: Q11798074
 12321142-n:
   definition:
   - evergreen trees and shrubs having oily one-seeded fruits
@@ -42465,6 +43248,7 @@
   - 12322130-n
   - 12322283-n
   partOfSpeech: n
+  wikidata: Q296910
 12321357-n:
   definition:
   - a tree of the genus Olea cultivated for its fruit
@@ -42543,6 +43327,7 @@
   mero_member:
   - 12322588-n
   partOfSpeech: n
+  wikidata: Q615000
 12322588-n:
   definition:
   - any of various small decorative flowering trees or shrubs of the genus Chionanthus
@@ -42574,6 +43359,7 @@
   mero_member:
   - 12323082-n
   partOfSpeech: n
+  wikidata: Q355080
 12323082-n:
   definition:
   - any plant of the genus Forestiera
@@ -42609,6 +43395,7 @@
   mero_member:
   - 12323600-n
   partOfSpeech: n
+  wikidata: Q672980
 12323600-n:
   definition:
   - any of various early blooming oleaceous shrubs of the genus Forsythia; native
@@ -42632,6 +43419,7 @@
   mero_member:
   - 12323979-n
   partOfSpeech: n
+  wikidata: Q128887
 12323979-n:
   definition:
   - any of various deciduous pinnate-leaved ornamental or timber trees of the genus
@@ -42835,6 +43623,7 @@
   mero_member:
   - 12327234-n
   partOfSpeech: n
+  wikidata: Q82014
 12327234-n:
   definition:
   - any of several shrubs and vines of the genus Jasminum chiefly native to Asia
@@ -42900,6 +43689,7 @@
   mero_member:
   - 12328273-n
   partOfSpeech: n
+  wikidata: Q753099
 12328273-n:
   definition:
   - any of various Old World shrubs having smooth entire leaves and terminal panicles
@@ -42999,6 +43789,7 @@
   mero_member:
   - 12330147-n
   partOfSpeech: n
+  wikidata: Q618810
 12330147-n:
   definition:
   - small tree of southern United States having panicles of dull white flowers followed
@@ -43023,6 +43814,7 @@
   mero_member:
   - 12330538-n
   partOfSpeech: n
+  wikidata: Q1512683
 12330538-n:
   definition:
   - evergreen shrub with white flowers and olivelike fruits
@@ -43045,6 +43837,7 @@
   mero_member:
   - 12330866-n
   partOfSpeech: n
+  wikidata: Q157449
 12330866-n:
   definition:
   - any of various plants of the genus Syringa having large panicles of usually fragrant
@@ -43171,6 +43964,7 @@
   - Haemodorum
   - genus Haemodorum
   partOfSpeech: n
+  wikidata: Q9001832
 12332922-n:
   definition:
   - genus of monocotyledonous plants with curious woolly flowers on sturdy stems above
@@ -43185,6 +43979,7 @@
   mero_member:
   - 12333245-n
   partOfSpeech: n
+  wikidata: Q1795386
 12333245-n:
   definition:
   - sedgelike spring-flowering herb having clustered flowers covered with woolly hairs;
@@ -43264,6 +44059,7 @@
   - Hamamelites
   - genus Hamamelites
   partOfSpeech: n
+  wikidata: Q2696900
 12334832-n:
   definition:
   - comprises genera Hamamelis, Corylopsis, Fothergilla, Liquidambar, Parrotia, and
@@ -43283,6 +44079,7 @@
   - 12337681-n
   - 12338128-n
   partOfSpeech: n
+  wikidata: Q148479
 12335169-n:
   definition:
   - 'deciduous shrubs or small trees: witch hazel'
@@ -43295,6 +44092,7 @@
   mero_member:
   - 12335325-n
   partOfSpeech: n
+  wikidata: Q148463
 12335325-n:
   definition:
   - any of several shrubs or trees of the genus Hamamelis; bark yields an astringent
@@ -43366,6 +44164,7 @@
   mero_member:
   - 12336516-n
   partOfSpeech: n
+  wikidata: Q1400384
 12336516-n:
   definition:
   - any of several deciduous low-growing shrubs of the genus Fothergilla having showy
@@ -43391,6 +44190,7 @@
   - 12336961-n
   - 12337089-n
   partOfSpeech: n
+  wikidata: Q183543
 12336961-n:
   definition:
   - any tree of the genus Liquidambar
@@ -43484,6 +44284,7 @@
   - Parrotiopsis
   - genus Parrotiopsis
   partOfSpeech: n
+  wikidata: Q7139851
 12338280-n:
   definition:
   - coextensive with the family Juglandaceae
@@ -43496,6 +44297,7 @@
   mero_member:
   - 12338436-n
   partOfSpeech: n
+  wikidata: Q2697385
 12338436-n:
   definition:
   - 'trees having usually edible nuts: butternuts, walnuts, hickories, pecans'
@@ -43528,6 +44330,7 @@
   - 12339721-n
   - 12339931-n
   partOfSpeech: n
+  wikidata: Q2453469
 12338895-n:
   definition:
   - any of various trees of the genus Juglans
@@ -43630,6 +44433,7 @@
   - 12342390-n
   - 12342616-n
   partOfSpeech: n
+  wikidata: Q142788
 12340527-n:
   definition:
   - American hardwood tree bearing edible nuts
@@ -43788,6 +44592,7 @@
   mero_member:
   - 12343018-n
   partOfSpeech: n
+  wikidata: Q1420126
 12343018-n:
   definition:
   - any tree of the genus Pterocarya; fruit is a small winged nutlet; Caucasus to
@@ -43837,6 +44642,7 @@
   - 12368409-n
   - 12369291-n
   partOfSpeech: n
+  wikidata: Q9371647
 12343928-n:
   definition:
   - a family of tropical trees and shrubs of the order Myrtales
@@ -43853,6 +44659,7 @@
   - 12345273-n
   - 12345610-n
   partOfSpeech: n
+  wikidata: Q44002
 12344182-n:
   definition:
   - an Indian tree of the family Combretaceae that is a source of timber and gum
@@ -43877,6 +44684,7 @@
   - 12344905-n
   - 12345075-n
   partOfSpeech: n
+  wikidata: Q1777188
 12344573-n:
   definition:
   - any of numerous shrubs or small trees of the genus Combretum having spikes of
@@ -43930,6 +44738,7 @@
   - Conocarpus
   - genus Conocarpus
   partOfSpeech: n
+  wikidata: Q260261
 12345423-n:
   definition:
   - evergreen tree or shrub with fruit resembling buttons and yielding heavy hard
@@ -43955,6 +44764,7 @@
   mero_member:
   - 12345751-n
   partOfSpeech: n
+  wikidata: Q2705317
 12345751-n:
   definition:
   - shrub to moderately large tree that grows in brackish water along the seacoasts
@@ -43979,6 +44789,7 @@
   mero_member:
   - 12346184-n
   partOfSpeech: n
+  wikidata: Q156326
 12346184-n:
   definition:
   - oleaster
@@ -43991,6 +44802,7 @@
   mero_member:
   - 12346304-n
   partOfSpeech: n
+  wikidata: Q161042
 12346304-n:
   definition:
   - any of several shrubs of the genus Elaeagnus having silver-white twigs and yellow
@@ -44089,6 +44901,7 @@
   - 12347924-n
   - 12348235-n
   partOfSpeech: n
+  wikidata: Q161929
 12347924-n:
   definition:
   - anchovy pear tree
@@ -44101,6 +44914,7 @@
   mero_member:
   - 12348045-n
   partOfSpeech: n
+  wikidata: Q5608540
 12348045-n:
   definition:
   - West Indian tree bearing edible fruit resembling mango
@@ -44127,6 +44941,7 @@
   mero_member:
   - 12348363-n
   partOfSpeech: n
+  wikidata: Q2899339
 12348363-n:
   definition:
   - tall South American tree bearing brazil nuts
@@ -44155,6 +44970,7 @@
   - 12348758-n
   - 12349537-n
   partOfSpeech: n
+  wikidata: Q156022
 12348758-n:
   definition:
   - loosestrife
@@ -44218,6 +45034,7 @@
   - 12349777-n
   - 12349990-n
   partOfSpeech: n
+  wikidata: Q775229
 12349777-n:
   definition:
   - ornamental shrub from eastern India commonly planted in the southern United States
@@ -44298,6 +45115,7 @@
   mero_member:
   - 12351104-n
   partOfSpeech: n
+  wikidata: Q165152
 12350986-n:
   definition:
   - any evergreen shrub or tree of the genus Myrtus
@@ -44330,6 +45148,7 @@
   - 12351408-n
   - 12351583-n
   partOfSpeech: n
+  wikidata: Q133541
 12351408-n:
   definition:
   - West Indian tree; source of bay rum
@@ -44382,6 +45201,7 @@
   - 12352547-n
   - 12352735-n
   partOfSpeech: n
+  wikidata: Q975998
 12352172-n:
   definition:
   - Australian tree with sour red fruit
@@ -44439,6 +45259,7 @@
   mero_member:
   - 12353072-n
   partOfSpeech: n
+  wikidata: Q83638494
 12353072-n:
   definition:
   - South American shrub having edible greenish plumlike fruit
@@ -44461,6 +45282,7 @@
   - Jambos
   - genus Jambos
   partOfSpeech: n
+  wikidata: Q87289773
 12353383-n:
   definition:
   - a genus of tropical American trees and shrubs of the myrtle family
@@ -44505,6 +45327,7 @@
   - 12354047-n
   - 12354288-n
   partOfSpeech: n
+  wikidata: Q320179
 12354047-n:
   definition:
   - small tropical American shrubby tree; widely cultivated in warm regions for its
@@ -44590,6 +45413,7 @@
   mero_member:
   - 12355408-n
   partOfSpeech: n
+  wikidata: Q45669
 12355408-n:
   definition:
   - a tree of the genus Eucalyptus
@@ -44938,6 +45762,7 @@
   mero_member:
   - 12360719-n
   partOfSpeech: n
+  wikidata: Q204564
 12360719-n:
   definition:
   - 'tupelos: deciduous trees of moist habitats especially swamps and beside ponds'
@@ -44950,6 +45775,7 @@
   mero_member:
   - 12360900-n
   partOfSpeech: n
+  wikidata: Q964952
 12360900-n:
   definition:
   - any of several gum trees of swampy areas of North America
@@ -45026,6 +45852,7 @@
   mero_member:
   - 12362059-n
   partOfSpeech: n
+  wikidata: Q158100
 12362059-n:
   definition:
   - any of several erect perennial rhizomatous herbs of the genus Circaea having white
@@ -45070,6 +45897,7 @@
   - 12363015-n
   - 12363369-n
   partOfSpeech: n
+  wikidata: Q157637
 12362816-n:
   definition:
   - a plant of the genus Epilobium having pink or yellow flowers and seeds with silky
@@ -45131,6 +45959,7 @@
   mero_member:
   - 12363997-n
   partOfSpeech: n
+  wikidata: Q161066
 12363997-n:
   definition:
   - any of various tropical shrubs widely cultivated for their showy drooping purplish
@@ -45246,6 +46075,7 @@
   mero_member:
   - 12365797-n
   partOfSpeech: n
+  wikidata: Q4959355
 12365797-n:
   definition:
   - shrub or small tree native to southwestern Asia having large red many-seeded fruit
@@ -45272,6 +46102,7 @@
   mero_member:
   - 12366226-n
   partOfSpeech: n
+  wikidata: Q740873
 12366226-n:
   definition:
   - type genus of the Rhizophoraceae; a small genus of tropical trees and shrubs
@@ -45284,6 +46115,7 @@
   mero_member:
   - 12366416-n
   partOfSpeech: n
+  wikidata: Q131521
 12366416-n:
   definition:
   - a tropical tree or shrub bearing fruit that germinates while still on the tree
@@ -45312,6 +46144,7 @@
   - 12366965-n
   - 12368007-n
   partOfSpeech: n
+  wikidata: Q156109
 12366965-n:
   definition:
   - usually evergreen Eurasian shrubs
@@ -45323,6 +46156,7 @@
   mero_member:
   - 12367095-n
   partOfSpeech: n
+  wikidata: Q122990
 12367095-n:
   definition:
   - any of several ornamental shrubs with shiny mostly evergreen leaves and clusters
@@ -45391,6 +46225,7 @@
   mero_member:
   - 12368156-n
   partOfSpeech: n
+  wikidata: Q3487223
 12368156-n:
   definition:
   - deciduous shrub of eastern North America having tough flexible branches and pliable
@@ -45432,6 +46267,7 @@
   mero_member:
   - 12368811-n
   partOfSpeech: n
+  wikidata: Q2487780
 12368811-n:
   definition:
   - a plant of the genus Trapa bearing spiny four-pronged edible nutlike fruits
@@ -45485,6 +46321,7 @@
   - 12370008-n
   - 12370433-n
   partOfSpeech: n
+  wikidata: Q648380
 12369608-n:
   definition:
   - type genus of Melastomataceae; Asiatic shrubs with leathery leaves and large purple
@@ -45496,6 +46333,7 @@
   - Melastoma
   - genus Melastoma
   partOfSpeech: n
+  wikidata: Q2464325
 12369832-n:
   definition:
   - evergreen spreading shrub of India and southeastern Asia having large purple flowers
@@ -45519,6 +46357,7 @@
   mero_member:
   - 12370228-n
   partOfSpeech: n
+  wikidata: Q1100242
 12370228-n:
   definition:
   - a beautiful tropical evergreen epiphytic shrub grown for its lush foliage and
@@ -45542,6 +46381,7 @@
   mero_member:
   - 12370549-n
   partOfSpeech: n
+  wikidata: Q7320496
 12370549-n:
   definition:
   - any of several plants of the genus Rhexia usually having pink-purple to magenta
@@ -45569,6 +46409,7 @@
   - 12374585-n
   - 12375837-n
   partOfSpeech: n
+  wikidata: Q99438741
 12370950-n:
   definition:
   - coextensive with the genus Canna
@@ -45581,6 +46422,7 @@
   mero_member:
   - 12371095-n
   partOfSpeech: n
+  wikidata: Q160012
 12371095-n:
   definition:
   - 'type and sole genus of the Cannaceae: perennial lily-like herbs of New World
@@ -45593,6 +46435,7 @@
   mero_member:
   - 12371275-n
   partOfSpeech: n
+  wikidata: Q161182
 12371275-n:
   definition:
   - any plant of the genus Canna having large sheathing leaves and clusters of large
@@ -45653,6 +46496,7 @@
   mero_member:
   - 12372117-n
   partOfSpeech: n
+  wikidata: Q1342315
 12372117-n:
   definition:
   - any of numerous herbs of the genus Maranta having tuberous starchy roots and large
@@ -45689,6 +46533,7 @@
   - 12372667-n
   - 12374121-n
   partOfSpeech: n
+  wikidata: Q156525
 12372667-n:
   definition:
   - 'type genus of the Musaceae: bananas'
@@ -45701,6 +46546,7 @@
   mero_member:
   - 12372804-n
   partOfSpeech: n
+  wikidata: Q8666090
 12372804-n:
   definition:
   - any of several tropical and subtropical treelike herbs of the genus Musa having
@@ -45818,6 +46664,7 @@
   - 12374891-n
   - 12375366-n
   partOfSpeech: n
+  wikidata: Q147867
 12374891-n:
   definition:
   - small genus of large perennial evergreen herbs having leaves resembling those
@@ -45831,6 +46678,7 @@
   mero_member:
   - 12375136-n
   partOfSpeech: n
+  wikidata: Q147888
 12375136-n:
   definition:
   - ornamental plant of tropical South Africa and South America having stalks of orange
@@ -45853,6 +46701,7 @@
   mero_member:
   - 12375540-n
   partOfSpeech: n
+  wikidata: Q932196
 12375540-n:
   definition:
   - giant treelike plant having edible nuts and leafstalks that yield a refreshing
@@ -45897,6 +46746,7 @@
   mero_member:
   - 12376277-n
   partOfSpeech: n
+  wikidata: Q163563
 12376277-n:
   definition:
   - perennial plants having thick branching aromatic rhizomes and leafy reedlike stems
@@ -45935,6 +46785,7 @@
   mero_member:
   - 12376912-n
   partOfSpeech: n
+  wikidata: Q33551
 12376912-n:
   definition:
   - widely cultivated tropical plant of India having yellow flowers and a large aromatic
@@ -45968,6 +46819,7 @@
   - 12377860-n
   - 12378002-n
   partOfSpeech: n
+  wikidata: Q150572
 12377477-n:
   definition:
   - southeastern Asian perennial with aromatic roots
@@ -46028,6 +46880,7 @@
   mero_member:
   - 12378485-n
   partOfSpeech: n
+  wikidata: Q2607361
 12378485-n:
   definition:
   - West African plant bearing pungent peppery seeds
@@ -46053,6 +46906,7 @@
   mero_member:
   - 12378810-n
   partOfSpeech: n
+  wikidata: Q312218
 12378810-n:
   definition:
   - rhizomatous herb of India having aromatic seeds used as seasoning
@@ -46120,6 +46974,7 @@
   - 12407718-n
   - 12949821-n
   partOfSpeech: n
+  wikidata: Q99394804
 12380095-n:
   definition:
   - used in some classifications; coextensive with Parietales
@@ -46130,6 +46985,7 @@
   - Guttiferales
   - order Guttiferales
   partOfSpeech: n
+  wikidata: Q2279424
 12380251-n:
   definition:
   - monoecious succulent herbs or shrubs of tropical and warm regions especially America
@@ -46143,6 +46999,7 @@
   mero_member:
   - 12380469-n
   partOfSpeech: n
+  wikidata: Q161189
 12380469-n:
   definition:
   - large genus of tropical succulent plants widely cultivated
@@ -46154,6 +47011,7 @@
   mero_member:
   - 12380625-n
   partOfSpeech: n
+  wikidata: Q158617
 12380625-n:
   definition:
   - any of numerous plants of the genus Begonia grown for their attractive glossy
@@ -46312,6 +47170,7 @@
   - 12383627-n
   - 12384097-n
   partOfSpeech: n
+  wikidata: Q756019
 12383627-n:
   definition:
   - East Indian and Australian shrubs and trees having panicles of large white or
@@ -46324,6 +47183,7 @@
   mero_member:
   - 12383818-n
   partOfSpeech: n
+  wikidata: Q138842
 12383818-n:
   definition:
   - any of several evergreen trees or shrubs of the genus Dillenia grown for their
@@ -46348,6 +47208,7 @@
   mero_member:
   - 12384285-n
   partOfSpeech: n
+  wikidata: Q2709465
 12384285-n:
   definition:
   - any of several Australasian evergreen vines widely cultivated in warm regions
@@ -46397,6 +47258,7 @@
   - 12385802-n
   - 12385979-n
   partOfSpeech: n
+  wikidata: Q2697391
 12385121-n:
   definition:
   - any of several East Indian trees of the genus Calophyllum having shiny leathery
@@ -46476,6 +47338,7 @@
   - 12386703-n
   - 12386830-n
   partOfSpeech: n
+  wikidata: Q765930
 12386417-n:
   definition:
   - an aromatic tree of the genus Clusia having large white or yellow or pink flowers
@@ -46530,6 +47393,7 @@
   - 12387192-n
   - 12387387-n
   partOfSpeech: n
+  wikidata: Q311454
 12387192-n:
   definition:
   - East Indian tree with thick leathery leaves and edible fruit
@@ -46569,6 +47433,7 @@
   - Hypericaceae
   - family Hypericaceae
   partOfSpeech: n
+  wikidata: Q158185
 12387823-n:
   definition:
   - large almost cosmopolitan genus of evergreen or deciduous shrubs and herbs with
@@ -46583,6 +47448,7 @@
   mero_member:
   - 12388128-n
   partOfSpeech: n
+  wikidata: Q156935
 12388128-n:
   definition:
   - any of numerous plants of the genus Hypericum having yellow flowers and transparently
@@ -46749,6 +47615,7 @@
   mero_member:
   - 12391066-n
   partOfSpeech: n
+  wikidata: Q3237856
 12391066-n:
   definition:
   - handsome East Indian evergreen tree often planted as an ornamental for its fragrant
@@ -46847,6 +47714,7 @@
   mero_member:
   - 12392641-n
   partOfSpeech: n
+  wikidata: Q131304
 12392641-n:
   definition:
   - a genus containing the species Canella winterana (Canella)
@@ -46858,6 +47726,7 @@
   mero_member:
   - 12392750-n
   partOfSpeech: n
+  wikidata: Q14550679
 12392750-n:
   definition:
   - large evergreen shrub or small tree having white aromatic bark and leathery leaves
@@ -46913,6 +47782,7 @@
   mero_member:
   - 12393617-n
   partOfSpeech: n
+  wikidata: Q1752510
 12393617-n:
   definition:
   - tropical American shrub or small tree having huge deeply palmately cleft leaves
@@ -46942,6 +47812,7 @@
   mero_member:
   - 12394043-n
   partOfSpeech: n
+  wikidata: Q131345
 12394043-n:
   definition:
   - type genus of the Caryocaraceae; South American trees yielding strong fine-grained
@@ -47061,6 +47932,7 @@
   mero_member:
   - 12396035-n
   partOfSpeech: n
+  wikidata: Q162895
 12396035-n:
   definition:
   - any plant of the genus Helianthemum; vigorous plants of stony alpine meadows and
@@ -47122,6 +47994,7 @@
   - 12397070-n
   - 12397257-n
   partOfSpeech: n
+  wikidata: Q3137293
 12397070-n:
   definition:
   - North American decumbent evergreen heathlike plant with yellow flowers
@@ -47160,6 +48033,7 @@
   - 12397715-n
   - 12397845-n
   partOfSpeech: n
+  wikidata: Q580593
 12397715-n:
   definition:
   - tree of the family Dipterocarpaceae
@@ -47181,6 +48055,7 @@
   mero_member:
   - 12398011-n
   partOfSpeech: n
+  wikidata: Q132419
 12398011-n:
   definition:
   - valuable Philippine timber tree
@@ -47221,6 +48096,7 @@
   - 12401114-n
   - 12401443-n
   partOfSpeech: n
+  wikidata: Q778168
 12398597-n:
   definition:
   - often spiny trees or shrubs of tropical Asia and Africa
@@ -47233,6 +48109,7 @@
   mero_member:
   - 12398766-n
   partOfSpeech: n
+  wikidata: Q610295
 12398766-n:
   definition:
   - small shrubby tree of Madagascar cultivated in tropical regions as a hedge plant
@@ -47261,6 +48138,7 @@
   - 12399270-n
   - 12399480-n
   partOfSpeech: n
+  wikidata: Q611140
 12399270-n:
   definition:
   - vigorous South African spiny shrub grown for its round yellow juicy edible fruits
@@ -47310,6 +48188,7 @@
   - 12400048-n
   - 12400298-n
   partOfSpeech: n
+  wikidata: Q2234756
 12400048-n:
   definition:
   - East Indian tree with oily seeds yield chaulmoogra oil used to treat leprosy
@@ -47357,6 +48236,7 @@
   mero_member:
   - 12400822-n
   partOfSpeech: n
+  wikidata: Q1284309
 12400822-n:
   definition:
   - deciduous roundheaded Asiatic tree widely grown in mild climates as an ornamental
@@ -47382,6 +48262,7 @@
   mero_member:
   - 12401278-n
   partOfSpeech: n
+  wikidata: Q9017548
 12401278-n:
   definition:
   - large much-branched shrub grown primarily for its evergreen foliage
@@ -47403,6 +48284,7 @@
   mero_member:
   - 12401612-n
   partOfSpeech: n
+  wikidata: Q5222959
 12401612-n:
   definition:
   - shrub or small tree grown as an ornamental in mild climates for its neat evergreen
@@ -47427,6 +48309,7 @@
   mero_member:
   - 12402183-n
   partOfSpeech: n
+  wikidata: Q1209796
 12402028-n:
   definition:
   - any of several resinous trees or shrubs often burned for light
@@ -47493,6 +48376,7 @@
   mero_member:
   - 12403216-n
   partOfSpeech: n
+  wikidata: Q133319
 12403216-n:
   definition:
   - type genus of Ochnaceae; evergreen trees and shrubs of Old World tropics
@@ -47505,6 +48389,7 @@
   mero_member:
   - 12403392-n
   partOfSpeech: n
+  wikidata: Q573859
 12403392-n:
   definition:
   - shrub with narrow-elliptic glossy evergreen leaves and yellow flowers with leathery
@@ -47529,6 +48414,7 @@
   mero_member:
   - 12403773-n
   partOfSpeech: n
+  wikidata: Q157164
 12403773-n:
   definition:
   - type genus of the Passifloraceae
@@ -47541,6 +48427,7 @@
   mero_member:
   - 12403919-n
   partOfSpeech: n
+  wikidata: Q161185
 12403919-n:
   definition:
   - any of various chiefly tropical American vines some bearing edible fruit
@@ -47678,6 +48565,7 @@
   - 12406083-n
   - 12406347-n
   partOfSpeech: n
+  wikidata: Q161061
 12405946-n:
   definition:
   - any plant of the genus Reseda
@@ -47727,6 +48615,7 @@
   - 12406780-n
   - 12407241-n
   partOfSpeech: n
+  wikidata: Q161244
 12406780-n:
   definition:
   - genus of deciduous shrubs or small trees of eastern Mediterranean regions and
@@ -47740,6 +48629,7 @@
   mero_member:
   - 12406979-n
   partOfSpeech: n
+  wikidata: Q164163
 12406979-n:
   definition:
   - any shrub or small tree of the genus Tamarix having small scalelike or needle-shaped
@@ -47802,6 +48692,7 @@
   - 12411628-n
   - 12411797-n
   partOfSpeech: n
+  wikidata: Q156060
 12407995-n:
   definition:
   - large genus of flowering herbs of temperate regions
@@ -47814,6 +48705,7 @@
   mero_member:
   - 12408150-n
   partOfSpeech: n
+  wikidata: Q146095
 12408150-n:
   definition:
   - any of the numerous plants of the genus Viola
@@ -48027,6 +48919,7 @@
   - Hybanthus
   - genus Hybanthus
   partOfSpeech: n
+  wikidata: Q3309645
 12411628-n:
   definition:
   - a genus of slender evergreen shrubs; grow in Australia and New Zealand
@@ -48037,6 +48930,7 @@
   - Hymenanthera
   - genus Hymenanthera
   partOfSpeech: n
+  wikidata: Q3015095
 12411797-n:
   definition:
   - a genus of deciduous shrubs or trees; fruit is a berry; grow in New Zealand and
@@ -48085,6 +48979,7 @@
   - 12415378-n
   - 12416234-n
   partOfSpeech: n
+  wikidata: Q156332
 12412587-n:
   definition:
   - any of numerous plants having stinging hairs that cause skin irritation on contact
@@ -48108,6 +49003,7 @@
   - 12413066-n
   - 12413282-n
   partOfSpeech: n
+  wikidata: Q121671
 12413066-n:
   definition:
   - perennial Eurasian nettle established in North America having broad coarsely toothed
@@ -48142,6 +49038,7 @@
   - 12413603-n
   - 12413786-n
   partOfSpeech: n
+  wikidata: Q2130176
 12413603-n:
   definition:
   - any of several flowering weeds of the genus Boehmeria lacking stinging hairs
@@ -48180,6 +49077,7 @@
   mero_member:
   - 12414240-n
   partOfSpeech: n
+  wikidata: Q2706200
 12414240-n:
   definition:
   - prostrate or creeping Corsican herb with moss-like small round short-stemmed leaves
@@ -48206,6 +49104,7 @@
   - 12414635-n
   - 12414845-n
   partOfSpeech: n
+  wikidata: Q139118
 12414635-n:
   definition:
   - American perennial herb found in rich woods and provided with stinging hairs;
@@ -48240,6 +49139,7 @@
   mero_member:
   - 12415155-n
   partOfSpeech: n
+  wikidata: Q163536
 12415155-n:
   definition:
   - herb that grows in crevices having long narrow leaves and small pink apetalous
@@ -48267,6 +49167,7 @@
   - 12415806-n
   - 12415980-n
   partOfSpeech: n
+  wikidata: Q7222652
 12415585-n:
   definition:
   - a plants of the genus Pilea having drooping green flower clusters and smooth translucent
@@ -48317,6 +49218,7 @@
   - 12416423-n
   - 12416608-n
   partOfSpeech: n
+  wikidata: Q374148
 12416423-n:
   definition:
   - Australian plant of genus Pipturus whose fiber is used in making cloth
@@ -48354,6 +49256,7 @@
   - 12417183-n
   - 12418099-n
   partOfSpeech: n
+  wikidata: Q156338
 12417183-n:
   definition:
   - 'hemp: genus of coarse annuals native to central Asia and widely naturalized in
@@ -48366,6 +49269,7 @@
   mero_member:
   - 12417441-n
   partOfSpeech: n
+  wikidata: Q79817
 12417441-n:
   definition:
   - any plant of the genus Cannabis; a coarse bushy annual with palmate leaves and
@@ -48498,6 +49402,7 @@
   mero_member:
   - 12419637-n
   partOfSpeech: n
+  wikidata: Q44789
 12419637-n:
   definition:
   - any of several trees of the genus Morus having edible fruit that resembles the
@@ -48637,6 +49542,7 @@
   - 12422556-n
   - 12424018-n
   partOfSpeech: n
+  wikidata: Q59798
 12421840-n:
   definition:
   - any moraceous tree of the tropical genus Ficus; produces a closed pear-shaped
@@ -48786,6 +49692,7 @@
   mero_member:
   - 12424499-n
   partOfSpeech: n
+  wikidata: Q600114
 12424499-n:
   definition:
   - shrubby Asiatic tree having bark (tapa) that resembles cloth; grown as a shade
@@ -48810,6 +49717,7 @@
   mero_member:
   - 12424989-n
   partOfSpeech: n
+  wikidata: Q2801817
 12424989-n:
   definition:
   - large genus of tropical American trees that yield a bast fiber used for cordage
@@ -48823,6 +49731,7 @@
   mero_member:
   - 12425234-n
   partOfSpeech: n
+  wikidata: Q414264
 12425234-n:
   definition:
   - tropical American tree with large peltate leaves and hollow stems
@@ -48855,6 +49764,7 @@
   - 12430537-n
   - 12430710-n
   partOfSpeech: n
+  wikidata: Q156311
 12425714-n:
   definition:
   - type genus of family Ulmaceae; deciduous trees having simple serrate leaves; widely
@@ -48883,6 +49793,7 @@
   - 12429222-n
   - 12429378-n
   partOfSpeech: n
+  wikidata: Q131113
 12426219-n:
   definition:
   - 'any of various trees of the genus Ulmus: important timber or shade trees'
@@ -49092,6 +50003,7 @@
   - 12430156-n
   - 12430345-n
   partOfSpeech: n
+  wikidata: Q248582
 12429736-n:
   definition:
   - any of various trees of the genus Celtis having inconspicuous flowers and small
@@ -49160,6 +50072,7 @@
   - Trema
   - genus Trema
   partOfSpeech: n
+  wikidata: Q945999
 12430886-n:
   definition:
   - 'one of four subclasses or superorders of Monocotyledones; comprises 17 families
@@ -49198,6 +50111,7 @@
   - 12495955-n
   - 12496541-n
   partOfSpeech: n
+  wikidata: Q53478
 12431589-n:
   definition:
   - large family of usually perennial geophytic herbs with rhizomes or corms or bulbs
@@ -49218,6 +50132,7 @@
   - 12438570-n
   - 12438861-n
   partOfSpeech: n
+  wikidata: Q155941
 12431966-n:
   definition:
   - any bulbous plant of the family Iridaceae
@@ -49242,6 +50157,7 @@
   - 12433111-n
   - 12433355-n
   partOfSpeech: n
+  wikidata: Q156901
 12432427-n:
   definition:
   - plants with sword-shaped leaves and erect stalks bearing bright-colored flowers
@@ -49497,6 +50413,7 @@
   mero_member:
   - 12436578-n
   partOfSpeech: n
+  wikidata: Q19286980
 12436578-n:
   definition:
   - garden plant whose capsule discloses when ripe a mass of seeds resembling a blackberry
@@ -49520,6 +50437,7 @@
   mero_member:
   - 12436928-n
   partOfSpeech: n
+  wikidata: Q157806
 12436928-n:
   definition:
   - any of numerous low-growing plants of the genus Crocus having slender grasslike
@@ -49556,6 +50474,7 @@
   mero_member:
   - 12437567-n
   partOfSpeech: n
+  wikidata: Q157392
 12437567-n:
   definition:
   - any of several plants of the genus Freesia valued for their one-sided clusters
@@ -49577,6 +50496,7 @@
   mero_member:
   - 12437887-n
   partOfSpeech: n
+  wikidata: Q156207
 12437887-n:
   definition:
   - any of numerous plants of the genus Gladiolus native chiefly to tropical and South
@@ -49604,6 +50524,7 @@
   mero_member:
   - 12438341-n
   partOfSpeech: n
+  wikidata: Q134748
 12438341-n:
   definition:
   - any of several South African plants of the genus Ixia having grasslike leaves
@@ -49626,6 +50547,7 @@
   mero_member:
   - 12438726-n
   partOfSpeech: n
+  wikidata: Q2357709
 12438726-n:
   definition:
   - plant with grasslike foliage and delicate blue flowers
@@ -49647,6 +50569,7 @@
   mero_member:
   - 12439012-n
   partOfSpeech: n
+  wikidata: Q124864
 12439012-n:
   definition:
   - a showy often-cultivated plant with tawny yellow often purple-spotted flowers
@@ -49677,6 +50600,7 @@
   - 12441839-n
   - 12442904-n
   partOfSpeech: n
+  wikidata: Q155848
 12439542-n:
   definition:
   - bulbous plant having showy white to reddish flowers
@@ -49697,6 +50621,7 @@
   mero_member:
   - 12439899-n
   partOfSpeech: n
+  wikidata: Q161577
 12439899-n:
   definition:
   - amaryllis of South Africa often cultivated for its fragrant white or rose flowers
@@ -49722,6 +50647,7 @@
   - 12440383-n
   - 12440629-n
   partOfSpeech: n
+  wikidata: Q891753
 12440383-n:
   definition:
   - tropical vine having pink-and-yellow flowers spotted purple and edible roots sometimes
@@ -49792,6 +50718,7 @@
   mero_member:
   - 12441642-n
   partOfSpeech: n
+  wikidata: Q757257
 12441642-n:
   definition:
   - amaryllis of tropical America often cultivated as a houseplant for its showy white
@@ -49814,6 +50741,7 @@
   mero_member:
   - 12441972-n
   partOfSpeech: n
+  wikidata: Q29465
 12441972-n:
   definition:
   - bulbous plant having erect linear leaves and showy yellow or white flowers either
@@ -49878,6 +50806,7 @@
   mero_member:
   - 12443064-n
   partOfSpeech: n
+  wikidata: Q159042
 12443064-n:
   definition:
   - Mexican bulbous herb cultivated for its handsome bright red solitary flower
@@ -49901,6 +50830,7 @@
   mero_member:
   - 12443436-n
   partOfSpeech: n
+  wikidata: Q131282
 12443436-n:
   definition:
   - 'small plants that resemble amaryllis and that grow from a corm and bear flowers
@@ -49915,6 +50845,7 @@
   mero_member:
   - 12443716-n
   partOfSpeech: n
+  wikidata: Q4308690
 12443716-n:
   definition:
   - 'any plant of the genus Hypoxis having long grasslike leaves and yellow star-shaped
@@ -50018,6 +50949,7 @@
   - 12494511-n
   - 12495125-n
   partOfSpeech: n
+  wikidata: Q53480
 12445786-n:
   definition:
   - plant growing from a bulb or corm or rhizome or tuber
@@ -50040,6 +50972,7 @@
   - 12446753-n
   - 12447128-n
   partOfSpeech: n
+  wikidata: Q5194627
 12446753-n:
   definition:
   - any liliaceous plant of the genus Lilium having showy pendulous flowers
@@ -50217,6 +51150,7 @@
   - 12449653-n
   - 12449857-n
   partOfSpeech: n
+  wikidata: Q159541
 12449653-n:
   definition:
   - any of various plants of the genus Agapanthus having umbels of showy blue to purple
@@ -50253,6 +51187,7 @@
   mero_member:
   - 12450275-n
   partOfSpeech: n
+  wikidata: Q2245221
 12450275-n:
   definition:
   - any of various plants of the genus Albuca having large clusters of pale yellow
@@ -50327,6 +51262,7 @@
   - Alliaceae
   - family Alliaceae
   partOfSpeech: n
+  wikidata: Q14554991
 12451633-n:
   definition:
   - 'large genus of perennial and biennial pungent bulbous plants: garlic, leek, onion,
@@ -50342,6 +51278,7 @@
   - 12452366-n
   - 12452574-n
   partOfSpeech: n
+  wikidata: Q49391
 12451939-n:
   definition:
   - bulbous plants having a characteristic pungent onion odor
@@ -50669,6 +51606,7 @@
   - family Aloeaceae
   - aloe family
   partOfSpeech: n
+  wikidata: Q1806950
 12456995-n:
   definition:
   - large genus of chiefly African liliaceous plants; in some systems placed in family
@@ -50681,6 +51619,7 @@
   mero_member:
   - 12457182-n
   partOfSpeech: n
+  wikidata: Q127134
 12457182-n:
   definition:
   - succulent plants having rosettes of leaves usually with fiber like hemp and spikes
@@ -50726,6 +51665,7 @@
   mero_member:
   - 12458018-n
   partOfSpeech: n
+  wikidata: Q157905
 12458018-n:
   definition:
   - a plant of the genus Kniphofia having long grasslike leaves and tall scapes of
@@ -50773,6 +51713,7 @@
   - Alstroemeriaceae
   - family Alstroemeriaceae
   partOfSpeech: n
+  wikidata: Q660752
 12458829-n:
   definition:
   - genus of showy South American herbs with leafy stems; sometimes placed in family
@@ -50786,6 +51727,7 @@
   - 12459076-n
   - 12459288-n
   partOfSpeech: n
+  wikidata: Q917833
 12459076-n:
   definition:
   - any of various South American plants of the genus Alstroemeria valued for their
@@ -50820,6 +51762,7 @@
   mero_member:
   - 12459659-n
   partOfSpeech: n
+  wikidata: Q16868575
 12459659-n:
   definition:
   - all parts of plant are highly toxic; bulb pounded and used as a fly poison; sometimes
@@ -50846,6 +51789,7 @@
   - 12460131-n
   - 12460335-n
   partOfSpeech: n
+  wikidata: Q158937
 12460131-n:
   definition:
   - southern European plant commonly cultivated for its spikes of small starry greenish-white
@@ -50881,6 +51825,7 @@
   - Aphyllanthaceae
   - family Aphyllanthaceae
   partOfSpeech: n
+  wikidata: Q13835212
 12460890-n:
   definition:
   - one species; small fibrous-rooted perennial with rushlike foliage and deep blue
@@ -50892,6 +51837,7 @@
   - Aphyllanthes
   - genus Aphyllanthes
   partOfSpeech: n
+  wikidata: Q2858279
 12461128-n:
   definition:
   - 'one of many families or subfamilies into which some classification systems subdivide
@@ -50903,6 +51849,7 @@
   - Asparagaceae
   - family Asparagaceae
   partOfSpeech: n
+  wikidata: Q157167
 12461374-n:
   definition:
   - large genus of Old World perennial herbs with erect or spreading or climbing stems
@@ -50918,6 +51865,7 @@
   - 12461895-n
   - 12462057-n
   partOfSpeech: n
+  wikidata: Q2853420
 12461688-n:
   definition:
   - plant whose succulent young shoots are cooked and eaten as a vegetable
@@ -50965,6 +51913,7 @@
   - Asphodelaceae
   - family Asphodelaceae
   partOfSpeech: n
+  wikidata: Q14554941
 12462463-n:
   definition:
   - any of various chiefly Mediterranean plants of the genera Asphodeline and Asphodelus
@@ -51023,6 +51972,7 @@
   - Asphodelus
   - genus Asphodelus
   partOfSpeech: n
+  wikidata: Q382873
 12463649-n:
   definition:
   - genus of eastern Asiatic herbs; sometimes placed in the family Convallariaceae
@@ -51034,6 +51984,7 @@
   mero_member:
   - 12463828-n
   partOfSpeech: n
+  wikidata: Q1429377
 12463828-n:
   definition:
   - evergreen perennial with large handsome basal leaves; grown primarily as a foliage
@@ -51059,6 +52010,7 @@
   mero_member:
   - 12464241-n
   partOfSpeech: n
+  wikidata: Q2710558
 12464241-n:
   definition:
   - half-hardy Mexican herb cultivated for its drooping terminal umbels of showy red-and-white
@@ -51082,6 +52034,7 @@
   mero_member:
   - 12464600-n
   partOfSpeech: n
+  wikidata: Q137543
 12464600-n:
   definition:
   - any of several plants of the genus Blandfordia having large orange or crimson
@@ -51105,6 +52058,7 @@
   mero_member:
   - 12464995-n
   partOfSpeech: n
+  wikidata: Q2711355
 12464995-n:
   definition:
   - California plant having grasslike leaves and showy orange flowers
@@ -51129,6 +52083,7 @@
   mero_member:
   - 12465403-n
   partOfSpeech: n
+  wikidata: Q4951022
 12465403-n:
   definition:
   - much-branched leafless twining South African herb cultivated as an ornamental
@@ -51153,6 +52108,7 @@
   - 12465892-n
   - 12466133-n
   partOfSpeech: n
+  wikidata: Q1894962
 12465892-n:
   definition:
   - any of several plants of the genus Brodiaea having basal grasslike leaves and
@@ -51195,6 +52151,7 @@
   - 12468641-n
   - 12468866-n
   partOfSpeech: n
+  wikidata: Q1288804
 12466705-n:
   definition:
   - any of several plants of the genus Calochortus having tulip-shaped flowers with
@@ -51341,6 +52298,7 @@
   - 12470289-n
   - 12470439-n
   partOfSpeech: n
+  wikidata: Q1810294
 12469801-n:
   definition:
   - any of several plants of the genus Camassia; North and South America
@@ -51400,6 +52358,7 @@
   - 12470849-n
   - 12472071-n
   partOfSpeech: n
+  wikidata: Q143756
 12470849-n:
   definition:
   - perennial woodland spring-flowering plant; widely cultivated
@@ -51494,6 +52453,7 @@
   mero_member:
   - 12472420-n
   partOfSpeech: n
+  wikidata: Q157503
 12472420-n:
   definition:
   - any liliaceous plant of the genus Fritillaria having nodding variously colored
@@ -51622,6 +52582,7 @@
   mero_member:
   - 12474664-n
   partOfSpeech: n
+  wikidata: Q93201
 12474664-n:
   definition:
   - any of numerous perennial bulbous herbs having linear or broadly lanceolate leaves
@@ -51695,6 +52656,7 @@
   - Colchicaceae
   - family Colchicaceae
   partOfSpeech: n
+  wikidata: Q186181
 12475847-n:
   definition:
   - chiefly fall-blooming perennial cormous herbs; sometimes placed in family Colchicaceae
@@ -51733,6 +52695,7 @@
   mero_member:
   - 12476455-n
   partOfSpeech: n
+  wikidata: Q1454851
 12476455-n:
   definition:
   - any plant of the genus Gloriosa of tropical Africa and Asia; a perennial herb
@@ -51759,6 +52722,7 @@
   - Hemerocallidaceae
   - family Hemerocallidaceae
   partOfSpeech: n
+  wikidata: Q10375920
 12477032-n:
   definition:
   - 'east Asian rhizomatous clump-forming perennial herbs having flowers on long leafless
@@ -51810,6 +52774,7 @@
   - Funkaceae
   - family Funkaceae
   partOfSpeech: n
+  wikidata: Q2668294
 12478024-n:
   definition:
   - 'robust east Asian clump-forming perennial herbs having racemose flowers: plantain
@@ -51825,6 +52790,7 @@
   mero_member:
   - 12478276-n
   partOfSpeech: n
+  wikidata: Q623347
 12478276-n:
   definition:
   - any of numerous perennials having mounds of sumptuous broad ribbed leaves and
@@ -51847,6 +52813,7 @@
   - Hyacinthaceae
   - family Hyacinthaceae
   partOfSpeech: n
+  wikidata: Q13833438
 12478729-n:
   definition:
   - sometimes placed in family Hyacinthaceae as the type genus
@@ -51858,6 +52825,7 @@
   mero_member:
   - 12478888-n
   partOfSpeech: n
+  wikidata: Q158758
 12478888-n:
   definition:
   - any of numerous bulbous perennial herbs
@@ -51913,6 +52881,7 @@
   mero_member:
   - 12479780-n
   partOfSpeech: n
+  wikidata: Q159311
 12479780-n:
   definition:
   - sometimes placed in genus Scilla
@@ -51939,6 +52908,7 @@
   mero_member:
   - 12480134-n
   partOfSpeech: n
+  wikidata: Q161148
 12480134-n:
   definition:
   - any of several perennial plants of the genus Ornithogalum native to the Mediterranean
@@ -51997,6 +52967,7 @@
   mero_member:
   - 12481202-n
   partOfSpeech: n
+  wikidata: Q161151
 12481202-n:
   definition:
   - any of various early flowering spring hyacinths native to Eurasia having dense
@@ -52040,6 +53011,7 @@
   mero_member:
   - 12481971-n
   partOfSpeech: n
+  wikidata: Q157238
 12481971-n:
   definition:
   - an Old World plant of the genus Scilla having narrow basal leaves and pink or
@@ -52110,6 +53082,7 @@
   mero_member:
   - 12483087-n
   partOfSpeech: n
+  wikidata: Q10388250
 12483087-n:
   definition:
   - having dense spikes of small white flowers and yielding a bulb with medicinal
@@ -52172,6 +53145,7 @@
   - Melanthiaceae
   - family Melanthiaceae
   partOfSpeech: n
+  wikidata: Q157234
 12484079-n:
   definition:
   - bog asphodels; sometimes placed in family Melanthiaceae
@@ -52228,6 +53202,7 @@
   mero_member:
   - 12484981-n
   partOfSpeech: n
+  wikidata: Q161870
 12484981-n:
   definition:
   - perennial herbs of the lily family having thick toxic rhizomes
@@ -52262,6 +53237,7 @@
   - Ruscaceae
   - family Ruscaceae
   partOfSpeech: n
+  wikidata: Q2721029
 12485612-n:
   definition:
   - a family of flowering plants, placed in the order Asparagales of the monocots,
@@ -52273,6 +53249,7 @@
   - Tecophilaeacea
   - family Tecophilaeacea
   partOfSpeech: n
+  wikidata: Q331169
 12485826-n:
   definition:
   - 'small genus of North American herbs having grasslike basal leaves: squaw grass;
@@ -52286,6 +53263,7 @@
   mero_member:
   - 12486062-n
   partOfSpeech: n
+  wikidata: Q136216
 12486062-n:
   definition:
   - plant of western North America having woody rhizomes and tufts of stiff grasslike
@@ -52325,6 +53303,7 @@
   mero_member:
   - 12486711-n
   partOfSpeech: n
+  wikidata: Q767448
 12486711-n:
   definition:
   - any of several Australian evergreen perennials having short thick woody stems
@@ -52352,6 +53331,7 @@
   - 12487938-n
   - 12488097-n
   partOfSpeech: n
+  wikidata: Q2707469
 12487232-n:
   definition:
   - any of various plants of the genus Zigadenus having glaucous leaves and terminal
@@ -52431,6 +53411,7 @@
   mero_member:
   - 12488748-n
   partOfSpeech: n
+  wikidata: Q475629
 12488748-n:
   definition:
   - any liliaceous plant of the genus Trillium having a whorl of three leaves at the
@@ -52503,6 +53484,7 @@
   mero_member:
   - 12490022-n
   partOfSpeech: n
+  wikidata: Q162121
 12490022-n:
   definition:
   - European herb with yellow-green flowers resembling and closely related to the
@@ -52540,6 +53522,7 @@
   - 12490597-n
   - 12491017-n
   partOfSpeech: n
+  wikidata: Q165315
 12490597-n:
   definition:
   - any of various prickly climbing plants of the tropical American genus Smilax having
@@ -52603,6 +53586,7 @@
   - Convallariaceae
   - family Convallariaceae
   partOfSpeech: n
+  wikidata: Q1023651
 12491871-n:
   definition:
   - 'sometimes placed in family Convallariaceae: lily of the valley'
@@ -52643,6 +53627,7 @@
   - 12493064-n
   - 12493283-n
   partOfSpeech: n
+  wikidata: Q136034
 12492529-n:
   definition:
   - any temperate liliaceous plant of the genus Clintonia having broad basal leaves
@@ -52702,6 +53687,7 @@
   mero_member:
   - 12493676-n
   partOfSpeech: n
+  wikidata: Q1065926
 12493676-n:
   definition:
   - Asiatic perennial tufted herb with grasslike evergreen foliage and clusters of
@@ -52762,6 +53748,7 @@
   mero_member:
   - 12494672-n
   partOfSpeech: n
+  wikidata: Q161152
 12494672-n:
   definition:
   - any of several plants of the genus Polygonatum having paired drooping yellowish-green
@@ -52814,6 +53801,7 @@
   - 12495540-n
   - 12495747-n
   partOfSpeech: n
+  wikidata: Q2623950
 12495540-n:
   definition:
   - any of various plants of the genus Uvularia having yellowish drooping bell-shaped
@@ -52850,6 +53838,7 @@
   mero_member:
   - 12496098-n
   partOfSpeech: n
+  wikidata: Q2630221
 12496098-n:
   definition:
   - genus of tropical plants with creeping rootstocks and small umbellate flowers
@@ -52862,6 +53851,7 @@
   mero_member:
   - 12496279-n
   partOfSpeech: n
+  wikidata: Q311670
 12496279-n:
   definition:
   - perennial herb of East Indies to Polynesia and Australia; cultivated for its large
@@ -52899,6 +53889,7 @@
   - 12501182-n
   - 12502311-n
   partOfSpeech: n
+  wikidata: Q218221
 12497015-n:
   definition:
   - tropical American plants with basal rosettes of fibrous sword-shaped leaves and
@@ -52926,6 +53917,7 @@
   - 12498252-n
   - 12498488-n
   partOfSpeech: n
+  wikidata: Q155874
 12497668-n:
   definition:
   - widely cultivated American monocarpic plant with greenish-white flowers on a tall
@@ -53013,6 +54005,7 @@
   - 12499011-n
   - 12499273-n
   partOfSpeech: n
+  wikidata: Q1543189
 12499011-n:
   definition:
   - shrub with terminal tufts of elongated leaves used locally for thatching and clothing;
@@ -53065,6 +54058,7 @@
   mero_member:
   - 12500042-n
   partOfSpeech: n
+  wikidata: Q158009
 12500042-n:
   definition:
   - an agave that is often cultivated for its decorative foliage
@@ -53096,6 +54090,7 @@
   mero_member:
   - 12500509-n
   partOfSpeech: n
+  wikidata: Q139062
 12500509-n:
   definition:
   - stemless plant with tufts of grasslike leaves and erect panicle of minute creamy
@@ -53121,6 +54116,7 @@
   mero_member:
   - 12500961-n
   partOfSpeech: n
+  wikidata: Q2346876
 12500961-n:
   definition:
   - a tuberous Mexican herb having grasslike leaves and cultivated for its spikes
@@ -53144,6 +54140,7 @@
   mero_member:
   - 12501400-n
   partOfSpeech: n
+  wikidata: Q312160
 12501400-n:
   definition:
   - grown as a houseplant for its mottled fleshy sword-shaped leaves or as a source
@@ -53213,6 +54210,7 @@
   mero_member:
   - 12502536-n
   partOfSpeech: n
+  wikidata: Q156317
 12502536-n:
   definition:
   - any of several evergreen plants of the genus Yucca having usually tall stout stems
@@ -53353,6 +54351,7 @@
   mero_member:
   - 12505117-n
   partOfSpeech: n
+  wikidata: Q161177
 12505117-n:
   definition:
   - 'the type genus of the Menyanthaceae; one species: bogbeans'
@@ -53365,6 +54364,7 @@
   mero_member:
   - 12505289-n
   partOfSpeech: n
+  wikidata: Q12179906
 12505289-n:
   definition:
   - perennial plant of Europe and America having racemes of white or purplish flowers
@@ -53396,6 +54396,7 @@
   - 12506028-n
   - 12506316-n
   partOfSpeech: n
+  wikidata: Q500842
 12505836-n:
   definition:
   - type genus of the Loganiaceae; Australian and New Zealand shrubs sometimes cultivated
@@ -53407,6 +54408,7 @@
   - Logania
   - genus Logania
   partOfSpeech: n
+  wikidata: Q1757681
 12506028-n:
   definition:
   - shrubs or trees of warm regions
@@ -53418,6 +54420,7 @@
   mero_member:
   - 12506158-n
   partOfSpeech: n
+  wikidata: Q87179161
 12506158-n:
   definition:
   - tropical shrub having clusters of white or violet or yellow flowers
@@ -53441,6 +54444,7 @@
   mero_member:
   - 12506486-n
   partOfSpeech: n
+  wikidata: Q134232
 12506486-n:
   definition:
   - poisonous woody evergreen vine of southeastern United States having fragrant yellow
@@ -53468,6 +54472,7 @@
   mero_member:
   - 12506902-n
   partOfSpeech: n
+  wikidata: Q155951
 12506902-n:
   definition:
   - a herbaceous plant genus of the family Linaceae with small sessile leaves
@@ -53480,6 +54485,7 @@
   mero_member:
   - 12507079-n
   partOfSpeech: n
+  wikidata: Q161100
 12507079-n:
   definition:
   - plant of the genus Linum that is cultivated for its seeds and for the fibers of
@@ -53502,6 +54508,7 @@
   mero_member:
   - 12507387-n
   partOfSpeech: n
+  wikidata: Q4348640
 12507387-n:
   definition:
   - tropical African woody vine yielding calabar beans
@@ -53547,6 +54554,7 @@
   - Caesalpiniaceae
   - family Caesalpiniaceae
   partOfSpeech: n
+  wikidata: Q2677138
 12508152-n:
   definition:
   - alternative name in some classification systems for the family Caesalpiniaceae
@@ -53592,6 +54600,7 @@
   - 12510559-n
   - 12519244-n
   partOfSpeech: n
+  wikidata: Q608215
 12508959-n:
   definition:
   - tropical tree with large prickly pods of seeds that resemble beans and are used
@@ -53716,6 +54725,7 @@
   mero_member:
   - 12510995-n
   partOfSpeech: n
+  wikidata: Q3279279
 12510995-n:
   definition:
   - East Indian timber tree with hard durable wood used especially for tea boxes
@@ -53740,6 +54750,7 @@
   - 12511332-n
   - 12511522-n
   partOfSpeech: n
+  wikidata: Q287313
 12511332-n:
   definition:
   - shrub or small tree of Dutch Guiana having clusters of pink flowers streaked with
@@ -53775,6 +54786,7 @@
   mero_member:
   - 12511940-n
   partOfSpeech: n
+  wikidata: Q135604
 12511940-n:
   definition:
   - small shrubby African tree having compound leaves and racemes of small fragrant
@@ -53799,6 +54811,7 @@
   mero_member:
   - 12512331-n
   partOfSpeech: n
+  wikidata: Q162882
 12512331-n:
   definition:
   - any of various trees or shrubs of the genus Cassia having pinnately compound leaves
@@ -53916,6 +54929,7 @@
   - Cercidium
   - genus Cercidium
   partOfSpeech: n
+  wikidata: Q16326803
 12514373-n:
   definition:
   - a thorny shrub of the genus Cercidium that grows in dry parts of the southwestern
@@ -53940,6 +54954,7 @@
   mero_member:
   - 12514863-n
   partOfSpeech: n
+  wikidata: Q2948035
 12514863-n:
   definition:
   - tropical American plant having leaflets somewhat sensitive to the touch; sometimes
@@ -54019,6 +55034,7 @@
   - 12516175-n
   - 12516400-n
   partOfSpeech: n
+  wikidata: Q161250
 12516175-n:
   definition:
   - honey locust of swamps and bottomlands of southern United States having short
@@ -54056,6 +55072,7 @@
   mero_member:
   - 12516932-n
   partOfSpeech: n
+  wikidata: Q429179
 12516932-n:
   definition:
   - handsome tree of central and eastern North America having large bipinnate leaves
@@ -54126,6 +55143,7 @@
   - 12518174-n
   - 12518560-n
   partOfSpeech: n
+  wikidata: Q1826576
 12518174-n:
   definition:
   - large shrub or shrubby tree having sharp spines and pinnate leaves with small
@@ -54203,6 +55221,7 @@
   - 12520814-n
   - 12521023-n
   partOfSpeech: n
+  wikidata: Q311117
 12519668-n:
   definition:
   - any of various plants of the genus Senna having pinnately compound leaves and
@@ -54316,6 +55335,7 @@
   mero_member:
   - 12521707-n
   partOfSpeech: n
+  wikidata: Q14566708
 12521707-n:
   definition:
   - long-lived tropical evergreen tree with a spreading crown and feathery evergreen
@@ -54344,6 +55364,7 @@
   - Papilionaceae
   - family Papilionacea
   partOfSpeech: n
+  wikidata: Q2615411
 12522250-n:
   definition:
   - alternative name used in some classification systems for the family Papilionaceae
@@ -54470,6 +55491,7 @@
   mero_member:
   - 12524599-n
   partOfSpeech: n
+  wikidata: Q1318931
 12524599-n:
   definition:
   - any plant of the genus Amorpha having odd-pinnate leaves and purplish spicate
@@ -54533,6 +55555,7 @@
   mero_member:
   - 12525758-n
   partOfSpeech: n
+  wikidata: Q3310152
 12525758-n:
   definition:
   - vine widely distributed in eastern North America producing racemes of purple to
@@ -54585,6 +55608,7 @@
   - 12526686-n
   - 12526846-n
   partOfSpeech: n
+  wikidata: Q2576870
 12526686-n:
   definition:
   - any of several tropical American trees of the genus Andira
@@ -54621,6 +55645,7 @@
   - 12527289-n
   - 12527496-n
   partOfSpeech: n
+  wikidata: Q751134
 12527289-n:
   definition:
   - silvery hairy European shrub with evergreen foliage and pale yellow flowers
@@ -54656,6 +55681,7 @@
   mero_member:
   - 12527884-n
   partOfSpeech: n
+  wikidata: Q2537603
 12527884-n:
   definition:
   - a North American vine with fragrant blossoms and edible tubers; important food
@@ -54686,6 +55712,7 @@
   mero_member:
   - 12528328-n
   partOfSpeech: n
+  wikidata: Q783956
 12528328-n:
   definition:
   - South African shrub having flat acuminate leaves and yellow flowers; leaves are
@@ -54711,6 +55738,7 @@
   mero_member:
   - 12528814-n
   partOfSpeech: n
+  wikidata: Q157184
 12528814-n:
   definition:
   - any of various plants of the genus Astragalus
@@ -54767,6 +55795,7 @@
   mero_member:
   - 12529614-n
   partOfSpeech: n
+  wikidata: Q3314278
 12529614-n:
   definition:
   - small shrubby African tree with hard wood used as a dyewood yielding a red dye
@@ -54790,6 +55819,7 @@
   mero_member:
   - 12529981-n
   partOfSpeech: n
+  wikidata: Q2698539
 12529981-n:
   definition:
   - any of several plants of the genus Baptisia
@@ -54846,6 +55876,7 @@
   mero_member:
   - 12530848-n
   partOfSpeech: n
+  wikidata: Q3322044
 12530848-n:
   definition:
   - East Indian tree bearing a profusion of intense vermilion velvet-textured blooms
@@ -54873,6 +55904,7 @@
   mero_member:
   - 12531279-n
   partOfSpeech: n
+  wikidata: Q3239959
 12531279-n:
   definition:
   - tropical woody herb with showy yellow flowers and flat pods; much cultivated in
@@ -54943,6 +55975,7 @@
   mero_member:
   - 12532361-n
   partOfSpeech: n
+  wikidata: Q849443
 12532361-n:
   definition:
   - any plant of the genus Caragana having even-pinnate leaves and mostly yellow flowers
@@ -54989,6 +56022,7 @@
   mero_member:
   - 12533179-n
   partOfSpeech: n
+  wikidata: Q10438724
 12533179-n:
   definition:
   - Australian tree having pinnate leaves and orange-yellow flowers followed by large
@@ -55038,6 +56072,7 @@
   mero_member:
   - 12534118-n
   partOfSpeech: n
+  wikidata: Q29033
 12534118-n:
   definition:
   - 'small tree of the eastern Mediterranean having abundant purplish-red flowers
@@ -55086,6 +56121,7 @@
   mero_member:
   - 12535097-n
   partOfSpeech: n
+  wikidata: Q964986
 12535097-n:
   definition:
   - shrub of Canary Islands having bristle-tipped oblanceolate leaves; used as cattle
@@ -55113,6 +56149,7 @@
   mero_member:
   - 12535497-n
   partOfSpeech: n
+  wikidata: Q5104990
 12535497-n:
   definition:
   - small shrubby tree of New Zealand having weeping branches and racemes of white
@@ -55135,6 +56172,7 @@
   mero_member:
   - 12535898-n
   partOfSpeech: n
+  wikidata: Q1306236
 12535898-n:
   definition:
   - any of several small shrubs or twining vines having entire or lobed leaves and
@@ -55218,6 +56256,7 @@
   mero_member:
   - 12537089-n
   partOfSpeech: n
+  wikidata: Q2975317
 12537089-n:
   definition:
   - any of various shrubs or vines of the genus Clianthus having compound leaves and
@@ -55268,6 +56307,7 @@
   mero_member:
   - 12537950-n
   partOfSpeech: n
+  wikidata: Q2472930
 12537950-n:
   definition:
   - large-flowered wild twining vine of southeastern and central United States having
@@ -55331,6 +56371,7 @@
   mero_member:
   - 12538986-n
   partOfSpeech: n
+  wikidata: Q157674
 12538986-n:
   definition:
   - yellow-flowered European shrub cultivated for its succession of yellow flowers
@@ -55355,6 +56396,7 @@
   - 12539384-n
   - 12539594-n
   partOfSpeech: n
+  wikidata: Q158849
 12539384-n:
   definition:
   - any of various plants of the genus Coronilla having purple or pink or yellow flowers
@@ -55391,6 +56433,7 @@
   - 12540329-n
   - 12540520-n
   partOfSpeech: n
+  wikidata: Q311148
 12540068-n:
   definition:
   - any of various plants of the genus Crotalaria having inflated pods within which
@@ -55463,6 +56506,7 @@
   - 12541691-n
   - 12541899-n
   partOfSpeech: n
+  wikidata: Q157226
 12541369-n:
   definition:
   - any of various shrubs of the genera Cytisus or Genista or Spartium having long
@@ -55529,6 +56573,7 @@
   - 12543980-n
   - 12544355-n
   partOfSpeech: n
+  wikidata: Q1370281
 12542693-n:
   definition:
   - any of those hardwood trees of the genus Dalbergia that yield rosewood — valuable
@@ -55681,6 +56726,7 @@
   mero_member:
   - 12545138-n
   partOfSpeech: n
+  wikidata: Q2716243
 12545138-n:
   definition:
   - greyish-green shrub of desert regions of southwestern United States and Mexico
@@ -55729,6 +56775,7 @@
   - 12546018-n
   - 12546258-n
   partOfSpeech: n
+  wikidata: Q1768643
 12546018-n:
   definition:
   - any of various usually woody vines of the genus Derris of tropical Asia whose
@@ -55765,6 +56812,7 @@
   mero_member:
   - 12546683-n
   partOfSpeech: n
+  wikidata: Q3466310
 12546683-n:
   definition:
   - perennial herb of North American prairies having dense heads of small white flowers
@@ -55825,6 +56873,7 @@
   mero_member:
   - 12547586-n
   partOfSpeech: n
+  wikidata: Q5280036
 12547586-n:
   definition:
   - South African evergreen partly woody vine grown for its clusters of rosy purple
@@ -55848,6 +56897,7 @@
   - Dolichos
   - genus Dolichos
   partOfSpeech: n
+  wikidata: Q526727
 12548074-n:
   definition:
   - genus of attractive tropical shrubs or trees with usually red flowers
@@ -55859,6 +56909,7 @@
   mero_member:
   - 12548243-n
   partOfSpeech: n
+  wikidata: Q1340386
 12548243-n:
   definition:
   - any of various shrubs or shrubby trees of the genus Erythrina having trifoliate
@@ -55980,6 +57031,7 @@
   mero_member:
   - 12550410-n
   partOfSpeech: n
+  wikidata: Q2496817
 12550410-n:
   definition:
   - any of various Australian evergreen shrubs of the genus Gastrolobium having whorled
@@ -56089,6 +57141,7 @@
   mero_member:
   - 12552232-n
   partOfSpeech: n
+  wikidata: Q12549487
 12552232-n:
   definition:
   - any of several small deciduous trees valued for their dark wood and dense racemes
@@ -56112,6 +57165,7 @@
   mero_member:
   - 12552673-n
   partOfSpeech: n
+  wikidata: Q311395
 12552673-n:
   definition:
   - erect bushy hairy annual herb having trifoliate leaves and purple to pink flowers;
@@ -56157,6 +57211,7 @@
   - 12553391-n
   - 12553695-n
   partOfSpeech: n
+  wikidata: Q157830
 12553391-n:
   definition:
   - deep-rooted coarse-textured plant native to the Mediterranean region having blue
@@ -56207,6 +57262,7 @@
   mero_member:
   - 12554235-n
   partOfSpeech: n
+  wikidata: Q861520
 12554235-n:
   definition:
   - spiny shrub of the Caspian salt plains and Siberia having elegant silvery, downy
@@ -56257,6 +57313,7 @@
   - 12555130-n
   - 12555367-n
   partOfSpeech: n
+  wikidata: Q148973
 12555130-n:
   definition:
   - perennial of western United States having racemes of pink to purple flowers followed
@@ -56292,6 +57349,7 @@
   - Hippocrepis
   - genus Hippocrepis
   partOfSpeech: n
+  wikidata: Q133632
 12555759-n:
   definition:
   - European woody perennial with yellow umbellate flowers followed by flattened pods
@@ -56315,6 +57373,7 @@
   mero_member:
   - 12556098-n
   partOfSpeech: n
+  wikidata: Q2714213
 12556098-n:
   definition:
   - any of several attractive evergreen shrubs of Australia grown for their glossy
@@ -56339,6 +57398,7 @@
   mero_member:
   - 12556545-n
   partOfSpeech: n
+  wikidata: Q310648
 12556545-n:
   definition:
   - deciduous subshrub of southeastern Asia having pinnate leaves and clusters of
@@ -56374,6 +57434,7 @@
   - Jacksonia
   - genus Jacksonia
   partOfSpeech: n
+  wikidata: Q1308636
 12557170-n:
   definition:
   - genus of Australian woody vines having showy red or purplish flowers
@@ -56434,6 +57495,7 @@
   mero_member:
   - 12558074-n
   partOfSpeech: n
+  wikidata: Q16625423
 12558074-n:
   definition:
   - perennial twining vine of Old World tropics having trifoliate leaves and racemes
@@ -56466,6 +57528,7 @@
   - 12558714-n
   - 12558885-n
   partOfSpeech: n
+  wikidata: Q147184
 12558714-n:
   definition:
   - an ornamental shrub or tree of the genus Laburnum
@@ -56518,6 +57581,7 @@
   - 12562745-n
   - 12562971-n
   partOfSpeech: n
+  wikidata: Q157209
 12559579-n:
   definition:
   - any of various small plants of the genus Lathyrus; climb usually by means of tendrils
@@ -56728,6 +57792,7 @@
   - 12564144-n
   - 12564331-n
   partOfSpeech: n
+  wikidata: Q1017395
 12563415-n:
   definition:
   - shrubby or herbaceous plants widely used for forage, soil improvement, and especially
@@ -56797,6 +57862,7 @@
   - Lens
   - genus Lens
   partOfSpeech: n
+  wikidata: Q148983
 12564745-n:
   definition:
   - widely cultivated Eurasian annual herb grown for its edible flattened seeds that
@@ -56835,6 +57901,7 @@
   mero_member:
   - 12565367-n
   partOfSpeech: n
+  wikidata: Q1756340
 12565367-n:
   definition:
   - any of several tropical American woody plants of the genus Lonchocarpus whose
@@ -56857,6 +57924,7 @@
   mero_member:
   - 12566140-n
   partOfSpeech: n
+  wikidata: Q3645698
 12565737-n:
   definition:
   - North American annual with red or rose-colored flowers
@@ -56920,6 +57988,7 @@
   - 12567122-n
   - 12567467-n
   partOfSpeech: n
+  wikidata: Q156811
 12566688-n:
   definition:
   - any plant of the genus Lupinus; bearing erect spikes of usually purplish-blue
@@ -57046,6 +58115,7 @@
   mero_member:
   - 12568785-n
   partOfSpeech: n
+  wikidata: Q159549
 12568785-n:
   definition:
   - any of several Old World herbs of the genus Medicago having small flowers and
@@ -57134,6 +58204,7 @@
   mero_member:
   - 12570304-n
   partOfSpeech: n
+  wikidata: Q2628493
 12570304-n:
   definition:
   - any of several tropical trees or shrubs yielding showy streaked dark reddish or
@@ -57158,6 +58229,7 @@
   mero_member:
   - 12570715-n
   partOfSpeech: n
+  wikidata: Q2574724
 12570715-n:
   definition:
   - any of several erect or climbing woody plants of the genus Mucuna; widespread
@@ -57212,6 +58284,7 @@
   - 12571678-n
   - 12571962-n
   partOfSpeech: n
+  wikidata: Q589643
 12571678-n:
   definition:
   - medium-sized tropical American tree yielding tolu balsam and a fragrant hard wood
@@ -57275,6 +58348,7 @@
   mero_member:
   - 12572814-n
   partOfSpeech: n
+  wikidata: Q156932
 12572814-n:
   definition:
   - Eurasian perennial herb having pale pink flowers and curved pods; naturalized
@@ -57347,6 +58421,7 @@
   - 12574247-n
   - 12574534-n
   partOfSpeech: n
+  wikidata: Q2872596
 12574078-n:
   definition:
   - a tree of the genus Ormosia having seeds used as beads
@@ -57396,6 +58471,7 @@
   mero_member:
   - 12575031-n
   partOfSpeech: n
+  wikidata: Q1424322
 12575031-n:
   definition:
   - any of several leguminous plants of western North America causing locoism in livestock
@@ -57442,6 +58518,7 @@
   - 12575760-n
   - 12576058-n
   partOfSpeech: n
+  wikidata: Q1361402
 12575760-n:
   definition:
   - Central American twining plant with edible roots and pods; large tubers are eaten
@@ -57508,6 +58585,7 @@
   - 12578930-n
   - 12579185-n
   partOfSpeech: n
+  wikidata: Q310438
 12576812-n:
   definition:
   - any of various leguminous plants grown for their edible seeds and pods
@@ -57671,6 +58749,7 @@
   mero_member:
   - 12579549-n
   partOfSpeech: n
+  wikidata: Q9059394
 12579549-n:
   definition:
   - spiny evergreen xerophytic shrub having showy rose and purple flowers and forming
@@ -57696,6 +58775,7 @@
   mero_member:
   - 12580023-n
   partOfSpeech: n
+  wikidata: Q2037012
 12580023-n:
   definition:
   - small tree of West Indies and Florida having large odd-pinnate leaves and panicles
@@ -57723,6 +58803,7 @@
   - 12580521-n
   - 12580925-n
   partOfSpeech: n
+  wikidata: Q144795
 12580521-n:
   definition:
   - a leguminous plant of the genus Pisum with small white flowers and long green
@@ -57841,6 +58922,7 @@
   - 12582402-n
   - 12582646-n
   partOfSpeech: n
+  wikidata: Q388267
 12582402-n:
   definition:
   - evergreen shrub having almost heart-shaped foliage and bright yellow pea-like
@@ -57876,6 +58958,7 @@
   mero_member:
   - 12583082-n
   partOfSpeech: n
+  wikidata: Q5222889
 12583082-n:
   definition:
   - any of several tropical American trees some yielding economically important timber
@@ -57944,6 +59027,7 @@
   mero_member:
   - 12584207-n
   partOfSpeech: n
+  wikidata: Q2717831
 12584207-n:
   definition:
   - evergreen Asiatic tree having glossy pinnate leaves and racemose creamy-white
@@ -57967,6 +59051,7 @@
   mero_member:
   - 12584588-n
   partOfSpeech: n
+  wikidata: Q3310331
 12584588-n:
   definition:
   - a tuberous twining annual vine bearing clusters of purplish flowers and pods with
@@ -58170,6 +59255,7 @@
   mero_member:
   - 12587995-n
   partOfSpeech: n
+  wikidata: Q2699268
 12587995-n:
   definition:
   - desert shrub of Syria and Arabia having small white flowers; constitutes the juniper
@@ -58200,6 +59286,7 @@
   - 12588691-n
   - 12589154-n
   partOfSpeech: n
+  wikidata: Q472943
 12588455-n:
   definition:
   - large shrub or small tree of the eastern United States having bristly stems and
@@ -58285,6 +59372,7 @@
   - 12589931-n
   - 12590356-n
   partOfSpeech: n
+  wikidata: Q311305
 12589931-n:
   definition:
   - any of various plants of the genus Sesbania having pinnate leaves and large showy
@@ -58333,6 +59421,7 @@
   - 12591208-n
   - 12591477-n
   partOfSpeech: n
+  wikidata: Q309213
 12590899-n:
   definition:
   - handsome roundheaded deciduous tree having compound dark green leaves and profuse
@@ -58384,6 +59473,7 @@
   mero_member:
   - 12591835-n
   partOfSpeech: n
+  wikidata: Q14566707
 12591835-n:
   definition:
   - tall thornless shrub having pale yellow flowers and flexible rushlike twigs used
@@ -58434,6 +59524,7 @@
   mero_member:
   - 12592693-n
   partOfSpeech: n
+  wikidata: Q1610712
 12592693-n:
   definition:
   - Australian shrub having simple obovate leaves and brilliant scarlet flowers
@@ -58457,6 +59548,7 @@
   mero_member:
   - 12593051-n
   partOfSpeech: n
+  wikidata: Q3236409
 12593051-n:
   definition:
   - a plant of the genus Tephrosia having pinnate leaves and white or purplish flowers
@@ -58503,6 +59595,7 @@
   mero_member:
   - 12593761-n
   partOfSpeech: n
+  wikidata: Q2465131
 12593761-n:
   definition:
   - any of various plants of the genus Thermopsis having trifoliate leaves and yellow
@@ -58548,6 +59641,7 @@
   mero_member:
   - 12594416-n
   partOfSpeech: n
+  wikidata: Q732394
 12594416-n:
   definition:
   - semi-evergreen South American tree with odd-pinnate leaves and golden yellow flowers
@@ -58574,6 +59668,7 @@
   - 12594825-n
   - 12594975-n
   partOfSpeech: n
+  wikidata: Q132655
 12594825-n:
   definition:
   - Old World herb related to fenugreek
@@ -58641,6 +59736,7 @@
   - 12596534-n
   - 12597343-n
   partOfSpeech: n
+  wikidata: Q147337
 12595827-n:
   definition:
   - any of various climbing plants of the genus Vicia having pinnately compound leaves
@@ -58765,6 +59861,7 @@
   - 12599374-n
   - 12599786-n
   partOfSpeech: n
+  wikidata: Q132634
 12597867-n:
   definition:
   - East Indian legume having hairy foliage and small yellow flowers followed by cylindrical
@@ -58893,6 +59990,7 @@
   mero_member:
   - 12600152-n
   partOfSpeech: n
+  wikidata: Q2083913
 12600152-n:
   definition:
   - Australian leafless shrub resembling broom and having small yellow flowers
@@ -58918,6 +60016,7 @@
   - 12600570-n
   - 12600760-n
   partOfSpeech: n
+  wikidata: Q7933846
 12600570-n:
   definition:
   - tree with odd-pinnate leaves and racemes of fragrant pink to purple flowers
@@ -58952,6 +60051,7 @@
   mero_member:
   - 12601205-n
   partOfSpeech: n
+  wikidata: Q261903
 12601205-n:
   definition:
   - any flowering vine of the genus Wisteria
@@ -59016,6 +60116,7 @@
   mero_member:
   - 12602129-n
   partOfSpeech: n
+  wikidata: Q1096533
 12602129-n:
   definition:
   - chiefly tropical trees and shrubs and vines usually having a tall columnar trunk
@@ -59061,6 +60162,7 @@
   - 12618094-n
   - 12618401-n
   partOfSpeech: n
+  wikidata: Q14080
 12602979-n:
   definition:
   - any plant of the family Palmae having an unbranched trunk crowned by large pinnate
@@ -59120,6 +60222,7 @@
   mero_member:
   - 12604429-n
   partOfSpeech: n
+  wikidata: Q3642755
 12604429-n:
   definition:
   - tropical American palm having edible nuts and yielding a useful fiber
@@ -59158,6 +60261,7 @@
   mero_member:
   - 12604939-n
   partOfSpeech: n
+  wikidata: Q157289
 12604939-n:
   definition:
   - any of several tall tropical palms native to southeastern Asia having egg-shaped
@@ -59194,6 +60298,7 @@
   mero_member:
   - 12605476-n
   partOfSpeech: n
+  wikidata: Q142023
 12605476-n:
   definition:
   - Malaysian feather palm with base densely clothed with fibers; yields a sweet sap
@@ -59222,6 +60327,7 @@
   mero_member:
   - 12605898-n
   partOfSpeech: n
+  wikidata: Q141226
 12605898-n:
   definition:
   - Brazilian palm yielding fibers used in making ropes, mats, and brushes
@@ -59298,6 +60404,7 @@
   mero_member:
   - 12607059-n
   partOfSpeech: n
+  wikidata: Q165260
 12607059-n:
   definition:
   - any tropical Asian palm of the genus Calamus; light tough stems are a source of
@@ -59382,6 +60489,7 @@
   mero_member:
   - 12608248-n
   partOfSpeech: n
+  wikidata: Q137815
 12608248-n:
   definition:
   - palm of the Andes yielding a resinous wax which is mixed with tallow to make candles
@@ -59405,6 +60513,7 @@
   mero_member:
   - 12608564-n
   partOfSpeech: n
+  wikidata: Q13099531
 12608564-n:
   definition:
   - tall palm tree bearing coconuts as fruits; widely planted throughout the tropics
@@ -59444,6 +60553,7 @@
   - 12609081-n
   - 12609541-n
   partOfSpeech: n
+  wikidata: Q135429
 12609081-n:
   definition:
   - Brazilian fan palm having an edible root; source of a useful leaf fiber and a
@@ -59497,6 +60607,7 @@
   mero_member:
   - 12609903-n
   partOfSpeech: n
+  wikidata: Q87148432
 12609903-n:
   definition:
   - any of several tropical American palms bearing corozo nuts
@@ -59570,6 +60681,7 @@
   mero_member:
   - 12610993-n
   partOfSpeech: n
+  wikidata: Q7609983
 12610993-n:
   definition:
   - pinnate-leaved palms of the genus Elaeis having dense clusters of crowded flowers
@@ -59628,6 +60740,7 @@
   mero_member:
   - 12611778-n
   partOfSpeech: n
+  wikidata: Q132712
 12611778-n:
   definition:
   - Brazilian palm of genus Euterpe whose leaf buds are eaten like cabbage when young
@@ -59673,6 +60786,7 @@
   - Metroxylon
   - genus Metroxylon
   partOfSpeech: n
+  wikidata: Q312187
 12612463-n:
   definition:
   - Malaysian palm whose pithy trunk yields sago — a starch used as a food thickener
@@ -59699,6 +60813,7 @@
   mero_member:
   - 12612819-n
   partOfSpeech: n
+  wikidata: Q16060743
 12612819-n:
   definition:
   - any creeping semiaquatic feather palm of the genus Nipa found in mangrove swamps
@@ -59726,6 +60841,7 @@
   - 12613305-n
   - 12613883-n
   partOfSpeech: n
+  wikidata: Q10341267
 12613305-n:
   definition:
   - tall feather palm of northern Brazil with hard-shelled nuts yielding valuable
@@ -59822,6 +60938,7 @@
   - phoenix
   - genus Phoenix
   partOfSpeech: n
+  wikidata: Q27685
 12614755-n:
   definition:
   - tall tropical feather palm tree native to Syria bearing sweet edible fruit
@@ -59846,6 +60963,7 @@
   mero_member:
   - 12615085-n
   partOfSpeech: n
+  wikidata: Q161190
 12615085-n:
   definition:
   - a stemless palm tree of Brazil and Peru bearing ivory nuts
@@ -59889,6 +61007,7 @@
   mero_member:
   - 12615750-n
   partOfSpeech: n
+  wikidata: Q133289
 12615750-n:
   definition:
   - a large feather palm of Africa and Madagascar having very long pinnatisect fronds
@@ -60031,6 +61150,7 @@
   mero_member:
   - 12617895-n
   partOfSpeech: n
+  wikidata: Q132826
 12617895-n:
   definition:
   - low-growing fan-leaved palm of coastal southern United States having edible leaf
@@ -60055,6 +61175,7 @@
   mero_member:
   - 12618227-n
   partOfSpeech: n
+  wikidata: Q16060807
 12618227-n:
   definition:
   - small hardy clump-forming spiny palm of southern United States
@@ -60079,6 +61200,7 @@
   - 12618559-n
   - 12618788-n
   partOfSpeech: n
+  wikidata: Q142326
 12618559-n:
   definition:
   - small palm of southern Florida and West Indies closely resembling the silvertop
@@ -60134,6 +61256,7 @@
   mero_member:
   - 12619390-n
   partOfSpeech: n
+  wikidata: Q1748235
 12619390-n:
   definition:
   - type genus of the family Plantaginaceae; large cosmopolitan genus of mostly small
@@ -60147,6 +61270,7 @@
   mero_member:
   - 12619587-n
   partOfSpeech: n
+  wikidata: Q164686
 12619587-n:
   definition:
   - any of numerous plants of the genus Plantago; mostly small roadside or dooryard
@@ -60246,6 +61370,7 @@
   mero_member:
   - 12621335-n
   partOfSpeech: n
+  wikidata: Q923240
 12621335-n:
   definition:
   - a family of plants of order Polygonales chiefly of the north temperate zone; includes
@@ -60264,6 +61389,7 @@
   - 12623611-n
   - 12624545-n
   partOfSpeech: n
+  wikidata: Q156117
 12621649-n:
   definition:
   - diverse genus of herbs or woody subshrubs of north temperate regions
@@ -60278,6 +61404,7 @@
   - 12622255-n
   - 12622566-n
   partOfSpeech: n
+  wikidata: Q271400
 12621867-n:
   definition:
   - twining perennial vine having racemes of fragrant greenish flowers; western China
@@ -60301,6 +61428,7 @@
   - Fagopyrum
   - genus Fagopyrum
   partOfSpeech: n
+  wikidata: Q7223832
 12622255-n:
   definition:
   - a member of the genus Fagopyrum; annual Asian plant with clusters of small pinkish
@@ -60341,6 +61469,7 @@
   mero_member:
   - 12623023-n
   partOfSpeech: n
+  wikidata: Q2707277
 12623023-n:
   definition:
   - any plant of the genus Eriogonum with small clustered flowers
@@ -60387,6 +61516,7 @@
   - 12623741-n
   - 12624034-n
   partOfSpeech: n
+  wikidata: Q7217716
 12623741-n:
   definition:
   - plants having long green or reddish acidic leafstalks growing in basal clumps;
@@ -60449,6 +61579,7 @@
   mero_member:
   - 12624720-n
   partOfSpeech: n
+  wikidata: Q157264
 12624720-n:
   definition:
   - any of certain coarse weedy plants with long taproots, sometimes used as table
@@ -60548,6 +61679,7 @@
   mero_member:
   - 12626280-n
   partOfSpeech: n
+  wikidata: Q131613
 12626280-n:
   definition:
   - chiefly American marsh plants, having usually yellow flowers
@@ -60596,6 +61728,7 @@
   - 12627306-n
   - 12627558-n
   partOfSpeech: n
+  wikidata: Q156674
 12626988-n:
   definition:
   - 'type genus of the Commelinaceae; large genus of herbs of branching or creeping
@@ -60608,6 +61741,7 @@
   mero_member:
   - 12627199-n
   partOfSpeech: n
+  wikidata: Q161075
 12627199-n:
   definition:
   - any plant of the genus Commelina
@@ -60648,6 +61782,7 @@
   - Tradescantia
   - genus Tradescantia
   partOfSpeech: n
+  wikidata: Q157498
 12627668-n:
   definition:
   - a family of tropical American plants of order Xyridales including several (as
@@ -60664,6 +61799,7 @@
   - 12628478-n
   - 12628657-n
   partOfSpeech: n
+  wikidata: Q156529
 12627959-n:
   definition:
   - a genus of tropical American plants have sword-shaped leaves and a fleshy compound
@@ -60677,6 +61813,7 @@
   mero_member:
   - 12628217-n
   partOfSpeech: n
+  wikidata: Q147316
 12628217-n:
   definition:
   - a tropical American plant bearing a large fleshy edible fruit with a terminal
@@ -60742,6 +61879,7 @@
   mero_member:
   - 12629381-n
   partOfSpeech: n
+  wikidata: Q13701399
 12629381-n:
   definition:
   - small genus of delicate mossy bog plants having white or violet flowers
@@ -60752,6 +61890,7 @@
   - Mayaca
   - genus Mayaca
   partOfSpeech: n
+  wikidata: Q131609
 12629539-n:
   definition:
   - South American herbs somewhat resembling members of the Juncaceae
@@ -60762,6 +61901,7 @@
   - Rapateaceae
   - family Rapateaceae
   partOfSpeech: n
+  wikidata: Q131516
 12629702-n:
   definition:
   - 'chiefly tropical aquatic or bog herbs: pipeworts'
@@ -60775,6 +61915,7 @@
   mero_member:
   - 12629889-n
   partOfSpeech: n
+  wikidata: Q131321
 12629889-n:
   definition:
   - 'type genus of the Eriocaulaceae: rushlike aquatic or marginal perennials usually
@@ -60816,6 +61957,7 @@
   - 12630947-n
   - 12631370-n
   partOfSpeech: n
+  wikidata: Q725748
 12630603-n:
   definition:
   - pickerelweed
@@ -60912,6 +62054,7 @@
   - 12638500-n
   - 12639097-n
   partOfSpeech: n
+  wikidata: Q1112837
 12632004-n:
   definition:
   - monotypic family of aquatic plants having narrow leaves and small flowers
@@ -60927,6 +62070,7 @@
   mero_member:
   - 12632240-n
   partOfSpeech: n
+  wikidata: Q2720121
 12632240-n:
   definition:
   - sole genus of the family Naiadaceae
@@ -60967,6 +62111,7 @@
   - 12632781-n
   - 12633171-n
   partOfSpeech: n
+  wikidata: Q156025
 12632781-n:
   definition:
   - small genus of aquatic or semiaquatic plants
@@ -60979,6 +62124,7 @@
   mero_member:
   - 12632931-n
   partOfSpeech: n
+  wikidata: Q157350
 12632931-n:
   definition:
   - marsh plant having clusters of small white or pinkish flowers and broad pointed
@@ -61002,6 +62148,7 @@
   - Sagittaria
   - genus Sagittaria
   partOfSpeech: n
+  wikidata: Q157652
 12633401-n:
   definition:
   - a weed (Sagittaria latifolia)
@@ -61050,6 +62197,7 @@
   - 12635723-n
   - 12635858-n
   partOfSpeech: n
+  wikidata: Q156029
 12634046-n:
   definition:
   - frogbit
@@ -61062,6 +62210,7 @@
   mero_member:
   - 12634169-n
   partOfSpeech: n
+  wikidata: Q158871
 12634169-n:
   definition:
   - European floating plant with roundish heart-shaped leaves and white flowers
@@ -61085,6 +62234,7 @@
   mero_member:
   - 12634467-n
   partOfSpeech: n
+  wikidata: Q2720105
 12634467-n:
   definition:
   - submersed plant with whorled lanceolate leaves and solitary axillary flowers;
@@ -61109,6 +62259,7 @@
   mero_member:
   - 12634857-n
   partOfSpeech: n
+  wikidata: Q643368
 12634857-n:
   definition:
   - American plant with roundish heart-shaped or kidney-shaped leaves; usually rooted
@@ -61177,6 +62328,7 @@
   - Egeria
   - genus Egeria
   partOfSpeech: n
+  wikidata: Q164297
 12635858-n:
   definition:
   - eelgrass; eel grass
@@ -61189,6 +62341,7 @@
   mero_member:
   - 12635993-n
   partOfSpeech: n
+  wikidata: Q157369
 12635993-n:
   definition:
   - submerged aquatic plant with ribbonlike leaves; Old World and Australia
@@ -61218,6 +62371,7 @@
   - 12637586-n
   - 12639285-n
   partOfSpeech: n
+  wikidata: Q156233
 12636471-n:
   definition:
   - any of several submerged or floating freshwater perennial aquatic weeds belonging
@@ -61243,6 +62397,7 @@
   - 12637203-n
   - 12637391-n
   partOfSpeech: n
+  wikidata: Q161728
 12637009-n:
   definition:
   - European herb naturalized in the eastern United States and California
@@ -61287,6 +62442,7 @@
   mero_member:
   - 12637757-n
   partOfSpeech: n
+  wikidata: Q163477
 12637757-n:
   definition:
   - very similar to Potamogeton; of western Africa, Asia, and Europe
@@ -61311,6 +62467,7 @@
   mero_member:
   - 12638145-n
   partOfSpeech: n
+  wikidata: Q862544
 12638145-n:
   definition:
   - perennial or annual bog or marsh plants; includes arrow grass
@@ -61346,6 +62503,7 @@
   mero_member:
   - 12638711-n
   partOfSpeech: n
+  wikidata: Q2494235
 12638711-n:
   definition:
   - 'horned pondweed: completely submerged herbs; in some classifications included
@@ -61381,6 +62539,7 @@
   - family Zosteraceae
   - eelgrass family
   partOfSpeech: n
+  wikidata: Q21037
 12639285-n:
   definition:
   - (or in some classifications family Zosteraceae) small genus of widely distributed
@@ -61394,6 +62553,7 @@
   mero_member:
   - 12639488-n
   partOfSpeech: n
+  wikidata: Q157371
 12639488-n:
   definition:
   - submerged marine plant with very long narrow leaves found in abundance along North
@@ -61429,6 +62589,7 @@
   - 12825381-n
   - 12827030-n
   partOfSpeech: n
+  wikidata: Q21895
 12640067-n:
   definition:
   - a large family of dicotyledonous plants of order Rosales; have alternate leaves
@@ -61467,6 +62628,7 @@
   - 12678701-n
   - 12679964-n
   partOfSpeech: n
+  wikidata: Q46299
 12640792-n:
   definition:
   - large genus of erect or climbing prickly shrubs including roses
@@ -61479,6 +62641,7 @@
   mero_member:
   - 12640957-n
   partOfSpeech: n
+  wikidata: Q34687
 12640957-n:
   definition:
   - any of many shrubs of the genus Rosa that bear roses
@@ -61654,6 +62817,7 @@
   mero_member:
   - 12643636-n
   partOfSpeech: n
+  wikidata: Q264427
 12643636-n:
   definition:
   - a plant of the genus Agrimonia having spikelike clusters of small yellow flowers
@@ -61696,6 +62860,7 @@
   mero_member:
   - 12644285-n
   partOfSpeech: n
+  wikidata: Q156957
 12644285-n:
   definition:
   - any of various North American trees or shrubs having showy white flowers and edible
@@ -61747,6 +62912,7 @@
   mero_member:
   - 12645142-n
   partOfSpeech: n
+  wikidata: Q157616
 12645142-n:
   definition:
   - Asiatic ornamental shrub with spiny branches and pink or red blossoms
@@ -61790,6 +62956,7 @@
   mero_member:
   - 12645764-n
   partOfSpeech: n
+  wikidata: Q2719919
 12645764-n:
   definition:
   - small tropical American tree bearing edible plumlike fruit
@@ -61816,6 +62983,7 @@
   mero_member:
   - 12646144-n
   partOfSpeech: n
+  wikidata: Q5538
 12646144-n:
   definition:
   - 'any shrub of the genus Cotoneaster: erect or creeping shrubs having richly colored
@@ -61867,6 +63035,7 @@
   - 12648821-n
   - 12649117-n
   partOfSpeech: n
+  wikidata: Q132557
 12647114-n:
   definition:
   - a spring-flowering shrub or small tree of the genus Crataegus
@@ -62013,6 +63182,7 @@
   mero_member:
   - 12649747-n
   partOfSpeech: n
+  wikidata: Q13418162
 12649747-n:
   definition:
   - small Asian tree with pinkish flowers and pear-shaped fruit; widely cultivated
@@ -62038,6 +63208,7 @@
   mero_member:
   - 12650066-n
   partOfSpeech: n
+  wikidata: Q123279
 12650066-n:
   definition:
   - creeping evergreen shrub with large white flowers; widely distributed in northern
@@ -62096,6 +63267,7 @@
   - 12651524-n
   - 12651760-n
   partOfSpeech: n
+  wikidata: Q745
 12650905-n:
   definition:
   - any of various low perennial herbs with many runners and bearing white flowers
@@ -62168,6 +63340,7 @@
   mero_member:
   - 12652092-n
   partOfSpeech: n
+  wikidata: Q156771
 12652092-n:
   definition:
   - any of various perennials of the genus Geum having usually pinnate basal leaves
@@ -62276,6 +63449,7 @@
   mero_member:
   - 12653822-n
   partOfSpeech: n
+  wikidata: Q2655434
 12653822-n:
   definition:
   - ornamental evergreen treelike shrub of the Pacific coast of the United States
@@ -62307,6 +63481,7 @@
   - 12655747-n
   - 12655912-n
   partOfSpeech: n
+  wikidata: Q104819
 12654399-n:
   definition:
   - any tree of the genus Malus especially those bearing firm rounded edible fruits
@@ -62465,6 +63640,7 @@
   mero_member:
   - 12656985-n
   partOfSpeech: n
+  wikidata: Q148723
 12656985-n:
   definition:
   - small deciduous Eurasian tree cultivated for its fruit that resemble crab apples
@@ -62491,6 +63667,7 @@
   - Photinia
   - genus Photinia
   partOfSpeech: n
+  wikidata: Q1070845
 12657466-n:
   definition:
   - 'chiefly perennial Northern Hemisphere herbs and shrubs: cinquefoil'
@@ -62503,6 +63680,7 @@
   mero_member:
   - 12657646-n
   partOfSpeech: n
+  wikidata: Q156512
 12657646-n:
   definition:
   - any of a numerous plants grown for their five-petaled flowers; abundant in temperate
@@ -62539,6 +63717,7 @@
   mero_member:
   - 12658246-n
   partOfSpeech: n
+  wikidata: Q7234870
 12658246-n:
   definition:
   - European garden herb with purple-tinged flowers and leaves that are sometimes
@@ -62582,6 +63761,7 @@
   - 12670484-n
   - 12671317-n
   partOfSpeech: n
+  wikidata: Q190545
 12658979-n:
   definition:
   - any of several trees producing edible oval fruit having a smooth skin and a single
@@ -62983,6 +64163,7 @@
   mero_member:
   - 12665474-n
   partOfSpeech: n
+  wikidata: Q2505501
 12665474-n:
   definition:
   - used in former classifications for peach and almond trees which are now included
@@ -62994,6 +64175,7 @@
   - Amygdalus
   - genus Amygdalus
   partOfSpeech: n
+  wikidata: Q14566635
 12665663-n:
   definition:
   - any of several small bushy trees having pink or white blossoms and usually bearing
@@ -63383,6 +64565,7 @@
   mero_member:
   - 12671990-n
   partOfSpeech: n
+  wikidata: Q157748
 12671990-n:
   definition:
   - any of various thorny shrubs of the genus Pyracantha bearing small white flowers
@@ -63409,6 +64592,7 @@
   mero_member:
   - 12672372-n
   partOfSpeech: n
+  wikidata: Q434
 12672372-n:
   definition:
   - Old World tree having sweet gritty-textured juicy fruit; widely cultivated in
@@ -63866,6 +65050,7 @@
   mero_member:
   - 12680117-n
   partOfSpeech: n
+  wikidata: Q148745
 12680117-n:
   definition:
   - any rosaceous plant of the genus Spiraea; has sprays of small white or pink flowers
@@ -63905,6 +65090,7 @@
   - 12702815-n
   - 12970482-n
   partOfSpeech: n
+  wikidata: Q2102991
 12680770-n:
   definition:
   - widely distributed family of mostly tropical trees and shrubs and herbs; includes
@@ -63935,6 +65121,7 @@
   - 12690933-n
   - 12691319-n
   partOfSpeech: n
+  wikidata: Q156569
 12681362-n:
   definition:
   - any of numerous trees or shrubs or vines of the family Rubiaceae
@@ -63958,6 +65145,7 @@
   mero_member:
   - 12681806-n
   partOfSpeech: n
+  wikidata: Q162108
 12681806-n:
   definition:
   - perennial East Indian creeping or climbing herb used for dye in the orient
@@ -63992,6 +65180,7 @@
   mero_member:
   - 12682299-n
   partOfSpeech: n
+  wikidata: Q157934
 12682299-n:
   definition:
   - any plant of the genus Asperula
@@ -64025,6 +65214,7 @@
   mero_member:
   - 12682835-n
   partOfSpeech: n
+  wikidata: Q5024620
 12682835-n:
   definition:
   - source of a tough elastic wood
@@ -64048,6 +65238,7 @@
   mero_member:
   - 12683140-n
   partOfSpeech: n
+  wikidata: Q2963804
 12683140-n:
   definition:
   - evergreen climbing shrub of southern Florida and West Indies grown for its racemes
@@ -64072,6 +65263,7 @@
   mero_member:
   - 12683533-n
   partOfSpeech: n
+  wikidata: Q156354
 12683533-n:
   definition:
   - any of several small trees and shrubs native to the tropical Old World yielding
@@ -64133,6 +65325,7 @@
   - 12684948-n
   - 12685230-n
   partOfSpeech: n
+  wikidata: Q160090
 12684565-n:
   definition:
   - any of several trees of the genus Cinchona
@@ -64207,6 +65400,7 @@
   mero_member:
   - 12685809-n
   partOfSpeech: n
+  wikidata: Q148633
 12685809-n:
   definition:
   - any of several plants of the genus Galium
@@ -64313,6 +65507,7 @@
   mero_member:
   - 12687529-n
   partOfSpeech: n
+  wikidata: Q740887
 12687529-n:
   definition:
   - any of various shrubs and small trees of the genus Gardenia having large fragrant
@@ -64349,6 +65544,7 @@
   - 12688167-n
   - 12688343-n
   partOfSpeech: n
+  wikidata: Q2345542
 12688167-n:
   definition:
   - any tree of the genus Genipa bearing yellow flowers and edible fruit with a thick
@@ -64385,6 +65581,7 @@
   mero_member:
   - 12688725-n
   partOfSpeech: n
+  wikidata: Q2673632
 12688725-n:
   definition:
   - any of several flowering tropical or subtropical shrubs of the genus Hamelia
@@ -64421,6 +65618,7 @@
   mero_member:
   - 12689278-n
   partOfSpeech: n
+  wikidata: Q3236710
 12689278-n:
   definition:
   - creeping woody plant of eastern North America with shiny evergreen leaves and
@@ -64447,6 +65645,7 @@
   mero_member:
   - 12689678-n
   partOfSpeech: n
+  wikidata: Q2719941
 12689678-n:
   definition:
   - large African forest tree yielding a strong hard yellow to golden brown lumber;
@@ -64472,6 +65671,7 @@
   mero_member:
   - 12690123-n
   partOfSpeech: n
+  wikidata: Q9059889
 12690123-n:
   definition:
   - ornamental shrub or small tree of swampy areas in southwestern United States having
@@ -64497,6 +65697,7 @@
   mero_member:
   - 12690564-n
   partOfSpeech: n
+  wikidata: Q904250
 12690564-n:
   definition:
   - South African evergreen having hard tough wood
@@ -64560,6 +65761,7 @@
   - 12691519-n
   - 12691723-n
   partOfSpeech: n
+  wikidata: Q2473658
 12691519-n:
   definition:
   - small deciduous tree of southern Africa having edible fruit
@@ -64608,6 +65810,7 @@
   - 12700886-n
   - 12702529-n
   partOfSpeech: n
+  wikidata: Q156301
 12692290-n:
   definition:
   - chiefly east Asian shrubs
@@ -64619,6 +65822,7 @@
   mero_member:
   - 12692412-n
   partOfSpeech: n
+  wikidata: Q158261
 12692412-n:
   definition:
   - any of various deciduous or evergreen ornamental shrubs of the genus Abelia having
@@ -64643,6 +65847,7 @@
   - 12692844-n
   - 12693050-n
   partOfSpeech: n
+  wikidata: Q2697991
 12692844-n:
   definition:
   - spreading bush of northeastern United States having small clusters of fragrant
@@ -64704,6 +65909,7 @@
   mero_member:
   - 12693773-n
   partOfSpeech: n
+  wikidata: Q139038
 12693773-n:
   definition:
   - shrub honeysuckle with drooping spikes of purplish flowers
@@ -64727,6 +65933,7 @@
   - 12694089-n
   - 12694349-n
   partOfSpeech: n
+  wikidata: Q5114721
 12694089-n:
   definition:
   - creeping evergreen subshrub of the northern parts of Europe and Asia with delicate
@@ -64774,6 +65981,7 @@
   - 12697701-n
   - 12697881-n
   partOfSpeech: n
+  wikidata: Q156047
 12694881-n:
   definition:
   - shrub or vine of the genus Lonicera
@@ -64958,6 +66166,7 @@
   mero_member:
   - 12698602-n
   partOfSpeech: n
+  wikidata: Q157972
 12698373-n:
   definition:
   - deciduous shrub of western North America having spikes of pink flowers followed
@@ -64998,6 +66207,7 @@
   - 12699555-n
   - 12699784-n
   partOfSpeech: n
+  wikidata: Q131448
 12698985-n:
   definition:
   - any of numerous shrubs or small trees of temperate and subtropical Northern Hemisphere
@@ -65098,6 +66308,7 @@
   mero_member:
   - 12700637-n
   partOfSpeech: n
+  wikidata: Q3312339
 12700637-n:
   definition:
   - coarse weedy American perennial herb with large usually perfoliate leaves and
@@ -65129,6 +66340,7 @@
   - 12702137-n
   - 12702340-n
   partOfSpeech: n
+  wikidata: Q158492
 12701163-n:
   definition:
   - deciduous North American shrub or small tree having three-lobed leaves and red
@@ -65218,6 +66430,7 @@
   mero_member:
   - 12702654-n
   partOfSpeech: n
+  wikidata: Q157840
 12702654-n:
   definition:
   - deciduous shrub widely cultivated for its white or pink or red flowers
@@ -65241,6 +66454,7 @@
   - 12703025-n
   - 12704009-n
   partOfSpeech: n
+  wikidata: Q156665
 12703025-n:
   definition:
   - 'type genus of the Dipsacaceae: teasel'
@@ -65311,6 +66525,7 @@
   mero_member:
   - 12704168-n
   partOfSpeech: n
+  wikidata: Q147772
 12704168-n:
   definition:
   - any of various plants of the genus Scabiosa
@@ -65370,6 +66585,7 @@
   mero_member:
   - 12705140-n
   partOfSpeech: n
+  wikidata: Q141672
 12705140-n:
   definition:
   - North American annual plant with usually yellow or orange flowers; grows chiefly
@@ -65413,6 +66629,7 @@
   - 12741292-n
   - 12937695-n
   partOfSpeech: n
+  wikidata: Q14272
 12705975-n:
   definition:
   - chiefly herbaceous plants
@@ -65429,6 +66646,7 @@
   - 12707972-n
   - 12709287-n
   partOfSpeech: n
+  wikidata: Q155945
 12706192-n:
   definition:
   - any of numerous plants of the family Geraniaceae
@@ -65449,6 +66667,7 @@
   mero_member:
   - 12706592-n
   partOfSpeech: n
+  wikidata: Q157211
 12706592-n:
   definition:
   - any of numerous geraniums of the genus Geranium
@@ -65545,6 +66764,7 @@
   - 12708948-n
   - 12709133-n
   partOfSpeech: n
+  wikidata: Q146118
 12708223-n:
   definition:
   - any of several southern African geraniums having fragrant three-lobed to five-lobed
@@ -65616,6 +66836,7 @@
   mero_member:
   - 12709477-n
   partOfSpeech: n
+  wikidata: Q162920
 12709477-n:
   definition:
   - any of various plants of the genus Erodium
@@ -65677,6 +66898,7 @@
   - Erythroxylaceae
   - family Erythroxylaceae
   partOfSpeech: n
+  wikidata: Q157231
 12710569-n:
   definition:
   - a large genus of South American shrubs and small trees of the family Erythroxylaceae
@@ -65692,6 +66914,7 @@
   - 12710807-n
   - 12711001-n
   partOfSpeech: n
+  wikidata: Q158138
 12710807-n:
   definition:
   - a South American shrub whose leaves are chewed by natives of the Andes; a source
@@ -65730,6 +66953,7 @@
   - 12713084-n
   - 12713794-n
   partOfSpeech: n
+  wikidata: Q161237
 12711414-n:
   definition:
   - any of various tropical trees of the family Burseraceae yielding fragrant gums
@@ -65836,6 +67060,7 @@
   - 12713282-n
   - 12713475-n
   partOfSpeech: n
+  wikidata: Q1648255
 12713282-n:
   definition:
   - small evergreen tree of Africa and Asia; leaves have a strong aromatic odor when
@@ -65884,6 +67109,7 @@
   - 12714005-n
   - 12714113-n
   partOfSpeech: n
+  wikidata: Q2261600
 12714005-n:
   definition:
   - tropical American tree harvested by locals for resin, food, wood, and other medical
@@ -65924,6 +67150,7 @@
   mero_member:
   - 12714495-n
   partOfSpeech: n
+  wikidata: Q2703020
 12714495-n:
   definition:
   - water starworts
@@ -65936,6 +67163,7 @@
   mero_member:
   - 12714626-n
   partOfSpeech: n
+  wikidata: Q156846
 12714626-n:
   definition:
   - any of several aquatic plants having a star-shaped rosette of floating leaves;
@@ -65971,6 +67199,7 @@
   mero_member:
   - 12715097-n
   partOfSpeech: n
+  wikidata: Q768283
 12715097-n:
   definition:
   - Cuban timber tree with hard wood very resistant to moisture
@@ -66021,6 +67250,7 @@
   - 12720979-n
   - 12721591-n
   partOfSpeech: n
+  wikidata: Q158979
 12715905-n:
   definition:
   - any of various tropical timber trees of the family Meliaceae especially the genus
@@ -66057,6 +67287,7 @@
   mero_member:
   - 12716736-n
   partOfSpeech: n
+  wikidata: Q2703639
 12716736-n:
   definition:
   - tree of northern India and China having purple blossoms and small inedible yellow
@@ -66130,6 +67361,7 @@
   mero_member:
   - 12717913-n
   partOfSpeech: n
+  wikidata: Q162792
 12717913-n:
   definition:
   - tropical American tree yielding fragrant wood used especially for boxes
@@ -66155,6 +67387,7 @@
   mero_member:
   - 12718275-n
   partOfSpeech: n
+  wikidata: Q13055458
 12718275-n:
   definition:
   - East Indian tree with valuable hard lustrous yellowish wood
@@ -66190,6 +67423,7 @@
   mero_member:
   - 12718787-n
   partOfSpeech: n
+  wikidata: Q133937
 12718787-n:
   definition:
   - African tree having rather lightweight cedar-scented wood varying in color from
@@ -66259,6 +67493,7 @@
   mero_member:
   - 12719791-n
   partOfSpeech: n
+  wikidata: Q134051
 12719791-n:
   definition:
   - African tree having hard heavy odorless wood
@@ -66279,6 +67514,7 @@
   mero_member:
   - 12720061-n
   partOfSpeech: n
+  wikidata: Q11983219
 12720061-n:
   definition:
   - East Indian tree bearing an edible yellow berry
@@ -66329,6 +67565,7 @@
   mero_member:
   - 12720682-n
   partOfSpeech: n
+  wikidata: Q133418
 12720682-n:
   definition:
   - mahogany tree of West Indies
@@ -66363,6 +67600,7 @@
   mero_member:
   - 12721117-n
   partOfSpeech: n
+  wikidata: Q2697430
 12721117-n:
   definition:
   - Philippine timber tree having hard red fragrant wood
@@ -66407,6 +67645,7 @@
   mero_member:
   - 12721756-n
   partOfSpeech: n
+  wikidata: Q2235097
 12721756-n:
   definition:
   - any of numerous trees and shrubs grown for their beautiful glossy foliage and
@@ -66432,6 +67671,7 @@
   - 12722251-n
   - 12722661-n
   partOfSpeech: n
+  wikidata: Q132073
 12722251-n:
   definition:
   - a genus of dicotyledonous trees belonging to the family Lepidobotryaceae
@@ -66443,6 +67683,7 @@
   mero_member:
   - 12722426-n
   partOfSpeech: n
+  wikidata: Q6527439
 12722426-n:
   definition:
   - African tree often classified in other families; similar to the Costa Rican caracolito
@@ -66466,6 +67707,7 @@
   mero_member:
   - 12722884-n
   partOfSpeech: n
+  wikidata: Q9284783
 12722884-n:
   definition:
   - large Costa Rican tree having light-colored wood suitable for cabinetry; similar
@@ -66506,6 +67748,7 @@
   mero_member:
   - 12723708-n
   partOfSpeech: n
+  wikidata: Q157378
 12723708-n:
   definition:
   - any plant or flower of the genus Oxalis
@@ -66635,6 +67878,7 @@
   mero_member:
   - 12725604-n
   partOfSpeech: n
+  wikidata: Q156360
 12725604-n:
   definition:
   - 'type genus of the Polygalaceae: milkwort, senega, snakeroot'
@@ -66758,6 +68002,7 @@
   - 12734874-n
   - 12735310-n
   partOfSpeech: n
+  wikidata: Q146030
 12727800-n:
   definition:
   - type genus of the Rutaceae; strong-scented Eurasian herbs
@@ -66770,6 +68015,7 @@
   mero_member:
   - 12727959-n
   partOfSpeech: n
+  wikidata: Q165250
 12727959-n:
   definition:
   - European strong-scented perennial herb with grey-green bitter-tasting leaves;
@@ -66808,6 +68054,7 @@
   - 12732744-n
   - 12732577-n
   partOfSpeech: n
+  wikidata: Q81513
 12728541-n:
   definition:
   - any of numerous tropical usually thorny evergreen trees of the genus Citrus having
@@ -67091,6 +68338,7 @@
   mero_member:
   - 12733080-n
   partOfSpeech: n
+  wikidata: Q21396652
 12733080-n:
   definition:
   - more aromatic and acidic than oranges
@@ -67114,6 +68362,7 @@
   - Dictamnus
   - genus Dictamnus
   partOfSpeech: n
+  wikidata: Q2643074
 12733386-n:
   definition:
   - Eurasian perennial herb with white flowers that emit flammable vapor in hot weather
@@ -67141,6 +68390,7 @@
   - 12733823-n
   - 12734118-n
   partOfSpeech: n
+  wikidata: Q106090
 12733823-n:
   definition:
   - any of several trees or shrubs of the genus Fortunella bearing small orange-colored
@@ -67247,6 +68497,7 @@
   - 12735709-n
   - 12735955-n
   partOfSpeech: n
+  wikidata: Q147050
 12735515-n:
   definition:
   - any of a number of trees or shrubs of the genus Zanthoxylum having spiny branches
@@ -67315,6 +68566,7 @@
   - 12739074-n
   - 12739567-n
   partOfSpeech: n
+  wikidata: Q156679
 12736674-n:
   definition:
   - any of various trees or shrubs of the family Simaroubaceae having wood and bark
@@ -67339,6 +68591,7 @@
   - 12737160-n
   - 12737354-n
   partOfSpeech: n
+  wikidata: Q3308399
 12737160-n:
   definition:
   - tree of the Amazon valley yielding a light brittle timber locally regarded as
@@ -67376,6 +68629,7 @@
   - 12737832-n
   - 12737984-n
   partOfSpeech: n
+  wikidata: Q160580
 12737832-n:
   definition:
   - any of several deciduous Asian trees of the genus Ailanthus
@@ -67439,6 +68693,7 @@
   mero_member:
   - 12738834-n
   partOfSpeech: n
+  wikidata: Q2293602
 12738834-n:
   definition:
   - small African deciduous tree with spreading crown having leaves clustered toward
@@ -67498,6 +68753,7 @@
   mero_member:
   - 12739755-n
   partOfSpeech: n
+  wikidata: Q1947702
 12739755-n:
   definition:
   - handsome South American shrub or small tree having bright scarlet flowers and
@@ -67524,6 +68780,7 @@
   mero_member:
   - 12740215-n
   partOfSpeech: n
+  wikidata: Q163937
 12740215-n:
   definition:
   - a tropical American genus of dicotyledonous climbing or diffuse pungent herbs
@@ -67537,6 +68794,7 @@
   mero_member:
   - 12740444-n
   partOfSpeech: n
+  wikidata: Q158271
 12740444-n:
   definition:
   - any tropical American plant of the genus Tropaeolum having pungent juice and long-spurred
@@ -67602,6 +68860,7 @@
   - 12743644-n
   - 12744206-n
   partOfSpeech: n
+  wikidata: Q155982
 12741653-n:
   definition:
   - 'usually tropical herbs or shrubs having ill-smelling foliage and flower buds
@@ -67615,6 +68874,7 @@
   mero_member:
   - 12741882-n
   partOfSpeech: n
+  wikidata: Q245426
 12741882-n:
   definition:
   - perennial shrub of the eastern Mediterranean region and southwestern Asia having
@@ -67640,6 +68900,7 @@
   mero_member:
   - 12742237-n
   partOfSpeech: n
+  wikidata: Q1949708
 12742237-n:
   definition:
   - South American tree of dry interior regions of Argentina and Paraguay having resinous
@@ -67676,6 +68937,7 @@
   - 12742831-n
   - 12743327-n
   partOfSpeech: n
+  wikidata: Q1429385
 12742831-n:
   definition:
   - small evergreen tree of Caribbean and southern Central America to northern South
@@ -67735,6 +68997,7 @@
   mero_member:
   - 12743822-n
   partOfSpeech: n
+  wikidata: Q2521134
 12743822-n:
   definition:
   - desert shrub of southwestern United States and New Mexico having persistent resinous
@@ -67771,6 +69034,7 @@
   mero_member:
   - 12744370-n
   partOfSpeech: n
+  wikidata: Q1017217
 12744370-n:
   definition:
   - tropical annual procumbent poisonous subshrub having fruit that splits into five
@@ -67810,6 +69074,7 @@
   - 12744961-n
   - 12751962-n
   partOfSpeech: n
+  wikidata: Q158487
 12744961-n:
   definition:
   - 'a large and widespread genus varying in size from small shrubs to large trees:
@@ -67852,6 +69117,7 @@
   - 12751536-n
   - 12751789-n
   partOfSpeech: n
+  wikidata: Q36050
 12745702-n:
   definition:
   - any of numerous deciduous trees and shrubs of the genus Salix
@@ -68216,6 +69482,7 @@
   mero_member:
   - 12752161-n
   partOfSpeech: n
+  wikidata: Q25356
 12752161-n:
   definition:
   - any of numerous trees of north temperate regions having light soft wood and flowers
@@ -68410,6 +69677,7 @@
   - 12758143-n
   - 12759619-n
   partOfSpeech: n
+  wikidata: Q21851
 12755482-n:
   definition:
   - chiefly tropical herbs or shrubs or trees bearing nuts or one-seeded fruit
@@ -68427,6 +69695,7 @@
   - 12757215-n
   - 12757600-n
   partOfSpeech: n
+  wikidata: Q327639
 12755769-n:
   definition:
   - parasitic trees of Indonesia and Malaysia
@@ -68475,6 +69744,7 @@
   mero_member:
   - 12756577-n
   partOfSpeech: n
+  wikidata: Q2380527
 12756577-n:
   definition:
   - parasitic shrub of the eastern United States having opposite leaves and insignificant
@@ -68499,6 +69769,7 @@
   mero_member:
   - 12756988-n
   partOfSpeech: n
+  wikidata: Q5150546
 12756988-n:
   definition:
   - woody creeping parasite of western North America having numerous thick powdery
@@ -68524,6 +69795,7 @@
   mero_member:
   - 12757363-n
   partOfSpeech: n
+  wikidata: Q87151592
 12757363-n:
   definition:
   - Australian tree with edible flesh and edible nutlike seed
@@ -68596,6 +69868,7 @@
   - 12758847-n
   - 12759240-n
   partOfSpeech: n
+  wikidata: Q156691
 12758505-n:
   definition:
   - 'type genus of the Loranthaceae: 1 species'
@@ -68608,6 +69881,7 @@
   mero_member:
   - 12758658-n
   partOfSpeech: n
+  wikidata: Q163517
 12758658-n:
   definition:
   - shrub of central and southeastern Europe; partially parasitic on beeches, chestnuts
@@ -68656,6 +69930,7 @@
   mero_member:
   - 12759359-n
   partOfSpeech: n
+  wikidata: Q15102057
 12759359-n:
   definition:
   - a terrestrial evergreen shrub or small tree of western Australia having brilliant
@@ -68684,6 +69959,7 @@
   - 12759832-n
   - 12760355-n
   partOfSpeech: n
+  wikidata: Q145544
 12759832-n:
   definition:
   - 'type genus of the Viscaceae: Old World evergreen shrubs parasitic on many trees
@@ -68723,6 +69999,7 @@
   mero_member:
   - 12760561-n
   partOfSpeech: n
+  wikidata: Q144322
 12760561-n:
   definition:
   - American plants closely resembling Old World mistletoe
@@ -68768,6 +70045,7 @@
   - 12788711-n
   - 12790190-n
   partOfSpeech: n
+  wikidata: Q26316
 12761274-n:
   definition:
   - chiefly tropical New and Old World deciduous and evergreen trees and shrubs bearing
@@ -68790,6 +70068,7 @@
   - 12765416-n
   - 12765920-n
   partOfSpeech: n
+  wikidata: Q27147
 12761727-n:
   definition:
   - a small Hawaiian tree with hard dark wood
@@ -68836,6 +70115,7 @@
   - 12762346-n
   - 12762552-n
   partOfSpeech: n
+  wikidata: Q321451
 12762346-n:
   definition:
   - deciduous tree of southwestern United States having pulpy fruit containing saponin
@@ -68875,6 +70155,7 @@
   mero_member:
   - 12763050-n
   partOfSpeech: n
+  wikidata: Q1021709
 12763050-n:
   definition:
   - widely cultivated in tropical and subtropical regions for its fragrant flowers
@@ -68902,6 +70183,7 @@
   mero_member:
   - 12763501-n
   partOfSpeech: n
+  wikidata: Q2702934
 12763501-n:
   definition:
   - tendril-climbing vine
@@ -68975,6 +70257,7 @@
   mero_member:
   - 12764583-n
   partOfSpeech: n
+  wikidata: Q2691018
 12764583-n:
   definition:
   - any of various tree of the genus Harpullia
@@ -69017,6 +70300,7 @@
   mero_member:
   - 12765147-n
   partOfSpeech: n
+  wikidata: Q655597
 12765147-n:
   definition:
   - Chinese tree cultivated especially in Philippines and India for its edible fruit;
@@ -69082,6 +70366,7 @@
   - 12766146-n
   - 12766324-n
   partOfSpeech: n
+  wikidata: Q2697447
 12766146-n:
   definition:
   - Malayan tree bearing spiny red fruit
@@ -69124,6 +70409,7 @@
   - 12766736-n
   - 12767493-n
   partOfSpeech: n
+  wikidata: Q156680
 12766736-n:
   definition:
   - type genus of the Buxaceae
@@ -69136,6 +70422,7 @@
   mero_member:
   - 12766866-n
   partOfSpeech: n
+  wikidata: Q158703
 12766866-n:
   definition:
   - evergreen shrubs or small trees
@@ -69183,6 +70470,7 @@
   mero_member:
   - 12767644-n
   partOfSpeech: n
+  wikidata: Q159189
 12767644-n:
   definition:
   - any plant of the genus Pachysandra; low-growing evergreen herbs or subshrubs having
@@ -69232,6 +70520,7 @@
   - 12768721-n
   - 12769575-n
   partOfSpeech: n
+  wikidata: Q135336
 12768591-n:
   definition:
   - any small tree or twining shrub of the genus Celastrus
@@ -69256,6 +70545,7 @@
   - 12769008-n
   - 12769294-n
   partOfSpeech: n
+  wikidata: Q811662
 12769008-n:
   definition:
   - twining shrub of North America having yellow capsules enclosing scarlet seeds
@@ -69302,6 +70592,7 @@
   - 12770612-n
   - 12770836-n
   partOfSpeech: n
+  wikidata: Q161113
 12769809-n:
   definition:
   - any shrubby trees or woody vines of the genus Euonymus having showy usually reddish
@@ -69385,6 +70676,7 @@
   - 12771337-n
   - 12771803-n
   partOfSpeech: n
+  wikidata: Q132989
 12771337-n:
   definition:
   - 'one species: trees and shrubs having flowers with acute or twisted petals and
@@ -69397,6 +70689,7 @@
   mero_member:
   - 12771527-n
   partOfSpeech: n
+  wikidata: Q15102396
 12771527-n:
   definition:
   - shrub or small tree of southeastern United States to West Indies and Brazil; grown
@@ -69422,6 +70715,7 @@
   mero_member:
   - 12771932-n
   partOfSpeech: n
+  wikidata: Q13560627
 12771932-n:
   definition:
   - tree of low-lying coastal areas of southeastern United States having glossy leaves
@@ -69498,6 +70792,7 @@
   mero_member:
   - 12772965-n
   partOfSpeech: n
+  wikidata: Q42292
 12772965-n:
   definition:
   - any of numerous trees or shrubs of the genus Acer bearing winged seeds in pairs;
@@ -69731,6 +71026,7 @@
   - Dipteronia
   - genus Dipteronia
   partOfSpeech: n
+  wikidata: Q1227342
 12777046-n:
   definition:
   - widely distributed shrubs and trees
@@ -69769,6 +71065,7 @@
   - 12777217-n
   - 12777875-n
   partOfSpeech: n
+  wikidata: Q117085
 12777875-n:
   definition:
   - dense rounded evergreen shrub of China having spiny leaves; widely cultivated
@@ -69936,6 +71233,7 @@
   - 12786439-n
   - 12787001-n
   partOfSpeech: n
+  wikidata: Q156589
 12779880-n:
   definition:
   - 'type genus of the Anacardiaceae: cashew'
@@ -70051,6 +71349,7 @@
   mero_member:
   - 12781635-n
   partOfSpeech: n
+  wikidata: Q11690375
 12781635-n:
   definition:
   - small aromatic evergreen shrub of California having paniculate leaves and whitish
@@ -70075,6 +71374,7 @@
   mero_member:
   - 12782044-n
   partOfSpeech: n
+  wikidata: Q161807
 12782044-n:
   definition:
   - large evergreen tropical tree cultivated for its large oval fruit
@@ -70103,6 +71403,7 @@
   - 12782665-n
   - 12782809-n
   partOfSpeech: n
+  wikidata: Q35987
 12782462-n:
   definition:
   - small tree of southern Europe and Asia Minor bearing small hard-shelled nuts
@@ -70151,6 +71452,7 @@
   mero_member:
   - 12783165-n
   partOfSpeech: n
+  wikidata: Q10360410
 12783165-n:
   definition:
   - evergreen of Australia yielding a dark yellow wood
@@ -70176,6 +71478,7 @@
   mero_member:
   - 12783656-n
   partOfSpeech: n
+  wikidata: Q157649
 12783656-n:
   definition:
   - a shrub or tree of the genus Rhus (usually limited to the non-poisonous members
@@ -70295,6 +71598,7 @@
   - 12785738-n
   - 12785875-n
   partOfSpeech: n
+  wikidata: Q786249
 12785738-n:
   definition:
   - small resinous tree or shrub of Brazil
@@ -70334,6 +71638,7 @@
   - 12786606-n
   - 12786803-n
   partOfSpeech: n
+  wikidata: Q311460
 12786606-n:
   definition:
   - tropical American tree having edible yellow fruit
@@ -70379,6 +71684,7 @@
   - 12788183-n
   - 12788408-n
   partOfSpeech: n
+  wikidata: Q1777115
 12787355-n:
   definition:
   - smooth American swamp shrub with pinnate leaves and greenish flowers followed
@@ -70461,6 +71767,7 @@
   mero_member:
   - 12788937-n
   partOfSpeech: n
+  wikidata: Q635009
 12788937-n:
   definition:
   - deciduous trees or some shrubs of North America; southeastern Europe; eastern
@@ -70474,6 +71781,7 @@
   mero_member:
   - 12789129-n
   partOfSpeech: n
+  wikidata: Q158752
 12789129-n:
   definition:
   - tree having palmate leaves and large clusters of white to red flowers followed
@@ -70557,6 +71865,7 @@
   mero_member:
   - 12790423-n
   partOfSpeech: n
+  wikidata: Q157386
 12790423-n:
   definition:
   - a genus of small trees or shrubs of the family Staphylaceae
@@ -70614,6 +71923,7 @@
   - 12792150-n
   - 12792357-n
   partOfSpeech: n
+  wikidata: Q165258
 12791289-n:
   definition:
   - tropical tree of southern Asia having hard dark-colored heartwood used in cabinetwork
@@ -70730,6 +72040,7 @@
   - 12795985-n
   - 12796290-n
   partOfSpeech: n
+  wikidata: Q158981
 12793179-n:
   definition:
   - tropical trees having papery leaves and large fruit
@@ -70740,6 +72051,7 @@
   - Achras
   - genus Achras
   partOfSpeech: n
+  wikidata: Q14566630
 12793317-n:
   definition:
   - deciduous or evergreen American shrubs small trees having very hard wood and milky
@@ -70753,6 +72065,7 @@
   mero_member:
   - 12793513-n
   partOfSpeech: n
+  wikidata: Q59922303
 12793513-n:
   definition:
   - any shrub or small tree of the genus Bumelia
@@ -70800,6 +72113,7 @@
   - Calocarpum
   - genus Calocarpum
   partOfSpeech: n
+  wikidata: Q87145833
 12794248-n:
   definition:
   - tropical American evergreen trees or shrubs
@@ -70812,6 +72126,7 @@
   mero_member:
   - 12794411-n
   partOfSpeech: n
+  wikidata: Q2105812
 12794411-n:
   definition:
   - evergreen tree of West Indies and Central America having edible purple fruit star-shaped
@@ -70851,6 +72166,7 @@
   mero_part:
   - 12795401-n
   partOfSpeech: n
+  wikidata: Q309947
 12795059-n:
   definition:
   - a tropical hardwood tree yielding balata gum and heavy red timber
@@ -70905,6 +72221,7 @@
   mero_member:
   - 12795830-n
   partOfSpeech: n
+  wikidata: Q160364
 12795830-n:
   definition:
   - one of several East Indian trees yielding gutta-percha of the getah taban merah
@@ -70928,6 +72245,7 @@
   mero_member:
   - 12796153-n
   partOfSpeech: n
+  wikidata: Q598477
 12796153-n:
   definition:
   - one of several East Indian trees yielding gutta-percha of the getah soondie variety
@@ -70993,6 +72311,7 @@
   mero_member:
   - 12797151-n
   partOfSpeech: n
+  wikidata: Q588797
 12797151-n:
   definition:
   - type and sole genus of Symplocaceae including sweetleaf
@@ -71005,6 +72324,7 @@
   mero_member:
   - 12797318-n
   partOfSpeech: n
+  wikidata: Q133714
 12797318-n:
   definition:
   - small yellowwood tree of southern United States having small fragrant white flowers;
@@ -71063,6 +72383,7 @@
   mero_member:
   - 12798196-n
   partOfSpeech: n
+  wikidata: Q525062
 12798196-n:
   definition:
   - any shrub or small tree of the genus Styrax having fragrant bell-shaped flowers
@@ -71167,6 +72488,7 @@
   - 12802868-n
   - 12804756-n
   partOfSpeech: n
+  wikidata: Q14914658
 12799993-n:
   definition:
   - insectivorous plants
@@ -71271,6 +72593,7 @@
   mero_member:
   - 12801767-n
   partOfSpeech: n
+  wikidata: Q15582088
 12801767-n:
   definition:
   - marsh or bog herb having solitary pendulous yellow-green flowers and somewhat
@@ -71294,6 +72617,7 @@
   mero_member:
   - 12802181-n
   partOfSpeech: n
+  wikidata: Q1758059
 12802181-n:
   definition:
   - any of several herbs of Guiana highlands having racemes of nodding white or pink
@@ -71330,6 +72654,7 @@
   mero_member:
   - 12802700-n
   partOfSpeech: n
+  wikidata: Q217530
 12802700-n:
   definition:
   - any of several tropical carnivorous shrubs or woody herbs of the genus Nepenthes
@@ -71355,6 +72680,7 @@
   - 12803933-n
   - 12804361-n
   partOfSpeech: n
+  wikidata: Q156185
 12803098-n:
   definition:
   - the type genus of Droseraceae including many low bog-inhabiting insectivorous
@@ -71368,6 +72694,7 @@
   mero_member:
   - 12803290-n
   partOfSpeech: n
+  wikidata: Q266
 12803290-n:
   definition:
   - any of various bog plants of the genus Drosera having leaves covered with sticky
@@ -71392,6 +72719,7 @@
   mero_member:
   - 12803675-n
   partOfSpeech: n
+  wikidata: Q12311673
 12803675-n:
   definition:
   - carnivorous plant of coastal plains of the Carolinas having sensitive hinged marginally
@@ -71443,6 +72771,7 @@
   mero_member:
   - 12804490-n
   partOfSpeech: n
+  wikidata: Q13107254
 12804490-n:
   definition:
   - perennial of dry habitats whose leaves have glandular hairs that secrete adhesive
@@ -71479,6 +72808,7 @@
   mero_member:
   - 12805131-n
   partOfSpeech: n
+  wikidata: Q1066203
 12805131-n:
   definition:
   - either of 2 species of the genus Roridula; South African viscid perennial low-growing
@@ -71501,6 +72831,7 @@
   mero_member:
   - 12805498-n
   partOfSpeech: n
+  wikidata: Q2946333
 12805498-n:
   definition:
   - 'one species: Australian pitcher plant'
@@ -71513,6 +72844,7 @@
   mero_member:
   - 12805649-n
   partOfSpeech: n
+  wikidata: Q2181577
 12805649-n:
   definition:
   - a carnivorous perennial herb having a green pitcher and hinged lid both with red
@@ -71539,6 +72871,7 @@
   - 12806259-n
   - 12807444-n
   partOfSpeech: n
+  wikidata: Q155938
 12806072-n:
   definition:
   - type genus of Crassulaceae; herbs and small shrubs having woody stems and succulent
@@ -71550,6 +72883,7 @@
   - Crassula
   - genus Crassula
   partOfSpeech: n
+  wikidata: Q158253
 12806259-n:
   definition:
   - large genus of rock plants having thick fleshy leaves
@@ -71565,6 +72899,7 @@
   - 12807033-n
   - 12807224-n
   partOfSpeech: n
+  wikidata: Q156851
 12806484-n:
   definition:
   - any of various plants of the genus Sedum
@@ -71635,6 +72970,7 @@
   mero_member:
   - 12807596-n
   partOfSpeech: n
+  wikidata: Q152874
 12807596-n:
   definition:
   - perennial subshrub of Tenerife having leaves in rosettes resembling pinwheels
@@ -71701,6 +73037,7 @@
   - 12811416-n
   - 12812299-n
   partOfSpeech: n
+  wikidata: Q156609
 12808606-n:
   definition:
   - type genus of Hydrangeaceae; large genus of shrubs and some trees and vines with
@@ -71718,6 +73055,7 @@
   - 12809814-n
   - 12809986-n
   partOfSpeech: n
+  wikidata: Q155997
 12808961-n:
   definition:
   - any of various deciduous or evergreen shrubs of the genus Hydrangea
@@ -71790,6 +73128,7 @@
   mero_member:
   - 12810314-n
   partOfSpeech: n
+  wikidata: Q5045752
 12810314-n:
   definition:
   - California evergreen shrub having glossy opposite leaves and terminal clusters
@@ -71814,6 +73153,7 @@
   mero_member:
   - 12810737-n
   partOfSpeech: n
+  wikidata: Q3932024
 12810737-n:
   definition:
   - woody climber of southeastern United States having white flowers in compound terminal
@@ -71838,6 +73178,7 @@
   mero_member:
   - 12811190-n
   partOfSpeech: n
+  wikidata: Q157860
 12811190-n:
   definition:
   - any of various shrubs of the genus Deutzia having usually toothed opposite leaves
@@ -71873,6 +73214,7 @@
   - 12811824-n
   - 12812089-n
   partOfSpeech: n
+  wikidata: Q107394
 12811824-n:
   definition:
   - any of various chiefly deciduous ornamental shrubs of the genus Philadelphus having
@@ -71910,6 +73252,7 @@
   mero_member:
   - 12812550-n
   partOfSpeech: n
+  wikidata: Q3310749
 12812550-n:
   definition:
   - climbing shrub with adhesive aerial roots having opposite leaves and small white
@@ -71951,6 +73294,7 @@
   - 12824277-n
   - 12824976-n
   partOfSpeech: n
+  wikidata: Q2543932
 12813398-n:
   definition:
   - 'type genus of the Saxifragaceae; large genus of usually perennial herbs of Arctic
@@ -71971,6 +73315,7 @@
   - 12815127-n
   - 12815328-n
   partOfSpeech: n
+  wikidata: Q156146
 12813775-n:
   definition:
   - any of various plants of the genus Saxifraga
@@ -72075,6 +73420,7 @@
   mero_member:
   - 12815745-n
   partOfSpeech: n
+  wikidata: Q159001
 12815745-n:
   definition:
   - any plant of the genus Astilbe having compound leaves and showy panicles of tiny
@@ -72132,6 +73478,7 @@
   mero_member:
   - 12816782-n
   partOfSpeech: n
+  wikidata: Q156699
 12816782-n:
   definition:
   - any plant of the genus Bergenia; valued as an evergreen ground cover and for the
@@ -72156,6 +73503,7 @@
   mero_member:
   - 12817145-n
   partOfSpeech: n
+  wikidata: Q143754
 12817145-n:
   definition:
   - plant with leaves mostly at the base and openly branched clusters of small white
@@ -72182,6 +73530,7 @@
   - 12817609-n
   - 12817785-n
   partOfSpeech: n
+  wikidata: Q157593
 12817609-n:
   definition:
   - any of various low aquatic herbs of the genus Chrysosplenium
@@ -72217,6 +73566,7 @@
   mero_member:
   - 12818128-n
   partOfSpeech: n
+  wikidata: Q13099524
 12818128-n:
   definition:
   - rhizomatous perennial herb with large dramatic peltate leaves and white to bright
@@ -72243,6 +73593,7 @@
   mero_member:
   - 12818620-n
   partOfSpeech: n
+  wikidata: Q17442513
 12818620-n:
   definition:
   - Chilean evergreen shrub having delicate spikes of small white flowers
@@ -72269,6 +73620,7 @@
   - 12819392-n
   - 12819670-n
   partOfSpeech: n
+  wikidata: Q972663
 12819044-n:
   definition:
   - any of several herbs of the genus Heuchera
@@ -72325,6 +73677,7 @@
   mero_member:
   - 12820029-n
   partOfSpeech: n
+  wikidata: Q13390024
 12820029-n:
   definition:
   - plant with basal leathery elliptic leaves and erect leafless flower stalks each
@@ -72393,6 +73746,7 @@
   - 12821592-n
   - 12821832-n
   partOfSpeech: n
+  wikidata: Q144225
 12821346-n:
   definition:
   - any of various rhizomatous perennial herbs of the genus Mitella having a capsule
@@ -72440,6 +73794,7 @@
   - 12822541-n
   - 12822726-n
   partOfSpeech: n
+  wikidata: Q159077
 12822280-n:
   definition:
   - any of various usually evergreen bog plants of the genus Parnassia having broad
@@ -72486,6 +73841,7 @@
   - 12823202-n
   - 12823467-n
   partOfSpeech: n
+  wikidata: Q9080458
 12823202-n:
   definition:
   - any of several American plants of the genus Suksdorfia having orbicular to kidney-shaped
@@ -72521,6 +73877,7 @@
   mero_member:
   - 12823986-n
   partOfSpeech: n
+  wikidata: Q13390019
 12823986-n:
   definition:
   - plant growing in clumps with mostly basal leaves and cream-colored or pale pink
@@ -72548,6 +73905,7 @@
   - 12824514-n
   - 12824718-n
   partOfSpeech: n
+  wikidata: Q1456298
 12824514-n:
   definition:
   - stoloniferous white-flowered spring-blooming woodland plant
@@ -72585,6 +73943,7 @@
   mero_member:
   - 12825112-n
   partOfSpeech: n
+  wikidata: Q15704941
 12825112-n:
   definition:
   - vigorous perennial herb with flowers in erect racemes and having young plants
@@ -72612,6 +73971,7 @@
   mero_member:
   - 12825626-n
   partOfSpeech: n
+  wikidata: Q41387
 12825626-n:
   definition:
   - a flowering shrub bearing currants or gooseberries; native to Northern Hemisphere
@@ -72629,6 +73989,7 @@
   - 12826659-n
   - 12826775-n
   partOfSpeech: n
+  wikidata: Q22691
 12825906-n:
   definition:
   - any of various deciduous shrubs of the genus Ribes bearing currants
@@ -72716,6 +74077,7 @@
   mero_member:
   - 12827215-n
   partOfSpeech: n
+  wikidata: Q171425
 12827215-n:
   definition:
   - 'genus of large monoecious mostly deciduous trees: London plane; sycamore'
@@ -72733,6 +74095,7 @@
   - 12828533-n
   - 12828767-n
   partOfSpeech: n
+  wikidata: Q163025
 12827492-n:
   definition:
   - any of several trees of the genus Platanus having thin pale bark that scales off
@@ -72867,6 +74230,7 @@
   - 12831078-n
   - 12832054-n
   partOfSpeech: n
+  wikidata: Q157168
 12829993-n:
   definition:
   - type genus of the Polemoniaceae
@@ -72878,6 +74242,7 @@
   mero_member:
   - 12830125-n
   partOfSpeech: n
+  wikidata: Q157357
 12830125-n:
   definition:
   - any plant of the genus Polemonium; most are low-growing often foul-smelling plants
@@ -72949,6 +74314,7 @@
   - 12831355-n
   - 12831607-n
   partOfSpeech: n
+  wikidata: Q652016
 12831355-n:
   definition:
   - any polemoniaceous plant of the genus Phlox; chiefly North American; cultivated
@@ -72999,6 +74365,7 @@
   - 12832261-n
   - 12832473-n
   partOfSpeech: n
+  wikidata: Q2713077
 12832261-n:
   definition:
   - low wiry-stemmed branching herb or southern California having fringed pink flowers
@@ -73038,6 +74405,7 @@
   - 12833425-n
   - 12833784-n
   partOfSpeech: n
+  wikidata: Q53475
 12832881-n:
   definition:
   - bear's breeches
@@ -73049,6 +74417,7 @@
   mero_member:
   - 12832995-n
   partOfSpeech: n
+  wikidata: Q158091
 12832995-n:
   definition:
   - any plant of the genus Acanthus having large spiny leaves and spikes or white
@@ -73083,6 +74452,7 @@
   mero_member:
   - 12833561-n
   partOfSpeech: n
+  wikidata: Q1936027
 12833561-n:
   definition:
   - tropical Old World shrub having purple or red tubular flowers and leaf markings
@@ -73106,6 +74476,7 @@
   mero_member:
   - 12833949-n
   partOfSpeech: n
+  wikidata: Q162036
 12833949-n:
   definition:
   - tropical African climbing plant having yellow flowers with a dark purple center
@@ -73134,6 +74505,7 @@
   - 12835820-n
   - 12836194-n
   partOfSpeech: n
+  wikidata: Q213453
 12834513-n:
   definition:
   - any woody plant of the family Bignoniaceae
@@ -73155,6 +74527,7 @@
   mero_member:
   - 12834763-n
   partOfSpeech: n
+  wikidata: Q794756
 12834763-n:
   definition:
   - woody flowering vine of southern United States; stems show a cross in transverse
@@ -73194,6 +74567,7 @@
   mero_member:
   - 12835403-n
   partOfSpeech: n
+  wikidata: Q158072
 12835403-n:
   definition:
   - tree of the genus Catalpa with large leaves and white flowers followed by long
@@ -73236,6 +74610,7 @@
   mero_member:
   - 12835958-n
   partOfSpeech: n
+  wikidata: Q16744460
 12835958-n:
   definition:
   - evergreen shrubby tree resembling a willow of dry regions of southwestern North
@@ -73261,6 +74636,7 @@
   mero_member:
   - 12836428-n
   partOfSpeech: n
+  wikidata: Q1321860
 12836428-n:
   definition:
   - tropical American evergreen that produces large round gourds
@@ -73306,6 +74682,7 @@
   - 12843044-n
   - 12843410-n
   partOfSpeech: n
+  wikidata: Q26568
 12837119-n:
   definition:
   - perennial herbs of the Mediterranean region
@@ -73318,6 +74695,7 @@
   mero_member:
   - 12837268-n
   partOfSpeech: n
+  wikidata: Q149122
 12837268-n:
   definition:
   - hairy blue-flowered European annual herb long used in herbal medicine and eaten
@@ -73345,6 +74723,7 @@
   - 12837702-n
   - 12837889-n
   partOfSpeech: n
+  wikidata: Q2354690
 12837702-n:
   definition:
   - annual of western United States with coiled spikes of yellow-orange coiled flowers
@@ -73378,6 +74757,7 @@
   mero_member:
   - 12838224-n
   partOfSpeech: n
+  wikidata: Q27946
 12838224-n:
   definition:
   - any of various Old World herbs of the genus Anchusa having one-sided clusters
@@ -73432,6 +74812,7 @@
   - 12839106-n
   - 12839361-n
   partOfSpeech: n
+  wikidata: Q716132
 12839106-n:
   definition:
   - large tropical American tree of the genus Cordia grown for its abundant creamy
@@ -73518,6 +74899,7 @@
   mero_member:
   - 12840488-n
   partOfSpeech: n
+  wikidata: Q157711
 12840488-n:
   definition:
   - a coarse prickly European weed with spikes of blue flowers; naturalized in United
@@ -73546,6 +74928,7 @@
   mero_member:
   - 12840873-n
   partOfSpeech: n
+  wikidata: Q5222530
 12840873-n:
   definition:
   - Eurasian and North American plants having small prickly nutlets that stick to
@@ -73627,6 +75010,7 @@
   mero_member:
   - 12842265-n
   partOfSpeech: n
+  wikidata: Q765547
 12842265-n:
   definition:
   - smooth erect herb of eastern North America having entire leaves and showy blue
@@ -73652,6 +75036,7 @@
   - 12842655-n
   - 12842875-n
   partOfSpeech: n
+  wikidata: Q147149
 12842655-n:
   definition:
   - small biennial to perennial herb of Europe, northern Africa and western Asia having
@@ -73686,6 +75071,7 @@
   mero_member:
   - 12843226-n
   partOfSpeech: n
+  wikidata: Q9052508
 12843226-n:
   definition:
   - any of several North American perennial herbs with hairy foliage and small yellowish
@@ -73755,6 +75141,7 @@
   - 12846709-n
   - 12847155-n
   partOfSpeech: n
+  wikidata: Q145777
 12844291-n:
   definition:
   - 'genus of mostly climbing or scrambling herbs and shrubs: bindweed'
@@ -73767,6 +75154,7 @@
   - 12844477-n
   - 12844813-n
   partOfSpeech: n
+  wikidata: Q147507
 12844477-n:
   definition:
   - any of numerous plants of the genus Convolvulus
@@ -73915,6 +75303,7 @@
   mero_member:
   - 12846903-n
   partOfSpeech: n
+  wikidata: Q140232
 12846903-n:
   definition:
   - a creeping perennial herb with hairy stems and orbicular to reniform leaves and
@@ -73938,6 +75327,7 @@
   mero_member:
   - 12847276-n
   partOfSpeech: n
+  wikidata: Q161173
 12847276-n:
   definition:
   - any of various twining vines having funnel-shaped flowers that close late in the
@@ -74120,6 +75510,7 @@
   - 12854101-n
   - 12854553-n
   partOfSpeech: n
+  wikidata: Q156686
 12850342-n:
   definition:
   - 'any of numerous tropical or subtropical small shrubs or treelets or epiphytic
@@ -74141,6 +75532,7 @@
   mero_member:
   - 12850735-n
   partOfSpeech: n
+  wikidata: Q1981007
 12850735-n:
   definition:
   - any plant of the genus Gesneria
@@ -74161,6 +75553,7 @@
   mero_member:
   - 12850982-n
   partOfSpeech: n
+  wikidata: Q158834
 12850982-n:
   definition:
   - any plant of the genus Achimenes having showy bell-shaped flowers that resemble
@@ -74183,6 +75576,7 @@
   mero_member:
   - 12851328-n
   partOfSpeech: n
+  wikidata: Q1635829
 12851328-n:
   definition:
   - a plant of the genus Aeschynanthus having somewhat red or orange flowers and seeds
@@ -74216,6 +75610,7 @@
   mero_member:
   - 12851901-n
   partOfSpeech: n
+  wikidata: Q590832
 12851901-n:
   definition:
   - low-growing creeping perennial of Central America having deeply fringed white
@@ -74239,6 +75634,7 @@
   mero_member:
   - 12852295-n
   partOfSpeech: n
+  wikidata: Q2573370
 12852295-n:
   definition:
   - tropical plant having thick hairy somewhat toothed leaves and solitary or clustered
@@ -74260,6 +75656,7 @@
   mero_member:
   - 12852692-n
   partOfSpeech: n
+  wikidata: Q2573318
 12852692-n:
   definition:
   - any plant of the genus Episcia; usually creeping and stoloniferous and of cascading
@@ -74281,6 +75678,7 @@
   mero_member:
   - 12853298-n
   partOfSpeech: n
+  wikidata: Q5239844
 12853075-n:
   definition:
   - any of several plants of the genera Gloxinia or Sinningia (greenhouse gloxinias)
@@ -74312,6 +75710,7 @@
   mero_member:
   - 12853582-n
   partOfSpeech: n
+  wikidata: Q2585772
 12853582-n:
   definition:
   - shrubby herb cultivated for their soft velvety foliage and showy scarlet flowers
@@ -74333,6 +75732,7 @@
   mero_member:
   - 12853909-n
   partOfSpeech: n
+  wikidata: Q7233959
 12853909-n:
   definition:
   - tropical African plant cultivated as a houseplant for its violet or white or pink
@@ -74357,6 +75757,7 @@
   mero_member:
   - 12854286-n
   partOfSpeech: n
+  wikidata: Q159407
 12854286-n:
   definition:
   - South American herb cultivated in many varieties as a houseplant for its large
@@ -74381,6 +75782,7 @@
   - 12854745-n
   - 12854950-n
   partOfSpeech: n
+  wikidata: Q159180
 12854745-n:
   definition:
   - any of various plants of the genus Streptocarpus having leaves in a basal rosette
@@ -74469,6 +75871,7 @@
   mero_member:
   - 12856091-n
   partOfSpeech: n
+  wikidata: Q3053009
 12856091-n:
   definition:
   - viscid herb of arid or desert habitats of southwestern United States having pendulous
@@ -74494,6 +75897,7 @@
   mero_member:
   - 12856526-n
   partOfSpeech: n
+  wikidata: Q147134
 12856526-n:
   definition:
   - viscid evergreen shrub of western United States with white to deep lilac flowers;
@@ -74517,6 +75921,7 @@
   - 12856972-n
   - 12857097-n
   partOfSpeech: n
+  wikidata: Q2738306
 12856972-n:
   definition:
   - any plant of the genus Nemophila
@@ -74558,6 +75963,7 @@
   mero_member:
   - 12857622-n
   partOfSpeech: n
+  wikidata: Q133285
 12857622-n:
   definition:
   - any plant of the genus Phacelia
@@ -74619,6 +76025,7 @@
   mero_member:
   - 12858563-n
   partOfSpeech: n
+  wikidata: Q7187096
 12858563-n:
   definition:
   - straggling California annual herb with deep purple or violet flowers; sometimes
@@ -74697,6 +76104,7 @@
   - 12891152-n
   - 12891834-n
   partOfSpeech: n
+  wikidata: Q53476
 12860079-n:
   definition:
   - any member of the mint family of plants
@@ -74799,6 +76207,7 @@
   mero_member:
   - 12861509-n
   partOfSpeech: n
+  wikidata: Q158472
 12861509-n:
   definition:
   - any of various low-growing annual or perennial evergreen herbs native to Eurasia;
@@ -74868,6 +76277,7 @@
   mero_member:
   - 12862632-n
   partOfSpeech: n
+  wikidata: Q158853
 12862632-n:
   definition:
   - ill-smelling European herb with rugose leaves and whorls of dark purple flowers
@@ -74940,6 +76350,7 @@
   mero_member:
   - 12863647-n
   partOfSpeech: n
+  wikidata: Q820063
 12863647-n:
   definition:
   - perennial aromatic herbs growing in hedgerows or scrub or open woodlands from
@@ -75001,6 +76412,7 @@
   mero_member:
   - 12864730-n
   partOfSpeech: n
+  wikidata: Q164026
 12864730-n:
   definition:
   - aromatic herb having heads of small pink or whitish flowers; widely distributed
@@ -75055,6 +76467,7 @@
   mero_member:
   - 12865699-n
   partOfSpeech: n
+  wikidata: Q17114803
 12865699-n:
   definition:
   - any of various Old World tropical plants of the genus Coleus having multicolored
@@ -75154,6 +76567,7 @@
   mero_member:
   - 12867450-n
   partOfSpeech: n
+  wikidata: Q1754165
 12867450-n:
   definition:
   - any of various aromatic herbs of the genus Elsholtzia having blue or purple flowers
@@ -75177,6 +76591,7 @@
   mero_member:
   - 12867768-n
   partOfSpeech: n
+  wikidata: Q161675
 12867768-n:
   definition:
   - coarse bristly Eurasian plant with white or reddish flowers and foliage resembling
@@ -75201,6 +76616,7 @@
   mero_member:
   - 12868134-n
   partOfSpeech: n
+  wikidata: Q604345
 12868134-n:
   definition:
   - trailing European aromatic plant of the mint family having rounded leaves and
@@ -75232,6 +76648,7 @@
   mero_member:
   - 12868687-n
   partOfSpeech: n
+  wikidata: Q3776462
 12868687-n:
   definition:
   - erect hairy branching American herb having purple-blue flowers; yields an essential
@@ -75269,6 +76686,7 @@
   mero_member:
   - 12869259-n
   partOfSpeech: n
+  wikidata: Q720501
 12869259-n:
   definition:
   - a European mint with aromatic and pungent leaves used in perfumery and as a seasoning
@@ -75305,6 +76723,7 @@
   - 12870039-n
   - 12870176-n
   partOfSpeech: n
+  wikidata: Q146675
 12869821-n:
   definition:
   - any of various plants of the genus Lamium having clusters of small usually purplish
@@ -75348,6 +76767,7 @@
   mero_member:
   - 12870477-n
   partOfSpeech: n
+  wikidata: Q171892
 12870477-n:
   definition:
   - any of various Old World aromatic shrubs or subshrubs with usually mauve or blue
@@ -75420,6 +76840,7 @@
   - 12871666-n
   - 12871854-n
   partOfSpeech: n
+  wikidata: Q952840
 12871666-n:
   definition:
   - relatively nontoxic South African herb smoked like tobacco
@@ -75458,6 +76879,7 @@
   mero_member:
   - 12872229-n
   partOfSpeech: n
+  wikidata: Q157982
 12872229-n:
   definition:
   - bitter Old World herb of hedgerows and woodland margins having toothed leaves
@@ -75484,6 +76906,7 @@
   mero_member:
   - 12872620-n
   partOfSpeech: n
+  wikidata: Q2836393
 12872620-n:
   definition:
   - California plant with woolly stems and leaves and large white flowers
@@ -75509,6 +76932,7 @@
   - 12873188-n
   - 12873330-n
   partOfSpeech: n
+  wikidata: Q158341
 12872994-n:
   definition:
   - a mildly narcotic and astringent aromatic herb having small whitish flowers; eastern
@@ -75558,6 +76982,7 @@
   - 12874242-n
   - 12874466-n
   partOfSpeech: n
+  wikidata: Q205265
 12873690-n:
   definition:
   - small genus of herbs usually included in the genus Origanum
@@ -75568,6 +76993,7 @@
   - Majorana
   - genus Majorana
   partOfSpeech: n
+  wikidata: Q10323229
 12873840-n:
   definition:
   - any of various fragrant aromatic herbs of the genus Origanum used as seasonings
@@ -75633,6 +77059,7 @@
   mero_member:
   - 12874808-n
   partOfSpeech: n
+  wikidata: Q159392
 12874808-n:
   definition:
   - any of various aromatic herbs of the genus Marrubium
@@ -75666,6 +77093,7 @@
   mero_member:
   - 12875360-n
   partOfSpeech: n
+  wikidata: Q920402
 12875360-n:
   definition:
   - bushy perennial Old World mint having small white or yellowish flowers and fragrant
@@ -75696,6 +77124,7 @@
   mero_member:
   - 12875802-n
   partOfSpeech: n
+  wikidata: Q47859
 12875802-n:
   definition:
   - any north temperate plant of the genus Mentha with aromatic leaves and small mauve
@@ -75867,6 +77296,7 @@
   mero_member:
   - 12878539-n
   partOfSpeech: n
+  wikidata: Q2916241
 12878539-n:
   definition:
   - aromatic annual with a tall stems of small whitish flowers enclosed in a greatly
@@ -75890,6 +77320,7 @@
   mero_member:
   - 12878910-n
   partOfSpeech: n
+  wikidata: Q157665
 12878910-n:
   definition:
   - any of various aromatic herbs of the genus Monarda
@@ -75981,6 +77412,7 @@
   mero_member:
   - 12880439-n
   partOfSpeech: n
+  wikidata: Q5223309
 12880439-n:
   definition:
   - fragrant California annual herb having lanceolate leaves and clusters of rose-purple
@@ -76004,6 +77436,7 @@
   mero_member:
   - 12880746-n
   partOfSpeech: n
+  wikidata: Q303820
 12880746-n:
   definition:
   - hairy aromatic perennial herb having whorls of small white purple-spotted flowers
@@ -76067,6 +77500,7 @@
   mero_member:
   - 12881738-n
   partOfSpeech: n
+  wikidata: Q7168518
 12881738-n:
   definition:
   - plant grown for its ornamental red or purple foliage
@@ -76090,6 +77524,7 @@
   - 12882105-n
   - 12882301-n
   partOfSpeech: n
+  wikidata: Q157874
 12882105-n:
   definition:
   - any of various plants of the genus Phlomis; grown primarily for their dense whorls
@@ -76122,6 +77557,7 @@
   mero_member:
   - 12882652-n
   partOfSpeech: n
+  wikidata: Q2702592
 12882652-n:
   definition:
   - any of various plants of the genus Physostegia having sessile linear to oblong
@@ -76157,6 +77593,7 @@
   mero_member:
   - 12883272-n
   partOfSpeech: n
+  wikidata: Q1862564
 12883272-n:
   definition:
   - any of various ornamental plants of the genus Plectranthus
@@ -76178,6 +77615,7 @@
   mero_member:
   - 12883588-n
   partOfSpeech: n
+  wikidata: Q855490
 12883588-n:
   definition:
   - small East Indian shrubby mint; fragrant oil from its leaves is used in perfumes
@@ -76204,6 +77642,7 @@
   mero_member:
   - 12883994-n
   partOfSpeech: n
+  wikidata: Q148652
 12883994-n:
   definition:
   - decumbent blue-flowered European perennial thought to possess healing properties;
@@ -76265,6 +77704,7 @@
   mero_member:
   - 12884920-n
   partOfSpeech: n
+  wikidata: Q1865680
 12884920-n:
   definition:
   - widely cultivated for its fragrant grey-green leaves used in cooking and in perfumery
@@ -76289,6 +77729,7 @@
   mero_member:
   - 12885305-n
   partOfSpeech: n
+  wikidata: Q157151
 12885305-n:
   definition:
   - any of various plants of the genus Salvia; a cosmopolitan herb
@@ -76452,6 +77893,7 @@
   mero_member:
   - 12887728-n
   partOfSpeech: n
+  wikidata: Q22858
 12887728-n:
   definition:
   - any of several aromatic herbs or subshrubs of the genus Satureja having spikes
@@ -76537,6 +77979,7 @@
   - Sideritis
   - genus Sideritis
   partOfSpeech: n
+  wikidata: Q431310
 12889178-n:
   definition:
   - genus of shrubby often succulent herbs of tropical Africa and Asia; includes some
@@ -76563,6 +78006,7 @@
   - 12889640-n
   - 12889821-n
   partOfSpeech: n
+  wikidata: Q156294
 12889640-n:
   definition:
   - foul-smelling perennial Eurasiatic herb with a green creeping rhizome
@@ -76600,6 +78044,7 @@
   mero_member:
   - 12890238-n
   partOfSpeech: n
+  wikidata: Q157714
 12890238-n:
   definition:
   - any of various plants of the genus Teucrium
@@ -76669,6 +78114,7 @@
   mero_member:
   - 12891295-n
   partOfSpeech: n
+  wikidata: Q131224
 12891295-n:
   definition:
   - any of various mints of the genus Thymus
@@ -76775,6 +78221,7 @@
   - 12893458-n
   - 12893942-n
   partOfSpeech: n
+  wikidata: Q161952
 12893017-n:
   definition:
   - 'bladderworts: large genus of aquatic carnivorous plants; cosmopolitan in distribution'
@@ -76787,6 +78234,7 @@
   mero_member:
   - 12893218-n
   partOfSpeech: n
+  wikidata: Q161195
 12893218-n:
   definition:
   - any of numerous aquatic carnivorous plants of the genus Utricularia some of whose
@@ -76833,6 +78281,7 @@
   mero_member:
   - 12894101-n
   partOfSpeech: n
+  wikidata: Q596158
 12894101-n:
   definition:
   - rootless carnivorous swamp plants having at the base of the stem a rosette of
@@ -76854,6 +78303,7 @@
   - Martyniaceae
   - family Martyniaceae
   partOfSpeech: n
+  wikidata: Q53477
 12894594-n:
   definition:
   - in some classifications includes the unicorn plants
@@ -76865,6 +78315,7 @@
   mero_member:
   - 12894744-n
   partOfSpeech: n
+  wikidata: Q14565641
 12894744-n:
   definition:
   - sprawling annual or perennial herb of Central America and West Indies having creamy-white
@@ -76888,6 +78339,7 @@
   - family Orobanchaceae
   - broomrape family
   partOfSpeech: n
+  wikidata: Q156192
 12895189-n:
   definition:
   - the family of plants of order Polemoniales
@@ -76903,6 +78355,7 @@
   - 12895402-n
   - 12895756-n
   partOfSpeech: n
+  wikidata: Q161187
 12895402-n:
   definition:
   - tropical African and Indian herbs
@@ -76915,6 +78368,7 @@
   mero_member:
   - 12895543-n
   partOfSpeech: n
+  wikidata: Q47334
 12895543-n:
   definition:
   - East Indian annual erect herb; source of sesame seed or benniseed and sesame oil
@@ -76945,6 +78399,7 @@
   - 12896457-n
   - 12896621-n
   partOfSpeech: n
+  wikidata: Q137309
 12896029-n:
   definition:
   - annual of southern United States to Mexico having large whitish or yellowish flowers
@@ -77023,6 +78478,7 @@
   - 12909493-n
   - 12910769-n
   partOfSpeech: n
+  wikidata: Q53473
 12897444-n:
   definition:
   - 'type genus of Scrophulariaceae; named for the plants'' supposed ability to cure
@@ -77059,6 +78515,7 @@
   mero_member:
   - 12898004-n
   partOfSpeech: n
+  wikidata: Q157646
 12898004-n:
   definition:
   - a garden plant of the genus Antirrhinum having showy white or yellow or crimson
@@ -77114,6 +78571,7 @@
   mero_member:
   - 12898929-n
   partOfSpeech: n
+  wikidata: Q7217568
 12898929-n:
   definition:
   - a plant of the genus Besseya having fluffy spikes of flowers
@@ -77184,6 +78642,7 @@
   mero_member:
   - 12900287-n
   partOfSpeech: n
+  wikidata: Q1137428
 12900287-n:
   definition:
   - any garden plant of the genus Calceolaria having flowers with large inflated slipper-shaped
@@ -77210,6 +78669,7 @@
   mero_member:
   - 12900723-n
   partOfSpeech: n
+  wikidata: Q311122
 12900723-n:
   definition:
   - any of various plants of the genus Castilleja having dense spikes of hooded flowers
@@ -77277,6 +78737,7 @@
   mero_member:
   - 12901865-n
   partOfSpeech: n
+  wikidata: Q965025
 12901865-n:
   definition:
   - showy perennial of marshlands of eastern and central North America having waxy
@@ -77308,6 +78769,7 @@
   - 12902673-n
   - 12902918-n
   partOfSpeech: n
+  wikidata: Q1828247
 12902391-n:
   definition:
   - white and lavender to pale-blue flowers grow in perfect rings of widely spaced
@@ -77370,6 +78832,7 @@
   mero_member:
   - 12903539-n
   partOfSpeech: n
+  wikidata: Q156533
 12903539-n:
   definition:
   - any of several plants of the genus Digitalis
@@ -77420,6 +78883,7 @@
   mero_member:
   - 12904388-n
   partOfSpeech: n
+  wikidata: Q629836
 12904388-n:
   definition:
   - any plant of the genus Gerardia
@@ -77440,6 +78904,7 @@
   - Agalinis
   - genus Agalinis
   partOfSpeech: n
+  wikidata: Q4691145
 12904683-n:
   definition:
   - 'genus of herbs and subshrubs having showy flowers: spurred snapdragon'
@@ -77452,6 +78917,7 @@
   mero_member:
   - 12905020-n
   partOfSpeech: n
+  wikidata: Q156692
 12904860-n:
   definition:
   - North American plant having racemes of blue-violet flowers
@@ -77505,6 +78971,7 @@
   - 12908994-n
   - 12909217-n
   partOfSpeech: n
+  wikidata: Q809265
 12905805-n:
   definition:
   - plant of southwestern United States having long open clusters of scarlet flowers
@@ -77698,6 +79165,7 @@
   mero_member:
   - 12909666-n
   partOfSpeech: n
+  wikidata: Q57051
 12909666-n:
   definition:
   - any of various plants of the genus Verbascum having large usually woolly leaves
@@ -77773,6 +79241,7 @@
   - 12911853-n
   - 12912229-n
   partOfSpeech: n
+  wikidata: Q7216874
 12911025-n:
   definition:
   - any plant of the genus Veronica
@@ -77927,6 +79396,7 @@
   - 12934405-n
   - 12934808-n
   partOfSpeech: n
+  wikidata: Q134172
 12913854-n:
   definition:
   - 'type genus of the Solanaceae: nightshade, potato, eggplant, bittersweet'
@@ -77949,6 +79419,7 @@
   - 12918548-n
   - 12918759-n
   partOfSpeech: n
+  wikidata: Q146555
 12914223-n:
   definition:
   - any of numerous shrubs or herbs or vines of the genus Solanum; most are poisonous
@@ -78239,6 +79710,7 @@
   mero_member:
   - 12919534-n
   partOfSpeech: n
+  wikidata: Q133827
 12919534-n:
   definition:
   - any of several herbs of the genus Browallia cultivated for their blue or violet
@@ -78344,6 +79816,7 @@
   - 12922484-n
   - 12922781-n
   partOfSpeech: n
+  wikidata: Q201959
 12921222-n:
   definition:
   - any of various tropical plants of the genus Capsicum bearing peppers
@@ -78460,6 +79933,7 @@
   - 12923226-n
   - 12923422-n
   partOfSpeech: n
+  wikidata: Q1364444
 12923226-n:
   definition:
   - West Indian evergreen shrub having clusters of funnel-shaped white flowers that
@@ -78495,6 +79969,7 @@
   mero_member:
   - 12923774-n
   partOfSpeech: n
+  wikidata: Q14944340
 12923774-n:
   definition:
   - South American arborescent shrub having pale pink blossoms followed by egg-shaped
@@ -78518,6 +79993,7 @@
   mero_member:
   - 12924127-n
   partOfSpeech: n
+  wikidata: Q192497
 12924127-n:
   definition:
   - any of several plants of the genus Datura
@@ -78554,6 +80030,7 @@
   mero_member:
   - 12924724-n
   partOfSpeech: n
+  wikidata: Q286158
 12924724-n:
   definition:
   - Peruvian shrub with small pink to lavender tubular flowers; leaves yield a tonic
@@ -78579,6 +80056,7 @@
   - 12925074-n
   - 12925322-n
   partOfSpeech: n
+  wikidata: Q158510
 12925074-n:
   definition:
   - poisonous fetid Old World herb having sticky hairy leaves and yellow-brown flowers;
@@ -78617,7 +80095,7 @@
   - 12925698-n
   - 12926172-n
   partOfSpeech: n
-  wikidata: Q889275
+  wikidata: Q3268411
 12925698-n:
   definition:
   - any of various shrubs or vines of the genus Lycium with showy flowers and bright
@@ -78668,6 +80146,7 @@
   mero_member:
   - 12926781-n
   partOfSpeech: n
+  wikidata: Q12339542
 12926577-n:
   definition:
   - native to South America; widely cultivated in many varieties
@@ -78715,6 +80194,7 @@
   mero_member:
   - 12927258-n
   partOfSpeech: n
+  wikidata: Q212742
 12927258-n:
   definition:
   - a plant of southern Europe and North Africa having purple flowers, yellow fruits
@@ -78751,6 +80231,7 @@
   mero_member:
   - 12927817-n
   partOfSpeech: n
+  wikidata: Q3339559
 12927817-n:
   definition:
   - coarse South American herb grown for its blue-and-white flowers followed by a
@@ -78775,6 +80256,7 @@
   mero_member:
   - 12928225-n
   partOfSpeech: n
+  wikidata: Q851829
 12928225-n:
   definition:
   - aromatic annual or perennial herbs and shrubs
@@ -78847,6 +80329,7 @@
   - 12929614-n
   - 12929828-n
   partOfSpeech: n
+  wikidata: Q1702276
 12929405-n:
   definition:
   - any of various plants of the genus Nierembergia having upturned bell-shaped flowers
@@ -78892,6 +80375,7 @@
   mero_member:
   - 12930181-n
   partOfSpeech: n
+  wikidata: Q161103
 12930181-n:
   definition:
   - any of numerous tropical herbs having fluted funnel-shaped flowers
@@ -78947,6 +80431,7 @@
   - 12931045-n
   - 12931839-n
   partOfSpeech: n
+  wikidata: Q158663
 12931045-n:
   definition:
   - any of numerous cosmopolitan annual or perennial herbs of the genus Physalis bearing
@@ -79084,6 +80569,7 @@
   mero_member:
   - 12933430-n
   partOfSpeech: n
+  wikidata: Q676731
 12933430-n:
   definition:
   - any plant of the genus Salpiglossis
@@ -79115,6 +80601,7 @@
   mero_member:
   - 12933904-n
   partOfSpeech: n
+  wikidata: Q1425929
 12933904-n:
   definition:
   - any plant of the genus Schizanthus having finely divided leaves and showy variegated
@@ -79140,6 +80627,7 @@
   mero_member:
   - 12934284-n
   partOfSpeech: n
+  wikidata: Q1431469
 12934284-n:
   definition:
   - herb that is a source of scopolamine
@@ -79161,6 +80649,7 @@
   mero_member:
   - 12934551-n
   partOfSpeech: n
+  wikidata: Q136929
 12934551-n:
   definition:
   - Mexican evergreen climbing plant having large solitary funnel-shaped fragrant
@@ -79186,6 +80675,7 @@
   mero_member:
   - 12934953-n
   partOfSpeech: n
+  wikidata: Q3500355
 12934953-n:
   definition:
   - evergreen South American shrub having showy trumpet-shaped orange flowers; grown
@@ -79218,6 +80708,7 @@
   - 12936785-n
   - 12937116-n
   partOfSpeech: n
+  wikidata: Q156960
 12935491-n:
   definition:
   - type genus of the Verbenaceae; genus of herbaceous perennials and subshrubs
@@ -79230,6 +80721,7 @@
   - 12935683-n
   - 12935900-n
   partOfSpeech: n
+  wikidata: Q165290
 12935683-n:
   definition:
   - any of numerous tropical or subtropical American plants of the genus Verbena grown
@@ -79264,6 +80756,7 @@
   - 12936328-n
   - 12936571-n
   partOfSpeech: n
+  wikidata: Q132645
 12936160-n:
   definition:
   - 'used in some classifications: coextensive with the genus Avicennia'
@@ -79274,6 +80767,7 @@
   - Avicenniaceae
   - family Avicenniaceae
   partOfSpeech: n
+  wikidata: Q664810
 12936328-n:
   definition:
   - a mangrove of the West Indies and the southern Florida coast; occurs in dense
@@ -79308,6 +80802,7 @@
   mero_member:
   - 12936939-n
   partOfSpeech: n
+  wikidata: Q4687573
 12936939-n:
   definition:
   - an Australian tree resembling the black mangrove of the West Indies and Florida
@@ -79380,6 +80875,7 @@
   - 12948681-n
   - 12949450-n
   partOfSpeech: n
+  wikidata: Q156584
 12938098-n:
   definition:
   - 'type genus of the Euphorbiaceae: very large genus of diverse plants all having
@@ -79411,6 +80907,7 @@
   - 12942628-n
   - 12942879-n
   partOfSpeech: n
+  wikidata: Q146567
 12938661-n:
   definition:
   - any of numerous plants of the genus Euphorbia; usually having milky often poisonous
@@ -79677,6 +81174,7 @@
   - 12943523-n
   - 12943868-n
   partOfSpeech: n
+  wikidata: Q519802
 12943523-n:
   definition:
   - tropical Asiatic shrub; source of croton oil
@@ -79761,6 +81259,7 @@
   - 12944796-n
   - 12945044-n
   partOfSpeech: n
+  wikidata: Q157606
 12944796-n:
   definition:
   - Eurafrican annual naturalized in America as a weed; formerly dried for use as
@@ -79797,6 +81296,7 @@
   mero_member:
   - 12945383-n
   partOfSpeech: n
+  wikidata: Q9069137
 12945383-n:
   definition:
   - large shrub of tropical Africa and Asia having large palmate leaves and spiny
@@ -79826,6 +81326,7 @@
   mero_member:
   - 12945939-n
   partOfSpeech: n
+  wikidata: Q2711979
 12945939-n:
   definition:
   - a stinging herb of tropical America
@@ -79854,6 +81355,7 @@
   mero_member:
   - 12946343-n
   partOfSpeech: n
+  wikidata: Q152986
 12946343-n:
   definition:
   - small tropical American tree yielding purple dye and a tanning extract and bearing
@@ -79878,6 +81380,7 @@
   - rubber tree
   - genus Hevea
   partOfSpeech: n
+  wikidata: Q2350189
 12946799-n:
   definition:
   - deciduous tree of the Amazon and Orinoco Rivers having leathery leaves and fragrant
@@ -79973,6 +81476,7 @@
   - 12948254-n
   - 12948518-n
   partOfSpeech: n
+  wikidata: Q141267
 12948254-n:
   definition:
   - large tree native to southeastern Asia; the nuts yield oil used in varnishes;
@@ -80011,6 +81515,7 @@
   mero_member:
   - 12948831-n
   partOfSpeech: n
+  wikidata: Q10347160
 12948831-n:
   definition:
   - any of several tropical American shrubby succulent plants resembling cacti but
@@ -80061,6 +81566,7 @@
   mero_part:
   - 12949579-n
   partOfSpeech: n
+  wikidata: Q5220377
 12949579-n:
   definition:
   - seed of Mexican shrubs of the genus Sebastiana containing the larva of a moth
@@ -80086,6 +81592,7 @@
   mero_member:
   - 12949997-n
   partOfSpeech: n
+  wikidata: Q156574
 12949997-n:
   definition:
   - tropical Asiatic evergreen shrubs or small trees
@@ -80098,6 +81605,7 @@
   - 12950163-n
   - 12950543-n
   partOfSpeech: n
+  wikidata: Q212815
 12950163-n:
   definition:
   - any of several shrubs or small evergreen trees having solitary white or pink or
@@ -80175,6 +81683,7 @@
   - 12965720-n
   - 12966468-n
   partOfSpeech: n
+  wikidata: Q145794
 12951538-n:
   definition:
   - any of numerous aromatic herbs of the family Umbelliferae
@@ -80207,6 +81716,7 @@
   mero_member:
   - 12951991-n
   partOfSpeech: n
+  wikidata: Q2274537
 12951991-n:
   definition:
   - European weed naturalized in America that resembles parsley but causes nausea
@@ -80230,6 +81740,7 @@
   - Anethum
   - genus Anethum
   partOfSpeech: n
+  wikidata: Q2542121
 12952302-n:
   definition:
   - aromatic Old World herb having aromatic threadlike foliage and seeds used as seasoning
@@ -80255,6 +81766,7 @@
   mero_member:
   - 12952666-n
   partOfSpeech: n
+  wikidata: Q219666
 12952666-n:
   definition:
   - any of various tall and stout herbs of the genus Angelica having pinnately compound
@@ -80303,6 +81815,7 @@
   - 12953466-n
   - 12953726-n
   partOfSpeech: n
+  wikidata: Q745445
 12953466-n:
   definition:
   - aromatic annual Old World herb cultivated for its finely divided and often curly
@@ -80340,6 +81853,7 @@
   mero_member:
   - 12954034-n
   partOfSpeech: n
+  wikidata: Q2284228
 12954034-n:
   definition:
   - herb of Europe and temperate Asia
@@ -80392,6 +81906,7 @@
   mero_member:
   - 12954796-n
   partOfSpeech: n
+  wikidata: Q158975
 12954796-n:
   definition:
   - any plant of the genus Astrantia
@@ -80426,6 +81941,7 @@
   mero_member:
   - 12955239-n
   partOfSpeech: n
+  wikidata: Q149079
 12955239-n:
   definition:
   - a Eurasian plant with small white flowers yielding caraway seed
@@ -80462,6 +81978,7 @@
   - 12955745-n
   - 12955926-n
   partOfSpeech: n
+  wikidata: Q2093588
 12955745-n:
   definition:
   - tall erect highly poisonous Eurasiatic perennial herb locally abundant in marshy
@@ -80498,6 +82015,7 @@
   mero_member:
   - 12956369-n
   partOfSpeech: n
+  wikidata: Q6491516
 12956369-n:
   definition:
   - large branching biennial herb native to Eurasia and Africa and adventive in North
@@ -80580,6 +82098,7 @@
   mero_part:
   - 12957586-n
   partOfSpeech: n
+  wikidata: Q2511981
 12957586-n:
   definition:
   - dwarf Mediterranean annual long cultivated for its aromatic seeds
@@ -80606,6 +82125,7 @@
   - 12957890-n
   - 12958148-n
   partOfSpeech: n
+  wikidata: Q27949
 12957890-n:
   definition:
   - a widely naturalized Eurasian herb with finely cut foliage and white compound
@@ -80720,6 +82240,7 @@
   mero_member:
   - 12959864-n
   partOfSpeech: n
+  wikidata: Q27030
 12959864-n:
   definition:
   - any of several aromatic herbs having edible seeds and leaves and stems
@@ -80769,6 +82290,7 @@
   mero_member:
   - 12960634-n
   partOfSpeech: n
+  wikidata: Q327106
 12960634-n:
   definition:
   - tall coarse plant having thick stems and cluster of white to purple flowers
@@ -80792,6 +82314,7 @@
   mero_member:
   - 12960986-n
   partOfSpeech: n
+  wikidata: Q2701345
 12960986-n:
   definition:
   - herb native to southern Europe; cultivated for its edible stalks and foliage and
@@ -80844,6 +82367,7 @@
   - 12961699-n
   - 12961980-n
   partOfSpeech: n
+  wikidata: Q2737226
 12961699-n:
   definition:
   - European poisonous herb having tuberous roots, yellow juice that stains the skin,
@@ -80879,6 +82403,7 @@
   mero_member:
   - 12962296-n
   partOfSpeech: n
+  wikidata: Q1479657
 12962296-n:
   definition:
   - a strong-scented plant cultivated for its edible root
@@ -80935,6 +82460,7 @@
   mero_member:
   - 12963155-n
   partOfSpeech: n
+  wikidata: Q310933
 12963155-n:
   definition:
   - annual or perennial herb with aromatic leaves
@@ -80979,6 +82505,7 @@
   mero_member:
   - 12963809-n
   partOfSpeech: n
+  wikidata: Q588740
 12963809-n:
   definition:
   - native to Egypt but cultivated widely for its aromatic seeds and the oil from
@@ -81063,6 +82590,7 @@
   mero_member:
   - 12965150-n
   partOfSpeech: n
+  wikidata: Q592341
 12965150-n:
   definition:
   - any plant of the genus Seseli having dense umbels of small white or pink flowers
@@ -81086,6 +82614,7 @@
   mero_member:
   - 12965483-n
   partOfSpeech: n
+  wikidata: Q4361719
 12965483-n:
   definition:
   - a slender roadside herb of western Europe and Mediterranean areas that has foliage
@@ -81112,6 +82641,7 @@
   - 12966126-n
   - 12966309-n
   partOfSpeech: n
+  wikidata: Q943721
 12965937-n:
   definition:
   - stout white-flowered perennial found wild in shallow fresh water; northern United
@@ -81157,6 +82687,7 @@
   mero_member:
   - 12966588-n
   partOfSpeech: n
+  wikidata: Q1979414
 12966588-n:
   definition:
   - European herb somewhat resembling celery widely naturalized in Britain coastal
@@ -81191,6 +82722,7 @@
   - 12969738-n
   - 12970309-n
   partOfSpeech: n
+  wikidata: Q161403
 12967192-n:
   definition:
   - hardy evergreen dioecious shrubs and small trees from Japan
@@ -81201,6 +82733,7 @@
   - Aucuba
   - genus Aucuba
   partOfSpeech: n
+  wikidata: Q162931
 12967338-n:
   definition:
   - 'a rosid dicot genus of the family Cornaceae including: dogwood; cornel: perennial
@@ -81214,6 +82747,7 @@
   mero_member:
   - 12967609-n
   partOfSpeech: n
+  wikidata: Q159545
 12967609-n:
   definition:
   - a tree of shrub of the genus Cornus often having showy bracts resembling flowers
@@ -81343,6 +82877,7 @@
   - Curtisia
   - genus Curtisia
   partOfSpeech: n
+  wikidata: Q284644
 12969738-n:
   definition:
   - evergreen shrubs of New Zealand and South America
@@ -81356,6 +82891,7 @@
   - 12969920-n
   - 12970121-n
   partOfSpeech: n
+  wikidata: Q135212
 12969920-n:
   definition:
   - South American shrub or small tree having long shining evergreen leaves and panicles
@@ -81404,6 +82940,7 @@
   - 12971261-n
   - 12971744-n
   partOfSpeech: n
+  wikidata: Q156682
 12970715-n:
   definition:
   - genus of widely distributed perennial herbs and some shrubs
@@ -81416,6 +82953,7 @@
   mero_member:
   - 12970886-n
   partOfSpeech: n
+  wikidata: Q159559
 12970886-n:
   definition:
   - a plant of the genus Valeriana having lobed or dissected leaves and cymose white
@@ -81450,6 +82988,7 @@
   mero_member:
   - 12971429-n
   partOfSpeech: n
+  wikidata: Q161504
 12971429-n:
   definition:
   - a plant of the genus Valerianella
@@ -81483,6 +83022,7 @@
   mero_member:
   - 12971906-n
   partOfSpeech: n
+  wikidata: Q543142
 12971906-n:
   definition:
   - European herb with small fragrant crimson or white spurred flowers
@@ -81518,6 +83058,7 @@
   - 12972428-n
   - 12972782-n
   partOfSpeech: n
+  wikidata: Q1066700
 12972428-n:
   definition:
   - 'type genus of the Hymenophyllaceae: filmy ferns'
@@ -81554,6 +83095,7 @@
   mero_member:
   - 12972925-n
   partOfSpeech: n
+  wikidata: Q2704784
 12972925-n:
   definition:
   - any fern of the genus Trichomanes having large pinnatifid often translucent fronds;
@@ -81610,6 +83152,7 @@
   - 12974945-n
   - 12975394-n
   partOfSpeech: n
+  wikidata: Q843318
 12973839-n:
   definition:
   - type genus of the Osmundaceae
@@ -81621,6 +83164,7 @@
   mero_member:
   - 12973966-n
   partOfSpeech: n
+  wikidata: Q1427328
 12973966-n:
   definition:
   - 'any fern of the genus Osmunda: large ferns with creeping rhizomes; naked sporangia
@@ -81712,6 +83256,7 @@
   mero_member:
   - 12975559-n
   partOfSpeech: n
+  wikidata: Q3978390
 12975559-n:
   definition:
   - fern of rain forests of tropical Australia and New Zealand and South Africa
@@ -81738,6 +83283,7 @@
   - 12976789-n
   - 12977551-n
   partOfSpeech: n
+  wikidata: Q7431556
 12975951-n:
   definition:
   - 'type genus of the Schizaeaceae cosmopolitan especially in tropics; small leptosporangiate
@@ -81777,6 +83323,7 @@
   mero_member:
   - 12976600-n
   partOfSpeech: n
+  wikidata: Q3353348
 12976600-n:
   definition:
   - fern of Florida and West Indies and Central America with rhizome densely clad
@@ -81800,6 +83347,7 @@
   mero_member:
   - 12976930-n
   partOfSpeech: n
+  wikidata: Q2491168
 12976930-n:
   definition:
   - any of several ferns of the genus Lygodium that climb by twining
@@ -81847,6 +83395,7 @@
   mero_member:
   - 12977682-n
   partOfSpeech: n
+  wikidata: Q6894349
 12977682-n:
   definition:
   - sweetly scented African fern with narrow bipinnate fronds
@@ -81882,6 +83431,7 @@
   - 12978900-n
   - 12979230-n
   partOfSpeech: n
+  wikidata: Q1115420
 12978227-n:
   definition:
   - a genus of water-clover ferns (Marsilea)
@@ -81895,6 +83445,7 @@
   - 12978368-n
   - 12978684-n
   partOfSpeech: n
+  wikidata: Q2363141
 12978368-n:
   definition:
   - any of several water ferns of the genus Marsilea having four leaflets
@@ -81941,6 +83492,7 @@
   mero_member:
   - 12979021-n
   partOfSpeech: n
+  wikidata: Q1813370
 12979021-n:
   definition:
   - European water fern found around margins of bodies of water or in wet acid soil
@@ -81963,6 +83515,7 @@
   mero_member:
   - 12979375-n
   partOfSpeech: n
+  wikidata: Q3374427
 12979375-n:
   definition:
   - small latex-containing aquatic fern of southern Brazil
@@ -81987,6 +83540,7 @@
   - 12979681-n
   - 12980131-n
   partOfSpeech: n
+  wikidata: Q867194
 12979681-n:
   definition:
   - 'type genus of the Salviniaceae: water ferns'
@@ -81999,6 +83553,7 @@
   mero_member:
   - 12979834-n
   partOfSpeech: n
+  wikidata: Q836341
 12979834-n:
   definition:
   - free-floating aquatic ferns
@@ -82021,6 +83576,7 @@
   - Azollaceae
   - family Azollaceae
   partOfSpeech: n
+  wikidata: Q19384228
 12980131-n:
   definition:
   - a genus of fern sometimes placed in its own family Azollaceae
@@ -82033,6 +83589,7 @@
   mero_member:
   - 12980298-n
   partOfSpeech: n
+  wikidata: Q1128633
 12980298-n:
   definition:
   - small free-floating aquatic fern from the eastern United States to tropical America;
@@ -82059,6 +83616,7 @@
   mero_member:
   - 12980727-n
   partOfSpeech: n
+  wikidata: Q767431
 12980727-n:
   definition:
   - a family of succulent ferns of order Ophioglossales; cosmopolitan in distribution
@@ -82073,6 +83631,7 @@
   - 12981489-n
   - 12982449-n
   partOfSpeech: n
+  wikidata: Q740217
 12980971-n:
   definition:
   - the type genus of the fern family Ophioglossaceae
@@ -82283,6 +83842,7 @@
   mero_member:
   - 12984067-n
   partOfSpeech: n
+  wikidata: Q934008
 12984067-n:
   definition:
   - family of fungi parasitic mostly on leaves; includes powdery mildews
@@ -82295,6 +83855,7 @@
   mero_member:
   - 12984254-n
   partOfSpeech: n
+  wikidata: Q1755354
 12984254-n:
   definition:
   - genus of powdery mildews
@@ -82307,6 +83868,7 @@
   mero_member:
   - 12984388-n
   partOfSpeech: n
+  wikidata: Q5396379
 12984388-n:
   definition:
   - any of various fungi of the genus Erysiphe producing powdery conidia on the host
@@ -82333,6 +83895,7 @@
   - 12985969-n
   - 12987146-n
   partOfSpeech: n
+  wikidata: Q143039
 12984890-n:
   definition:
   - parasitic fungi having globose and sometimes necked or beaked perithecia
@@ -82345,6 +83908,7 @@
   mero_member:
   - 12985081-n
   partOfSpeech: n
+  wikidata: Q4429008
 12985081-n:
   definition:
   - genus of fungi with black perithecia used extensively in genetic research; includes
@@ -82356,6 +83920,7 @@
   - Neurospora
   - genus Neurospora
   partOfSpeech: n
+  wikidata: Q309943
 12985332-n:
   definition:
   - fungi having carbonous perithecia with long necks
@@ -82416,6 +83981,7 @@
   mero_member:
   - 12986223-n
   partOfSpeech: n
+  wikidata: Q3144255
 12986223-n:
   definition:
   - fungi parasitic upon the ovaries of various grasses
@@ -82428,6 +83994,7 @@
   mero_member:
   - 12986386-n
   partOfSpeech: n
+  wikidata: Q6445454
 12986386-n:
   definition:
   - a fungus that infects various cereal plants forming compact black masses of branching
@@ -82490,6 +84057,7 @@
   - 12987341-n
   - 12987884-n
   partOfSpeech: n
+  wikidata: Q1755367
 12987341-n:
   definition:
   - type genus of Xylariaceae; fungi with perithecia in the upper part of erect black
@@ -82504,6 +84072,7 @@
   - 12987564-n
   - 12987705-n
   partOfSpeech: n
+  wikidata: Q1625602
 12987564-n:
   definition:
   - fungus causing black root rot in apples
@@ -82552,6 +84121,7 @@
   - 12988536-n
   - 13247424-n
   partOfSpeech: n
+  wikidata: Q134490
 12988264-n:
   definition:
   - a fungus family of order Helotiales, generally found in tropical areas, with 117
@@ -82576,6 +84146,7 @@
   - Helotium
   - genus Helotium
   partOfSpeech: n
+  wikidata: Q5709958
 12988536-n:
   definition:
   - a fungus family of order Helotiales, with many species in the family being plant
@@ -82590,6 +84161,7 @@
   - 12988715-n
   - 12989069-n
   partOfSpeech: n
+  wikidata: Q2292808
 12988715-n:
   definition:
   - large genus of ascomycetous fungi including various destructive plant pathogens
@@ -82601,6 +84173,7 @@
   mero_member:
   - 12988896-n
   partOfSpeech: n
+  wikidata: Q1969330
 12988896-n:
   definition:
   - any fungus of the genus Sclerotinia; some causing brown rot diseases in plants
@@ -82663,6 +84236,7 @@
   - 12990430-n
   - 12990687-n
   partOfSpeech: n
+  wikidata: Q1383511
 12989891-n:
   definition:
   - any of various fungi of the genus Scleroderma having hard-skinned subterranean
@@ -82742,6 +84316,7 @@
   mero_member:
   - 12991320-n
   partOfSpeech: n
+  wikidata: Q10706187
 12991320-n:
   definition:
   - type genus of the Tulostomaceae
@@ -82793,6 +84368,7 @@
   - 12992384-n
   - 12992716-n
   partOfSpeech: n
+  wikidata: Q1339567
 12992160-n:
   definition:
   - any of various fungi of the family Rhizopogonaceae having subterranean fruiting
@@ -82815,6 +84391,7 @@
   mero_member:
   - 12992564-n
   partOfSpeech: n
+  wikidata: Q874176
 12992564-n:
   definition:
   - a large whitish Rhizopogon that becomes greyish brown in maturity
@@ -82875,6 +84452,7 @@
   - 12993578-n
   - 12995046-n
   partOfSpeech: n
+  wikidata: Q3543148
 12993578-n:
   definition:
   - an order of mostly saprophytic fungi
@@ -82887,6 +84465,7 @@
   mero_member:
   - 12993726-n
   partOfSpeech: n
+  wikidata: Q141280
 12993726-n:
   definition:
   - large family of chiefly saprophytic fungi that includes many common molds destructive
@@ -82901,6 +84480,7 @@
   - 12993962-n
   - 12994301-n
   partOfSpeech: n
+  wikidata: Q3268436
 12993962-n:
   definition:
   - type genus of the Mucoraceae; genus of molds having cylindrical or pear-shaped
@@ -82913,6 +84493,7 @@
   mero_member:
   - 12994203-n
   partOfSpeech: n
+  wikidata: Q310801
 12994203-n:
   definition:
   - any mold of the genus Mucor
@@ -82937,6 +84518,7 @@
   - 12994697-n
   - 12994822-n
   partOfSpeech: n
+  wikidata: Q134258
 12994551-n:
   definition:
   - any of various rot causing fungi of the genus Rhizopus
@@ -82980,6 +84562,7 @@
   mero_member:
   - 12995217-n
   partOfSpeech: n
+  wikidata: Q1257561
 12995217-n:
   definition:
   - mostly parasitic lower fungi that typically develop in the bodies of insects
@@ -82992,6 +84575,7 @@
   mero_member:
   - 12995422-n
   partOfSpeech: n
+  wikidata: Q4532109
 12995422-n:
   definition:
   - type genus of the Entomophthoraceae; fungi parasitic on insects
@@ -83002,6 +84586,7 @@
   - Entomophthora
   - genus Entomophthora
   partOfSpeech: n
+  wikidata: Q4532108
 12995586-n:
   definition:
   - any of various slender filaments that function as roots in mosses and ferns and
@@ -83052,6 +84637,7 @@
   mero_member:
   - 12996564-n
   partOfSpeech: n
+  wikidata: Q19830063
 12996564-n:
   definition:
   - a slime mold of the class Myxomycetes
@@ -83099,6 +84685,7 @@
   mero_member:
   - 12997314-n
   partOfSpeech: n
+  wikidata: Q17146891
 12997314-n:
   definition:
   - any slime mold of the genus Dictostylium
@@ -83152,6 +84739,7 @@
   - 13000991-n
   - 13003977-n
   partOfSpeech: n
+  wikidata: Q21445833
 12998325-n:
   definition:
   - a class of mostly aquatic fungi; saprophytic or parasitic on algae or fungi or
@@ -83166,6 +84754,7 @@
   - 12998555-n
   - 12999141-n
   partOfSpeech: n
+  wikidata: Q1137709
 12998555-n:
   definition:
   - simple aquatic fungi mostly saprophytic but some parasitic on higher plants or
@@ -83200,6 +84789,7 @@
   - Chytridiaceae
   - family Chytridiaceae
   partOfSpeech: n
+  wikidata: Q10452650
 12999141-n:
   definition:
   - fungi that carry out asexual reproduction by thick-walled resting spores that
@@ -83213,6 +84803,7 @@
   mero_member:
   - 12999414-n
   partOfSpeech: n
+  wikidata: Q882055
 12999414-n:
   definition:
   - a family of saprobic fungi of order Blastocladiales
@@ -83225,6 +84816,7 @@
   mero_member:
   - 12999586-n
   partOfSpeech: n
+  wikidata: Q10431050
 12999586-n:
   definition:
   - a genus of fungi of the family Blastodiaceae
@@ -83235,6 +84827,7 @@
   - Blastocladia
   - genus Blastocladia
   partOfSpeech: n
+  wikidata: Q9174248
 12999729-n:
   definition:
   - a fungus family of order Chytridiales
@@ -83247,6 +84840,7 @@
   mero_member:
   - 12999889-n
   partOfSpeech: n
+  wikidata: Q10687374
 12999889-n:
   definition:
   - simple parasitic fungi including pond scum parasites
@@ -83260,6 +84854,7 @@
   - 12998836-n
   - 13000076-n
   partOfSpeech: n
+  wikidata: Q10687375
 13000076-n:
   definition:
   - fungus causing potato wart disease in potato tubers
@@ -83297,6 +84892,7 @@
   - 13000589-n
   - 13000840-n
   partOfSpeech: n
+  wikidata: Q134922
 13000589-n:
   definition:
   - 'a fungus that attacks living fish and tadpoles and spawn causing white fungus
@@ -83362,6 +84958,7 @@
   - 13002061-n
   - 13002203-n
   partOfSpeech: n
+  wikidata: Q1650703
 13001600-n:
   definition:
   - any of various fungi of the family Peronosporaceae parasitic on e.g. grapes and
@@ -83417,6 +85014,7 @@
   mero_member:
   - 13002551-n
   partOfSpeech: n
+  wikidata: Q1956444
 13002551-n:
   definition:
   - type genus of the Albuginaceae; fungi causing white rusts
@@ -83429,6 +85027,7 @@
   mero_member:
   - 13002714-n
   partOfSpeech: n
+  wikidata: Q4749920
 13002714-n:
   definition:
   - fungus causing a disease characterized by a white powdery mass of conidia
@@ -83452,6 +85051,7 @@
   - 13003098-n
   - 13003483-n
   partOfSpeech: n
+  wikidata: Q3926088
 13003098-n:
   definition:
   - destructive root-parasitic fungi
@@ -83463,6 +85063,7 @@
   mero_member:
   - 13003228-n
   partOfSpeech: n
+  wikidata: Q2699011
 13003228-n:
   definition:
   - any fungus of the genus Pythium
@@ -83527,6 +85128,7 @@
   mero_member:
   - 13004164-n
   partOfSpeech: n
+  wikidata: Q15241144
 13004164-n:
   definition:
   - type genus of Plasmodiophoraceae comprising minute plant parasitic fungi similar
@@ -83540,6 +85142,7 @@
   mero_member:
   - 13004414-n
   partOfSpeech: n
+  wikidata: Q724130
 13004414-n:
   definition:
   - a fungus resembling slime mold that causes swellings or distortions of the roots
@@ -83664,6 +85267,7 @@
   mero_member:
   - 13006180-n
   partOfSpeech: n
+  wikidata: Q7850807
 13006180-n:
   definition:
   - any of various highly prized edible subterranean fungi of the genus Tuber; grow
@@ -83721,6 +85325,7 @@
   - 13006987-n
   - 13007097-n
   partOfSpeech: n
+  wikidata: Q2466809
 13006987-n:
   definition:
   - a fungus of the family Hydnaceae
@@ -83740,6 +85345,7 @@
   - Hydnum
   - genus Hydnum
   partOfSpeech: n
+  wikidata: Q159023
 13007207-n:
   definition:
   - comprising the lichens which grow symbiotically with algae; sometimes treated
@@ -83772,6 +85378,7 @@
   - Lichenales
   - order Lichenales
   partOfSpeech: n
+  wikidata: Q6543292
 13007816-n:
   definition:
   - any thallophytic plant of the division Lichenes; occur as crusty patches or bushy
@@ -83810,6 +85417,7 @@
   - Lechanorales
   - order Lechanorales
   partOfSpeech: n
+  wikidata: Q133589
 13008594-n:
   definition:
   - a fungus family of the division Lichenes
@@ -83822,6 +85430,7 @@
   mero_member:
   - 13008753-n
   partOfSpeech: n
+  wikidata: Q615824
 13008753-n:
   definition:
   - type genus of Lecanoraceae; crustaceous lichens
@@ -83834,6 +85443,7 @@
   - 13008918-n
   - 13009332-n
   partOfSpeech: n
+  wikidata: Q290423
 13008918-n:
   definition:
   - any lichen of the genus Lecanora; some used in dyeing; some used for food
@@ -83877,6 +85487,7 @@
   mero_member:
   - 13009618-n
   partOfSpeech: n
+  wikidata: Q3052493
 13009618-n:
   definition:
   - chiefly fruticose maritime rock-inhabiting lichens
@@ -83888,6 +85499,7 @@
   mero_member:
   - 13009767-n
   partOfSpeech: n
+  wikidata: Q7353702
 13009767-n:
   definition:
   - a source of the dye archil and of litmus
@@ -83939,6 +85551,7 @@
   - 13011010-n
   - 13011167-n
   partOfSpeech: n
+  wikidata: Q111721087
 13010499-n:
   definition:
   - widely distributed lichens usually having a greyish or yellow pendulous freely
@@ -83952,6 +85565,7 @@
   mero_member:
   - 13010698-n
   partOfSpeech: n
+  wikidata: Q121799
 13010698-n:
   definition:
   - greenish grey pendulous lichen growing on trees
@@ -83997,6 +85611,7 @@
   mero_member:
   - 13011357-n
   partOfSpeech: n
+  wikidata: Q3442095
 13011357-n:
   definition:
   - any of several lichens of the genus Alectoria having a thallus consisting of filaments
@@ -84063,6 +85678,7 @@
   - 13012405-n
   - 13012782-n
   partOfSpeech: n
+  wikidata: Q2573345
 13012405-n:
   definition:
   - type genus of the Parmeliaceae; a large genus of chiefly alpine foliaceous lichens
@@ -84075,6 +85691,7 @@
   mero_member:
   - 13012597-n
   partOfSpeech: n
+  wikidata: Q310585
 13012597-n:
   definition:
   - any of several lichens of the genus Parmelia from which reddish brown or purple
@@ -84134,6 +85751,7 @@
   - 13013628-n
   - 13015739-n
   partOfSpeech: n
+  wikidata: Q764
 13013628-n:
   definition:
   - an organism of the kingdom Fungi lacking chlorophyll and feeding on organic matter;
@@ -84248,6 +85866,7 @@
   - Deuteromycetes
   - class Deuteromycetes
   partOfSpeech: n
+  wikidata: Q648056
 13016985-n:
   definition:
   - comprises fungi bearing the spores on a basidium; includes Gasteromycetes (puffballs)
@@ -84345,6 +85964,7 @@
   - Hymenomycetes
   - class Hymenomycetes
   partOfSpeech: n
+  wikidata: Q21004311
 13019109-n:
   definition:
   - typical gilled mushrooms belonging to the subdivision Basidiomycota
@@ -84481,6 +86101,7 @@
   - 13022690-n
   - 13022969-n
   partOfSpeech: n
+  wikidata: Q2033960
 13022690-n:
   definition:
   - edible east Asian mushroom having a golden or dark brown to blackish cap and an
@@ -84525,6 +86146,7 @@
   - 13024282-n
   - 13024472-n
   partOfSpeech: n
+  wikidata: Q213938
 13023510-n:
   definition:
   - widely distributed edible mushroom resembling the fly agaric
@@ -84640,6 +86262,7 @@
   - 13025586-n
   - 13025752-n
   partOfSpeech: n
+  wikidata: Q922335
 13025183-n:
   definition:
   - widely distributed edible mushroom rich yellow in color with a smooth cap and
@@ -84696,6 +86319,7 @@
   mero_member:
   - 13026089-n
   partOfSpeech: n
+  wikidata: Q2521208
 13026089-n:
   definition:
   - a large poisonous agaric with orange caps and narrow clustered stalks; the gills
@@ -84723,6 +86347,7 @@
   - 13026744-n
   - 13026931-n
   partOfSpeech: n
+  wikidata: Q289890
 13026595-n:
   definition:
   - used in some classifications for the genus Coprinus
@@ -84792,6 +86417,7 @@
   mero_member:
   - 13027654-n
   partOfSpeech: n
+  wikidata: Q1520016
 13027654-n:
   definition:
   - mushroom that grows in a fairy ring
@@ -84828,6 +86454,7 @@
   - 13028177-n
   - 13028389-n
   partOfSpeech: n
+  wikidata: Q852065
 13028177-n:
   definition:
   - edible agaric with a soft greyish cap growing in shelving masses on dead wood
@@ -84871,6 +86498,7 @@
   - 13030189-n
   - 13030416-n
   partOfSpeech: n
+  wikidata: Q584812
 13028917-n:
   definition:
   - a fungus with a smooth orange cap and yellow gills and pale yellow stalk
@@ -84975,6 +86603,7 @@
   - Russula
   - genus Russula
   partOfSpeech: n
+  wikidata: Q216110
 13030824-n:
   definition:
   - used in some classification systems for the genus Russula
@@ -84985,6 +86614,7 @@
   - Russulaceae
   - family Russulaceae
   partOfSpeech: n
+  wikidata: Q831743
 13030979-n:
   definition:
   - sometimes included in family Agaricaceae
@@ -84998,6 +86628,7 @@
   - 13028530-n
   - 13031161-n
   partOfSpeech: n
+  wikidata: Q1362608
 13031161-n:
   definition:
   - genus of gill fungi with brown spores that is closely related to Agaricus; here
@@ -85105,6 +86736,7 @@
   - 13033013-n
   - 13033229-n
   partOfSpeech: n
+  wikidata: Q2099
 13033013-n:
   definition:
   - a deadly poisonous agaric; a large cap that is first white (livid or lead-colored)
@@ -85139,6 +86771,7 @@
   - 13033595-n
   - 13033947-n
   partOfSpeech: n
+  wikidata: Q10557717
 13033595-n:
   definition:
   - a genus of fungus belonging to the family Lepiotaceae
@@ -85148,6 +86781,7 @@
   members:
   - genus Chlorophyllum
   partOfSpeech: n
+  wikidata: Q604880
 13033733-n:
   definition:
   - a poisonous agaric with a fibrillose cap and brown scales on a white ground color;
@@ -85179,6 +86813,7 @@
   - 13035501-n
   - 13035639-n
   partOfSpeech: n
+  wikidata: Q1090886
 13034294-n:
   definition:
   - any fungus of the genus Lepiota
@@ -85279,6 +86914,7 @@
   - 13035989-n
   - 13036586-n
   partOfSpeech: n
+  wikidata: Q3041757
 13035989-n:
   definition:
   - genus of fungi having simple smooth sporophores; some are parasitic on wood or
@@ -85293,6 +86929,7 @@
   - 13036269-n
   - 13036448-n
   partOfSpeech: n
+  wikidata: Q2998103
 13036269-n:
   definition:
   - fungus causing pink disease in citrus and coffee and rubber trees etc
@@ -85327,6 +86964,7 @@
   - 13036836-n
   - 13037049-n
   partOfSpeech: n
+  wikidata: Q105187047
 13036836-n:
   definition:
   - fungus causing a disease in potatoes characterized by black scurfy spots on the
@@ -85509,6 +87147,7 @@
   mero_member:
   - 13039666-n
   partOfSpeech: n
+  wikidata: Q10716674
 13039666-n:
   definition:
   - a parasite on various trees
@@ -85532,6 +87171,7 @@
   - 13039962-n
   - 13040771-n
   partOfSpeech: n
+  wikidata: Q1199784
 13039962-n:
   definition:
   - a large genus of fungi belonging to the family Pluteaceae; the shape of the cap
@@ -85548,6 +87188,7 @@
   - 13040403-n
   - 13040595-n
   partOfSpeech: n
+  wikidata: Q1156750
 13040256-n:
   definition:
   - an agaric with a brilliant scarlet cap and a slender stalk
@@ -85706,6 +87347,7 @@
   mero_member:
   - 13042970-n
   partOfSpeech: n
+  wikidata: Q1765838
 13042970-n:
   definition:
   - an edible agaric that is available in early spring or late fall when few other
@@ -85796,6 +87438,7 @@
   - 13049097-n
   - 13052450-n
   partOfSpeech: n
+  wikidata: Q2303475
 13044772-n:
   definition:
   - any fungus of the class Ascomycetes (or subdivision Ascomycota) in which the spores
@@ -85851,6 +87494,7 @@
   mero_member:
   - 13045727-n
   partOfSpeech: n
+  wikidata: Q1069627
 13045727-n:
   definition:
   - fungi having a zygote or a single cell developing directly into an ascus
@@ -85865,6 +87509,7 @@
   - 13046407-n
   - 13046906-n
   partOfSpeech: n
+  wikidata: Q5147886
 13045957-n:
   definition:
   - 'family of fungi comprising the typical yeasts: reproduce by budding and ferment
@@ -85892,6 +87537,7 @@
   - 13046614-n
   - 13046775-n
   partOfSpeech: n
+  wikidata: Q1146293
 13046407-n:
   definition:
   - any of various single-celled fungi that reproduce asexually by budding or division
@@ -85946,6 +87592,7 @@
   - Schizosaccharomyces
   - genus Schizosaccharomyces
   partOfSpeech: n
+  wikidata: Q1317935
 13047289-n:
   definition:
   - class of fungi in which the fruiting body is a cleistothecium (it releases spores
@@ -85959,6 +87606,7 @@
   mero_member:
   - 13047523-n
   partOfSpeech: n
+  wikidata: Q132180
 13047523-n:
   definition:
   - order of fungi having a closed ascocarp (cleistothecium) with the asci scattered
@@ -85975,6 +87623,7 @@
   - 13047809-n
   - 13047950-n
   partOfSpeech: n
+  wikidata: Q135266
 13047809-n:
   definition:
   - a genus of fungi belonging to the order Eurotiales
@@ -85985,6 +87634,7 @@
   - Eurotium
   - genus Eurotium
   partOfSpeech: n
+  wikidata: Q10491525
 13047950-n:
   definition:
   - family of fungi including some common molds
@@ -85998,6 +87648,7 @@
   - 13048135-n
   - 13048430-n
   partOfSpeech: n
+  wikidata: Q33373960
 13048135-n:
   definition:
   - genus of common molds causing food spoilage and some pathogenic to plants and
@@ -86009,6 +87660,7 @@
   - Aspergillus
   - genus Aspergillus
   partOfSpeech: n
+  wikidata: Q335130
 13048317-n:
   definition:
   - a mold causing aspergillosis in birds and man
@@ -86031,6 +87683,7 @@
   mero_member:
   - 13048639-n
   partOfSpeech: n
+  wikidata: Q7783988
 13048639-n:
   definition:
   - fungus causing brown root rot in plants of the pea and potato and cucumber families
@@ -86056,6 +87709,7 @@
   - 12984556-n
   - 12985816-n
   partOfSpeech: n
+  wikidata: Q133607
 13049097-n:
   definition:
   - a large and taxonomically difficult group of Ascomycetes in which the fleshy fruiting
@@ -86149,6 +87803,7 @@
   - 13055037-n
   - 13055713-n
   partOfSpeech: n
+  wikidata: Q660555
 13050917-n:
   definition:
   - large family comprising many typical cup fungi
@@ -86185,6 +87840,7 @@
   - 13051376-n
   - 13051612-n
   partOfSpeech: n
+  wikidata: Q1080155
 13051376-n:
   definition:
   - a discomycetous fungus of the genus Peziza; the fragile fruiting body is a ghostly
@@ -86267,6 +87923,7 @@
   - 13054639-n
   - 13054822-n
   partOfSpeech: n
+  wikidata: Q656782
 13052716-n:
   definition:
   - 'genus of edible fungi: morel'
@@ -86280,6 +87937,7 @@
   - 13052875-n
   - 13053141-n
   partOfSpeech: n
+  wikidata: Q371101
 13052875-n:
   definition:
   - any of various edible mushrooms of the genus Morchella having a brownish spongelike
@@ -86409,6 +88067,7 @@
   - Wynnea
   - genus Wynnea
   partOfSpeech: n
+  wikidata: Q4111634
 13055315-n:
   definition:
   - a fungus composed of several apothecia that look like elongated rabbit ears; the
@@ -86447,6 +88106,7 @@
   - 13057352-n
   - 13057884-n
   partOfSpeech: n
+  wikidata: Q2453095
 13056001-n:
   definition:
   - a fungus of the family Helvellaceae
@@ -86479,6 +88139,7 @@
   - 13056876-n
   - 13057072-n
   partOfSpeech: n
+  wikidata: Q1514169
 13056467-n:
   definition:
   - any fungus of the genus Helvella having the ascocarps stalked or pleated or often
@@ -86535,6 +88196,7 @@
   mero_member:
   - 13057667-n
   partOfSpeech: n
+  wikidata: Q5281455
 13057564-n:
   definition:
   - any fungus of the genus Discina
@@ -86571,6 +88233,7 @@
   - 13059337-n
   - 13059504-n
   partOfSpeech: n
+  wikidata: Q580989
 13058166-n:
   definition:
   - any fungus of the genus Gyromitra
@@ -86669,6 +88332,7 @@
   - 13062485-n
   - 13068145-n
   partOfSpeech: n
+  wikidata: Q811147
 13060109-n:
   definition:
   - any fungus of the class Gasteromycetes
@@ -86724,6 +88388,7 @@
   - 13061389-n
   - 13061556-n
   partOfSpeech: n
+  wikidata: Q2064470
 13061063-n:
   definition:
   - any of various ill-smelling brown-capped fungi of the order Phallales
@@ -86769,6 +88434,7 @@
   - Dictyophera
   - genus Dictyophera
   partOfSpeech: n
+  wikidata: Q21220172
 13061932-n:
   definition:
   - a genus of fungi belonging to the family Phallaceae
@@ -86779,6 +88445,7 @@
   - Mutinus
   - genus Mutinus
   partOfSpeech: n
+  wikidata: Q1637675
 13062072-n:
   definition:
   - a stinkhorn having a stalk without a cap; the slimy gleba is simply plastered
@@ -86804,6 +88471,7 @@
   - 13062894-n
   - 13063076-n
   partOfSpeech: n
+  wikidata: Q9184296
 13062703-n:
   definition:
   - a gasteromycete with a leathery stalk and a fruiting body that is globose and
@@ -86847,6 +88515,7 @@
   - 13063454-n
   - 13063574-n
   partOfSpeech: n
+  wikidata: Q27990016
 13063454-n:
   definition:
   - type genus of the Clathraceae
@@ -86857,6 +88526,7 @@
   - Clathrus
   - genus Clathrus
   partOfSpeech: n
+  wikidata: Q913940
 13063574-n:
   definition:
   - a genus of fungi belonging to the family Clathraceae
@@ -86897,6 +88567,7 @@
   - 13064276-n
   - 13065301-n
   partOfSpeech: n
+  wikidata: Q3268477
 13064276-n:
   definition:
   - a fungus family belonging to the order Lycoperdales; includes puffballs
@@ -86922,6 +88593,7 @@
   - Lycoperdon
   - genus Lycoperdon
   partOfSpeech: n
+  wikidata: Q1335970
 13064686-n:
   definition:
   - any of various fungi of the family Lycoperdaceae whose round fruiting body discharges
@@ -86946,6 +88618,7 @@
   mero_member:
   - 13065135-n
   partOfSpeech: n
+  wikidata: Q1549736
 13065135-n:
   definition:
   - huge edible puffball up to 2 feet diameter and 25 pounds in weight
@@ -86971,6 +88644,7 @@
   - 13066189-n
   - 13066594-n
   partOfSpeech: n
+  wikidata: Q3100041
 13065538-n:
   definition:
   - any fungus of the family Geastraceae; in form suggesting a puffball whose outer
@@ -87036,6 +88710,7 @@
   - Astreus
   - genus Astreus
   partOfSpeech: n
+  wikidata: Q10420904
 13066735-n:
   definition:
   - the largest earthstar; the fruiting body can measure 15 cm across when the rays
@@ -87069,6 +88744,7 @@
   - 13067272-n
   - 13067771-n
   partOfSpeech: n
+  wikidata: Q123439032
 13067272-n:
   definition:
   - bird's-nest fungi
@@ -87082,6 +88758,7 @@
   - 13067429-n
   - 13067647-n
   partOfSpeech: n
+  wikidata: Q76854
 13067429-n:
   definition:
   - any of various fungi of the family Nidulariaceae having a cup-shaped body containing
@@ -87102,6 +88779,7 @@
   - Nidularia
   - genus Nidularia
   partOfSpeech: n
+  wikidata: Q1316092
 13067771-n:
   definition:
   - monotypic family of fungi in which the more or less spherical gleba is forcibly
@@ -87113,6 +88791,7 @@
   - Sphaerobolaceae
   - family Sphaerobolaceae
   partOfSpeech: n
+  wikidata: Q31270304
 13068145-n:
   definition:
   - a family of fungi that have a stalk and cap and a wrinkled mass of tissue (the
@@ -87141,6 +88820,7 @@
   mero_member:
   - 13068622-n
   partOfSpeech: n
+  wikidata: Q62749439
 13068622-n:
   definition:
   - a species of Gastrocybe fungus that has a conic cap and a thin stalk; at first
@@ -87166,6 +88846,7 @@
   mero_member:
   - 13069207-n
   partOfSpeech: n
+  wikidata: Q10573574
 13069207-n:
   definition:
   - a small fungus with a fragile cap that cracks to expose the white context and
@@ -87190,6 +88871,7 @@
   - 13069692-n
   - 13069865-n
   partOfSpeech: n
+  wikidata: Q1939318
 13069692-n:
   definition:
   - a dingy yellow brown fungus with a rough stalk that superficially resembles a
@@ -87224,6 +88906,7 @@
   - 13070321-n
   - 13073947-n
   partOfSpeech: n
+  wikidata: Q2858281
 13070321-n:
   definition:
   - fungi that become corky or woody with age, often forming shelflike growths on
@@ -87247,6 +88930,7 @@
   - 13073191-n
   - 13074576-n
   partOfSpeech: n
+  wikidata: Q658831
 13070713-n:
   definition:
   - woody pore fungi; any fungus of the family Polyporaceae or family Boletaceae having
@@ -87281,6 +88965,7 @@
   - Albatrellus
   - genus Albatrellus
   partOfSpeech: n
+  wikidata: Q1073187
 13071465-n:
   definition:
   - a rare fungus having a large (up to 14 inches wide) yellow fruiting body with
@@ -87356,6 +89041,7 @@
   - Oligoporus
   - genus Oligoporus
   partOfSpeech: n
+  wikidata: Q80595
 13072774-n:
   definition:
   - a pore fungus with a whitish cottony soft cap found on conifer logs in forests
@@ -87391,6 +89077,7 @@
   - 13073430-n
   - 13073691-n
   partOfSpeech: n
+  wikidata: Q1548736
 13073430-n:
   definition:
   - large greyish-brown edible fungus forming a mass of overlapping caps that somewhat
@@ -87429,6 +89116,7 @@
   mero_member:
   - 13074210-n
   partOfSpeech: n
+  wikidata: Q931058
 13074210-n:
   definition:
   - fungi having each pore separate though crowded
@@ -87441,6 +89129,7 @@
   mero_member:
   - 13074368-n
   partOfSpeech: n
+  wikidata: Q3010372
 13074368-n:
   definition:
   - a popular edible fungus with a cap the color of liver or raw meat; abundant in
@@ -87466,6 +89155,7 @@
   mero_member:
   - 13074833-n
   partOfSpeech: n
+  wikidata: Q2524023
 13074833-n:
   definition:
   - fungus used in the preparation of punk for fuses
@@ -87530,6 +89220,7 @@
   - 13078182-n
   - 13078399-n
   partOfSpeech: n
+  wikidata: Q19744
 13076183-n:
   definition:
   - a fungus convex cap and a dingy yellow under surface and a dry stalk
@@ -87669,6 +89360,7 @@
   - 13078797-n
   - 13079032-n
   partOfSpeech: n
+  wikidata: Q57418268
 13078797-n:
   definition:
   - an edible fungus with a pinkish purple cap and stalk and a pore surface that is
@@ -87727,6 +89419,7 @@
   mero_member:
   - 13079723-n
   partOfSpeech: n
+  wikidata: Q1831149
 13079723-n:
   definition:
   - a fungus with a broadly convex brown cap and pores that extend part way down the
@@ -87751,6 +89444,7 @@
   mero_member:
   - 13080058-n
   partOfSpeech: n
+  wikidata: Q1338220
 13080058-n:
   definition:
   - a short squat edible fungus with a reddish brown cap and white stalk; fruits under
@@ -87832,6 +89526,7 @@
   - 13082872-n
   - 13083390-n
   partOfSpeech: n
+  wikidata: Q206636
 13081449-n:
   definition:
   - a family of basidiomycetous fungi of the order Tremellales that have the basidium
@@ -87845,6 +89540,7 @@
   mero_member:
   - 13081672-n
   partOfSpeech: n
+  wikidata: Q557221
 13081672-n:
   definition:
   - fungi with yellowish gelatinous sporophores having convolutions resembling those
@@ -87861,6 +89557,7 @@
   - 13082231-n
   - 13082464-n
   partOfSpeech: n
+  wikidata: Q206627
 13081932-n:
   definition:
   - popular in China and Japan and Taiwan; gelatinous mushrooms; most are dried
@@ -87913,6 +89610,7 @@
   - Auriculariales
   - order Auriculariales
   partOfSpeech: n
+  wikidata: Q892462
 13082872-n:
   definition:
   - fungi having gelatinous sporophores
@@ -87938,6 +89636,7 @@
   mero_member:
   - 13083181-n
   partOfSpeech: n
+  wikidata: Q1633488
 13083181-n:
   definition:
   - widely distributed edible fungus shaped like a human ear and growing on decaying
@@ -87991,6 +89690,7 @@
   - 13084544-n
   - 13085438-n
   partOfSpeech: n
+  wikidata: Q10657222
 13084029-n:
   definition:
   - any of various fungi causing rust disease in plants
@@ -88035,6 +89735,7 @@
   - 13084696-n
   - 13085007-n
   partOfSpeech: n
+  wikidata: Q10580133
 13084696-n:
   definition:
   - rusts having sessile one-celled teliospores in a single layer
@@ -88136,6 +89837,7 @@
   mero_member:
   - 13086274-n
   partOfSpeech: n
+  wikidata: Q3272185
 13086274-n:
   definition:
   - rust fungus causing rust spots on apples and pears etc
@@ -88158,6 +89860,7 @@
   - Tiliomycetes
   - class Tiliomycetes
   partOfSpeech: n
+  wikidata: Q10692511
 13086662-n:
   definition:
   - parasitic fungi causing smuts; sometimes placed in class Tiliomycetes
@@ -88172,6 +89875,7 @@
   - 13087391-n
   - 13088605-n
   partOfSpeech: n
+  wikidata: Q594740
 13086889-n:
   definition:
   - any fungus of the order Ustilaginales
@@ -88206,6 +89910,7 @@
   - 13087951-n
   - 13088292-n
   partOfSpeech: n
+  wikidata: Q3233983
 13087563-n:
   definition:
   - type genus of the Ustilaginaceae; genus comprising the loose smuts
@@ -88219,6 +89924,7 @@
   - 13087739-n
   - 13088090-n
   partOfSpeech: n
+  wikidata: Q2361375
 13087739-n:
   definition:
   - a smut fungus of the genus Ustilago causing a smut disease of grains in which
@@ -88262,6 +89968,7 @@
   mero_member:
   - 13088432-n
   partOfSpeech: n
+  wikidata: Q10674930
 13088432-n:
   definition:
   - smut fungus attacking heads of corn or sorghum and causing a covered smut
@@ -88301,6 +90008,7 @@
   - 13089015-n
   - 13089194-n
   partOfSpeech: n
+  wikidata: Q626766
 13089015-n:
   definition:
   - fungus that destroys kernels of wheat by replacing them with greasy masses of
@@ -88335,6 +90043,7 @@
   mero_member:
   - 13089677-n
   partOfSpeech: n
+  wikidata: Q7900813
 13089495-n:
   definition:
   - smut fungus causing blackish blisters on scales and leaves of onions; especially
@@ -88379,6 +90088,7 @@
   mero_member:
   - 13090295-n
   partOfSpeech: n
+  wikidata: Q10665828
 13090295-n:
   definition:
   - 'type genus of Septobasidiaceae: smooth shelf fungi usually having a well-developed
@@ -88422,6 +90132,7 @@
   - 13093971-n
   - 13094286-n
   partOfSpeech: n
+  wikidata: Q596145
 13091068-n:
   definition:
   - any fungus of the family Hygrophoraceae having gills that are more or less waxy
@@ -88445,6 +90156,7 @@
   mero_member:
   - 13091635-n
   partOfSpeech: n
+  wikidata: Q520530
 13091635-n:
   definition:
   - a fungus having an acutely conic cap and dry stalks
@@ -88477,6 +90189,7 @@
   - 13093623-n
   - 13093815-n
   partOfSpeech: n
+  wikidata: Q622043
 13092131-n:
   definition:
   - a fungus with a white convex cap and arcuate white gills and a stalk that tapers
@@ -88589,6 +90302,7 @@
   mero_member:
   - 13094140-n
   partOfSpeech: n
+  wikidata: Q62523353
 13094140-n:
   definition:
   - a small grey-brown fungus with an unpleasant odor of mothballs
@@ -88611,6 +90325,7 @@
   mero_member:
   - 13094463-n
   partOfSpeech: n
+  wikidata: Q5235841
 13094463-n:
   definition:
   - a fungus with a small brown convex cap with a depressed disc; waxy wine-colored
@@ -88763,6 +90478,7 @@
   - 13097403-n
   - 13097591-n
   partOfSpeech: n
+  wikidata: Q1498027
 13097165-n:
   definition:
   - a fungus with a brownish orange fruiting body and a ring near the top of the stalk;
@@ -88844,6 +90560,7 @@
   mero_member:
   - 13098781-n
   partOfSpeech: n
+  wikidata: Q2452570
 13098781-n:
   definition:
   - a fungus of the genus Verticillium
@@ -88871,6 +90588,7 @@
   - 13100535-n
   - 13100713-n
   partOfSpeech: n
+  wikidata: Q21229502
 13099243-n:
   definition:
   - a genus of fungus of the family Moniliaceae; causes ringworm and favus
@@ -88881,6 +90599,7 @@
   - Trichophyton
   - genus Trichophyton
   partOfSpeech: n
+  wikidata: Q310925
 13099412-n:
   definition:
   - a genus of fungus of the family Moniliaceae; causes ringworm
@@ -88891,6 +90610,7 @@
   - Microsporum
   - genus Microsporum
   partOfSpeech: n
+  wikidata: Q639799
 13099569-n:
   definition:
   - genus of parasitic yeastlike imperfect fungi having spherical or oval conidia
@@ -88904,6 +90624,7 @@
   mero_member:
   - 13099833-n
   partOfSpeech: n
+  wikidata: Q3320779
 13099833-n:
   definition:
   - any of the yeastlike imperfect fungi of the genus Monilia
@@ -88926,6 +90647,7 @@
   - 13100179-n
   - 13100327-n
   partOfSpeech: n
+  wikidata: Q131260
 13100179-n:
   definition:
   - any of the yeastlike imperfect fungi of the genus Candida
@@ -88956,6 +90678,7 @@
   - Cercosporella
   - genus Cercosporella
   partOfSpeech: n
+  wikidata: Q10446583
 13100713-n:
   definition:
   - genus of fungi commonly growing as green or blue molds on decaying food; used
@@ -88967,6 +90690,7 @@
   - Penicillium
   - genus Penicillium
   partOfSpeech: n
+  wikidata: Q843136
 13100934-n:
   definition:
   - genus of pathogenic yeastlike fungi
@@ -88977,6 +90701,7 @@
   - Blastomyces
   - genus Blastomyces
   partOfSpeech: n
+  wikidata: Q10431073
 13101066-n:
   definition:
   - any of various yeastlike budding fungi of the genus Blastomyces; cause disease
@@ -89000,6 +90725,7 @@
   - 13101434-n
   - 13101810-n
   partOfSpeech: n
+  wikidata: Q16628379
 13101434-n:
   definition:
   - form genus of imperfect fungi that are leaf parasites with long slender spores
@@ -89012,6 +90738,7 @@
   mero_member:
   - 13101626-n
   partOfSpeech: n
+  wikidata: Q2066868
 13101626-n:
   definition:
   - fungus causing yellow spot (a sugarcane disease in Australia)
@@ -89060,6 +90787,7 @@
   - 13102325-n
   - 13102538-n
   partOfSpeech: n
+  wikidata: Q2119178
 13102325-n:
   definition:
   - type genus of the Tuberculariaceae; fungi with nodules of red or pink conidia;
@@ -89082,6 +90810,7 @@
   members:
   - genus Fusarium
   partOfSpeech: n
+  wikidata: Q131672
 13102759-n:
   definition:
   - a fungus causing dry rot
@@ -89118,6 +90847,7 @@
   mero_member:
   - 13103328-n
   partOfSpeech: n
+  wikidata: Q2716477
 13103328-n:
   definition:
   - any fungus now or formerly belonging to the form genus Rhizoctinia
@@ -89137,6 +90867,7 @@
   - Ozonium
   - genus Ozonium
   partOfSpeech: n
+  wikidata: Q10614405
 13103589-n:
   definition:
   - form genus of sterile imperfect fungi; many form sclerotia; some cause sclerotium
@@ -89148,6 +90879,7 @@
   - Sclerotium
   - genus Sclerotium
   partOfSpeech: n
+  wikidata: Q3952473
 13103783-n:
   definition:
   - any of a variety of plants grown indoors for decorative purposes
@@ -91577,6 +93309,7 @@
   - 13164403-n
   - 13164707-n
   partOfSpeech: n
+  wikidata: Q156083
 13161770-n:
   definition:
   - 'type genus of the Rhamnaceae: buckthorns'
@@ -91589,6 +93322,7 @@
   mero_member:
   - 13161918-n
   partOfSpeech: n
+  wikidata: Q79190
 13161918-n:
   definition:
   - a shrub or shrubby tree of the genus Rhamnus; fruits are source of yellow dyes
@@ -91723,6 +93457,7 @@
   - 13164062-n
   - 13164260-n
   partOfSpeech: n
+  wikidata: Q310492
 13164062-n:
   definition:
   - spiny tree having dark red edible fruits
@@ -91761,6 +93496,7 @@
   mero_member:
   - 13164535-n
   partOfSpeech: n
+  wikidata: Q141273
 13164535-n:
   definition:
   - thorny Eurasian shrub with dry woody winged fruit
@@ -91815,6 +93551,7 @@
   - 13165288-n
   - 13168802-n
   partOfSpeech: n
+  wikidata: Q26220
 13165288-n:
   definition:
   - the type genus of the family Vitaceae; woody vines with simple leaves and small
@@ -91831,6 +93568,7 @@
   - 13166027-n
   - 13166221-n
   partOfSpeech: n
+  wikidata: Q191019
 13165571-n:
   definition:
   - any of numerous woody vines of genus Vitis bearing clusters of edible berries
@@ -92040,6 +93778,7 @@
   - 13168991-n
   - 13169167-n
   partOfSpeech: n
+  wikidata: Q157587
 13168991-n:
   definition:
   - Asiatic vine with three-lobed leaves and purple berries
@@ -92077,6 +93816,7 @@
   - 13172042-n
   - 13172345-n
   partOfSpeech: n
+  wikidata: Q27287
 13169574-n:
   definition:
   - tropical woody vines and herbaceous plants having aromatic herbage and minute
@@ -92092,6 +93832,7 @@
   - 13169822-n
   - 13171518-n
   partOfSpeech: n
+  wikidata: Q156522
 13169822-n:
   definition:
   - 'type genus of the Piperaceae: large genus of chiefly climbing tropical shrubs'
@@ -92108,6 +93849,7 @@
   - 13170753-n
   - 13170955-n
   partOfSpeech: n
+  wikidata: Q159536
 13170079-n:
   definition:
   - any of various shrubby vines of the genus Piper
@@ -92205,6 +93947,7 @@
   mero_member:
   - 13171671-n
   partOfSpeech: n
+  wikidata: Q1354632
 13171671-n:
   definition:
   - any of various plants of the genus Peperomia; grown primarily for their often
@@ -92266,6 +94009,7 @@
   - 13172980-n
   - 13173369-n
   partOfSpeech: n
+  wikidata: Q157072
 13172597-n:
   definition:
   - 'type genus of the Saururaceae: lizard''s-tails'
@@ -92304,6 +94048,7 @@
   mero_member:
   - 13173116-n
   partOfSpeech: n
+  wikidata: Q18200394
 13173116-n:
   definition:
   - stoloniferous herb of southwestern United States and Mexico having a pungent rootstock
@@ -92325,6 +94070,7 @@
   - Houttuynia
   - genus Houttuynia
   partOfSpeech: n
+  wikidata: Q162194
 13173519-n:
   definition:
   - the main organ of photosynthesis and transpiration in higher plants
@@ -93312,6 +95058,7 @@
   - 13247907-n
   - 13248133-n
   partOfSpeech: n
+  wikidata: Q21026831
 13190572-n:
   definition:
   - true (leptosporangiate) ferns
@@ -93337,6 +95084,7 @@
   - 13224740-n
   - 13226380-n
   partOfSpeech: n
+  wikidata: Q834805
 13190958-n:
   definition:
   - a family of ferns belonging to order Filicales
@@ -93352,6 +95100,7 @@
   - 13191559-n
   - 13191939-n
   partOfSpeech: n
+  wikidata: Q2264971
 13191184-n:
   definition:
   - 'type genus of Gleicheniaceae: leptosporangiate ferns with sessile sporangia;
@@ -93363,6 +95112,7 @@
   - Gleichenia
   - genus Gleichenia
   partOfSpeech: n
+  wikidata: Q429586
 13191396-n:
   definition:
   - terrestrial ferns of forest margin or open ground; pantropical
@@ -93436,6 +95186,7 @@
   mero_member:
   - 13192547-n
   partOfSpeech: n
+  wikidata: Q19385821
 13192547-n:
   definition:
   - a genus of pan-tropical water ferns (Ceratopteris)
@@ -93500,6 +95251,7 @@
   - 13204149-n
   - 13205062-n
   partOfSpeech: n
+  wikidata: Q849350
 13193623-n:
   definition:
   - a genus of ferns belonging to the family Polypodiaceae and having rounded naked
@@ -93513,6 +95265,7 @@
   mero_member:
   - 13193821-n
   partOfSpeech: n
+  wikidata: Q1135685
 13193821-n:
   definition:
   - any of numerous ferns of the genus Polypodium
@@ -93600,6 +95353,7 @@
   mero_member:
   - 13195252-n
   partOfSpeech: n
+  wikidata: Q4692851
 13195252-n:
   definition:
   - epiphytic fern with large fronds; Taiwan and Philippines
@@ -93622,6 +95376,7 @@
   mero_member:
   - 13195568-n
   partOfSpeech: n
+  wikidata: Q4566572
 13195568-n:
   definition:
   - fern with long narrow strap-shaped leaves
@@ -93665,6 +95420,7 @@
   - Drymoglossum
   - genus Drymoglossum
   partOfSpeech: n
+  wikidata: Q5814402
 13196382-n:
   definition:
   - large robust epiphytic ferns of tropical forest and scrub; Africa and Asia and
@@ -93678,6 +95434,7 @@
   mero_member:
   - 13196580-n
   partOfSpeech: n
+  wikidata: Q3020925
 13196580-n:
   definition:
   - giant epiphytic or lithophytic fern; Asia to Polynesia and Australia
@@ -93699,6 +95456,7 @@
   mero_member:
   - 13196898-n
   partOfSpeech: n
+  wikidata: Q6511489
 13196898-n:
   definition:
   - any of several bizarre ferns of the genus Lecanopteris having swollen hollow rhizomes
@@ -93721,6 +95479,7 @@
   mero_member:
   - 13197261-n
   partOfSpeech: n
+  wikidata: Q1803403
 13197261-n:
   definition:
   - epiphytic ferns with long rhizomes; tropical America
@@ -93743,6 +95502,7 @@
   mero_member:
   - 13197612-n
   partOfSpeech: n
+  wikidata: Q87298442
 13197612-n:
   definition:
   - tropical Africa to Australasia and Polynesia
@@ -93765,6 +95525,7 @@
   mero_member:
   - 13197946-n
   partOfSpeech: n
+  wikidata: Q2618227
 13197946-n:
   definition:
   - tropical American fern with brown scaly rhizomes cultivated for its large deeply
@@ -93841,6 +95602,7 @@
   mero_member:
   - 13199182-n
   partOfSpeech: n
+  wikidata: Q4250979
 13199182-n:
   definition:
   - east Asian fern having fronds shaped like tongues; sometimes placed in genus Cyclophorus
@@ -93866,6 +95628,7 @@
   mero_member:
   - 13199605-n
   partOfSpeech: n
+  wikidata: Q17188414
 13199605-n:
   definition:
   - small epiphytic fern of South America with tuberous swellings along rhizomes
@@ -93886,6 +95649,7 @@
   - Cyclophorus
   - genus Cyclophorus
   partOfSpeech: n
+  wikidata: Q17186486
 13199954-n:
   definition:
   - plant that affords shelter or food to ants that live in symbiotic relations with
@@ -93907,6 +95671,7 @@
   - Adiantaceae
   - family Adiantaceae
   partOfSpeech: n
+  wikidata: Q3735428
 13200308-n:
   definition:
   - 'one of a number of families into which Polypodiaceae has been subdivided in some
@@ -93920,6 +95685,7 @@
   mero_member:
   - 13200546-n
   partOfSpeech: n
+  wikidata: Q19387804
 13200546-n:
   definition:
   - tropical epiphytic ferns with straplike fronds
@@ -93960,6 +95726,7 @@
   - 13204567-n
   - 13204772-n
   partOfSpeech: n
+  wikidata: Q1137402
 13201202-n:
   definition:
   - a genus of about 700 species of ferns, often treated as the only genus in the
@@ -93977,6 +95744,7 @@
   - 13203954-n
   - 13204387-n
   partOfSpeech: n
+  wikidata: Q5347305
 13201432-n:
   definition:
   - any of various chiefly rock-inhabiting ferns of the genus Asplenium
@@ -94043,6 +95811,7 @@
   - Camptosorus
   - genus Camptosorus
   partOfSpeech: n
+  wikidata: Q12840797
 13202709-n:
   definition:
   - ferns having lanceolate fronds that root at the tip
@@ -94153,6 +95922,7 @@
   - Ceterach
   - genus Ceterach
   partOfSpeech: n
+  wikidata: Q1968640
 13204387-n:
   definition:
   - small European fern with chaffy leathery fronds
@@ -94176,6 +95946,7 @@
   - Pleurosorus
   - genus Pleurosorus
   partOfSpeech: n
+  wikidata: Q17278592
 13204772-n:
   definition:
   - genus of the family Aspleniaceae (Schaffneria)
@@ -94188,6 +95959,7 @@
   mero_member:
   - 13204899-n
   partOfSpeech: n
+  wikidata: Q17166649
 13204899-n:
   definition:
   - a fern of the genus Schaffneria
@@ -94211,6 +95983,7 @@
   - genus Phyllitis
   - genus Scolopendrium
   partOfSpeech: n
+  wikidata: Q17166671
 13205292-n:
   definition:
   - a fern thought to resemble a millipede
@@ -94238,6 +96011,7 @@
   - 13206896-n
   - 13207098-n
   partOfSpeech: n
+  wikidata: Q932153
 13205771-n:
   definition:
   - 'in some classification systems placed in family Polypodiaceae; terrestrial ferns
@@ -94285,6 +96059,7 @@
   mero_member:
   - 13206556-n
   partOfSpeech: n
+  wikidata: Q1802676
 13206556-n:
   definition:
   - any fern of the genus Doodia having pinnate fronds with sharply dentate pinnae
@@ -94306,6 +96081,7 @@
   - Sadleria
   - genus Sadleria
   partOfSpeech: n
+  wikidata: Q3424741
 13206896-n:
   definition:
   - 'large tropical ferns: some epiphytic climbers and some terrestrial bog ferns;
@@ -94330,6 +96106,7 @@
   mero_member:
   - 13207286-n
   partOfSpeech: n
+  wikidata: Q732221
 13207286-n:
   definition:
   - a fern of the genus Woodwardia having the sori in chainlike rows
@@ -94415,6 +96192,7 @@
   mero_member:
   - 13208724-n
   partOfSpeech: n
+  wikidata: Q138772
 13208724-n:
   definition:
   - Old World tropical fern; in some classification systems placed directly in family
@@ -94431,6 +96209,7 @@
   - 13209517-n
   - 13209665-n
   partOfSpeech: n
+  wikidata: Q2390278
 13208994-n:
   definition:
   - any fern of the genus Davallia; having scaly creeping rhizomes
@@ -94498,6 +96277,7 @@
   - 13210120-n
   - 13210554-n
   partOfSpeech: n
+  wikidata: Q358326
 13210120-n:
   definition:
   - chiefly terrestrial ferns; in some classification systems placed in family Polypodiaceae
@@ -94510,6 +96290,7 @@
   mero_member:
   - 13210326-n
   partOfSpeech: n
+  wikidata: Q1802726
 13210326-n:
   definition:
   - fern of eastern North America with pale green fronds and an aroma like hay
@@ -94536,6 +96317,7 @@
   - 13210742-n
   - 13210958-n
   partOfSpeech: n
+  wikidata: Q258034
 13210742-n:
   definition:
   - large coarse fern often several feet high; essentially weed ferns; cosmopolitan
@@ -94588,6 +96370,7 @@
   mero_member:
   - 13211645-n
   partOfSpeech: n
+  wikidata: Q133239
 13211645-n:
   definition:
   - of Australia and Tasmania; often cultivated; hardy in cool climates
@@ -94612,6 +96395,7 @@
   mero_member:
   - 13212046-n
   partOfSpeech: n
+  wikidata: Q138838
 13212046-n:
   definition:
   - Asiatic tree fern having dense matted hairs sometimes used as a styptic
@@ -94637,6 +96421,7 @@
   mero_member:
   - 13212518-n
   partOfSpeech: n
+  wikidata: Q143760
 13212518-n:
   definition:
   - resembles Pteridium aquilinum; of Queensland, Australia
@@ -94658,6 +96443,7 @@
   mero_member:
   - 13212782-n
   partOfSpeech: n
+  wikidata: Q15814215
 13212782-n:
   definition:
   - a terrestrial tree fern of South America
@@ -94728,6 +96514,7 @@
   - 13214041-n
   - 13214540-n
   partOfSpeech: n
+  wikidata: Q1335106
 13214041-n:
   definition:
   - European shield fern
@@ -94894,6 +96681,7 @@
   mero_member:
   - 13216659-n
   partOfSpeech: n
+  wikidata: Q881825
 13216659-n:
   definition:
   - any fern of the genus Cystopteris characterized by a hooded indusium or bladderlike
@@ -94978,6 +96766,7 @@
   - Diacalpa
   - genus Diacalpa
   partOfSpeech: n
+  wikidata: Q8767703
 13217983-n:
   definition:
   - 'oak ferns: in some classification systems included in genus Thelypteris'
@@ -95024,6 +96813,7 @@
   - Lastreopsis
   - genus Lastreopsis
   partOfSpeech: n
+  wikidata: Q6494975
 13218698-n:
   definition:
   - small genus sometimes included in genus Onoclea; in some classifications both
@@ -95039,6 +96829,7 @@
   mero_member:
   - 13218952-n
   partOfSpeech: n
+  wikidata: Q304969
 13218952-n:
   definition:
   - tall fern of northern temperate regions having graceful arched fronds and sporophylls
@@ -95064,6 +96855,7 @@
   - Olfersia
   - genus Olfersia
   partOfSpeech: n
+  wikidata: Q17167662
 13219380-n:
   definition:
   - tropical American terrestrial fern with leathery lanceolate fronds; sometimes
@@ -95090,6 +96882,7 @@
   mero_member:
   - 13219812-n
   partOfSpeech: n
+  wikidata: Q5590498
 13219812-n:
   definition:
   - beautiful spreading fern of eastern North America and eastern Asia naturalized
@@ -95131,6 +96924,7 @@
   - 13220868-n
   - 13221549-n
   partOfSpeech: n
+  wikidata: Q608099
 13220615-n:
   definition:
   - North American evergreen fern having pinnate leaves and dense clusters of lance-shaped
@@ -95210,6 +97004,7 @@
   mero_member:
   - 13221884-n
   partOfSpeech: n
+  wikidata: Q7379335
 13221884-n:
   definition:
   - widely distributed fern of tropical Southern Hemisphere having leathery pinnatifid
@@ -95237,6 +97032,7 @@
   - 13222321-n
   - 13222464-n
   partOfSpeech: n
+  wikidata: Q7692798
 13222321-n:
   definition:
   - Jamaican fern having round buttonlike bulbils
@@ -95269,6 +97065,7 @@
   mero_member:
   - 13222867-n
   partOfSpeech: n
+  wikidata: Q1314162
 13222867-n:
   definition:
   - any fern of the genus Woodsia
@@ -95328,6 +97125,7 @@
   - 13223831-n
   - 13224013-n
   partOfSpeech: n
+  wikidata: Q138776
 13223831-n:
   definition:
   - terrestrial or less than normally scandent ferns of tropical regions of Northern
@@ -95339,6 +97137,7 @@
   - Bolbitis
   - genus Bolbitis
   partOfSpeech: n
+  wikidata: Q1339138
 13224013-n:
   definition:
   - large scandent ferns of southeastern Asia
@@ -95349,6 +97148,7 @@
   - Lomogramma
   - genus Lomogramma
   partOfSpeech: n
+  wikidata: Q9023570
 13224149-n:
   definition:
   - very small family of tree ferns
@@ -95361,6 +97161,7 @@
   mero_member:
   - 13224303-n
   partOfSpeech: n
+  wikidata: Q33137959
 13224303-n:
   definition:
   - 'one species: tree fern of Central and South America'
@@ -95371,6 +97172,7 @@
   - Lophosoria
   - genus Lophosoria
   partOfSpeech: n
+  wikidata: Q11986775
 13224449-n:
   definition:
   - very small family of New Zealand ferns
@@ -95383,6 +97185,7 @@
   mero_member:
   - 13224606-n
   partOfSpeech: n
+  wikidata: Q769399
 13224606-n:
   definition:
   - one species of terrestrial ferns of New Zealand
@@ -95393,6 +97196,7 @@
   - Loxoma
   - genus Loxoma
   partOfSpeech: n
+  wikidata: Q87293338
 13224740-n:
   definition:
   - one of a number of families into which Polypodiaceae has been subdivided in some
@@ -95409,6 +97213,7 @@
   - 13225380-n
   - 13225544-n
   partOfSpeech: n
+  wikidata: Q15474808
 13225000-n:
   definition:
   - 'or family Polypodiaceae: tropical epiphytic or terrestrial ferns'
@@ -95443,6 +97248,7 @@
   - Arthropteris
   - genus Arthropteris
   partOfSpeech: n
+  wikidata: Q4797690
 13225544-n:
   definition:
   - small genus of tropical ferns; sometimes placed in Polypodiaceae
@@ -95530,6 +97336,7 @@
   mero_member:
   - 13227076-n
   partOfSpeech: n
+  wikidata: Q178400
 13227076-n:
   definition:
   - stout tropical swamp fern (especially tropical America) having large fronds with
@@ -95568,6 +97375,7 @@
   mero_member:
   - 13227715-n
   partOfSpeech: n
+  wikidata: Q673823
 13227715-n:
   definition:
   - any of various small to large terrestrial ferns of the genus Adiantum having delicate
@@ -95681,6 +97489,7 @@
   - 13229603-n
   - 13230027-n
   partOfSpeech: n
+  wikidata: Q2628740
 13229603-n:
   definition:
   - any of various terrestrial ferns of the genus Cheilanthes; cosmopolitan in arid
@@ -95748,6 +97557,7 @@
   mero_member:
   - 13230706-n
   partOfSpeech: n
+  wikidata: Q9297166
 13230706-n:
   definition:
   - fast-growing sturdy Japanese fern; cultivated for their attractive broad dark-green
@@ -95772,6 +97582,7 @@
   - 13231103-n
   - 13231248-n
   partOfSpeech: n
+  wikidata: Q2121229
 13231103-n:
   definition:
   - dwarf deciduous lithophytic ferns
@@ -95839,6 +97650,7 @@
   - Jamesonia
   - genus Jamesonia
   partOfSpeech: n
+  wikidata: Q2472635
 13232203-n:
   definition:
   - 'small terrestrial ferns of Old World tropics and subtropics: clawed ferns; sometimes
@@ -95850,6 +97662,7 @@
   - Onychium
   - genus Onychium
   partOfSpeech: n
+  wikidata: Q2572537
 13232414-n:
   definition:
   - genus of chiefly small rock-loving ferns; in some classification systems it is
@@ -95865,6 +97678,7 @@
   - 13232923-n
   - 13233457-n
   partOfSpeech: n
+  wikidata: Q654247
 13232688-n:
   definition:
   - any of several small lithophytic ferns of tropical and warm temperate regions
@@ -95937,6 +97751,7 @@
   - 13234295-n
   - 13234475-n
   partOfSpeech: n
+  wikidata: Q2637071
 13233964-n:
   definition:
   - fern of southern tropical Africa having fronds with white undersides
@@ -95994,6 +97809,7 @@
   - 13235238-n
   - 13235383-n
   partOfSpeech: n
+  wikidata: Q2451124
 13234929-n:
   definition:
   - any of various ferns of the genus Pteris having pinnately compound leaves and
@@ -96047,6 +97863,7 @@
   mero_member:
   - 13235711-n
   partOfSpeech: n
+  wikidata: Q15708883
 13235711-n:
   definition:
   - 'constituting the order Marattiales: chiefly tropical eusporangiate ferns with
@@ -96076,6 +97893,7 @@
   mero_member:
   - 13236156-n
   partOfSpeech: n
+  wikidata: Q6755059
 13236156-n:
   definition:
   - large Australasian evergreen fern with an edible rhizome sometimes used as a vegetable
@@ -96098,6 +97916,7 @@
   mero_member:
   - 13236484-n
   partOfSpeech: n
+  wikidata: Q4763285
 13236484-n:
   definition:
   - highly variable species of very large primitive ferns of the Pacific tropical
@@ -96121,6 +97940,7 @@
   - Danaea
   - genus Danaea
   partOfSpeech: n
+  wikidata: Q5214890
 13236834-n:
   definition:
   - 'whisk ferns; comprising the family Psilotaceae or Psilotatae: vascular plants
@@ -96136,6 +97956,7 @@
   mero_member:
   - 13237136-n
   partOfSpeech: n
+  wikidata: Q99233195
 13237136-n:
   definition:
   - lower vascular plants having dichotomously branched sporophyte divided into aerial
@@ -96162,6 +97983,7 @@
   mero_member:
   - 13237571-n
   partOfSpeech: n
+  wikidata: Q500230
 13237571-n:
   definition:
   - type genus of the Psilotaceae
@@ -96174,6 +97996,7 @@
   mero_member:
   - 13237710-n
   partOfSpeech: n
+  wikidata: Q139732
 13237710-n:
   definition:
   - chiefly tropical clump-forming plants of skeletal appearance resembling whisk
@@ -96210,6 +98033,7 @@
   - 13238522-n
   - 13239012-n
   partOfSpeech: n
+  wikidata: Q35134940
 13238392-n:
   definition:
   - 'any plant of the order Psilophytales: a savannah plant'
@@ -96231,6 +98055,7 @@
   mero_member:
   - 13238661-n
   partOfSpeech: n
+  wikidata: Q35145312
 13238661-n:
   definition:
   - 'type genus of the Psilophytaceae: genus of small wiry herbaceous Paleozoic plants
@@ -96243,6 +98068,7 @@
   mero_member:
   - 13238891-n
   partOfSpeech: n
+  wikidata: Q3338824
 13238891-n:
   definition:
   - any plant or fossil of the genus Psilophyton
@@ -96266,6 +98092,7 @@
   - 13239179-n
   - 13239402-n
   partOfSpeech: n
+  wikidata: Q116724894
 13239179-n:
   definition:
   - type genus of the Rhyniaceae; small leafless dichotomously branching fossil plants
@@ -96277,6 +98104,7 @@
   - Rhynia
   - genus Rhynia
   partOfSpeech: n
+  wikidata: Q18645387
 13239402-n:
   definition:
   - Devonian fossil plant considered one of the earliest forms of vascular land plants;
@@ -96288,6 +98116,7 @@
   - Horneophyton
   - genus Horneophyton
   partOfSpeech: n
+  wikidata: Q18643199
 13239620-n:
   definition:
   - horsetails and related forms
@@ -96302,6 +98131,7 @@
   mero_member:
   - 13239798-n
   partOfSpeech: n
+  wikidata: Q5384600
 13239798-n:
   definition:
   - lower tracheophytes in existence since the Devonian
@@ -96328,6 +98158,7 @@
   mero_member:
   - 13240156-n
   partOfSpeech: n
+  wikidata: Q517643
 13240156-n:
   definition:
   - horsetails; coextensive with the family Equisetaceae
@@ -96442,6 +98273,7 @@
   - 13244984-n
   - 13246627-n
   partOfSpeech: n
+  wikidata: Q1149748
 13242141-n:
   definition:
   - 'used in some classifications for the class Lycopsida: club mosses'
@@ -96513,6 +98345,7 @@
   mero_member:
   - 13243375-n
   partOfSpeech: n
+  wikidata: Q2577942
 13243375-n:
   definition:
   - a family of ferns belonging to the order Lycopodiales
@@ -96538,6 +98371,7 @@
   - Lycopodium
   - genus Lycopodium
   partOfSpeech: n
+  wikidata: Q624488
 13243775-n:
   definition:
   - a variety of club moss, also known as shining firmoss (Lycopodium lucidulum)
@@ -96641,6 +98475,7 @@
   mero_member:
   - 13245154-n
   partOfSpeech: n
+  wikidata: Q7062996
 13245154-n:
   definition:
   - 'lesser club mosses: terrestrial chiefly tropical plants resembling mosses'
@@ -96653,6 +98488,7 @@
   mero_member:
   - 13245352-n
   partOfSpeech: n
+  wikidata: Q2716448
 13245352-n:
   definition:
   - 'type and sole genus of the Selaginellaceae; evergreen moss-like plants: spike
@@ -96666,6 +98502,7 @@
   mero_member:
   - 13245571-n
   partOfSpeech: n
+  wikidata: Q379743
 13245571-n:
   definition:
   - any of numerous fern allies of the genus Selaginella
@@ -96746,6 +98583,7 @@
   mero_member:
   - 13246853-n
   partOfSpeech: n
+  wikidata: Q7170041
 13246853-n:
   definition:
   - quillworts; coextensive with the genus Isoetes
@@ -96759,6 +98597,7 @@
   mero_member:
   - 13247033-n
   partOfSpeech: n
+  wikidata: Q12840695
 13247033-n:
   definition:
   - type and genus of the Isoetaceae and sole extant genus of the order Isoetales
@@ -96771,6 +98610,7 @@
   mero_member:
   - 13247218-n
   partOfSpeech: n
+  wikidata: Q877973
 13247218-n:
   definition:
   - any of several spore-bearing aquatic or marsh plants having short rhizomes and
@@ -96793,6 +98633,7 @@
   mero_member:
   - 13247596-n
   partOfSpeech: n
+  wikidata: Q1349611
 13247596-n:
   definition:
   - type genus of the Geoglossaceae comprising the earthtongues
@@ -96908,6 +98749,7 @@
   mero_member:
   - 13249434-n
   partOfSpeech: n
+  wikidata: Q2213704
 13249434-n:
   definition:
   - any of several tropical ferns of the genus Christella having thin brittle fronds
@@ -96928,6 +98770,7 @@
   - Cyclosorus
   - genus Cyclosorus
   partOfSpeech: n
+  wikidata: Q5199019
 13249765-n:
   definition:
   - terrestrial ferns of Florida and West Indies to Central and South America
@@ -96938,6 +98781,7 @@
   - Goniopteris
   - genus Goniopteris
   partOfSpeech: n
+  wikidata: Q17195659
 13249916-n:
   definition:
   - medium to large terrestrial ferns of tropical Asia to Polynesia and Australia;
@@ -96960,6 +98804,7 @@
   - Meniscium
   - genus Meniscium
   partOfSpeech: n
+  wikidata: Q17197780
 13250256-n:
   definition:
   - 3 species of ferns formerly included in genus Dryopteris or Thelypteris
@@ -96998,6 +98843,7 @@
   - 13250849-n
   - 13251088-n
   partOfSpeech: n
+  wikidata: Q17195704
 13250849-n:
   definition:
   - slender shield fern of moist woods of eastern North America; sometimes placed
@@ -97035,6 +98881,7 @@
   mero_member:
   - 13251560-n
   partOfSpeech: n
+  wikidata: Q2698282
 13251560-n:
   definition:
   - any fern of the genus Phegopteris having deeply cut triangular fronds
@@ -97096,6 +98943,7 @@
   - 13252576-n
   - 13252817-n
   partOfSpeech: n
+  wikidata: Q952036
 13252576-n:
   definition:
   - any of several fungi of the genus Armillaria that form brown stringy rhizomorphs
@@ -97151,6 +98999,7 @@
   mero_member:
   - 13253677-n
   partOfSpeech: n
+  wikidata: Q61653739
 13253677-n:
   definition:
   - a honey-colored edible mushroom commonly associated with the roots of trees in
@@ -97186,6 +99035,7 @@
   - 13259726-n
   - 13260369-n
   partOfSpeech: n
+  wikidata: Q156689
 13254333-n:
   definition:
   - any plant of the family Asclepiadaceae
@@ -97207,6 +99057,7 @@
   mero_member:
   - 13254625-n
   partOfSpeech: n
+  wikidata: Q162153
 13254625-n:
   definition:
   - any of numerous plants of the genus Asclepias having milky juice and pods that
@@ -97346,6 +99197,7 @@
   mero_member:
   - 13256998-n
   partOfSpeech: n
+  wikidata: Q148954
 13256998-n:
   definition:
   - robust twining shrub having racemes of fragrant white or pink flowers with flat
@@ -97368,6 +99220,7 @@
   mero_member:
   - 13257393-n
   partOfSpeech: n
+  wikidata: Q285262
 13257393-n:
   definition:
   - any of various mostly giant tropical lianas of Africa and Madagascar having greenish
@@ -97389,6 +99242,7 @@
   mero_member:
   - 13257785-n
   partOfSpeech: n
+  wikidata: Q157749
 13257785-n:
   definition:
   - any plant of the genus Hoya having fleshy leaves and usually nectariferous flowers
@@ -97429,6 +99283,7 @@
   mero_member:
   - 13258406-n
   partOfSpeech: n
+  wikidata: Q811624
 13258406-n:
   definition:
   - deciduous climber for arches and fences having ill-scented but interesting flowers
@@ -97453,6 +99308,7 @@
   mero_member:
   - 13258886-n
   partOfSpeech: n
+  wikidata: Q1117141
 13258886-n:
   definition:
   - leafless East Indian vine; its sour milky juice formerly used to make an intoxicating
@@ -97477,6 +99333,7 @@
   - 13259273-n
   - 13259552-n
   partOfSpeech: n
+  wikidata: Q163930
 13259273-n:
   definition:
   - any of various plants of the genus Stapelia having succulent leafless toothed
@@ -97511,6 +99368,7 @@
   - 13259886-n
   - 13260075-n
   partOfSpeech: n
+  wikidata: Q135537
 13259886-n:
   definition:
   - any of various evergreen climbing shrubs of the genus Stephanotis having fragrant
@@ -97548,6 +99406,7 @@
   mero_member:
   - 13260634-n
   partOfSpeech: n
+  wikidata: Q158135
 13260634-n:
   definition:
   - twining vine with hairy foliage and dark purplish-brown flowers


### PR DESCRIPTION
This adds a manually validated list of mappings based on taxon names,
for example "genus Ursus".

This temporarily creates a few duplicate links as some taxon names are
also used generically, but these will be removed for the release.