### PR TITLE
Add links related to occupations

### DIFF
--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -1166,6 +1166,7 @@
   - out-migration
   - expatriation
   partOfSpeech: n
+  wikidata: Q187668
 00057131-n:
   definition:
   - migration into a place (especially migration to a country of which you are not
@@ -7310,6 +7311,7 @@
   members:
   - corruption
   partOfSpeech: n
+  wikidata: Q366
 00160440-n:
   definition:
   - the act of influencing by exciting hope or desire
@@ -7641,6 +7643,7 @@
   - ordination
   - ordinance
   partOfSpeech: n
+  wikidata: Q7519600
 00166384-n:
   definition:
   - designation by the chair granting a person the right to speak in a deliberative
@@ -10271,6 +10274,7 @@
   members:
   - retirement
   partOfSpeech: n
+  wikidata: Q946865
 00213226-n:
   definition:
   - the act of retiring into inactivity
@@ -10724,6 +10728,7 @@
   - slaying
   - execution
   partOfSpeech: n
+  wikidata: Q132821
 00221923-n:
   definition:
   - murder of a public figure by surprise attack
@@ -23458,6 +23463,7 @@
   - Greco-Roman wrestling
   - Graeco-Roman wrestling
   partOfSpeech: n
+  wikidata: Q389654
 00449111-n:
   definition:
   - wrestling for money
@@ -23468,6 +23474,7 @@
   members:
   - professional wrestling
   partOfSpeech: n
+  wikidata: Q131359
 00449217-n:
   definition:
   - a Japanese form of wrestling; you lose if you are forced out of a small ring or
@@ -24456,6 +24463,7 @@
   - 00563972-n
   - 01267288-n
   partOfSpeech: n
+  wikidata: Q41466
 00465105-n:
   definition:
   - the defensive position on an ice hockey or soccer or lacrosse team who stands
@@ -24976,6 +24984,7 @@
   mero_part:
   - 01267426-n
   partOfSpeech: n
+  wikidata: Q2736
 00479658-n:
   definition:
   - the propulsion of a ball by repeated taps or kicks
@@ -25113,6 +25122,7 @@
   - 00564531-n
   - 15282640-n
   partOfSpeech: n
+  wikidata: Q5372
 00482677-n:
   definition:
   - the act of starting a basketball game with a jump ball
@@ -27582,6 +27592,7 @@
   - sport
   - athletics
   partOfSpeech: n
+  wikidata: Q349
 00527296-n:
   definition:
   - a slow section of a pas de deux requiring great skill and strength by the dancers
@@ -32514,6 +32525,7 @@
   - trade
   - craft
   partOfSpeech: n
+  wikidata: Q2207288
 00608190-n:
   definition:
   - the craft of building and repairing airplanes
@@ -32733,6 +32745,7 @@
   members:
   - profession
   partOfSpeech: n
+  wikidata: Q28640
 00611490-n:
   definition:
   - an occupation for which you are especially well suited
@@ -32814,6 +32827,7 @@
   members:
   - journalism
   partOfSpeech: n
+  wikidata: Q11030
 00613161-n:
   definition:
   - journalism practiced for the newspapers
@@ -32834,6 +32848,7 @@
   members:
   - politics
   partOfSpeech: n
+  wikidata: Q7163
 00613447-n:
   definition:
   - the learned profession that is mastered by graduate training in a medical school
@@ -32849,6 +32864,7 @@
   - medicine
   - practice of medicine
   partOfSpeech: n
+  wikidata: Q11190
 00614569-n:
   definition:
   - the branch of medicine concerned with preventing disease
@@ -33295,6 +33311,7 @@
   members:
   - photography
   partOfSpeech: n
+  wikidata: Q11633
 00621992-n:
   definition:
   - productive work (especially physical work done for wages)
@@ -33604,6 +33621,7 @@
   - weightlift
   - weightlifting
   partOfSpeech: n
+  wikidata: Q83462
 00627663-n:
   definition:
   - raising a weight from shoulder height to above the head by straightening the arms
@@ -40829,6 +40847,7 @@
   - scam
   - cozenage
   partOfSpeech: n
+  wikidata: Q7023752
 00755767-n:
   definition:
   - a deception for profit to yourself
@@ -41159,6 +41178,7 @@
   - act of terrorism
   - terrorist act
   partOfSpeech: n
+  wikidata: Q7283
 00764485-n:
   definition:
   - terrorism using the weapons of biological warfare
@@ -44700,6 +44720,7 @@
   - tae kwon do
   - taekwondo
   partOfSpeech: n
+  wikidata: Q36389
 00828450-n:
   definition:
   - a Chinese system of slow meditative physical exercise designed for relaxation
@@ -48133,6 +48154,7 @@
   members:
   - athletics
   partOfSpeech: n
+  wikidata: Q542
 00888377-n:
   definition:
   - education provided by a college or university
@@ -48175,6 +48197,7 @@
   - instruction
   - pedagogy
   partOfSpeech: n
+  wikidata: Q7922
 00889222-n:
   definition:
   - a sport that involves competition between teams of players
@@ -48556,6 +48579,7 @@
   mero_part:
   - 00894768-n
   partOfSpeech: n
+  wikidata: Q603773
 00894768-n:
   definition:
   - presentation of an example of what the lecturer is discoursing about
@@ -49396,6 +49420,7 @@
   - cinematography
   - motion-picture photography
   partOfSpeech: n
+  wikidata: Q590870
 00909831-n:
   definition:
   - the act of photographing a scene or part of a scene without interruption
@@ -49684,6 +49709,7 @@
   - shipbuilding
   - ship building
   partOfSpeech: n
+  wikidata: Q474200
 00914791-n:
   definition:
   - the act or process of producing something
@@ -49807,6 +49833,7 @@
   members:
   - brewing
   partOfSpeech: n
+  wikidata: Q869095
 00917178-n:
   definition:
   - (especially of domestic fowl) breeding to reveal differential sex characteristics
@@ -50829,6 +50856,7 @@
   - artistic creation
   - artistic production
   partOfSpeech: n
+  wikidata: Q735
 00936820-n:
   definition:
   - the arts of decorative design and handicraft
@@ -50913,6 +50941,7 @@
   members:
   - gastronomy
   partOfSpeech: n
+  wikidata: Q171141
 00938272-n:
   definition:
   - the Japanese art of folding paper into shapes representing objects (e.g., flowers
@@ -50937,6 +50966,7 @@
   members:
   - painting
   partOfSpeech: n
+  wikidata: Q11629
 00938717-n:
   definition:
   - a method of painting in which the pigments are mixed with water and a binder;
@@ -57800,6 +57830,7 @@
   - healthcare
   - health care
   partOfSpeech: n
+  wikidata: Q31207
 01062025-n:
   definition:
   - the provision of health care
@@ -59541,6 +59572,7 @@
   members:
   - trade
   partOfSpeech: n
+  wikidata: Q601401
 01094239-n:
   definition:
   - trade that is conducted legally
@@ -60211,6 +60243,7 @@
   - agriculture
   - factory farm
   partOfSpeech: n
+  wikidata: Q396622
 01106449-n:
   definition:
   - growing vegetables for the market
@@ -60685,6 +60718,7 @@
   - 01115160-n
   - 07261731-n
   partOfSpeech: n
+  wikidata: Q39809
 01114662-n:
   definition:
   - marketing via a promotion delivered directly to the individual prospective customer
@@ -60797,6 +60831,7 @@
   members:
   - wholesale
   partOfSpeech: n
+  wikidata: Q220695
 01116934-n:
   definition:
   - a particular instance of selling
@@ -61897,6 +61932,7 @@
   - management
   - direction
   partOfSpeech: n
+  wikidata: Q2920921
 01136081-n:
   definition:
   - the direction of an orchestra or choir
@@ -66166,6 +66202,7 @@
   members:
   - social work
   partOfSpeech: n
+  wikidata: Q205398
 01211569-n:
   definition:
   - close sociological study of a maladjusted person or family for diagnosis and treatment

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -15049,6 +15049,7 @@
   - cacique
   - cazique
   partOfSpeech: n
+  wikidata: Q599898
 01576416-n:
   definition:
   - bobolinks

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -21049,6 +21049,7 @@
   members:
   - ceramic
   partOfSpeech: n
+  wikidata: Q45621
 03001214-n:
   definition:
   - utensils made from ceramic material
@@ -37011,6 +37012,7 @@
   members:
   - dubbing
   partOfSpeech: n
+  wikidata: Q187657
 03257774-n:
   definition:
   - a heavy cotton fabric of plain weave; used for clothing and tents
@@ -50358,6 +50360,7 @@
   mero_part:
   - 03346242-n
   partOfSpeech: n
+  wikidata: Q6607
 03472728-n:
   definition:
   - a plectrum used to pluck a guitar
@@ -66121,6 +66124,7 @@
   - manakin
   - form
   partOfSpeech: n
+  wikidata: Q855680
 03723595-n:
   definition:
   - a diuretic (trade name Osmitrol) used to promote the excretion of urine
@@ -68861,6 +68865,7 @@
   - millinery
   - hat shop
   partOfSpeech: n
+  wikidata: Q663375
 03772135-n:
   definition:
   - corrugated edge of a coin
@@ -71025,6 +71030,7 @@
   - mural
   - wall painting
   partOfSpeech: n
+  wikidata: Q219423
 03805398-n:
   definition:
   - a bed that can be folded or swung into a cabinet when not being used
@@ -72433,6 +72439,7 @@
   members:
   - newsstand
   partOfSpeech: n
+  wikidata: Q1528905
 03828307-n:
   definition:
   - reflecting telescope in which the image is viewed through an eyepiece perpendicular
@@ -74407,6 +74414,7 @@
   - 03935052-n
   - 04334462-n
   partOfSpeech: n
+  wikidata: Q281460
 03859941-n:
   definition:
   - a sheer stiff muslin
@@ -79053,6 +79061,7 @@
   - picture
   - pic
   partOfSpeech: n
+  wikidata: Q125191
 03932172-n:
   definition:
   - an existing photograph licensed for a specific use
@@ -114347,6 +114356,7 @@
   members:
   - trombone
   partOfSpeech: n
+  wikidata: Q8350
 04494832-n:
   definition:
   - a painting rendered in such great detail as to deceive the viewer concerning its
@@ -121563,6 +121573,7 @@
   mero_part:
   - 03689034-n
   partOfSpeech: n
+  wikidata: Q628858
 04610120-n:
   definition:
   - room where work is done

--- a/src/yaml/noun.cognition.yaml
+++ b/src/yaml/noun.cognition.yaml
@@ -8054,6 +8054,7 @@
   members:
   - fashion
   partOfSpeech: n
+  wikidata: Q12684
 05758945-n:
   definition:
   - the style in which a garment is cut
@@ -8226,6 +8227,7 @@
   members:
   - education
   partOfSpeech: n
+  wikidata: Q8434
 05761951-n:
   definition:
   - learning (of values or attitudes etc.) that is incorporated within yourself
@@ -16365,6 +16367,7 @@
   members:
   - activism
   partOfSpeech: n
+  wikidata: Q203764
 05910608-n:
   definition:
   - a policy of promoting oneself at the expense of others; used especially of national
@@ -17162,6 +17165,7 @@
   members:
   - feng shui
   partOfSpeech: n
+  wikidata: Q170537
 05924749-n:
   definition:
   - an idea that is suggested
@@ -19255,6 +19259,7 @@
   - Qabbalah
   - Qabbala
   partOfSpeech: n
+  wikidata: Q123006
 05963233-n:
   definition:
   - the doctrines of the Kabbalah
@@ -20044,6 +20049,7 @@
   members:
   - feminism
   partOfSpeech: n
+  wikidata: Q7252
 05976761-n:
   definition:
   - the power associated with a juju
@@ -20687,6 +20693,7 @@
   - witchcraft
   - witchery
   partOfSpeech: n
+  wikidata: Q259745
 05988321-n:
   definition:
   - a magical spell
@@ -21820,6 +21827,7 @@
   - math
   - maths
   partOfSpeech: n
+  wikidata: Q395
 06013012-n:
   definition:
   - the branches of mathematics that study and develop the principles of mathematics
@@ -23627,6 +23635,7 @@
   - biology
   - biological science
   partOfSpeech: n
+  wikidata: Q420
 06050997-n:
   definition:
   - the application of the principles of the natural sciences to medicine
@@ -23780,6 +23789,7 @@
   members:
   - anesthesiology
   partOfSpeech: n
+  wikidata: Q615057
 06056059-n:
   definition:
   - the branch of medical science that studies the blood and lymph vessels and their
@@ -24003,6 +24013,7 @@
   - gynecology
   - gynaecology
   partOfSpeech: n
+  wikidata: Q1221899
 06060665-n:
   definition:
   - the branch of medicine that deals with diseases of the blood and blood-forming
@@ -24491,6 +24502,7 @@
   - otorhinolaryngology
   - otolaryngology
   partOfSpeech: n
+  wikidata: Q189553
 06072622-n:
   definition:
   - the branch of medical science that deals with serums; especially with blood serums
@@ -24532,6 +24544,7 @@
   members:
   - surgery
   partOfSpeech: n
+  wikidata: Q40821
 06073656-n:
   definition:
   - the branch of medical science concerned with disorders or deformities of the spine
@@ -24749,6 +24762,7 @@
   - bionomics
   - environmental science
   partOfSpeech: n
+  wikidata: Q7150
 06080976-n:
   definition:
   - the branch of biology that studies the formation and early development of living
@@ -24789,6 +24803,7 @@
   members:
   - silviculture
   partOfSpeech: n
+  wikidata: Q720362
 06081825-n:
   definition:
   - the branch of zoology that studies insects
@@ -25142,6 +25157,7 @@
   members:
   - biochemistry
   partOfSpeech: n
+  wikidata: Q7094
 06089780-n:
   definition:
   - the branch of biochemistry dealing with the chemical nature and biological activity
@@ -25289,6 +25305,7 @@
   - chemistry
   - chemical science
   partOfSpeech: n
+  wikidata: Q2329
 06098583-n:
   definition:
   - the chemistry of compounds containing carbon (originally defined as the chemistry
@@ -26719,6 +26736,7 @@
   mero_part:
   - 06133966-n
   partOfSpeech: n
+  wikidata: Q12271
 06133966-n:
   definition:
   - the science of architecture
@@ -26872,6 +26890,7 @@
   members:
   - civil engineering
   partOfSpeech: n
+  wikidata: Q77590
 06137324-n:
   definition:
   - the branch of civil engineering dealing with the use and control of water in motion
@@ -26881,6 +26900,7 @@
   members:
   - hydraulic engineering
   partOfSpeech: n
+  wikidata: Q1130265
 06137475-n:
   definition:
   - the branch of engineering science that studies the uses of electricity and the
@@ -26893,6 +26913,7 @@
   - electrical engineering
   - EE
   partOfSpeech: n
+  wikidata: Q43035
 06137758-n:
   definition:
   - (often plural) the branch of electrical engineering concerned with the technology
@@ -26918,6 +26939,7 @@
   - computer science
   - computing
   partOfSpeech: n
+  wikidata: Q21198
 06142175-n:
   definition:
   - (computing) a discrete item that provides a description of virtually anything
@@ -27026,6 +27048,7 @@
   - information technology
   - IT
   partOfSpeech: n
+  wikidata: Q11661
 06144167-n:
   definition:
   - the branch of engineering that deals with the design and construction and operation
@@ -27036,6 +27059,7 @@
   members:
   - mechanical engineering
   partOfSpeech: n
+  wikidata: Q101333
 06144350-n:
   definition:
   - the branch of engineering that deals with things smaller than 100 nanometers (especially
@@ -27125,6 +27149,7 @@
   - psychology
   - psychological science
   partOfSpeech: n
+  wikidata: Q9418
 06147210-n:
   definition:
   - the branch of psychology concerned with abnormal behavior
@@ -27449,6 +27474,7 @@
   mero_part:
   - 06178050-n
   partOfSpeech: n
+  wikidata: Q23404
 06153532-n:
   definition:
   - the branch of anthropology that studies prehistoric people and their cultures
@@ -27459,6 +27485,7 @@
   - archeology
   - archaeology
   partOfSpeech: n
+  wikidata: Q23498
 06154213-n:
   definition:
   - archeology of the ancient Assyrians
@@ -27699,6 +27726,7 @@
   - political science
   - government
   partOfSpeech: n
+  wikidata: Q36442
 06158199-n:
   definition:
   - the study of the effects of economic geography on the powers of the state
@@ -27847,6 +27875,7 @@
   mero_part:
   - 06177868-n
   partOfSpeech: n
+  wikidata: Q21201
 06161412-n:
   definition:
   - the scientific study of crime and criminal behavior and law enforcement
@@ -28030,6 +28059,7 @@
   members:
   - interior design
   partOfSpeech: n
+  wikidata: Q179232
 06165130-n:
   definition:
   - the discipline that studies the English language and literature
@@ -28069,6 +28099,7 @@
   members:
   - art history
   partOfSpeech: n
+  wikidata: Q50637
 06165867-n:
   definition:
   - the branch of art history that studies visual images and their symbolic meaning
@@ -28708,6 +28739,7 @@
   members:
   - library science
   partOfSpeech: n
+  wikidata: Q199655
 06180756-n:
   definition:
   - the humanistic study of language and literature
@@ -28718,6 +28750,7 @@
   - linguistics
   - philology
   partOfSpeech: n
+  wikidata: Q40634
 06180981-n:
   definition:
   - the branch of philology that is devoted to the study of dialects
@@ -28805,6 +28838,7 @@
   members:
   - linguistics
   partOfSpeech: n
+  wikidata: Q8162
 06184139-n:
   definition:
   - the branch of linguistics that deals with syntax and morphology (and sometimes
@@ -29173,6 +29207,7 @@
   - theology
   - divinity
   partOfSpeech: n
+  wikidata: Q34178
 06192473-n:
   definition:
   - the branch of theology that is concerned with angels
@@ -31817,6 +31852,7 @@
   members:
   - Anabaptism
   partOfSpeech: n
+  wikidata: Q165580
 06242201-n:
   definition:
   - any of various doctrines closely related to Anabaptism

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -866,6 +866,7 @@
   members:
   - photojournalism
   partOfSpeech: n
+  wikidata: Q506858
 06277531-n:
   definition:
   - photography of newsworthy events
@@ -4821,6 +4822,7 @@
   members:
   - Hakham
   partOfSpeech: n
+  wikidata: Q1058384
 06352497-n:
   definition:
   - a German courtesy title or form of address for a man
@@ -4852,6 +4854,7 @@
   - Mr
   - Mr.
   partOfSpeech: n
+  wikidata: Q177053
 06352801-n:
   definition:
   - a form of address for a married woman
@@ -6780,6 +6783,7 @@
   - criticism
   - literary criticism
   partOfSpeech: n
+  wikidata: Q58854
 06386457-n:
   definition:
   - a method of literary criticism that analyzes details of a text in order to reveal
@@ -9675,6 +9679,7 @@
   - travel guidebook
   - itinerary
   partOfSpeech: n
+  wikidata: Q223638
 06435139-n:
   definition:
   - a handbook of tables used to facilitate computation
@@ -16156,6 +16161,7 @@
   - rendering
   - version
   partOfSpeech: n
+  wikidata: Q7553
 06548728-n:
   definition:
   - a piece of paper recording work planned or done on a project
@@ -16354,6 +16360,7 @@
   mero_part:
   - 06550886-n
   partOfSpeech: n
+  wikidata: Q146491
 06551493-n:
   definition:
   - a writ issued by a court of law requiring a person to do something or to refrain
@@ -18487,6 +18494,7 @@
   - interpreter
   - interpretive program
   partOfSpeech: n
+  wikidata: Q183065
 06588329-n:
   definition:
   - a program that is called to prepare each job to be run
@@ -18538,6 +18546,7 @@
   members:
   - text editor
   partOfSpeech: n
+  wikidata: Q131212
 06589069-n:
   definition:
   - a fully compiled or assembled program ready to be loaded into the computer
@@ -20840,6 +20849,7 @@
   - 06501959-n
   - 06627082-n
   partOfSpeech: n
+  wikidata: Q11424
 06626981-n:
   definition:
   - a movie that is made to be shown on television
@@ -26275,6 +26285,7 @@
   - Doctor of Osteopathy
   - DO
   partOfSpeech: n
+  wikidata: Q5287521
 06716597-n:
   definition:
   - a doctor's degree with a special disciplinary focus
@@ -26294,6 +26305,7 @@
   members:
   - Doctor of Philosophy
   partOfSpeech: n
+  wikidata: Q752297
 06716878-n:
   definition:
   - a doctorate usually based on at least 3 years graduate study and a dissertation;
@@ -34676,6 +34688,7 @@
   - label
   - recording label
   partOfSpeech: n
+  wikidata: Q18127
 06864792-n:
   definition:
   - a formally registered symbol (‘™’) identifying the manufacturer or distributor
@@ -41409,6 +41422,7 @@
   members:
   - Yiddish
   partOfSpeech: n
+  wikidata: Q8641
 06964877-n:
   definition:
   - a dialect of High German spoken in parts of Pennsylvania and Maryland
@@ -45654,6 +45668,7 @@
   members:
   - screenplay
   partOfSpeech: n
+  wikidata: Q103076
 07025530-n:
   definition:
   - the final detailed script for making a movie or TV program
@@ -45855,6 +45870,7 @@
   members:
   - comedy
   partOfSpeech: n
+  wikidata: Q40831
 07028955-n:
   definition:
   - comedy that uses black humor
@@ -46182,6 +46198,7 @@
   members:
   - dance
   partOfSpeech: n
+  wikidata: Q11639
 07033877-n:
   definition:
   - the representation of dancing by symbols as music is represented by notes
@@ -46191,6 +46208,7 @@
   members:
   - choreography
   partOfSpeech: n
+  wikidata: Q180856
 07034009-n:
   definition:
   - an artistic form of auditory communication incorporating instrumental or vocal
@@ -47049,6 +47067,7 @@
   - musical arrangement
   - arrangement
   partOfSpeech: n
+  wikidata: Q379755
 07052361-n:
   definition:
   - an arrangement of a piece of music for performance by an orchestra or band
@@ -48593,6 +48612,7 @@
   - gospel
   - gospel singing
   partOfSpeech: n
+  wikidata: Q180268
 07075717-n:
   definition:
   - a genre (usually a cappella) of Black vocal-harmony music of the 1950s that evolved
@@ -59059,6 +59079,7 @@
   - public relations
   - PR
   partOfSpeech: n
+  wikidata: Q133080
 07262728-n:
   definition:
   - a promotional statement (as found on the dust jackets of books)
@@ -61202,6 +61223,7 @@
   members:
   - voice over
   partOfSpeech: n
+  wikidata: Q1146822
 07296994-n:
   definition:
   - a thorough explanation (usually accompanied by a demonstration) of each step in

--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -6208,6 +6208,7 @@
   members:
   - local government
   partOfSpeech: n
+  wikidata: Q6501447
 08069755-n:
   definition:
   - government by the military and an army
@@ -6403,6 +6404,7 @@
   members:
   - enterprise
   partOfSpeech: n
+  wikidata: Q6881511
 08073223-n:
   definition:
   - an unusually large enterprise
@@ -6488,6 +6490,7 @@
   - carrier
   - common carrier
   partOfSpeech: n
+  wikidata: Q561457
 08074652-n:
   definition:
   - (business) a number of similar establishments (stores or restaurants or banks
@@ -6514,6 +6517,7 @@
   members:
   - company
   partOfSpeech: n
+  wikidata: Q783794
 08075773-n:
   definition:
   - a group of diverse companies under common ownership and run as a single organization
@@ -6728,6 +6732,7 @@
   - publishing firm
   - publishing company
   partOfSpeech: n
+  wikidata: Q2085381
 08079678-n:
   definition:
   - a conglomerate of publishing companies
@@ -6991,6 +6996,7 @@
   - auto maker
   - automaker
   partOfSpeech: n
+  wikidata: Q786820
 08083801-n:
   definition:
   - a business that manufactures and sells computers
@@ -7208,6 +7214,7 @@
   - printing business
   - printing company
   partOfSpeech: n
+  wikidata: Q6500733
 08086604-n:
   definition:
   - an industry that manufactures plastic articles
@@ -9514,6 +9521,7 @@
   members:
   - nursing
   partOfSpeech: n
+  wikidata: Q121176
 08130039-n:
   definition:
   - the body of individuals who manage businesses
@@ -11385,6 +11393,7 @@
   mero_member:
   - 10132203-n
   partOfSpeech: n
+  wikidata: Q131132
 08165834-n:
   definition:
   - a Roman Catholic mendicant order founded in the 12th century
@@ -11445,6 +11454,7 @@
   mero_member:
   - 10241190-n
   partOfSpeech: n
+  wikidata: Q36380
 08166788-n:
   definition:
   - a subdivision of a larger religious group
@@ -12282,6 +12292,7 @@
   - general assembly
   - law-makers
   partOfSpeech: n
+  wikidata: Q11204
 08180601-n:
   definition:
   - a unicameral legislature
@@ -13892,6 +13903,7 @@
   members:
   - circus
   partOfSpeech: n
+  wikidata: Q47928
 08206301-n:
   definition:
   - a troupe of performers in blackface typically giving a comic program of negro
@@ -14019,6 +14031,7 @@
   - 08208462-n
   - 08309677-n
   partOfSpeech: n
+  wikidata: Q4508
 08208917-n:
   definition:
   - the navy of the United States of America; the agency that maintains and trains
@@ -14374,6 +14387,7 @@
   mero_member:
   - 08215338-n
   partOfSpeech: n
+  wikidata: Q209572
 08215338-n:
   definition:
   - a unit that is part of some military service
@@ -14481,6 +14495,7 @@
   - paramilitary organization
   - paramilitary organisation
   partOfSpeech: n
+  wikidata: Q207320
 08224461-n:
   definition:
   - (plural) Arab guerrillas who operate mainly against Israel
@@ -14631,6 +14646,7 @@
   mero_member:
   - 10142659-n
   partOfSpeech: n
+  wikidata: Q204310
 08227332-n:
   definition:
   - religious police in Saudi Arabia whose duty is to ensure strict adherence to established
@@ -14703,6 +14719,7 @@
   mero_member:
   - 10337158-n
   partOfSpeech: n
+  wikidata: Q210815
 08228396-n:
   definition:
   - the military police of the navy
@@ -15583,6 +15600,7 @@
   - Islamic Ummah
   - Islam Nation
   partOfSpeech: n
+  wikidata: Q205766
 08241906-n:
   definition:
   - people sharing a given language or dialect
@@ -16765,6 +16783,7 @@
   mero_member:
   - 09996612-n
   partOfSpeech: n
+  wikidata: Q345844
 08260002-n:
   definition:
   - a crew of workers selected for a particular task
@@ -16909,6 +16928,7 @@
   mero_member:
   - 10021475-n
   partOfSpeech: n
+  wikidata: Q933495
 08261980-n:
   definition:
   - the criminal class
@@ -16934,6 +16954,7 @@
   mero_member:
   - 08260983-n
   partOfSpeech: n
+  wikidata: Q46952
 08262346-n:
   definition:
   - any tightly knit group of trusted associates
@@ -17134,6 +17155,7 @@
   mero_part:
   - 08233821-n
   partOfSpeech: n
+  wikidata: Q42998
 08265332-n:
   definition:
   - small orchestra; usually plays classical music
@@ -18773,6 +18795,7 @@
   - 08295090-n
   - 08303084-n
   partOfSpeech: n
+  wikidata: Q1211427
 08292002-n:
   definition:
   - the world of literary hacks
@@ -19064,6 +19087,7 @@
   mero_member:
   - 09778832-n
   partOfSpeech: n
+  wikidata: Q162633
 08297383-n:
   definition:
   - an academy that gives annual awards for achievements in motion picture production
@@ -20787,6 +20811,7 @@
   members:
   - council
   partOfSpeech: n
+  wikidata: Q4358176
 08328212-n:
   definition:
   - a municipal body that can pass ordinances and appropriate funds etc.
@@ -20853,6 +20878,7 @@
   members:
   - works council
   partOfSpeech: n
+  wikidata: Q671974
 08329171-n:
   definition:
   - government of a town by an assembly of the qualified voters
@@ -22601,6 +22627,7 @@
   mero_part:
   - 08362697-n
   partOfSpeech: n
+  wikidata: Q58967
 08362697-n:
   definition:
   - Israel's elite secret commando unit responsible for counterterrorist and top secret
@@ -23255,6 +23282,7 @@
   mero_member:
   - 09944917-n
   partOfSpeech: n
+  wikidata: Q11771944
 08374375-n:
   definition:
   - the British civil service
@@ -24531,6 +24559,7 @@
   mero_member:
   - 10357944-n
   partOfSpeech: n
+  wikidata: Q189459
 08397071-n:
   definition:
   - a social system that provides separate facilities for minority groups
@@ -25001,6 +25030,7 @@
   - landed gentry
   - squirearchy
   partOfSpeech: n
+  wikidata: Q844586
 08404537-n:
   definition:
   - the class of people exerting power or authority
@@ -25218,6 +25248,7 @@
   - infantry
   - foot
   partOfSpeech: n
+  wikidata: Q29171
 08407331-n:
   definition:
   - infantry trained and equipped to parachute
@@ -25564,6 +25595,7 @@
   mero_member:
   - 09922064-n
   partOfSpeech: n
+  wikidata: Q47315
 08414993-n:
   definition:
   - the troops who maintain and guard a fortified place
@@ -27042,6 +27074,7 @@
   - banking concern
   - banking company
   partOfSpeech: n
+  wikidata: Q22687
 08437796-n:
   definition:
   - a financial institution (often affiliated with a holding company or manufacturer)
@@ -28535,6 +28568,7 @@
   mero_member:
   - 08374185-n
   partOfSpeech: n
+  wikidata: Q72468
 08473899-n:
   definition:
   - a collection of live animals for study or display

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -4931,6 +4931,7 @@
   members:
   - preserve
   partOfSpeech: n
+  wikidata: Q179049
 08605126-n:
   definition:
   - a preserve on which hunting is permitted during certain months of the year

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -205,6 +205,7 @@
   members:
   - giant
   partOfSpeech: n
+  wikidata: Q3707571
 09512125-n:
   definition:
   - an imaginary being similar to a person but smaller and with hairy feet; invented
@@ -6044,6 +6045,7 @@
   members:
   - vestal virgin
   partOfSpeech: n
+  wikidata: Q188761
 09598726-n:
   definition:
   - (Greek mythology) a Titan who was forced by Zeus to bear the sky on his shoulders
@@ -8108,6 +8110,7 @@
   members:
   - auctioneer
   partOfSpeech: n
+  wikidata: Q2743689
 09631550-n:
   definition:
   - a psychologist who subscribes to behaviorism
@@ -8128,6 +8131,7 @@
   - benefactor
   - helper
   partOfSpeech: n
+  wikidata: Q4887411
 09632185-n:
   definition:
   - a woman benefactor
@@ -8336,6 +8340,7 @@
   members:
   - contestant
   partOfSpeech: n
+  wikidata: Q5165152
 09636589-n:
   definition:
   - an eccentric or undignified rustic
@@ -8387,6 +8392,7 @@
   members:
   - creator
   partOfSpeech: n
+  wikidata: Q2500638
 09637714-n:
   definition:
   - a person who cares for persons or property
@@ -8440,6 +8446,7 @@
   - applied scientist
   - technologist
   partOfSpeech: n
+  wikidata: Q81096
 09639603-n:
   definition:
   - a specialist in wine making
@@ -8538,6 +8545,7 @@
   members:
   - expert
   partOfSpeech: n
+  wikidata: Q381160
 09641790-n:
   definition:
   - someone who expounds and interprets or explains
@@ -8689,6 +8697,7 @@
   - intellectual
   - intellect
   partOfSpeech: n
+  wikidata: Q58968
 09645219-n:
   definition:
   - a young person, not fully developed
@@ -8739,6 +8748,7 @@
   members:
   - leader
   partOfSpeech: n
+  wikidata: Q1251441
 09647338-n:
   definition:
   - a person who belongs to the sex that cannot have babies
@@ -9039,6 +9049,7 @@
   members:
   - worker
   partOfSpeech: n
+  wikidata: Q327055
 09657157-n:
   definition:
   - a person who transgresses moral or civil law
@@ -11347,6 +11358,7 @@
   members:
   - Christian
   partOfSpeech: n
+  wikidata: Q106039
 09697977-n:
   definition:
   - a member of the Protestant church founded in the United States by Mary Baker Eddy
@@ -11553,6 +11565,7 @@
   - Muslim
   - Moslem
   partOfSpeech: n
+  wikidata: Q47740
 09702199-n:
   definition:
   - an orthodox Muslim
@@ -16231,6 +16244,7 @@
   members:
   - abbe
   partOfSpeech: n
+  wikidata: Q3430033
 09773548-n:
   definition:
   - the superior of a group of nuns
@@ -16402,6 +16416,7 @@
   members:
   - able-bodied sailor
   partOfSpeech: n
+  wikidata: Q10989378
 09775968-n:
   definition:
   - a reformer who favors abolishing slavery
@@ -16498,6 +16513,7 @@
   - abstainer
   - ascetic
   partOfSpeech: n
+  wikidata: Q779458
 09777755-n:
   definition:
   - a painter of abstract pictures
@@ -16567,6 +16583,7 @@
   members:
   - academician
   partOfSpeech: n
+  wikidata: Q414528
 09779015-n:
   definition:
   - the person (or institution) who accepts a check or draft and becomes responsible
@@ -16709,6 +16726,7 @@
   - registered representative
   - customer's broker
   partOfSpeech: n
+  wikidata: Q4672747
 09781434-n:
   definition:
   - a defendant in a criminal proceeding
@@ -16800,6 +16818,7 @@
   members:
   - acolyte
   partOfSpeech: n
+  wikidata: Q420421
 09783091-n:
   definition:
   - a physicist who specializes in acoustics
@@ -16840,6 +16859,7 @@
   members:
   - acrobat
   partOfSpeech: n
+  wikidata: Q11957145
 09784021-n:
   definition:
   - an acrobat who performs in the air (as on a rope or trapeze)
@@ -16849,6 +16869,7 @@
   members:
   - aerialist
   partOfSpeech: n
+  wikidata: Q4688043
 09784155-n:
   definition:
   - the case officer designated to perform an act during a clandestine operation (especially
@@ -17019,6 +17040,7 @@
   - claims adjustor
   - claim agent
   partOfSpeech: n
+  wikidata: Q691167
 09789602-n:
   definition:
   - an officer who acts as military assistant to a more senior officer
@@ -17032,6 +17054,7 @@
   - aide
   - aide-de-camp
   partOfSpeech: n
+  wikidata: Q369894
 09789782-n:
   definition:
   - a general's adjutant; chief administrative officer
@@ -17041,6 +17064,7 @@
   members:
   - adjutant general
   partOfSpeech: n
+  wikidata: Q2429942
 09789895-n:
   definition:
   - someone who manages a government agency or department
@@ -17061,6 +17085,7 @@
   members:
   - administrator
   partOfSpeech: n
+  wikidata: Q4683600
 09790372-n:
   definition:
   - someone who administers a business
@@ -17082,6 +17107,7 @@
   - admiral
   - full admiral
   partOfSpeech: n
+  wikidata: Q132851
 09790858-n:
   definition:
   - someone who admires a young woman
@@ -17244,6 +17270,7 @@
   - advertizer
   - adman
   partOfSpeech: n
+  wikidata: Q10355417
 09793590-n:
   definition:
   - someone who receives advice
@@ -17295,6 +17322,7 @@
   - counselor-at-law
   - pleader
   partOfSpeech: n
+  wikidata: Q380075
 09795348-n:
   definition:
   - an engineer concerned with the design and construction of aircraft
@@ -17392,6 +17420,7 @@
   - factor
   - broker
   partOfSpeech: n
+  wikidata: Q160117
 09796794-n:
   definition:
   - a representative who acts on behalf of other persons or organizations
@@ -17429,6 +17458,7 @@
   members:
   - literary agent
   partOfSpeech: n
+  wikidata: Q278919
 09797707-n:
   definition:
   - an operative serving as a penetration into an intelligence target
@@ -17575,6 +17605,7 @@
   members:
   - air attache
   partOfSpeech: n
+  wikidata: Q4698293
 09799988-n:
   definition:
   - a noncommissioned officer in the British Royal Air Force
@@ -17669,6 +17700,7 @@
   members:
   - alcalde
   partOfSpeech: n
+  wikidata: Q5663900
 09801362-n:
   definition:
   - one who was versed in the practice of alchemy and who sought an elixir of life
@@ -17705,6 +17737,7 @@
   members:
   - alderperson
   partOfSpeech: n
+  wikidata: Q3364526
 09802030-n:
   definition:
   - a member of the people inhabiting the Aleutian Islands and southwestern Alaska
@@ -17789,6 +17822,7 @@
   members:
   - alienist
   partOfSpeech: n
+  wikidata: Q4726509
 09803217-n:
   definition:
   - someone from whom the title of property is transferred
@@ -17901,6 +17935,7 @@
   - almoner
   - medical social worker
   partOfSpeech: n
+  wikidata: Q1657500
 09804850-n:
   definition:
   - a literate person who can arrange items in alphabetical order
@@ -17929,6 +17964,7 @@
   members:
   - alpinist
   partOfSpeech: n
+  wikidata: Q9149093
 09805227-n:
   definition:
   - a native or inhabitant of Alsace
@@ -18005,6 +18041,7 @@
   members:
   - amateur
   partOfSpeech: n
+  wikidata: Q455595
 09806363-n:
   definition:
   - a businessman who arranges an amalgamation of two or more commercial companies
@@ -18058,6 +18095,7 @@
   - ambassador
   - embassador
   partOfSpeech: n
+  wikidata: Q121998
 09807206-n:
   definition:
   - an informal representative
@@ -18377,6 +18415,7 @@
   - anchor
   - anchorperson
   partOfSpeech: n
+  wikidata: Q270389
 09812582-n:
   definition:
   - a person who lived in ancient times
@@ -18494,6 +18533,7 @@
   members:
   - animator
   partOfSpeech: n
+  wikidata: Q266569
 09814109-n:
   definition:
   - one who accepts the doctrine of animism
@@ -18616,6 +18656,7 @@
   members:
   - anthropologist
   partOfSpeech: n
+  wikidata: Q4773904
 09816250-n:
   definition:
   - a person who is opposed (to an action or policy or practice etc.)
@@ -18678,6 +18719,7 @@
   - antiquarian
   - archaist
   partOfSpeech: n
+  wikidata: Q5697103
 09817183-n:
   definition:
   - someone who hates and would persecute Jews
@@ -18899,6 +18941,7 @@
   - aquanaut
   - oceanaut
   partOfSpeech: n
+  wikidata: Q2859165
 09820956-n:
   definition:
   - an ambitious and aspiring young person
@@ -18927,6 +18970,7 @@
   - learner
   - prentice
   partOfSpeech: n
+  wikidata: Q253567
 09821473-n:
   definition:
   - one who estimates officially the worth or value or quality of things
@@ -18937,6 +18981,7 @@
   - appraiser
   - valuator
   partOfSpeech: n
+  wikidata: Q10855106
 09821662-n:
   definition:
   - one who determines authenticity (as of works of art) or who guarantees validity
@@ -18987,6 +19032,7 @@
   members:
   - Arabist
   partOfSpeech: n
+  wikidata: Q620573
 09822483-n:
   definition:
   - a member of one of a group of Semitic peoples inhabiting Aram and parts of Mesopotamia
@@ -19067,6 +19113,7 @@
   members:
   - archdeacon
   partOfSpeech: n
+  wikidata: Q633730
 09823941-n:
   definition:
   - a wife or widow of an archduke or a princess of the former ruling house of Austria
@@ -19105,6 +19152,7 @@
   members:
   - archbishop
   partOfSpeech: n
+  wikidata: Q49476
 09824747-n:
   definition:
   - a person who is expert in the use of a bow and arrow
@@ -19124,6 +19172,7 @@
   - architect
   - designer
   partOfSpeech: n
+  wikidata: Q42973
 09826367-n:
   definition:
   - a person in charge of collecting and cataloguing archives
@@ -19133,6 +19182,7 @@
   members:
   - archivist
   partOfSpeech: n
+  wikidata: Q635734
 09826498-n:
   definition:
   - a senior clergyman and dignitary
@@ -19247,6 +19297,7 @@
   - armourer
   - artificer
   partOfSpeech: n
+  wikidata: Q2101433
 09828372-n:
   definition:
   - a worker skilled in making armor or arms
@@ -19300,6 +19351,7 @@
   - army engineer
   - military engineer
   partOfSpeech: n
+  wikidata: Q151197
 09829154-n:
   definition:
   - an officer in the armed forces
@@ -19378,6 +19430,7 @@
   members:
   - art critic
   partOfSpeech: n
+  wikidata: Q4164507
 09830388-n:
   definition:
   - a dealer in works of art requiring esthetic evaluation
@@ -19387,6 +19440,7 @@
   members:
   - art dealer
   partOfSpeech: n
+  wikidata: Q173950
 09830517-n:
   definition:
   - the director in charge of the artistic features of a theatrical production (costumes
@@ -19397,6 +19451,7 @@
   members:
   - art director
   partOfSpeech: n
+  wikidata: Q706364
 09830686-n:
   definition:
   - an editor who is responsible for illustrations and layouts in printed matter
@@ -19415,6 +19470,7 @@
   members:
   - art historian
   partOfSpeech: n
+  wikidata: Q1792450
 09830973-n:
   definition:
   - a person afflicted with arthritis
@@ -19455,6 +19511,7 @@
   members:
   - illustrator
   partOfSpeech: n
+  wikidata: Q644687
 09831743-n:
   definition:
   - a person whose creative work shows sensitivity and imagination
@@ -19465,6 +19522,7 @@
   - artist
   - creative person
   partOfSpeech: n
+  wikidata: Q483501
 09832531-n:
   definition:
   - a public performer (a dancer or singer)
@@ -19484,6 +19542,7 @@
   - artist's model
   - sitter
   partOfSpeech: n
+  wikidata: Q1630100
 09832756-n:
   definition:
   - someone studying to be an artist
@@ -19561,6 +19620,7 @@
   members:
   - assayer
   partOfSpeech: n
+  wikidata: Q3058707
 09833786-n:
   definition:
   - a man who is a member of a legislative assembly
@@ -19689,6 +19749,7 @@
   members:
   - assistant professor
   partOfSpeech: n
+  wikidata: Q5669847
 09836176-n:
   definition:
   - a person who joins with others in some activity or endeavor
@@ -19752,6 +19813,7 @@
   - astrologer
   - astrologist
   partOfSpeech: n
+  wikidata: Q155647
 09837427-n:
   definition:
   - a person trained to travel in a spacecraft
@@ -19764,6 +19826,7 @@
   - astronaut
   - cosmonaut
   partOfSpeech: n
+  wikidata: Q11631
 09837748-n:
   definition:
   - a physicist who studies astronomy
@@ -19777,6 +19840,7 @@
   - uranologist
   - stargazer
   partOfSpeech: n
+  wikidata: Q11063
 09838696-n:
   definition:
   - an astronomer who studies the physical properties of celestial bodies
@@ -19806,6 +19870,7 @@
   members:
   - cosmologist
   partOfSpeech: n
+  wikidata: Q2998308
 09839265-n:
   definition:
   - an organism that has the characteristics of a more primitive type of that organism
@@ -19835,6 +19900,7 @@
   - athlete
   - jock
   partOfSpeech: n
+  wikidata: Q2066131
 09840488-n:
   definition:
   - a specialist assigned to the staff of a diplomatic mission
@@ -19844,6 +19910,7 @@
   members:
   - attache
   partOfSpeech: n
+  wikidata: Q544178
 09840655-n:
   definition:
   - someone who attacks
@@ -19869,6 +19936,7 @@
   - attender
   - tender
   partOfSpeech: n
+  wikidata: Q2596222
 09842042-n:
   definition:
   - someone who affirms or vouches for the correctness or truth or genuineness of
@@ -19901,6 +19969,7 @@
   members:
   - auditor
   partOfSpeech: n
+  wikidata: Q10949665
 09842555-n:
   definition:
   - a student who attends a course but does not take it for credit
@@ -19924,6 +19993,7 @@
   - augur
   - auspex
   partOfSpeech: n
+  wikidata: Q215909
 09842904-n:
   definition:
   - the sister of your father or mother; the wife of your uncle
@@ -19944,6 +20014,7 @@
   members:
   - au pair
   partOfSpeech: n
+  wikidata: Q212816
 09843234-n:
   definition:
   - a foreign girl serving as an au pair
@@ -19964,6 +20035,7 @@
   members:
   - auteur
   partOfSpeech: n
+  wikidata: Q788514
 09843467-n:
   definition:
   - a woman author
@@ -20077,6 +20149,7 @@
   - mechanic
   - grease monkey
   partOfSpeech: n
+  wikidata: Q706835
 09845341-n:
   definition:
   - an engineer concerned with the design and construction of automobiles
@@ -20154,6 +20227,7 @@
   members:
   - ayatollah
   partOfSpeech: n
+  wikidata: Q184402
 09846568-n:
   definition:
   - South African term for ‘boss’
@@ -20200,6 +20274,7 @@
   - babe
   - infant
   partOfSpeech: n
+  wikidata: Q998
 09847462-n:
   definition:
   - an unborn child; a human fetus
@@ -20247,6 +20322,7 @@
   - pediatrist
   - paediatrician
   partOfSpeech: n
+  wikidata: Q1919436
 09848234-n:
   definition:
   - someone who runs an establishment that houses and cares for babies for a fee
@@ -20597,6 +20673,7 @@
   members:
   - baker
   partOfSpeech: n
+  wikidata: Q160131
 09853111-n:
   definition:
   - an acrobat who balances themself in difficult positions
@@ -20675,6 +20752,7 @@
   - ballerina
   - danseuse
   partOfSpeech: n
+  wikidata: Q4070300
 09854087-n:
   definition:
   - a trained dancer who is a member of a ballet company
@@ -20684,6 +20762,7 @@
   members:
   - ballet dancer
   partOfSpeech: n
+  wikidata: Q805221
 09854273-n:
   definition:
   - a man who directs and teaches and rehearses dancers for a ballet company
@@ -20693,6 +20772,7 @@
   members:
   - ballet master
   partOfSpeech: n
+  wikidata: Q805253
 09854405-n:
   definition:
   - a woman who directs and teaches and rehearses dancers for a ballet company
@@ -20744,6 +20824,7 @@
   - ballplayer
   - baseball player
   partOfSpeech: n
+  wikidata: Q10871364
 09855445-n:
   definition:
   - a person suffering from bulimia
@@ -20763,6 +20844,7 @@
   - bullfighter
   - toreador
   partOfSpeech: n
+  wikidata: Q549322
 09855731-n:
   definition:
   - the bullfighter who implants decorated darts (banderillas) into the neck or shoulders
@@ -20773,6 +20855,7 @@
   members:
   - banderillero
   partOfSpeech: n
+  wikidata: Q2737671
 09855907-n:
   definition:
   - the principal bullfighter who is appointed to make the final passes and kill the
@@ -20783,6 +20866,7 @@
   members:
   - matador
   partOfSpeech: n
+  wikidata: Q2412523
 09856046-n:
   definition:
   - a bullfighter who is required to fight bulls less than four years of age
@@ -20803,6 +20887,7 @@
   members:
   - picador
   partOfSpeech: n
+  wikidata: Q2191547
 09856364-n:
   definition:
   - a matador or one of the supporting team during a bull fight
@@ -20833,6 +20918,7 @@
   members:
   - bandleader
   partOfSpeech: n
+  wikidata: Q806349
 09856748-n:
   definition:
   - the conductor of a band
@@ -20842,6 +20928,7 @@
   members:
   - bandmaster
   partOfSpeech: n
+  wikidata: Q4854651
 09856847-n:
   definition:
   - a player in a band (especially a military band)
@@ -20964,6 +21051,7 @@
   members:
   - barber
   partOfSpeech: n
+  wikidata: Q107198
 09858410-n:
   definition:
   - a lyric poet
@@ -20973,6 +21061,7 @@
   members:
   - bard
   partOfSpeech: n
+  wikidata: Q215144
 09858473-n:
   definition:
   - a drinker who frequents bars
@@ -21084,6 +21173,7 @@
   - top executive
   - tycoon
   partOfSpeech: n
+  wikidata: Q911554
 09859823-n:
   definition:
   - a British peer of the lowest rank
@@ -21138,6 +21228,7 @@
   members:
   - barrister
   partOfSpeech: n
+  wikidata: Q808967
 09860576-n:
   definition:
   - an employee who mixes and serves alcoholic drinks at a bar
@@ -21150,6 +21241,7 @@
   - barkeeper
   - mixologist
   partOfSpeech: n
+  wikidata: Q808266
 09860788-n:
   definition:
   - a trader who exchanges goods and not money
@@ -21171,6 +21263,7 @@
   - baseball coach
   - baseball manager
   partOfSpeech: n
+  wikidata: Q865935
 09861084-n:
   definition:
   - a baseball player on the team at bat who is on base (or attempting to reach a
@@ -21202,6 +21295,7 @@
   members:
   - basketball coach
   partOfSpeech: n
+  wikidata: Q5137571
 09861435-n:
   definition:
   - an athlete who plays basketball
@@ -21213,6 +21307,7 @@
   - basketeer
   - cager
   partOfSpeech: n
+  wikidata: Q3665646
 09861676-n:
   definition:
   - someone skilled in weaving baskets
@@ -21251,6 +21346,7 @@
   members:
   - bassist
   partOfSpeech: n
+  wikidata: Q584301
 09862104-n:
   definition:
   - a musician who plays the bassoon
@@ -21260,6 +21356,7 @@
   members:
   - bassoonist
   partOfSpeech: n
+  wikidata: Q12310971
 09862211-n:
   definition:
   - the illegitimate offspring of unmarried parents
@@ -21423,6 +21520,7 @@
   members:
   - beadle
   partOfSpeech: n
+  wikidata: Q2692509
 09864306-n:
   definition:
   - a male person who is paid to pray for the soul of another
@@ -21572,6 +21670,7 @@
   - apiarist
   - apiculturist
   partOfSpeech: n
+  wikidata: Q852389
 09866302-n:
   definition:
   - someone whose favorite drink is beer or ale
@@ -21692,6 +21791,7 @@
   members:
   - bellhop
   partOfSpeech: n
+  wikidata: Q2043489
 09868324-n:
   definition:
   - the supervisor of bellboys in a hotel
@@ -21721,6 +21821,7 @@
   members:
   - bell founder
   partOfSpeech: n
+  wikidata: Q474306
 09868664-n:
   definition:
   - someone who plays musical handbells
@@ -21961,6 +22062,7 @@
   members:
   - bey
   partOfSpeech: n
+  wikidata: Q181217
 09871838-n:
   definition:
   - a woman employed by a bar to act as a companion to men customers
@@ -21980,6 +22082,7 @@
   members:
   - bibliographer
   partOfSpeech: n
+  wikidata: Q10429346
 09872087-n:
   definition:
   - someone who loves (and usually collects) books
@@ -22158,6 +22261,7 @@
   members:
   - biochemist
   partOfSpeech: n
+  wikidata: Q2919046
 09874839-n:
   definition:
   - someone who writes an account of a person's life
@@ -22167,6 +22271,7 @@
   members:
   - biographer
   partOfSpeech: n
+  wikidata: Q864380
 09875036-n:
   definition:
   - (biology) a scientist who studies living organisms
@@ -22179,6 +22284,7 @@
   - biologist
   - life scientist
   partOfSpeech: n
+  wikidata: Q864503
 09875673-n:
   definition:
   - a physicist who applies the methods of physics to biology
@@ -22188,6 +22294,7 @@
   members:
   - biophysicist
   partOfSpeech: n
+  wikidata: Q14906342
 09875807-n:
   definition:
   - a person with a strong interest in birds
@@ -22256,6 +22363,7 @@
   members:
   - bishop
   partOfSpeech: n
+  wikidata: Q29182
 09877258-n:
   definition:
   - someone who bites
@@ -22344,6 +22452,7 @@
   members:
   - blacksmith
   partOfSpeech: n
+  wikidata: Q1639825
 09878691-n:
   definition:
   - a dashing young man
@@ -22547,6 +22656,7 @@
   members:
   - boater
   partOfSpeech: n
+  wikidata: Q2891167
 09881589-n:
   definition:
   - a petty officer on a merchant ship who controls the work of other seamen
@@ -22560,6 +22670,7 @@
   - bosun
   - bo'sun
   partOfSpeech: n
+  wikidata: Q303486
 09881751-n:
   definition:
   - a pupil who lives at school during term time
@@ -22623,6 +22734,7 @@
   - bodyguard
   - escort
   partOfSpeech: n
+  wikidata: Q851436
 09882644-n:
   definition:
   - a valet or personal maid
@@ -22827,6 +22939,7 @@
   members:
   - bookbinder
   partOfSpeech: n
+  wikidata: Q1413170
 09885244-n:
   definition:
   - a dealer in books; a merchant who sells books
@@ -22866,6 +22979,7 @@
   - bookmaker
   - bookie
   partOfSpeech: n
+  wikidata: Q664702
 09885760-n:
   definition:
   - a maker of books; someone who edits or publishes or binds books
@@ -22916,6 +23030,7 @@
   - bootblack
   - shoeblack
   partOfSpeech: n
+  wikidata: Q1517909
 09886328-n:
   definition:
   - someone who makes or sells illegal liquor
@@ -23020,6 +23135,7 @@
   - phytologist
   - plant scientist
   partOfSpeech: n
+  wikidata: Q2374149
 09888109-n:
   definition:
   - a person of low status
@@ -23059,6 +23175,7 @@
   - bouncer
   - chucker-out
   partOfSpeech: n
+  wikidata: Q10860242
 09888577-n:
   definition:
   - someone who bounds or leaps (as in competition)
@@ -23087,6 +23204,7 @@
   members:
   - bounty hunter
   partOfSpeech: n
+  wikidata: Q621613
 09888984-n:
   definition:
   - a member of the European royal family that ruled France
@@ -23124,6 +23242,7 @@
   members:
   - bowler
   partOfSpeech: n
+  wikidata: Q4951095
 09889502-n:
   definition:
   - a cricketer who delivers the ball to the batsman in cricket
@@ -23320,6 +23439,7 @@
   members:
   - brake worker
   partOfSpeech: n
+  wikidata: Q637934
 09892708-n:
   definition:
   - a high-ranking military officer
@@ -23426,6 +23546,7 @@
   members:
   - bricklayer
   partOfSpeech: n
+  wikidata: Q327321
 09894084-n:
   definition:
   - a woman who has recently been married
@@ -23539,6 +23660,7 @@
   members:
   - broker-dealer
   partOfSpeech: n
+  wikidata: Q11774490
 09895774-n:
   definition:
   - an outstanding person; as if produced by boiling down a savory broth
@@ -23844,6 +23966,7 @@
   - bureaucrat
   - administrative official
   partOfSpeech: n
+  wikidata: Q572700
 09900112-n:
   definition:
   - a citizen of an English borough
@@ -23874,6 +23997,7 @@
   members:
   - burgomaster
   partOfSpeech: n
+  wikidata: Q177529
 09900475-n:
   definition:
   - the military governor of a German town in the 12th and 13th centuries
@@ -24012,6 +24136,7 @@
   - busman
   - bus driver
   partOfSpeech: n
+  wikidata: Q829020
 09902904-n:
   definition:
   - a person (or thing) that breaks up or overpowers something
@@ -24084,6 +24209,7 @@
   - butcher
   - slaughterer
   partOfSpeech: n
+  wikidata: Q329737
 09903757-n:
   definition:
   - a brutal indiscriminate murderer
@@ -24114,6 +24240,7 @@
   members:
   - butler
   partOfSpeech: n
+  wikidata: Q833899
 09904118-n:
   definition:
   - a victim of ridicule or pranks
@@ -24167,6 +24294,7 @@
   - emptor
   - vendee
   partOfSpeech: n
+  wikidata: Q1308239
 09904786-n:
   definition:
   - a nonparticipant spectator
@@ -24217,6 +24345,7 @@
   members:
   - cabin boy
   partOfSpeech: n
+  wikidata: Q49640
 09905318-n:
   definition:
   - a woodworker who specializes in making furniture
@@ -24265,6 +24394,7 @@
   - caddie
   - golf caddie
   partOfSpeech: n
+  wikidata: Q1064569
 09905992-n:
   definition:
   - a military trainee (as at a military academy)
@@ -24277,6 +24407,7 @@
   - cadet
   - plebe
   partOfSpeech: n
+  wikidata: Q316498
 09906152-n:
   definition:
   - someone addicted to caffeine
@@ -24348,6 +24479,7 @@
   - khalif
   - khalifah
   partOfSpeech: n
+  wikidata: Q65997
 09907302-n:
   definition:
   - a social or business visitor
@@ -24408,6 +24540,7 @@
   - caller
   - caller-out
   partOfSpeech: n
+  wikidata: Q1027244
 09908284-n:
   definition:
   - the bettor in a card game who matches the bet and calls for a show of hands
@@ -24437,6 +24570,7 @@
   members:
   - call girl
   partOfSpeech: n
+  wikidata: Q814356
 09908622-n:
   definition:
   - someone skilled in penmanship
@@ -24467,6 +24601,7 @@
   - camera operator
   - cinematographer
   partOfSpeech: n
+  wikidata: Q1208175
 09909143-n:
   definition:
   - a politician who is running for public office
@@ -24607,6 +24742,7 @@
   - canoeist
   - paddler
   partOfSpeech: n
+  wikidata: Q13382566
 09911065-n:
   definition:
   - a priest who is a member of a cathedral chapter
@@ -24616,6 +24752,7 @@
   members:
   - canon
   partOfSpeech: n
+  wikidata: Q1104153
 09911182-n:
   definition:
   - a specialist in canon law
@@ -24625,6 +24762,7 @@
   members:
   - canonist
   partOfSpeech: n
+  wikidata: Q12027957
 09911316-n:
   definition:
   - the official of a synagogue who conducts the liturgical part of the service and
@@ -24636,6 +24774,7 @@
   - cantor
   - hazan
   partOfSpeech: n
+  wikidata: Q1067977
 09911518-n:
   definition:
   - a person who takes or counts votes
@@ -24728,6 +24867,7 @@
   members:
   - captain
   partOfSpeech: n
+  wikidata: Q19100
 09912796-n:
   definition:
   - the leader of a group of people
@@ -24760,6 +24900,7 @@
   - carabineer
   - carabinier
   partOfSpeech: n
+  wikidata: Q13386767
 09913368-n:
   definition:
   - a player who holds a card or cards in a card game
@@ -24872,6 +25013,7 @@
   members:
   - caregiver
   partOfSpeech: n
+  wikidata: Q553079
 09915153-n:
   definition:
   - a custodian who is hired to take care of something (property or a person)
@@ -24910,6 +25052,7 @@
   members:
   - caricaturist
   partOfSpeech: n
+  wikidata: Q3658608
 09915763-n:
   definition:
   - a musician who plays a carillon
@@ -24948,6 +25091,7 @@
   members:
   - carpenter
   partOfSpeech: n
+  wikidata: Q154549
 09916278-n:
   definition:
   - someone who constantly criticizes in a petty way
@@ -25008,6 +25152,7 @@
   - carrier
   - newsboy
   partOfSpeech: n
+  wikidata: Q1856852
 09917148-n:
   definition:
   - someone whose employment involves carrying something
@@ -25058,6 +25203,7 @@
   - cartographer
   - map maker
   partOfSpeech: n
+  wikidata: Q1734662
 09917798-n:
   definition:
   - a person who draws cartoons
@@ -25117,6 +25263,7 @@
   members:
   - cashier
   partOfSpeech: n
+  wikidata: Q1735282
 09918890-n:
   definition:
   - a shipwrecked person
@@ -25127,6 +25274,7 @@
   - castaway
   - shipwreck survivor
   partOfSpeech: n
+  wikidata: Q508230
 09918986-n:
   definition:
   - a male singer who was castrated before puberty and retains a soprano or alto voice
@@ -25136,6 +25284,7 @@
   members:
   - castrato
   partOfSpeech: n
+  wikidata: Q210970
 09919123-n:
   definition:
   - someone injured or killed in an accident
@@ -25260,6 +25409,7 @@
   members:
   - catechist
   partOfSpeech: n
+  wikidata: Q1735732
 09920955-n:
   definition:
   - a new convert being taught the principles of Christianity by a catechist
@@ -25393,6 +25543,7 @@
   - celebrity
   - famous person
   partOfSpeech: n
+  wikidata: Q211236
 09922820-n:
   definition:
   - an unmarried person who has taken a religious vow of chastity
@@ -25451,6 +25602,7 @@
   members:
   - centenarian
   partOfSpeech: n
+  wikidata: Q2944360
 09923774-n:
   definition:
   - (football) the person who plays center on the line of scrimmage and snaps the
@@ -25531,6 +25683,7 @@
   - certified public accountant
   - CPA
   partOfSpeech: n
+  wikidata: Q1056337
 09924983-n:
   definition:
   - (Yiddish) an attractive, unconventional woman
@@ -25584,6 +25737,7 @@
   members:
   - chamberlain
   partOfSpeech: n
+  wikidata: Q264323
 09925648-n:
   definition:
   - the treasurer of a municipal corporation
@@ -25646,6 +25800,7 @@
   members:
   - chancellor
   partOfSpeech: n
+  wikidata: Q61061
 09926439-n:
   definition:
   - the person who is head of government (in several countries)
@@ -25758,6 +25913,7 @@
   members:
   - chaplain
   partOfSpeech: n
+  wikidata: Q208762
 09928136-n:
   definition:
   - a male itinerant peddler
@@ -25777,6 +25933,7 @@
   members:
   - prison chaplain
   partOfSpeech: n
+  wikidata: Q1498177
 09928311-n:
   definition:
   - a person paid to drive a privately owned car
@@ -25786,6 +25943,7 @@
   members:
   - chauffeur
   partOfSpeech: n
+  wikidata: Q216541
 09928444-n:
   definition:
   - a woman chauffeur
@@ -25823,6 +25981,7 @@
   members:
   - character actor
   partOfSpeech: n
+  wikidata: Q948329
 09928935-n:
   definition:
   - a witness who testifies under oath as to the good reputation of another person
@@ -25842,6 +26001,7 @@
   members:
   - charcoal burner
   partOfSpeech: n
+  wikidata: Q729340
 09929218-n:
   definition:
   - a person committed to your care
@@ -25863,6 +26023,7 @@
   members:
   - charge d'affaires
   partOfSpeech: n
+  wikidata: Q217713
 09929542-n:
   definition:
   - an enlisted man who handles his unit's administrative matters after hours
@@ -25881,6 +26042,7 @@
   members:
   - charioteer
   partOfSpeech: n
+  wikidata: Q12456639
 09929832-n:
   definition:
   - a person who charms others (usually by personal attractiveness)
@@ -25901,6 +26063,7 @@
   members:
   - chartered accountant
   partOfSpeech: n
+  wikidata: Q1108818
 09930177-n:
   definition:
   - one of the original members when an organization was founded
@@ -25948,6 +26111,7 @@
   - cleaning woman
   - cleaning lady
   partOfSpeech: n
+  wikidata: Q5086996
 09930923-n:
   definition:
   - the mistress of a chateau or large country house
@@ -26131,6 +26295,7 @@
   members:
   - chemist
   partOfSpeech: n
+  wikidata: Q593644
 09934892-n:
   definition:
   - Egyptian Pharaoh of the 27th century BC who commissioned the Great Pyramid at
@@ -26170,6 +26335,7 @@
   members:
   - chess player
   partOfSpeech: n
+  wikidata: Q10873124
 09935422-n:
   definition:
   - someone who chews (especially someone who chews tobacco)
@@ -26199,6 +26365,7 @@
   members:
   - chief constable
   partOfSpeech: n
+  wikidata: Q3242291
 09935806-n:
   definition:
   - the corporate executive responsible for the operations of the firm; reports to
@@ -26211,6 +26378,7 @@
   - CEO
   - chief operating officer
   partOfSpeech: n
+  wikidata: Q484876
 09936059-n:
   definition:
   - the corporate executive having financial authority to make appropriations and
@@ -26222,6 +26390,7 @@
   - chief financial officer
   - CFO
   partOfSpeech: n
+  wikidata: Q623268
 09936246-n:
   definition:
   - the judge who presides over a supreme court
@@ -26244,6 +26413,7 @@
   members:
   - chief of staff
   partOfSpeech: n
+  wikidata: Q707492
 09936803-n:
   definition:
   - a person with the senior noncommissioned naval rank
@@ -26348,6 +26518,7 @@
   members:
   - chiropractor
   partOfSpeech: n
+  wikidata: Q2963953
 09938755-n:
   definition:
   - a specialist in care for the feet
@@ -26394,6 +26565,7 @@
   - precentor
   - cantor
   partOfSpeech: n
+  wikidata: Q330679
 09939357-n:
   definition:
   - an unfortunate person who is unable to perform effectively because of nervous
@@ -26428,6 +26600,7 @@
   members:
   - choreographer
   partOfSpeech: n
+  wikidata: Q2490358
 09940229-n:
   definition:
   - a singer in a choir
@@ -26449,6 +26622,7 @@
   - showgirl
   - chorine
   partOfSpeech: n
+  wikidata: Q3482594
 09940492-n:
   definition:
   - one who is the object of choice; who is given preference
@@ -26545,6 +26719,7 @@
   members:
   - churchwarden
   partOfSpeech: n
+  wikidata: Q3290825
 09942257-n:
   definition:
   - a church official
@@ -26621,6 +26796,7 @@
   members:
   - citizen
   partOfSpeech: n
+  wikidata: Q1020994
 09943454-n:
   definition:
   - the newspaper editor in charge of editing local news
@@ -26667,6 +26843,7 @@
   - civic leader
   - civil leader
   partOfSpeech: n
+  wikidata: Q1500610
 09943998-n:
   definition:
   - an engineer trained to design and construct and maintain public works (roads or
@@ -26677,6 +26854,7 @@
   members:
   - civil engineer
   partOfSpeech: n
+  wikidata: Q13582652
 09944200-n:
   definition:
   - a nonmilitary citizen
@@ -26686,6 +26864,7 @@
   members:
   - civilian
   partOfSpeech: n
+  wikidata: Q206887
 09944312-n:
   definition:
   - a libertarian who is actively concerned with the protection of civil liberties
@@ -26768,6 +26947,7 @@
   - clarinetist
   - clarinettist
   partOfSpeech: n
+  wikidata: Q118865
 09945884-n:
   definition:
   - an artist who has created classic works
@@ -26786,6 +26966,7 @@
   members:
   - classicist
   partOfSpeech: n
+  wikidata: Q2468727
 09946114-n:
   definition:
   - a student of ancient Greek and Latin
@@ -26823,6 +27004,7 @@
   members:
   - cleaner
   partOfSpeech: n
+  wikidata: Q1760141
 09946763-n:
   definition:
   - the operator of dry-cleaning establishment
@@ -26853,6 +27035,7 @@
   - divine
   - ecclesiastic
   partOfSpeech: n
+  wikidata: Q2259532
 09947822-n:
   definition:
   - one who advocates clericalism
@@ -26871,6 +27054,7 @@
   members:
   - clerk
   partOfSpeech: n
+  wikidata: Q738142
 09948303-n:
   definition:
   - an intellectual who is ostentatiously and irritatingly knowledgeable
@@ -26914,6 +27098,7 @@
   members:
   - climber
   partOfSpeech: n
+  wikidata: Q3951423
 09949035-n:
   definition:
   - a practitioner (of medicine or psychology) who does clinical work instead of laboratory
@@ -26927,6 +27112,7 @@
   members:
   - clinician
   partOfSpeech: n
+  wikidata: Q5133860
 09949228-n:
   definition:
   - a swindler who fleeces the victim
@@ -26948,6 +27134,7 @@
   - cloakmaker
   - furrier
   partOfSpeech: n
+  wikidata: Q2295938
 09949446-n:
   definition:
   - a worker preoccupied with the arrival of quitting time
@@ -26967,6 +27154,7 @@
   - clocksmith
   - clockmaker
   partOfSpeech: n
+  wikidata: Q2700922
 09949715-n:
   definition:
   - (baseball) a relief pitcher who can protect a lead in the last inning or two of
@@ -27023,6 +27211,7 @@
   - goofball
   - merry andrew
   partOfSpeech: n
+  wikidata: Q7358
 09950623-n:
   definition:
   - a rude or vulgar fool
@@ -27057,6 +27246,7 @@
   - private instructor
   - tutor
   partOfSpeech: n
+  wikidata: Q901222
 09951098-n:
   definition:
   - (sports) someone in charge of training an athlete or a team
@@ -27070,6 +27260,7 @@
   - manager
   - handler
   partOfSpeech: n
+  wikidata: Q41583
 09951447-n:
   definition:
   - an assistant football coach in charge of the linemen
@@ -27110,6 +27301,7 @@
   members:
   - coachman
   partOfSpeech: n
+  wikidata: Q1221610
 09951887-n:
   definition:
   - someone who delivers coal
@@ -27185,6 +27377,7 @@
   - cobbler
   - shoemaker
   partOfSpeech: n
+  wikidata: Q152355
 09952693-n:
   definition:
   - a person addicted to cocaine
@@ -27297,6 +27490,7 @@
   members:
   - cognitive scientist
   partOfSpeech: n
+  wikidata: Q14565186
 09954232-n:
   definition:
   - a man hairdresser
@@ -27328,6 +27522,7 @@
   - minter
   - moneyer
   partOfSpeech: n
+  wikidata: Q1861571
 09954565-n:
   definition:
   - someone who is a source of new words or new expressions
@@ -27438,6 +27633,7 @@
   - collector
   - aggregator
   partOfSpeech: n
+  wikidata: Q3243461
 09956283-n:
   definition:
   - an Irish girl
@@ -27541,6 +27737,7 @@
   - color bearer
   - standard-bearer
   partOfSpeech: n
+  wikidata: Q2486919
 09957907-n:
   definition:
   - a ceremonial escort for the (regimental) colors
@@ -27568,6 +27765,7 @@
   members:
   - colorist
   partOfSpeech: n
+  wikidata: Q1111648
 09958309-n:
   definition:
   - a native or inhabitant of the city of Colossae in ancient Phrygia
@@ -27645,6 +27843,7 @@
   - comedian
   - comic
   partOfSpeech: n
+  wikidata: Q245068
 09960183-n:
   definition:
   - an actor in a comedy
@@ -27714,6 +27913,7 @@
   members:
   - commander
   partOfSpeech: n
+  wikidata: Q6620231
 09961245-n:
   definition:
   - the officer who holds the supreme command
@@ -27752,6 +27952,7 @@
   - commando
   - ranger
   partOfSpeech: n
+  wikidata: Q1780133
 09961910-n:
   definition:
   - a writer who reports and analyzes events of the day
@@ -27782,6 +27983,7 @@
   - commissar
   - political commissar
   partOfSpeech: n
+  wikidata: Q168559
 09962350-n:
   definition:
   - a uniformed doorman
@@ -27835,6 +28037,7 @@
   members:
   - commissioner
   partOfSpeech: n
+  wikidata: Q524778
 09963501-n:
   definition:
   - a member of a commission
@@ -27904,6 +28107,7 @@
   - council member
   - councillor
   partOfSpeech: n
+  wikidata: Q708492
 09964410-n:
   definition:
   - a woman who is a council member
@@ -28053,6 +28257,7 @@
   members:
   - composer
   partOfSpeech: n
+  wikidata: Q36834
 09969425-n:
   definition:
   - one who sets written material into type
@@ -28065,6 +28270,7 @@
   - setter
   - typographer
   partOfSpeech: n
+  wikidata: Q1229025
 09969629-n:
   definition:
   - a United States federal official who supervises expenditures and settles claims
@@ -28126,6 +28332,7 @@
   members:
   - computer scientist
   partOfSpeech: n
+  wikidata: Q82594
 09970753-n:
   definition:
   - a person who uses computers for work or entertainment or communication or business
@@ -28183,6 +28390,7 @@
   members:
   - concierge
   partOfSpeech: n
+  wikidata: Q2664461
 09971642-n:
   definition:
   - someone who tries to bring peace
@@ -28224,6 +28432,7 @@
   - music director
   - director
   partOfSpeech: n
+  wikidata: Q158852
 09972531-n:
   definition:
   - the person who collects fares on a public conveyance
@@ -28262,6 +28471,7 @@
   - confectioner
   - candymaker
   partOfSpeech: n
+  wikidata: Q2992505
 09972962-n:
   definition:
   - someone who assists in a plot
@@ -28372,6 +28582,7 @@
   members:
   - con artist
   partOfSpeech: n
+  wikidata: Q10591707
 09974494-n:
   definition:
   - a person who swindles you by means of deception or fraud
@@ -28470,6 +28681,7 @@
   - connoisseur
   - cognoscente
   partOfSpeech: n
+  wikidata: Q1126160
 09976057-n:
   definition:
   - someone who is victorious by force of arms
@@ -28493,6 +28705,7 @@
   members:
   - conquistador
   partOfSpeech: n
+  wikidata: Q126236
 09976492-n:
   definition:
   - one who refuses to serve in the armed forces on grounds of conscience
@@ -28503,6 +28716,7 @@
   - conscientious objector
   - CO
   partOfSpeech: n
+  wikidata: Q2930613
 09976635-n:
   definition:
   - a person who is reluctant to accept changes and new ideas
@@ -28582,6 +28796,7 @@
   - consigner
   - consignor
   partOfSpeech: n
+  wikidata: Q877558
 09978203-n:
   definition:
   - the husband or wife of a reigning monarch
@@ -28591,6 +28806,7 @@
   members:
   - consort
   partOfSpeech: n
+  wikidata: Q5784340
 09978371-n:
   definition:
   - a member of a conspiracy
@@ -28626,6 +28842,7 @@
   - constable
   - police constable
   partOfSpeech: n
+  wikidata: Q165654
 09978866-n:
   definition:
   - an advocate of constitutional government
@@ -28665,6 +28882,7 @@
   members:
   - consul
   partOfSpeech: n
+  wikidata: Q207978
 09979480-n:
   definition:
   - a person with pulmonary tuberculosis
@@ -28843,6 +29061,7 @@
   members:
   - conveyancer
   partOfSpeech: n
+  wikidata: Q5166535
 09982268-n:
   definition:
   - a person who conveys (carries or transmits)
@@ -28888,6 +29107,7 @@
   members:
   - cook
   partOfSpeech: n
+  wikidata: Q156839
 09983053-n:
   definition:
   - a professional cook
@@ -28897,6 +29117,7 @@
   members:
   - chef
   partOfSpeech: n
+  wikidata: Q3499072
 09983159-n:
   definition:
   - the cook on a ranch or at a camp
@@ -28917,6 +29138,7 @@
   - cooper
   - barrel maker
   partOfSpeech: n
+  wikidata: Q38883
 09983393-n:
   definition:
   - someone whose task is to see that work goes harmoniously
@@ -28948,6 +29170,7 @@
   - copilot
   - co-pilot
   partOfSpeech: n
+  wikidata: Q123030
 09983845-n:
   definition:
   - someone who makes articles from copper
@@ -28957,6 +29180,7 @@
   members:
   - coppersmith
   partOfSpeech: n
+  wikidata: Q1551626
 09983941-n:
   definition:
   - someone who copies the words or behavior of another
@@ -28992,6 +29216,7 @@
   - scribe
   - scrivener
   partOfSpeech: n
+  wikidata: Q916292
 09984551-n:
   definition:
   - a person employed to write advertising or publicity copy
@@ -29126,6 +29351,7 @@
   - correspondent
   - newswriter
   partOfSpeech: n
+  wikidata: Q1155838
 09986471-n:
   definition:
   - a pirate along the Barbary Coast
@@ -29166,6 +29392,7 @@
   - cosmetic surgeon
   - plastic surgeon
   partOfSpeech: n
+  wikidata: Q5770349
 09986936-n:
   definition:
   - a sophisticated person who has travelled in many countries
@@ -29226,6 +29453,7 @@
   - costumer
   - costume designer
   partOfSpeech: n
+  wikidata: Q1323191
 09987963-n:
   definition:
   - one of two or more tenants holding title to the same property
@@ -29303,6 +29531,7 @@
   members:
   - count palatine
   partOfSpeech: n
+  wikidata: Q22932
 09989021-n:
   definition:
   - a person who counts things
@@ -29472,6 +29701,7 @@
   members:
   - coureur de bois
   partOfSpeech: n
+  wikidata: Q511878
 09991212-n:
   definition:
   - a huntsman who hunts small animals with fast dogs that use sight rather than scent
@@ -29492,6 +29722,7 @@
   members:
   - courtier
   partOfSpeech: n
+  wikidata: Q1511216
 09991540-n:
   definition:
   - the child of your aunt or uncle
@@ -29553,6 +29784,7 @@
   - cowhand
   - cowherd
   partOfSpeech: n
+  wikidata: Q5179781
 09992476-n:
   definition:
   - someone who is reckless or irresponsible (especially in driving vehicles)
@@ -29571,6 +29803,7 @@
   members:
   - rodeo rider
   partOfSpeech: n
+  wikidata: Q178521
 09992739-n:
   definition:
   - local names for a cowboy (‘vaquero’ is used especially in southwestern and central
@@ -29613,6 +29846,7 @@
   - coxswain
   - cox
   partOfSpeech: n
+  wikidata: Q1690874
 09993279-n:
   definition:
   - a forest fire fighter who is sent to battle remote and severe forest fires (often
@@ -29693,6 +29927,7 @@
   - artisan
   - artificer
   partOfSpeech: n
+  wikidata: Q1294787
 09994955-n:
   definition:
   - a creator of great skill in the manual arts
@@ -29834,6 +30069,7 @@
   members:
   - crew member
   partOfSpeech: n
+  wikidata: Q5184855
 09996856-n:
   definition:
   - an athlete who plays cricket
@@ -30024,6 +30260,7 @@
   members:
   - croupier
   partOfSpeech: n
+  wikidata: Q219184
 10000622-n:
   definition:
   - a male heir apparent to a throne
@@ -30158,6 +30395,7 @@
   members:
   - cultural attache
   partOfSpeech: n
+  wikidata: Q1390369
 10002403-n:
   definition:
   - a person (usually but not necessarily a woman) who is thoroughly disliked
@@ -30185,6 +30423,7 @@
   members:
   - cupbearer
   partOfSpeech: n
+  wikidata: Q1075791
 10002744-n:
   definition:
   - a cowardly or contemptible person
@@ -30212,6 +30451,7 @@
   members:
   - curandero
   partOfSpeech: n
+  wikidata: Q547457
 10003102-n:
   definition:
   - a person authorized to conduct religious worship
@@ -30239,6 +30479,7 @@
   - curator
   - conservator
   partOfSpeech: n
+  wikidata: Q674426
 10003577-n:
   definition:
   - a crusty irascible cantankerous old person full of stubborn ideas
@@ -30257,6 +30498,7 @@
   members:
   - currier
   partOfSpeech: n
+  wikidata: Q1326835
 10003828-n:
   definition:
   - one having charge of buildings or grounds or animals
@@ -30307,6 +30549,7 @@
   members:
   - cutler
   partOfSpeech: n
+  wikidata: Q5793597
 10004809-n:
   definition:
   - someone whose work is cutting (as e.g. cutting cloth for garments)
@@ -30381,6 +30624,7 @@
   - wheeler
   - biker
   partOfSpeech: n
+  wikidata: Q2125610
 10005988-n:
   definition:
   - a performer on the cymbals
@@ -30452,6 +30696,7 @@
   - tsar
   - tzar
   partOfSpeech: n
+  wikidata: Q44356
 10007111-n:
   definition:
   - the wife or widow of a czar
@@ -30519,6 +30764,7 @@
   - milkmaid
   - dairywoman
   partOfSpeech: n
+  wikidata: Q1934482
 10007849-n:
   definition:
   - a man who works in a dairy
@@ -30643,6 +30889,7 @@
   - dancer
   - social dancer
   partOfSpeech: n
+  wikidata: Q5716684
 10010228-n:
   definition:
   - someone who does clog dancing
@@ -30663,6 +30910,7 @@
   - dancing-master
   - dance master
   partOfSpeech: n
+  wikidata: Q2393361
 10010442-n:
   definition:
   - one of a pair of people who dance together
@@ -30690,6 +30938,7 @@
   - fashion plate
   - clotheshorse
   partOfSpeech: n
+  wikidata: Q876391
 10010823-n:
   definition:
   - a wise and upright judge
@@ -30822,6 +31071,7 @@
   - daughter
   - girl
   partOfSpeech: n
+  wikidata: Q308194
 10012578-n:
   definition:
   - the wife of your son
@@ -30913,6 +31163,7 @@
   - day laborer
   - day labourer
   partOfSpeech: n
+  wikidata: Q897359
 10014058-n:
   definition:
   - a cleric ranking just below a priest in Christian churches; one of the Holy Orders
@@ -30923,6 +31174,7 @@
   members:
   - deacon
   partOfSpeech: n
+  wikidata: Q161944
 10014211-n:
   definition:
   - a Protestant layman who assists the minister
@@ -31330,6 +31582,7 @@
   members:
   - delegate
   partOfSpeech: n
+  wikidata: Q994779
 10020538-n:
   definition:
   - a young offender
@@ -31443,6 +31696,7 @@
   - demographist
   - population scientist
   partOfSpeech: n
+  wikidata: Q12360779
 10022139-n:
   definition:
   - someone extremely diligent or skillful
@@ -31537,6 +31791,7 @@
   members:
   - dental assistant
   partOfSpeech: n
+  wikidata: Q489933
 10023532-n:
   definition:
   - someone trained to provide preventive dental service (cleaning teeth or taking
@@ -31558,6 +31813,7 @@
   - dental technician
   - denturist
   partOfSpeech: n
+  wikidata: Q144075
 10023833-n:
   definition:
   - a dentist qualified to perform surgical procedures
@@ -31578,6 +31834,7 @@
   - tooth doctor
   - dental practitioner
   partOfSpeech: n
+  wikidata: Q27349
 10024201-n:
   definition:
   - someone who leaves
@@ -31668,6 +31925,7 @@
   members:
   - deputy
   partOfSpeech: n
+  wikidata: Q1055894
 10025743-n:
   definition:
   - a person without a home, job, or property
@@ -31687,6 +31945,7 @@
   - dermatologist
   - skin doctor
   partOfSpeech: n
+  wikidata: Q2447386
 10025999-n:
   definition:
   - an ascetic Muslim monk; a member of an order noted for devotional exercises involving
@@ -31885,6 +32144,7 @@
   members:
   - detective
   partOfSpeech: n
+  wikidata: Q842782
 10029325-n:
   definition:
   - one who disparages or belittles the worth of something
@@ -31993,6 +32253,7 @@
   - diagnostician
   - pathologist
   partOfSpeech: n
+  wikidata: Q3368718
 10031014-n:
   definition:
   - a logician skilled in dialectic
@@ -32045,6 +32306,7 @@
   - dictator
   - potentate
   partOfSpeech: n
+  wikidata: Q183318
 10031898-n:
   definition:
   - a speaker who dictates to a secretary or a recording machine
@@ -32072,6 +32334,7 @@
   members:
   - nutritionist
   partOfSpeech: n
+  wikidata: Q2576499
 10032289-n:
   definition:
   - a specialist in the study of diet and nutrition
@@ -32177,6 +32440,7 @@
   - diplomat
   - diplomatist
   partOfSpeech: n
+  wikidata: Q193391
 10034403-n:
   definition:
   - a person who deals tactfully with others
@@ -32207,6 +32471,7 @@
   - manager
   - managing director
   partOfSpeech: n
+  wikidata: Q1162163
 10034960-n:
   definition:
   - someone who supervises the actors and directs the action in the production of
@@ -32219,6 +32484,7 @@
   - theater director
   - theatre director
   partOfSpeech: n
+  wikidata: Q3387717
 10035230-n:
   definition:
   - member of a board of directors
@@ -32300,6 +32566,7 @@
   - d.j.
   - DJ
   partOfSpeech: n
+  wikidata: Q130857
 10037147-n:
   definition:
   - employee of a transportation company who controls the departures of vehicles according
@@ -32310,6 +32577,7 @@
   members:
   - dispatcher
   partOfSpeech: n
+  wikidata: Q570755
 10037389-n:
   definition:
   - a messenger who carries military dispatches (usually on a motorcycle)
@@ -32352,6 +32620,7 @@
   - objector
   - contestant
   partOfSpeech: n
+  wikidata: Q181043
 10038098-n:
   definition:
   - a troubler who interrupts or interferes with peace and quiet; someone who causes
@@ -32411,6 +32680,7 @@
   - district attorney
   - DA
   partOfSpeech: n
+  wikidata: Q653368
 10038912-n:
   definition:
   - a manager who supervises the sales activity for a district
@@ -32520,6 +32790,7 @@
   members:
   - docent
   partOfSpeech: n
+  wikidata: Q462390
 10040615-n:
   definition:
   - a licensed medical practitioner
@@ -32536,6 +32807,7 @@
   - Dr.
   - medico
   partOfSpeech: n
+  wikidata: Q39631
 10041617-n:
   definition:
   - a person who holds Ph.D. degree (or the equivalent) from an academic institution
@@ -32548,6 +32820,7 @@
   - doctor
   - Dr.
   partOfSpeech: n
+  wikidata: Q4618975
 10041836-n:
   definition:
   - (Roman Catholic Church) a title conferred on 33 saints who distinguished themselves
@@ -32860,6 +33133,7 @@
   - gatekeeper
   - ostiary
   partOfSpeech: n
+  wikidata: Q1650716
 10046488-n:
   definition:
   - the lowest of the minor Holy Orders in the unreformed Western Church but now suppressed
@@ -32916,6 +33190,7 @@
   members:
   - double agent
   partOfSpeech: n
+  wikidata: Q1058375
 10047315-n:
   definition:
   - a person who says one thing and does another
@@ -33044,6 +33319,7 @@
   members:
   - draftsperson
   partOfSpeech: n
+  wikidata: Q683754
 10049154-n:
   definition:
   - an interpreter and guide in the Near East; in the Ottoman Empire in the 18th and
@@ -33055,6 +33331,7 @@
   members:
   - dragoman
   partOfSpeech: n
+  wikidata: Q1136290
 10049454-n:
   definition:
   - a fiercely vigilant and unpleasant woman
@@ -33076,6 +33353,7 @@
   members:
   - dragoon
   partOfSpeech: n
+  wikidata: Q194199
 10049710-n:
   definition:
   - British soldier; so-called because of the soldier's red coat (especially during
@@ -33117,6 +33395,7 @@
   members:
   - draper
   partOfSpeech: n
+  wikidata: Q593362
 10052067-n:
   definition:
   - the person (or bank) who is expected to pay a check or draft when it is presented
@@ -33204,6 +33483,7 @@
   - seamstress
   - sempstress
   partOfSpeech: n
+  wikidata: Q2034021
 10053297-n:
   definition:
   - someone who models dresses
@@ -33248,6 +33528,7 @@
   - drill master
   - drill instructor
   partOfSpeech: n
+  wikidata: Q5307556
 10053926-n:
   definition:
   - a person who drinks alcoholic beverages (especially to excess)
@@ -33306,6 +33587,7 @@
   members:
   - driver
   partOfSpeech: n
+  wikidata: Q352388
 10055380-n:
   definition:
   - a football kicker who drops the ball and kicks it just as it reaches the ground
@@ -33369,6 +33651,7 @@
   members:
   - Druid
   partOfSpeech: n
+  wikidata: Q131081
 10056299-n:
   definition:
   - the leader of a marching band or drum corps
@@ -33407,6 +33690,7 @@
   members:
   - drummer
   partOfSpeech: n
+  wikidata: Q386854
 10056805-n:
   definition:
   - someone who is intoxicated
@@ -33504,6 +33788,7 @@
   members:
   - duchess
   partOfSpeech: n
+  wikidata: Q4593319
 10058272-n:
   definition:
   - hunter of ducks
@@ -33531,6 +33816,7 @@
   members:
   - duke
   partOfSpeech: n
+  wikidata: Q166886
 10058654-n:
   definition:
   - a person who fights duels
@@ -33667,6 +33953,7 @@
   members:
   - dyer
   partOfSpeech: n
+  wikidata: Q6147194
 10060414-n:
   definition:
   - a person who has dyslexia
@@ -33876,6 +34163,7 @@
   - economist
   - economic expert
   partOfSpeech: n
+  wikidata: Q188094
 10064278-n:
   definition:
   - a frugal person who limits spending and avoids waste
@@ -33915,6 +34203,7 @@
   - editor
   - editor in chief
   partOfSpeech: n
+  wikidata: Q589298
 10065169-n:
   definition:
   - an assistant editor
@@ -33934,6 +34223,7 @@
   - educationist
   - educationalist
   partOfSpeech: n
+  wikidata: Q1231865
 10065521-n:
   definition:
   - someone who educates young people
@@ -34127,6 +34417,7 @@
   members:
   - electrical engineer
   partOfSpeech: n
+  wikidata: Q1326886
 10069171-n:
   definition:
   - a person who installs or repairs electrical or telephone lines
@@ -34212,6 +34503,7 @@
   members:
   - elevator operator
   partOfSpeech: n
+  wikidata: Q195651
 10070366-n:
   definition:
   - someone who believes in rule by an elite group
@@ -34325,6 +34617,7 @@
   - emigree
   - outgoer
   partOfSpeech: n
+  wikidata: Q4989857
 10071936-n:
   definition:
   - the boy whose upbringing was described by Jean-Jacques Rousseau
@@ -34364,6 +34657,7 @@
   - emeer
   - ameer
   partOfSpeech: n
+  wikidata: Q166382
 10072502-n:
   definition:
   - someone sent on a mission to represent the interests of someone else
@@ -34597,6 +34891,7 @@
   members:
   - endocrinologist
   partOfSpeech: n
+  wikidata: Q4531850
 10076922-n:
   definition:
   - a dentist specializing in diseases of the dental pulp and nerve
@@ -34647,6 +34942,7 @@
   - railroad engineer
   - engine driver
   partOfSpeech: n
+  wikidata: Q2775569
 10077726-n:
   definition:
   - someone who teaches English
@@ -34666,6 +34962,7 @@
   members:
   - engraver
   partOfSpeech: n
+  wikidata: Q329439
 10077963-n:
   definition:
   - a skilled worker who can inscribe designs or writing onto a surface by carving
@@ -34769,6 +35066,7 @@
   - bugologist
   - bug-hunter
   partOfSpeech: n
+  wikidata: Q3055126
 10079883-n:
   definition:
   - one who enters a competition
@@ -34799,6 +35097,7 @@
   - entrepreneur
   - enterpriser
   partOfSpeech: n
+  wikidata: Q131524
 10080429-n:
   definition:
   - someone who works to protect the environment from destruction or pollution
@@ -34830,6 +35129,7 @@
   - envoy extraordinary
   - minister plenipotentiary
   partOfSpeech: n
+  wikidata: Q11051391
 10081003-n:
   definition:
   - a person who is trained in or engaged in enzymology
@@ -34944,6 +35244,7 @@
   members:
   - equerry
   partOfSpeech: n
+  wikidata: Q1785507
 10082523-n:
   definition:
   - an erotic person
@@ -35111,6 +35412,7 @@
   members:
   - etcher
   partOfSpeech: n
+  wikidata: Q10862983
 10084873-n:
   definition:
   - a philosopher who specializes in ethics
@@ -35153,6 +35455,7 @@
   members:
   - ethnographer
   partOfSpeech: n
+  wikidata: Q12347522
 10085565-n:
   definition:
   - an anthropologist who studies ethnology
@@ -35212,6 +35515,7 @@
   - eunuch
   - castrate
   partOfSpeech: n
+  wikidata: Q179294
 10086431-n:
   definition:
   - a person who has been evacuated from a dangerous place
@@ -35367,6 +35671,7 @@
   - exchanger
   - money changer
   partOfSpeech: n
+  wikidata: Q988618
 10089103-n:
   definition:
   - a performer (usually of musical works)
@@ -35388,6 +35693,7 @@
   - executioner
   - public executioner
   partOfSpeech: n
+  wikidata: Q207651
 10089452-n:
   definition:
   - a person responsible for the administration of a business
@@ -35398,6 +35704,7 @@
   - executive
   - executive director
   partOfSpeech: n
+  wikidata: Q267936
 10089676-n:
   definition:
   - the officer second in command
@@ -35409,6 +35716,7 @@
   members:
   - executive officer
   partOfSpeech: n
+  wikidata: Q1383594
 10089788-n:
   definition:
   - a secretary having administrative duties and responsibilities
@@ -35436,6 +35744,7 @@
   members:
   - executor
   partOfSpeech: n
+  wikidata: Q654437
 10090184-n:
   definition:
   - a woman executor
@@ -35510,6 +35819,7 @@
   - expatriate
   - expat
   partOfSpeech: n
+  wikidata: Q12765670
 10091345-n:
   definition:
   - a philosopher who emphasizes freedom of choice and personal responsibility but
@@ -35541,6 +35851,7 @@
   - exorcist
   - exorciser
   partOfSpeech: n
+  wikidata: Q2467532
 10091975-n:
   definition:
   - one of the minor orders in the unreformed Western Church but now suppressed in
@@ -35561,6 +35872,7 @@
   members:
   - expert witness
   partOfSpeech: n
+  wikidata: Q663272
 10092334-n:
   definition:
   - a person who uses something or someone selfishly or unethically
@@ -35584,6 +35896,7 @@
   - explorer
   - adventurer
   partOfSpeech: n
+  wikidata: Q11900058
 10093422-n:
   definition:
   - a businessperson who transports goods abroad (for sale)
@@ -35726,6 +36039,7 @@
   members:
   - fabulist
   partOfSpeech: n
+  wikidata: Q3064032
 10095481-n:
   definition:
   - someone who makes progress easier
@@ -35735,6 +36049,7 @@
   members:
   - facilitator
   partOfSpeech: n
+  wikidata: Q1150166
 10095590-n:
   definition:
   - a servant employed to do a variety of jobs
@@ -35801,6 +36116,7 @@
   - faqir
   - faquir
   partOfSpeech: n
+  wikidata: Q491656
 10096263-n:
   definition:
   - a Spanish member of General Franco's political party
@@ -35916,6 +36232,7 @@
   - fancier
   - enthusiast
   partOfSpeech: n
+  wikidata: Q193432
 10098113-n:
   definition:
   - a woman's lover
@@ -35944,6 +36261,7 @@
   - fantast
   - futurist
   partOfSpeech: n
+  wikidata: Q846430
 10098423-n:
   definition:
   - a paying (taxi) passenger
@@ -35973,6 +36291,7 @@
   - granger
   - sodbuster
   partOfSpeech: n
+  wikidata: Q131512
 10098990-n:
   definition:
   - a woman working on a farm
@@ -36013,6 +36332,7 @@
   - farrier
   - horseshoer
   partOfSpeech: n
+  wikidata: Q694579
 10099549-n:
   definition:
   - a person of Iranian descent
@@ -36097,6 +36417,7 @@
   - male parent
   - begetter
   partOfSpeech: n
+  wikidata: Q7565
 10100973-n:
   definition:
   - ‘Father’ is a term of address for priests in some churches (especially the Roman
@@ -36354,6 +36675,7 @@
   members:
   - fence
   partOfSpeech: n
+  wikidata: Q12761281
 10104986-n:
   definition:
   - someone skilled at fencing
@@ -36436,6 +36758,7 @@
   members:
   - fiduciary
   partOfSpeech: n
+  wikidata: Q537098
 10106152-n:
   definition:
   - a member of the cricket team that is fielding rather than batting
@@ -36488,6 +36811,7 @@
   - field officer
   - FO
   partOfSpeech: n
+  wikidata: Q1053745
 10107024-n:
   definition:
   - a member of a clandestine subversive organization who tries to help a potential
@@ -36578,6 +36902,7 @@
   - film producer
   - movie maker
   partOfSpeech: n
+  wikidata: Q3282637
 10109253-n:
   definition:
   - a star who plays leading roles in the cinema
@@ -36620,6 +36945,7 @@
   - finance minister
   - minister of finance
   partOfSpeech: n
+  wikidata: Q7614320
 10109789-n:
   definition:
   - a person skilled in large scale financial transactions
@@ -36629,6 +36955,7 @@
   members:
   - financier
   partOfSpeech: n
+  wikidata: Q1979607
 10110267-n:
   definition:
   - someone who is the first to observe something
@@ -36695,6 +37022,7 @@
   - fire chief
   - fire marshal
   partOfSpeech: n
+  wikidata: Q5451558
 10111219-n:
   definition:
   - a performer who pretends to swallow fire
@@ -36728,6 +37056,7 @@
   - fire fighter
   - fire-eater
   partOfSpeech: n
+  wikidata: Q107711
 10111630-n:
   definition:
   - an official who is responsible for the prevention and investigation of fires
@@ -36758,6 +37087,7 @@
   - forest fire fighter
   - ranger
   partOfSpeech: n
+  wikidata: Q1479935
 10112068-n:
   definition:
   - (during World War II in Britain) someone whose duty was to watch for fires caused
@@ -36822,6 +37152,7 @@
   - first lieutenant
   - 1st lieutenant
   partOfSpeech: n
+  wikidata: Q330459
 10112936-n:
   definition:
   - someone convicted for the first time
@@ -36870,6 +37201,7 @@
   members:
   - fisher
   partOfSpeech: n
+  wikidata: Q331432
 10113587-n:
   definition:
   - someone who sells fish
@@ -36879,6 +37211,7 @@
   members:
   - fishmonger
   partOfSpeech: n
+  wikidata: Q550594
 10113677-n:
   definition:
   - someone who fits a garment to a particular person
@@ -37067,6 +37400,7 @@
   members:
   - flight engineer
   partOfSpeech: n
+  wikidata: Q432425
 10116277-n:
   definition:
   - a medical officer specializing in aviation medicine
@@ -37215,6 +37549,7 @@
   - flautist
   - flute player
   partOfSpeech: n
+  wikidata: Q12902372
 10118157-n:
   definition:
   - a debtor who flees to avoid paying
@@ -37462,6 +37797,7 @@
   - prognosticator
   - soothsayer
   partOfSpeech: n
+  wikidata: Q8011724
 10122569-n:
   definition:
   - the founder of a family
@@ -37539,6 +37875,7 @@
   - foreign minister
   - secretary of state
   partOfSpeech: n
+  wikidata: Q7330070
 10123690-n:
   definition:
   - someone who is excluded from or is not a member of a group
@@ -37607,6 +37944,7 @@
   - tree farmer
   - arboriculturist
   partOfSpeech: n
+  wikidata: Q1895303
 10124657-n:
   definition:
   - a woman in charge of a group of workers
@@ -37991,6 +38329,7 @@
   members:
   - freedperson
   partOfSpeech: n
+  wikidata: Q841571
 10129862-n:
   definition:
   - one of an interracial group of civil rights activists who rode buses through parts
@@ -38025,6 +38364,7 @@
   - independent
   - self-employed person
   partOfSpeech: n
+  wikidata: Q215279
 10130500-n:
   definition:
   - someone who gratifies physical appetites (especially for food and drink) with
@@ -38120,6 +38460,7 @@
   - friar
   - mendicant
   partOfSpeech: n
+  wikidata: Q548320
 10131898-n:
   definition:
   - a male religious living in a cloister and devoting himself to contemplation and
@@ -38131,6 +38472,7 @@
   - monk
   - monastic
   partOfSpeech: n
+  wikidata: Q733786
 10132203-n:
   definition:
   - a monk or nun belonging to the order founded by Saint Benedict
@@ -38163,6 +38505,7 @@
   - backwoodsman
   - mountain man
   partOfSpeech: n
+  wikidata: Q2308103
 10133018-n:
   definition:
   - a woman who lives on the frontier
@@ -38299,6 +38642,7 @@
   - fugitive
   - fugitive from justice
   partOfSpeech: n
+  wikidata: Q2917380
 10134739-n:
   definition:
   - someone who flees from an uncongenial situation
@@ -38372,6 +38716,7 @@
   - funambulist
   - tightrope walker
   partOfSpeech: n
+  wikidata: Q3090865
 10135750-n:
   definition:
   - a person with some ability to read and write but not enough for daily practical
@@ -38604,6 +38949,7 @@
   - gamekeeper
   - game warden
   partOfSpeech: n
+  wikidata: Q11682235
 10139148-n:
   definition:
   - the teacher in charge of games at a school
@@ -38672,6 +39018,7 @@
   - gangster
   - mobster
   partOfSpeech: n
+  wikidata: Q46961
 10139987-n:
   definition:
   - someone employed to collect and dispose of refuse
@@ -38684,6 +39031,7 @@
   - garbage hauler
   - refuse collector
   partOfSpeech: n
+  wikidata: Q1391360
 10140190-n:
   definition:
   - someone who takes care of a garden
@@ -38702,6 +39050,7 @@
   members:
   - gardener
   partOfSpeech: n
+  wikidata: Q758780
 10140473-n:
   definition:
   - a person who makes garments
@@ -38828,6 +39177,7 @@
   members:
   - gaucho
   partOfSpeech: n
+  wikidata: Q210377
 10142188-n:
   definition:
   - a spectator who stares stupidly without intelligent awareness
@@ -38857,6 +39207,7 @@
   - geisha
   - geisha girl
   partOfSpeech: n
+  wikidata: Q82723
 10142563-n:
   definition:
   - one who cuts and shapes precious stones
@@ -38884,6 +39235,7 @@
   members:
   - genealogist
   partOfSpeech: n
+  wikidata: Q8963721
 10142849-n:
   definition:
   - a native or resident of Geneva
@@ -38911,6 +39263,7 @@
   members:
   - genre painter
   partOfSpeech: n
+  wikidata: Q3964546
 10143152-n:
   definition:
   - a carnival performer who does disgusting acts
@@ -38983,6 +39336,7 @@
   - general practitioner
   - GP
   partOfSpeech: n
+  wikidata: Q6500773
 10145714-n:
   definition:
   - someone who originates or causes or initiates something
@@ -39078,6 +39432,7 @@
   members:
   - geographer
   partOfSpeech: n
+  wikidata: Q901402
 10147226-n:
   definition:
   - a specialist in geology
@@ -39087,6 +39442,7 @@
   members:
   - geologist
   partOfSpeech: n
+  wikidata: Q520549
 10147453-n:
   definition:
   - one who practices geomancy
@@ -39155,6 +39511,7 @@
   - ghostwriter
   - ghost
   partOfSpeech: n
+  wikidata: Q623386
 10148446-n:
   definition:
   - someone that is abnormally large and powerful
@@ -39209,6 +39566,7 @@
   members:
   - gilder
   partOfSpeech: n
+  wikidata: Q281795
 10149256-n:
   definition:
   - a young male attendant on a Scottish Highlander chief
@@ -39355,6 +39713,7 @@
   members:
   - gladiator
   partOfSpeech: n
+  wikidata: Q482999
 10151555-n:
   definition:
   - someone skilled in blowing bottles from molten glass
@@ -39377,6 +39736,7 @@
   - glazier
   - glazer
   partOfSpeech: n
+  wikidata: Q664283
 10151825-n:
   definition:
   - someone who cuts or grinds designs on glass
@@ -39424,6 +39784,7 @@
   - globetrotter
   - world traveler
   partOfSpeech: n
+  wikidata: Q1937330
 10152407-n:
   definition:
   - a scholiast who writes glosses or glossaries
@@ -39513,6 +39874,7 @@
   - netkeeper
   - netminder
   partOfSpeech: n
+  wikidata: Q172964
 10153698-n:
   definition:
   - a person who tends a flock of goats
@@ -39707,6 +40069,7 @@
   - goldworker
   - gold-worker
   partOfSpeech: n
+  wikidata: Q211423
 10156295-n:
   definition:
   - (Jewish folklore) an artificially created human being that is given life by supernatural
@@ -39730,6 +40093,7 @@
   - golfer
   - golf player
   partOfSpeech: n
+  wikidata: Q11303721
 10156887-n:
   definition:
   - someone who earns a living by playing or teaching golf
@@ -39876,6 +40240,7 @@
   members:
   - gossip columnist
   partOfSpeech: n
+  wikidata: Q10986570
 10159294-n:
   definition:
   - one of the Teutonic people who invaded the Roman Empire in the 3rd to 5th centuries
@@ -39924,6 +40289,7 @@
   members:
   - governor
   partOfSpeech: n
+  wikidata: Q132050
 10160117-n:
   definition:
   - a governor of high rank
@@ -39933,6 +40299,7 @@
   members:
   - governor general
   partOfSpeech: n
+  wikidata: Q382844
 10160203-n:
   definition:
   - an unpleasant person who grabs inconsiderately
@@ -40117,6 +40484,7 @@
   members:
   - grand mufti
   partOfSpeech: n
+  wikidata: Q2538679
 10162692-n:
   definition:
   - a parent of your father or mother
@@ -40224,6 +40592,7 @@
   members:
   - gravedigger
   partOfSpeech: n
+  wikidata: Q537575
 10164091-n:
   definition:
   - someone who takes bodies from graves and sells them for anatomical dissection
@@ -40423,6 +40792,7 @@
   - grenadier
   - grenade thrower
   partOfSpeech: n
+  wikidata: Q313303
 10166447-n:
   definition:
   - a person who greets
@@ -40465,6 +40835,7 @@
   members:
   - griot
   partOfSpeech: n
+  wikidata: Q511054
 10167008-n:
   definition:
   - worker who moves the camera around while a film or television show is being made
@@ -40474,6 +40845,7 @@
   members:
   - grip
   partOfSpeech: n
+  wikidata: Q3274496
 10167139-n:
   definition:
   - a person who groans
@@ -40492,6 +40864,7 @@
   members:
   - grocer
   partOfSpeech: n
+  wikidata: Q5669609
 10167369-n:
   definition:
   - a delivery boy for groceries
@@ -40588,6 +40961,7 @@
   members:
   - groupie
   partOfSpeech: n
+  wikidata: Q1145660
 10168648-n:
   definition:
   - a speaker whose voice sounds like a growl
@@ -40657,6 +41031,7 @@
   - screw
   - turnkey
   partOfSpeech: n
+  wikidata: Q311396
 10169591-n:
   definition:
   - a person who keeps watch over something or someone
@@ -40765,6 +41140,7 @@
   - guitarist
   - guitar player
   partOfSpeech: n
+  wikidata: Q855091
 10171477-n:
   definition:
   - a drinker who swallows large amounts greedily
@@ -40792,6 +41168,7 @@
   - torpedo
   - shooter
   partOfSpeech: n
+  wikidata: Q619851
 10171826-n:
   definition:
   - a noncommissioned officer ranking above a staff sergeant in the marines
@@ -40836,6 +41213,7 @@
   members:
   - guru
   partOfSpeech: n
+  wikidata: Q484260
 10172283-n:
   definition:
   - a recognized leader in some field or of some movement
@@ -40947,6 +41325,7 @@
   - gynaecologist
   - woman's doctor
   partOfSpeech: n
+  wikidata: Q2640827
 10173755-n:
   definition:
   - a member of a people with dark skin and hair who speak Romany and who traditionally
@@ -40999,6 +41378,7 @@
   members:
   - hacker
   partOfSpeech: n
+  wikidata: Q1487
 10174709-n:
   definition:
   - someone who plays golf poorly
@@ -41067,6 +41447,7 @@
   - stylist
   - styler
   partOfSpeech: n
+  wikidata: Q55187
 10175733-n:
   definition:
   - a disputant who makes unreasonably fine distinctions
@@ -41119,6 +41500,7 @@
   members:
   - hakim
   partOfSpeech: n
+  wikidata: Q4740650
 10176391-n:
   definition:
   - a member of a people of southeastern China (especially Hong Kong, Canton, and
@@ -41285,6 +41667,7 @@
   - animal trainer
   - handler
   partOfSpeech: n
+  wikidata: Q8011071
 10178779-n:
   definition:
   - a personal maid or female attendant
@@ -41295,6 +41678,7 @@
   - handmaid
   - handmaiden
   partOfSpeech: n
+  wikidata: Q1627992
 10178882-n:
   definition:
   - a man skilled in various odd jobs and other small tasks
@@ -41307,6 +41691,7 @@
   - jack of all trades
   - odd-job man
   partOfSpeech: n
+  wikidata: Q1552579
 10179027-n:
   definition:
   - a worker who hangs something
@@ -41415,6 +41800,7 @@
   - harpist
   - harper
   partOfSpeech: n
+  wikidata: Q3127709
 10180506-n:
   definition:
   - someone who launches harpoons
@@ -41434,6 +41820,7 @@
   members:
   - harpsichordist
   partOfSpeech: n
+  wikidata: Q5371902
 10180771-n:
   definition:
   - a persistent tormentor
@@ -41552,6 +41939,7 @@
   - milliner
   - modiste
   partOfSpeech: n
+  wikidata: Q1639239
 10182100-n:
   definition:
   - a haulage contractor
@@ -41711,6 +42099,7 @@
   - head of state
   - chief of state
   partOfSpeech: n
+  wikidata: Q48352
 10184590-n:
   definition:
   - a male executioner who beheads the condemned person
@@ -42054,6 +42443,7 @@
   members:
   - steerer
   partOfSpeech: n
+  wikidata: Q2309900
 10189530-n:
   definition:
   - a person who holds a high position in a hierarchy
@@ -42092,6 +42482,7 @@
   members:
   - histologist
   partOfSpeech: n
+  wikidata: Q2552072
 10190191-n:
   definition:
   - a helpful partner
@@ -42157,6 +42548,7 @@
   - herald
   - trumpeter
   partOfSpeech: n
+  wikidata: Q696819
 10191128-n:
   definition:
   - a therapist who heals by the use of herbs
@@ -42167,6 +42559,7 @@
   - herbalist
   - herb doctor
   partOfSpeech: n
+  wikidata: Q3133901
 10191239-n:
   definition:
   - someone who drives a herd
@@ -42177,6 +42570,7 @@
   - herder
   - drover
   partOfSpeech: n
+  wikidata: Q12059906
 10191427-n:
   definition:
   - a person who holds religious beliefs in conflict with the dogma of the Roman Catholic
@@ -42550,6 +42944,7 @@
   - historian
   - historiographer
   partOfSpeech: n
+  wikidata: Q201788
 10197708-n:
   definition:
   - a person who travels by getting free rides from passing vehicles
@@ -42833,6 +43228,7 @@
   - homeopath
   - homoeopath
   partOfSpeech: n
+  wikidata: Q12020057
 10202130-n:
   definition:
   - someone who owns a home
@@ -43066,6 +43462,7 @@
   - equestrian
   - horseback rider
   partOfSpeech: n
+  wikidata: Q2730732
 10205687-n:
   definition:
   - a hard bargainer
@@ -43075,6 +43472,7 @@
   members:
   - horse trader
   partOfSpeech: n
+  wikidata: Q3289685
 10205762-n:
   definition:
   - a woman skilled in equitation
@@ -43095,6 +43493,7 @@
   - horse wrangler
   - wrangler
   partOfSpeech: n
+  wikidata: Q8037570
 10205969-n:
   definition:
   - an expert in the science of cultivating plants (fruit or flowers or vegetables
@@ -43134,6 +43533,7 @@
   - innkeeper
   - boniface
   partOfSpeech: n
+  wikidata: Q1495428
 10206569-n:
   definition:
   - a traveler who lodges in hostels
@@ -43232,6 +43632,7 @@
   - hotel manager
   - hosteller
   partOfSpeech: n
+  wikidata: Q1631120
 10207765-n:
   definition:
   - a rash or impetuous person
@@ -43282,6 +43683,7 @@
   - house husband
   - househusband
   partOfSpeech: n
+  wikidata: Q2154210
 10208334-n:
   definition:
   - a servant who is employed to perform domestic task in a household
@@ -43291,6 +43693,7 @@
   members:
   - housekeeper
   partOfSpeech: n
+  wikidata: Q2596569
 10208475-n:
   definition:
   - teacher in charge of a school boardinghouse
@@ -43365,6 +43768,7 @@
   - lady of the house
   - woman of the house
   partOfSpeech: n
+  wikidata: Q1934684
 10209594-n:
   definition:
   - a wrecker of houses
@@ -43472,6 +43876,7 @@
   members:
   - humanist
   partOfSpeech: n
+  wikidata: Q10527030
 10211007-n:
   definition:
   - an advocate of the principles of humanism; someone concerned with the interests
@@ -43513,6 +43918,7 @@
   - humorist
   - humourist
   partOfSpeech: n
+  wikidata: Q12406482
 10212031-n:
   definition:
   - a person whose back is hunched because of abnormal curvature of the upper spine
@@ -43609,6 +44015,7 @@
   members:
   - hunter
   partOfSpeech: n
+  wikidata: Q1714828
 10213483-n:
   definition:
   - an athlete who runs the hurdles
@@ -43618,6 +44025,7 @@
   members:
   - hurdler
   partOfSpeech: n
+  wikidata: Q13724897
 10213586-n:
   definition:
   - a married man; a woman's partner in marriage
@@ -43649,6 +44057,7 @@
   members:
   - hussar
   partOfSpeech: n
+  wikidata: Q191713
 10214082-n:
   definition:
   - an adherent of the religious reforms of John Huss
@@ -43700,6 +44109,7 @@
   members:
   - hygienist
   partOfSpeech: n
+  wikidata: Q651566
 10214675-n:
   definition:
   - a person with hyperopia; a farsighted person
@@ -43811,6 +44221,7 @@
   members:
   - ice-skater
   partOfSpeech: n
+  wikidata: Q9394993
 10216236-n:
   definition:
   - a zoologist who studies fishes
@@ -43820,6 +44231,7 @@
   members:
   - ichthyologist
   partOfSpeech: n
+  wikidata: Q4205432
 10216344-n:
   definition:
   - someone who attacks cherished ideas or traditional institutions
@@ -43994,6 +44406,7 @@
   - imam
   - imaum
   partOfSpeech: n
+  wikidata: Q125482
 10219108-n:
   definition:
   - a person who comes to a country where they were not born in order to settle there
@@ -44003,6 +44416,7 @@
   members:
   - immigrant
   partOfSpeech: n
+  wikidata: Q12547146
 10219263-n:
   definition:
   - a person (such as an author) of enduring fame
@@ -44070,6 +44484,7 @@
   - impersonator
   - imitator
   partOfSpeech: n
+  wikidata: Q1148872
 10220150-n:
   definition:
   - an imported person brought from a foreign country
@@ -44125,6 +44540,7 @@
   - pseud
   - role player
   partOfSpeech: n
+  wikidata: Q1413522
 10221575-n:
   definition:
   - an artist who follows the theories of Impressionism
@@ -44226,6 +44642,7 @@
   members:
   - Indian agent
   partOfSpeech: n
+  wikidata: Q2643659
 10222917-n:
   definition:
   - the leader of a group of Native Americans
@@ -44277,6 +44694,7 @@
   members:
   - industrialist
   partOfSpeech: n
+  wikidata: Q6606110
 10224452-n:
   definition:
   - a person who murders an infant
@@ -44384,6 +44802,7 @@
   - squealer
   - blabber
   partOfSpeech: n
+  wikidata: Q1364673
 10226125-n:
   definition:
   - an artless innocent young girl (especially as portrayed on the stage)
@@ -44436,6 +44855,7 @@
   members:
   - polymath
   partOfSpeech: n
+  wikidata: Q270141
 10226788-n:
   definition:
   - a relative by marriage
@@ -44519,6 +44939,7 @@
   members:
   - Inquisitor
   partOfSpeech: n
+  wikidata: Q1664338
 10228184-n:
   definition:
   - an officer of a corporation or others who have access to private information about
@@ -44903,6 +45324,7 @@
   - discoverer
   - artificer
   partOfSpeech: n
+  wikidata: Q205375
 10235293-n:
   definition:
   - someone who investigates
@@ -44932,6 +45354,7 @@
   - investment banker
   - underwriter
   partOfSpeech: n
+  wikidata: Q2883465
 10235776-n:
   definition:
   - someone who commits capital in order to gain financial returns
@@ -44941,6 +45364,7 @@
   members:
   - investor
   partOfSpeech: n
+  wikidata: Q557880
 10236073-n:
   definition:
   - someone who watches examination candidates to prevent cheating
@@ -44993,6 +45417,7 @@
   members:
   - ironworker
   partOfSpeech: n
+  wikidata: Q3069732
 10236708-n:
   definition:
   - an advocate of irredentism
@@ -45164,6 +45589,7 @@
   members:
   - Janissary
   partOfSpeech: n
+  wikidata: Q130263
 10239123-n:
   definition:
   - a loyal supporter
@@ -45184,6 +45610,7 @@
   members:
   - janitor
   partOfSpeech: n
+  wikidata: Q1090219
 10239350-n:
   definition:
   - an advocate of Jansenism
@@ -45306,6 +45733,7 @@
   - fool
   - motley fool
   partOfSpeech: n
+  wikidata: Q215548
 10241190-n:
   definition:
   - a member of the Jesuit order
@@ -45434,6 +45862,7 @@
   members:
   - jockey
   partOfSpeech: n
+  wikidata: Q846750
 10242964-n:
   definition:
   - an operator of some vehicle or machine or apparatus
@@ -45488,6 +45917,7 @@
   members:
   - joiner
   partOfSpeech: n
+  wikidata: Q326358
 10243664-n:
   definition:
   - a person who likes to join groups
@@ -45540,6 +45970,7 @@
   members:
   - journalist
   partOfSpeech: n
+  wikidata: Q1930187
 10244788-n:
   definition:
   - someone who betrays under the guise of friendship
@@ -45563,6 +45994,7 @@
   - justice
   - jurist
   partOfSpeech: n
+  wikidata: Q16533
 10245457-n:
   definition:
   - a staff officer serving as legal adviser to a military commander
@@ -45618,6 +46050,7 @@
   members:
   - juggler
   partOfSpeech: n
+  wikidata: Q10540773
 10246226-n:
   definition:
   - a massive inexorable force that seems to crush everything in its way
@@ -45739,6 +46172,7 @@
   - jurist
   - legal expert
   partOfSpeech: n
+  wikidata: Q185351
 10247948-n:
   definition:
   - someone who serves (or waits to be called to serve) on a jury
@@ -45759,6 +46193,7 @@
   members:
   - justice of the peace
   partOfSpeech: n
+  wikidata: Q329455
 10248262-n:
   definition:
   - formerly a high judicial officer
@@ -45771,6 +46206,7 @@
   - justiciar
   - justiciary
   partOfSpeech: n
+  wikidata: Q1714329
 10248382-n:
   definition:
   - a masked dancer during a Pueblo religious ceremony who is thought to embody some
@@ -45860,6 +46296,7 @@
   members:
   - keyboardist
   partOfSpeech: n
+  wikidata: Q1075651
 10249653-n:
   definition:
   - a follower of the economic theories of John Maynard Keynes
@@ -45878,6 +46315,7 @@
   members:
   - khan
   partOfSpeech: n
+  wikidata: Q181888
 10249886-n:
   definition:
   - one of the Turkish viceroys who ruled Egypt between 1867 and 1914
@@ -46225,6 +46663,7 @@
   members:
   - knacker
   partOfSpeech: n
+  wikidata: Q307732
 10257824-n:
   definition:
   - someone who buys old buildings or ships and breaks them up to recover the materials
@@ -46254,6 +46693,7 @@
   members:
   - knight
   partOfSpeech: n
+  wikidata: Q102083
 10258446-n:
   definition:
   - a knight of the lowest order; could display only a pennon
@@ -46440,6 +46880,7 @@
   - doula
   - monitrice
   partOfSpeech: n
+  wikidata: Q749813
 10260997-n:
   definition:
   - someone who works with their hands; someone engaged in manual labor
@@ -46452,6 +46893,7 @@
   - labourer
   - jack
   partOfSpeech: n
+  wikidata: Q12713481
 10261729-n:
   definition:
   - a leader of a labor movement
@@ -46573,6 +47015,7 @@
   members:
   - lama
   partOfSpeech: n
+  wikidata: Q191421
 10263488-n:
   definition:
   - a believer in Lamarckism
@@ -46669,6 +47112,7 @@
   members:
   - land agent
   partOfSpeech: n
+  wikidata: Q6484023
 10264726-n:
   definition:
   - a count who had jurisdiction over a large territory in medieval Germany
@@ -46697,6 +47141,7 @@
   members:
   - landlord
   partOfSpeech: n
+  wikidata: Q618532
 10265038-n:
   definition:
   - an inexperienced sailor; a sailor on the first voyage
@@ -46975,6 +47420,7 @@
   - lawgiver
   - lawmaker
   partOfSpeech: n
+  wikidata: Q4175034
 10269156-n:
   definition:
   - an officer of the law
@@ -47007,6 +47453,7 @@
   - lawyer
   - attorney
   partOfSpeech: n
+  wikidata: Q40348
 10270224-n:
   definition:
   - someone who is not a clergyman or a professional person
@@ -47145,6 +47592,7 @@
   - lector
   - reader
   partOfSpeech: n
+  wikidata: Q1433533
 10272244-n:
   definition:
   - someone who lectures professionally
@@ -47237,6 +47685,7 @@
   - legionnaire
   - legionary
   partOfSpeech: n
+  wikidata: Q1629605
 10273584-n:
   definition:
   - a member of the American Legion
@@ -47299,6 +47748,7 @@
   - lepidopterologist
   - butterfly collector
   partOfSpeech: n
+  wikidata: Q497294
 10274662-n:
   definition:
   - a female homosexual
@@ -47479,6 +47929,7 @@
   - librarian
   - bibliothec
   partOfSpeech: n
+  wikidata: Q182436
 10277849-n:
   definition:
   - author of words to be set to music in an opera or operetta
@@ -47488,6 +47939,7 @@
   members:
   - librettist
   partOfSpeech: n
+  wikidata: Q8178443
 10278001-n:
   definition:
   - a nurse who has enough training to be licensed by a state to provide routine care
@@ -47500,6 +47952,7 @@
   - LPN
   - practical nurse
   partOfSpeech: n
+  wikidata: Q11848548
 10278190-n:
   definition:
   - someone to whom a license is granted
@@ -47614,6 +48067,7 @@
   members:
   - lieutenant commander
   partOfSpeech: n
+  wikidata: Q837582
 10279863-n:
   definition:
   - a general officer ranking above a major general and below a full general
@@ -47625,6 +48079,7 @@
   members:
   - lieutenant general
   partOfSpeech: n
+  wikidata: Q152951
 10280019-n:
   definition:
   - an elected official serving as deputy to the governor of a state of the United
@@ -47635,6 +48090,7 @@
   members:
   - lieutenant governor
   partOfSpeech: n
+  wikidata: Q1516453
 10280170-n:
   definition:
   - an officer holding a commissioned rank in the United States Navy or United States
@@ -47669,6 +48125,7 @@
   - lifeguard
   - lifesaver
   partOfSpeech: n
+  wikidata: Q259327
 10280640-n:
   definition:
   - a British peer whose title lapses at death
@@ -47761,6 +48218,7 @@
   members:
   - lighthouse keeper
   partOfSpeech: n
+  wikidata: Q1766113
 10281880-n:
   definition:
   - someone who is a frequent target of negative reactions and serves to distract
@@ -47924,6 +48382,7 @@
   - linguist
   - polyglot
   partOfSpeech: n
+  wikidata: Q323081
 10284134-n:
   definition:
   - a specialist in linguistics
@@ -48138,6 +48597,7 @@
   members:
   - liturgist
   partOfSpeech: n
+  wikidata: Q10567966
 10287755-n:
   definition:
   - infant who shows signs of life after birth
@@ -48197,6 +48657,7 @@
   members:
   - lobbyist
   partOfSpeech: n
+  wikidata: Q11986654
 10288524-n:
   definition:
   - a person whose occupation is catching lobsters
@@ -48235,6 +48696,7 @@
   members:
   - locksmith
   partOfSpeech: n
+  wikidata: Q3479990
 10288986-n:
   definition:
   - someone (physician or clergyman) who substitutes temporarily for another member
@@ -48277,6 +48739,7 @@
   - logician
   - logistician
   partOfSpeech: n
+  wikidata: Q14565331
 10289806-n:
   definition:
   - someone given to disputes over words
@@ -48691,6 +49154,7 @@
   - feller
   - faller
   partOfSpeech: n
+  wikidata: Q1124183
 10295935-n:
   definition:
   - a celebrity who is an inspiration to others
@@ -48795,6 +49259,7 @@
   members:
   - luthier
   partOfSpeech: n
+  wikidata: Q762707
 10297335-n:
   definition:
   - a musician who plays the lute
@@ -48825,6 +49290,7 @@
   - lyricist
   - lyrist
   partOfSpeech: n
+  wikidata: Q822146
 10297825-n:
   definition:
   - informal terms for a mother
@@ -48909,6 +49375,7 @@
   - mechanic
   - shop mechanic
   partOfSpeech: n
+  wikidata: Q196721
 10298916-n:
   definition:
   - a male exhibiting or characterized by machismo
@@ -49064,6 +49531,7 @@
   members:
   - magistrate
   partOfSpeech: n
+  wikidata: Q4594605
 10300873-n:
   definition:
   - a person of distinguished rank or appearance
@@ -49112,6 +49580,7 @@
   - maharaja
   - maharajah
   partOfSpeech: n
+  wikidata: Q1163330
 10301467-n:
   definition:
   - a great rani; a princess in India or the wife of a maharaja
@@ -49191,6 +49660,7 @@
   - housemaid
   - amah
   partOfSpeech: n
+  wikidata: Q833860
 10302542-n:
   definition:
   - an unmarried aunt
@@ -49404,6 +49874,7 @@
   members:
   - malik
   partOfSpeech: n
+  wikidata: Q849545
 10306236-n:
   definition:
   - someone shirking their duty by feigning illness or incapacity
@@ -49555,6 +50026,7 @@
   members:
   - managing editor
   partOfSpeech: n
+  wikidata: Q1068933
 10309332-n:
   definition:
   - a high public official of imperial China
@@ -49564,6 +50036,7 @@
   members:
   - mandarin
   partOfSpeech: n
+  wikidata: Q1126165
 10309427-n:
   definition:
   - any high government official or bureaucrat
@@ -49662,6 +50135,7 @@
   members:
   - manicurist
   partOfSpeech: n
+  wikidata: Q11325221
 10310771-n:
   definition:
   - a person who handles things manually
@@ -49696,6 +50170,7 @@
   members:
   - man-at-arms
   partOfSpeech: n
+  wikidata: Q2889457
 10311241-n:
   definition:
   - a person who is very small but who is not otherwise deformed or abnormal
@@ -49795,6 +50270,7 @@
   - Maquis
   - Maquisard
   partOfSpeech: n
+  wikidata: Q701165
 10312630-n:
   definition:
   - someone who participates in long-distance races (especially in marathons)
@@ -49870,6 +50346,7 @@
   members:
   - margrave
   partOfSpeech: n
+  wikidata: Q157802
 10313681-n:
   definition:
   - the military governor of a frontier province in medieval Germany
@@ -49943,6 +50420,7 @@
   - sharpshooter
   - crack shot
   partOfSpeech: n
+  wikidata: Q3529376
 10314851-n:
   definition:
   - a person who is stranded (as on an island)
@@ -49974,6 +50452,7 @@
   - marquis
   - marquess
   partOfSpeech: n
+  wikidata: Q209726
 10315258-n:
   definition:
   - (medieval Spain and Portugal) a disparaging term for a Jew who converted to Christianity
@@ -50018,6 +50497,7 @@
   - marshal
   - marshall
   partOfSpeech: n
+  wikidata: Q111837
 10316105-n:
   definition:
   - someone who demands exact conformity to rules and forms
@@ -50195,6 +50675,7 @@
   - sea captain
   - skipper
   partOfSpeech: n
+  wikidata: Q849424
 10318792-n:
   definition:
   - the senior petty officer; responsible for discipline aboard ship
@@ -50217,6 +50698,7 @@
   - host
   - MC
   partOfSpeech: n
+  wikidata: Q497240
 10319250-n:
   definition:
   - a senior noncommissioned officer in the Army or Marines
@@ -50257,6 +50739,7 @@
   - mate
   - first mate
   partOfSpeech: n
+  wikidata: Q1436517
 10319821-n:
   definition:
   - informal term for a friend of the same sex
@@ -50342,6 +50825,7 @@
   members:
   - mathematician
   partOfSpeech: n
+  wikidata: Q170790
 10322113-n:
   definition:
   - someone who teaches mathematics
@@ -50411,6 +50895,7 @@
   members:
   - matron
   partOfSpeech: n
+  wikidata: Q1396008
 10322977-n:
   definition:
   - a wardress in a prison
@@ -50461,6 +50946,7 @@
   - mayor
   - city manager
   partOfSpeech: n
+  wikidata: Q30185
 10323685-n:
   definition:
   - a woman mayor
@@ -50531,6 +51017,7 @@
   members:
   - mechanical engineer
   partOfSpeech: n
+  wikidata: Q1906857
 10324450-n:
   definition:
   - a philosopher who subscribes to the doctrine of mechanism
@@ -50584,6 +51071,7 @@
   - media consultant
   - media guru
   partOfSpeech: n
+  wikidata: Q6805589
 10325190-n:
   definition:
   - a person trained to assist medical professionals
@@ -50644,6 +51132,7 @@
   - spiritualist
   - sensitive
   partOfSpeech: n
+  wikidata: Q583271
 10326163-n:
   definition:
   - a pathological egotist
@@ -50729,6 +51218,7 @@
   members:
   - board member
   partOfSpeech: n
+  wikidata: Q2824523
 10327942-n:
   definition:
   - a member of a clan
@@ -50836,6 +51326,7 @@
   - mercenary
   - soldier of fortune
   partOfSpeech: n
+  wikidata: Q178197
 10329452-n:
   definition:
   - a dealer in textiles (especially silks)
@@ -50857,6 +51348,7 @@
   - merchant
   - merchandiser
   partOfSpeech: n
+  wikidata: Q215536
 10330071-n:
   definition:
   - a member of the Merovingian dynasty
@@ -50915,6 +51407,7 @@
   - messenger
   - courier
   partOfSpeech: n
+  wikidata: Q848466
 10330910-n:
   definition:
   - a messenger who bears or presents
@@ -51002,6 +51495,7 @@
   members:
   - meteorologist
   partOfSpeech: n
+  wikidata: Q2310145
 10332149-n:
   definition:
   - policewoman who is assigned to write parking tickets
@@ -51068,6 +51562,7 @@
   members:
   - metropolitan
   partOfSpeech: n
+  wikidata: Q189854
 10333099-n:
   definition:
   - a soprano with a voice between soprano and contralto
@@ -51290,6 +51785,7 @@
   members:
   - military attache
   partOfSpeech: n
+  wikidata: Q302691
 10336185-n:
   definition:
   - a chaplain in one of the military services
@@ -51325,6 +51821,7 @@
   members:
   - military leader
   partOfSpeech: n
+  wikidata: Q1402561
 10336665-n:
   definition:
   - any person in the armed services who holds a position of authority or command
@@ -51339,6 +51836,7 @@
   - military officer
   - officer
   partOfSpeech: n
+  wikidata: Q189290
 10337158-n:
   definition:
   - a member of the military police who polices soldiers and guards prisoners
@@ -51388,6 +51886,7 @@
   members:
   - miller
   partOfSpeech: n
+  wikidata: Q694116
 10337851-n:
   definition:
   - a girl who works in a mill
@@ -51462,6 +51961,7 @@
   - pantomimer
   - pantomimist
   partOfSpeech: n
+  wikidata: Q674067
 10338821-n:
   definition:
   - someone who mimics (especially an actor or actress)
@@ -51509,6 +52009,7 @@
   - miner
   - mineworker
   partOfSpeech: n
+  wikidata: Q820037
 10339654-n:
   definition:
   - a scientist trained in mineralogy
@@ -51518,6 +52019,7 @@
   members:
   - mineralogist
   partOfSpeech: n
+  wikidata: Q13416354
 10339764-n:
   definition:
   - someone who paints tiny pictures in great detail
@@ -51585,6 +52087,7 @@
   - minister
   - government minister
   partOfSpeech: n
+  wikidata: Q83307
 10340784-n:
   definition:
   - someone who serves as a minister
@@ -51734,6 +52237,7 @@
   - missionary
   - missioner
   partOfSpeech: n
+  wikidata: Q219477
 10343187-n:
   definition:
   - informal term of address for someone's wife
@@ -51767,6 +52271,7 @@
   - kept woman
   - fancy woman
   partOfSpeech: n
+  wikidata: Q625369
 10343657-n:
   definition:
   - a person whose ancestors belonged to two or more racial groups
@@ -51785,6 +52290,7 @@
   members:
   - mnemonist
   partOfSpeech: n
+  wikidata: Q6885897
 10344023-n:
   definition:
   - a British teenager or young adult in the 1960s; noted for their clothes consciousness
@@ -51833,6 +52339,7 @@
   members:
   - hero
   partOfSpeech: n
+  wikidata: Q162244
 10344909-n:
   definition:
   - model of excellence or perfection of a kind; one having no equal
@@ -52111,6 +52618,7 @@
   members:
   - monologist
   partOfSpeech: n
+  wikidata: Q6901699
 10348856-n:
   definition:
   - a person suffering from monomania
@@ -52171,6 +52679,7 @@
   members:
   - Monsignor
   partOfSpeech: n
+  wikidata: Q854905
 10349658-n:
   definition:
   - a cruel wicked and inhuman person
@@ -52310,6 +52819,7 @@
   - funeral undertaker
   - funeral director
   partOfSpeech: n
+  wikidata: Q316490
 10351729-n:
   definition:
   - an extremely old-fashioned conservative
@@ -52354,6 +52864,7 @@
   - mother
   - female parent
   partOfSpeech: n
+  wikidata: Q7560
 10352574-n:
   definition:
   - a term of address for a mother superior
@@ -52513,6 +53024,7 @@
   - mountebank
   - charlatan
   partOfSpeech: n
+  wikidata: Q1430956
 10354670-n:
   definition:
   - someone who ascends on foot
@@ -52634,6 +53146,7 @@
   - muazzin
   - muadhdhin
   partOfSpeech: n
+  wikidata: Q239718
 10356617-n:
   definition:
   - formerly an itinerant male peddler of muffins
@@ -52655,6 +53168,7 @@
   members:
   - mufti
   partOfSpeech: n
+  wikidata: Q185992
 10356847-n:
   definition:
   - a victim of a mugging
@@ -52691,6 +53205,7 @@
   - independent
   - fencesitter
   partOfSpeech: n
+  wikidata: Q327591
 10357358-n:
   definition:
   - someone who bolted from the Republican Party during the U.S. presidential election
@@ -52710,6 +53225,7 @@
   members:
   - mujahid
   partOfSpeech: n
+  wikidata: Q42759
 10357626-n:
   definition:
   - an Islamic scholar who engages in ijtihad, the effort to derive rules of divine
@@ -52744,6 +53260,7 @@
   - Mollah
   - Mulla
   partOfSpeech: n
+  wikidata: Q188942
 10358104-n:
   definition:
   - a chewer who makes a munching noise
@@ -52762,6 +53279,7 @@
   members:
   - muralist
   partOfSpeech: n
+  wikidata: Q3374326
 10358341-n:
   definition:
   - a victim who is murdered
@@ -52841,6 +53359,7 @@
   members:
   - musher
   partOfSpeech: n
+  wikidata: Q500097
 10359569-n:
   definition:
   - a critic of musical performances
@@ -52850,6 +53369,7 @@
   members:
   - music critic
   partOfSpeech: n
+  wikidata: Q1350157
 10359679-n:
   definition:
   - artist who composes or conducts music as a profession
@@ -52861,6 +53381,7 @@
   members:
   - musician
   partOfSpeech: n
+  wikidata: Q639669
 10360025-n:
   definition:
   - someone who plays a music as a profession
@@ -52881,6 +53402,7 @@
   members:
   - musicologist
   partOfSpeech: n
+  wikidata: Q14915627
 10361074-n:
   definition:
   - someone who teaches music
@@ -52890,6 +53412,7 @@
   members:
   - music teacher
   partOfSpeech: n
+  wikidata: Q2675537
 10361177-n:
   definition:
   - a foot soldier armed with a musket
@@ -52899,6 +53422,7 @@
   members:
   - musketeer
   partOfSpeech: n
+  wikidata: Q721960
 10361304-n:
   definition:
   - a Muslim woman
@@ -53103,6 +53627,7 @@
   - figure
   - public figure
   partOfSpeech: n
+  wikidata: Q662729
 10364387-n:
   definition:
   - someone who pretends that famous people are his/her friends
@@ -53157,6 +53682,7 @@
   - nursemaid
   - nurse
   partOfSpeech: n
+  wikidata: Q7070221
 10365033-n:
   definition:
   - a lawman concerned with narcotics violations
@@ -53255,6 +53781,7 @@
   - naturalist
   - natural scientist
   partOfSpeech: n
+  wikidata: Q18805
 10366686-n:
   definition:
   - an advocate of the doctrine that the world can be understood in scientific terms
@@ -53316,6 +53843,7 @@
   members:
   - naval officer
   partOfSpeech: n
+  wikidata: Q10669499
 10367614-n:
   definition:
   - in earlier times, a person who explored by ship
@@ -53369,6 +53897,7 @@
   members:
   - oblate
   partOfSpeech: n
+  wikidata: Q779280
 10368720-n:
   definition:
   - a person who has obsessions
@@ -54026,6 +54555,7 @@
   members:
   - ninja
   partOfSpeech: n
+  wikidata: Q9402
 10378816-n:
   definition:
   - an observant Muslim woman who covers her face and hands when in public or in the
@@ -54308,6 +54838,7 @@
   - notary
   - notary public
   partOfSpeech: n
+  wikidata: Q189010
 10383059-n:
   definition:
   - someone who gives formal notice
@@ -54337,6 +54868,7 @@
   members:
   - novelist
   partOfSpeech: n
+  wikidata: Q6625963
 10383612-n:
   definition:
   - someone new to a field or activity
@@ -54507,6 +55039,7 @@
   - numismatologist
   - coin collector
   partOfSpeech: n
+  wikidata: Q2004963
 10386665-n:
   definition:
   - one skilled in caring for young children or the sick (usually under the supervision
@@ -54560,6 +55093,7 @@
   - NP
   - nurse clinician
   partOfSpeech: n
+  wikidata: Q595071
 10387708-n:
   definition:
   - a woman religious
@@ -54569,6 +55103,7 @@
   members:
   - nun
   partOfSpeech: n
+  wikidata: Q191808
 10387812-n:
   definition:
   - (Roman Catholic Church) a diplomatic representative of the Pope having ambassadorial
@@ -54582,6 +55117,7 @@
   - nuncio
   - papal nuncio
   partOfSpeech: n
+  wikidata: Q157037
 10387990-n:
   definition:
   - an infant considered in relation to its nurse
@@ -54749,6 +55285,7 @@
   members:
   - oceanographer
   partOfSpeech: n
+  wikidata: Q3546255
 10389985-n:
   definition:
   - someone whose age is in the eighties
@@ -54767,6 +55304,7 @@
   members:
   - occultist
   partOfSpeech: n
+  wikidata: Q12797895
 10390302-n:
   definition:
   - a woman slave in a harem
@@ -54883,6 +55421,7 @@
   - official
   - functionary
   partOfSpeech: n
+  wikidata: Q599151
 10393089-n:
   definition:
   - a clergyman who officiates at a religious ceremony or service
@@ -55151,6 +55690,7 @@
   members:
   - ombudsperson
   partOfSpeech: n
+  wikidata: Q169180
 10397241-n:
   definition:
   - a person who eats all kinds of foods
@@ -55271,6 +55811,7 @@
   - eye doctor
   - oculist
   partOfSpeech: n
+  wikidata: Q12013238
 10398977-n:
   definition:
   - someone addicted to opium
@@ -55325,6 +55866,7 @@
   - optician
   - lens maker
   partOfSpeech: n
+  wikidata: Q1996635
 10399825-n:
   definition:
   - a person disposed to take a favorable view of things
@@ -55345,6 +55887,7 @@
   - optometrist
   - oculist
   partOfSpeech: n
+  wikidata: Q3354501
 10400198-n:
   definition:
   - a member of a society founded in Ireland in 1795 to uphold Protestantism and the
@@ -55368,6 +55911,7 @@
   - public speaker
   - speechifier
   partOfSpeech: n
+  wikidata: Q12859263
 10400799-n:
   definition:
   - an arranger who writes for orchestras
@@ -55377,6 +55921,7 @@
   members:
   - orchestrator
   partOfSpeech: n
+  wikidata: Q3355249
 10400913-n:
   definition:
   - a cleric who ordains; a cleric who admits someone to holy orders
@@ -55422,6 +55967,7 @@
   - orderly
   - hospital attendant
   partOfSpeech: n
+  wikidata: Q12177489
 10401680-n:
   definition:
   - a soldier who serves as an attendant to a superior officer
@@ -55472,6 +56018,7 @@
   members:
   - ordinary
   partOfSpeech: n
+  wikidata: Q1638918
 10402296-n:
   definition:
   - someone from whom an organ is taken for transplantation
@@ -55499,6 +56046,7 @@
   members:
   - organist
   partOfSpeech: n
+  wikidata: Q765778
 10402793-n:
   definition:
   - a male employee who sacrifices his own individuality for the good of an organization
@@ -55522,6 +56070,7 @@
   - organiser
   - arranger
   partOfSpeech: n
+  wikidata: Q1643514
 10403204-n:
   definition:
   - someone who enlists workers to join a union
@@ -55542,6 +56091,7 @@
   members:
   - orientalist
   partOfSpeech: n
+  wikidata: Q1731155
 10403515-n:
   definition:
   - someone who creates new things
@@ -55573,6 +56123,7 @@
   - ornithologist
   - bird watcher
   partOfSpeech: n
+  wikidata: Q1225716
 10404091-n:
   definition:
   - a child who has lost both parents
@@ -55601,6 +56152,7 @@
   members:
   - orthodontist
   partOfSpeech: n
+  wikidata: Q3842067
 10404471-n:
   definition:
   - Jew who practices strict observance of Mosaic law
@@ -55660,6 +56212,7 @@
   - osteopath
   - osteopathist
   partOfSpeech: n
+  wikidata: Q11885948
 10405406-n:
   definition:
   - a person who refuses to face reality or recognize the truth (a reference to the
@@ -56033,6 +56586,7 @@
   - page
   - pageboy
   partOfSpeech: n
+  wikidata: Q855855
 10411352-n:
   definition:
   - an artist who paints
@@ -56042,6 +56596,7 @@
   members:
   - painter
   partOfSpeech: n
+  wikidata: Q1028181
 10413608-n:
   definition:
   - a worker who is employed to cover objects with paint
@@ -56220,6 +56775,7 @@
   members:
   - paparazzo
   partOfSpeech: n
+  wikidata: Q156624
 10416607-n:
   definition:
   - a boy who sells or delivers newspapers
@@ -56230,6 +56786,7 @@
   members:
   - paperboy
   partOfSpeech: n
+  wikidata: Q187031
 10416700-n:
   definition:
   - one whose occupation is decorating walls with wallpaper
@@ -56283,6 +56840,7 @@
   - parachuter
   - parachute jumper
   partOfSpeech: n
+  wikidata: Q6060450
 10417393-n:
   definition:
   - a writer of paragraphs (as for publication on the editorial page of a newspaper)
@@ -56325,6 +56883,7 @@
   - paramedic
   - paramedical
   partOfSpeech: n
+  wikidata: Q330204
 10418069-n:
   definition:
   - a person afflicted with paranoia
@@ -56366,6 +56925,7 @@
   members:
   - parapsychologist
   partOfSpeech: n
+  wikidata: Q3363630
 10418718-n:
   definition:
   - a soldier in the paratroops
@@ -56376,6 +56936,7 @@
   - paratrooper
   - para
   partOfSpeech: n
+  wikidata: Q749387
 10418829-n:
   definition:
   - a medieval cleric who raised money for the church by selling papal indulgences
@@ -56558,6 +57119,7 @@
   - zealot
   - drumbeater
   partOfSpeech: n
+  wikidata: Q7140620
 10422030-n:
   definition:
   - an advocate of partitioning a country
@@ -56677,6 +57239,7 @@
   - passenger
   - rider
   partOfSpeech: n
+  wikidata: Q319604
 10423987-n:
   definition:
   - (football) a ball carrier who tries to gain ground by throwing a forward pass
@@ -56949,6 +57512,7 @@
   members:
   - patternmaker
   partOfSpeech: n
+  wikidata: Q230763
 10428684-n:
   definition:
   - a poor chess player
@@ -57001,6 +57565,7 @@
   members:
   - pawnbroker
   partOfSpeech: n
+  wikidata: Q176637
 10429379-n:
   definition:
   - a person to whom money is paid
@@ -57108,6 +57673,7 @@
   members:
   - peasant
   partOfSpeech: n
+  wikidata: Q838811
 10430908-n:
   definition:
   - a person who rides a pedal-driven vehicle (as a bicycle)
@@ -57142,6 +57708,7 @@
   - hawker
   - pitchman
   partOfSpeech: n
+  wikidata: Q638172
 10431612-n:
   definition:
   - a man who has sex (usually sodomy) with a boy as the passive partner
@@ -57166,6 +57733,7 @@
   - walker
   - footer
   partOfSpeech: n
+  wikidata: Q221488
 10432299-n:
   definition:
   - a dentist who specializes in the care of children's teeth
@@ -57220,6 +57788,7 @@
   members:
   - peer of the realm
   partOfSpeech: n
+  wikidata: Q7160407
 10433174-n:
   definition:
   - a thrower of missiles
@@ -57340,6 +57909,7 @@
   members:
   - percussionist
   partOfSpeech: n
+  wikidata: Q4351403
 10434975-n:
   definition:
   - a person who is displeased by anything that does not meet very high standards
@@ -57674,6 +58244,7 @@
   - petroleum geologist
   - oil geologist
   partOfSpeech: n
+  wikidata: Q7178961
 10440252-n:
   definition:
   - someone left in charge of pets while their owners are away from home
@@ -57718,6 +58289,7 @@
   - pharaoh
   - pharaoh of Egypt
   partOfSpeech: n
+  wikidata: Q37110
 10440928-n:
   definition:
   - a member of an ancient Jewish sect noted for strict obedience to Jewish traditions
@@ -57752,6 +58324,7 @@
   - pill pusher
   - pill roller
   partOfSpeech: n
+  wikidata: Q105186
 10441498-n:
   definition:
   - someone trained in the science of drugs (their composition and uses and effects)
@@ -57762,6 +58335,7 @@
   - pharmacologist
   - pharmaceutical chemist
   partOfSpeech: n
+  wikidata: Q2114605
 10441701-n:
   definition:
   - someone who makes charitable donations intended to increase human well-being
@@ -57772,6 +58346,7 @@
   - philanthropist
   - altruist
   partOfSpeech: n
+  wikidata: Q12362622
 10442150-n:
   definition:
   - a collector and student of postage stamps
@@ -57834,6 +58409,7 @@
   - philologist
   - philologue
   partOfSpeech: n
+  wikidata: Q13418253
 10443259-n:
   definition:
   - a lover of learning
@@ -57854,6 +58430,7 @@
   members:
   - philosopher
   partOfSpeech: n
+  wikidata: Q4964182
 10445710-n:
   definition:
   - a wise person who is calm and rational; someone who lives a life of reason with
@@ -57910,6 +58487,7 @@
   members:
   - photographer
   partOfSpeech: n
+  wikidata: Q33231
 10446867-n:
   definition:
   - a model who poses for photographers
@@ -57928,6 +58506,7 @@
   members:
   - photojournalist
   partOfSpeech: n
+  wikidata: Q957729
 10447123-n:
   definition:
   - someone who practices photometry
@@ -57980,6 +58559,7 @@
   members:
   - physicist
   partOfSpeech: n
+  wikidata: Q169470
 10449729-n:
   definition:
   - a biologist specializing in physiology
@@ -57989,6 +58569,7 @@
   members:
   - physiologist
   partOfSpeech: n
+  wikidata: Q2055046
 10450318-n:
   definition:
   - a chemist who specializes in the chemistry of plants
@@ -58008,6 +58589,7 @@
   - pianist
   - piano player
   partOfSpeech: n
+  wikidata: Q486748
 10450886-n:
   definition:
   - a person who makes pianos
@@ -58085,6 +58667,7 @@
   - cutpurse
   - dip
   partOfSpeech: n
+  wikidata: Q873750
 10451817-n:
   definition:
   - a casual acquaintance; often made in hope of sexual relationships
@@ -58131,6 +58714,7 @@
   members:
   - pilgrim
   partOfSpeech: n
+  wikidata: Q542704
 10452438-n:
   definition:
   - one of the colonists from England who sailed to America on the Mayflower and founded
@@ -58186,6 +58770,7 @@
   - pilot
   - airplane pilot
   partOfSpeech: n
+  wikidata: Q2095549
 10453216-n:
   definition:
   - a person qualified to guide ships through difficult waters going into or out of
@@ -58196,6 +58781,7 @@
   members:
   - pilot
   partOfSpeech: n
+  wikidata: Q475604
 10453374-n:
   definition:
   - a supposedly primitive man later proven to be a hoax
@@ -58224,6 +58810,7 @@
   - pandar
   - ponce
   partOfSpeech: n
+  wikidata: Q11679511
 10453818-n:
   definition:
   - a niggardly person who starves themself (and others)
@@ -58267,6 +58854,7 @@
   members:
   - pioneer
   partOfSpeech: n
+  wikidata: Q937283
 10454492-n:
   definition:
   - someone who helps to open up a new line of research or technology or art
@@ -58279,6 +58867,7 @@
   - trailblazer
   - groundbreaker
   partOfSpeech: n
+  wikidata: Q3492227
 10454714-n:
   definition:
   - the chief piper in a band of bagpipes
@@ -58369,6 +58958,7 @@
   - hurler
   - twirler
   partOfSpeech: n
+  wikidata: Q1048902
 10456101-n:
   definition:
   - an aggressive salesman who uses a fast line of talk to sell something
@@ -58558,6 +59148,7 @@
   - platelayer
   - tracklayer
   partOfSpeech: n
+  wikidata: Q741583
 10458970-n:
   definition:
   - a skilled worker who coats articles with a film of metal (usually silver or gold)
@@ -58619,6 +59210,7 @@
   - player
   - participant
   partOfSpeech: n
+  wikidata: Q4197743
 10460154-n:
   definition:
   - a person who pursues a number of different social and sexual partners simultaneously
@@ -58790,6 +59382,7 @@
   members:
   - plower
   partOfSpeech: n
+  wikidata: Q3214532
 10462497-n:
   definition:
   - a workman who makes and repairs plows
@@ -58810,6 +59403,7 @@
   - plumber
   - pipe fitter
   partOfSpeech: n
+  wikidata: Q252924
 10462744-n:
   definition:
   - someone who takes spoils or plunder (as in war)
@@ -58885,6 +59479,7 @@
   members:
   - poet
   partOfSpeech: n
+  wikidata: Q49757
 10466829-n:
   definition:
   - a woman poet
@@ -59010,6 +59605,7 @@
   members:
   - police commissioner
   partOfSpeech: n
+  wikidata: Q2101758
 10468557-n:
   definition:
   - a member of a police force
@@ -59022,6 +59618,7 @@
   - police officer
   - officer
   partOfSpeech: n
+  wikidata: Q384593
 10468986-n:
   definition:
   - a female member of a police force
@@ -59097,6 +59694,7 @@
   - pol
   - political leader
   partOfSpeech: n
+  wikidata: Q82955
 10470837-n:
   definition:
   - a leader engaged in civil administration
@@ -59332,6 +59930,7 @@
   - porter
   - Pullman porter
   partOfSpeech: n
+  wikidata: Q7259489
 10475013-n:
   definition:
   - a person employed to carry luggage and supplies
@@ -59341,6 +59940,7 @@
   members:
   - porter
   partOfSpeech: n
+  wikidata: Q1509714
 10475185-n:
   definition:
   - a painter or drawer of portraits
@@ -59353,6 +59953,7 @@
   - portrayer
   - limner
   partOfSpeech: n
+  wikidata: Q1825525
 10475387-n:
   definition:
   - a watchman on a wharf
@@ -59499,6 +60100,7 @@
   members:
   - postulator
   partOfSpeech: n
+  wikidata: Q477190
 10477343-n:
   definition:
   - someone who behaves in a manner calculated to impress or mislead others
@@ -59600,6 +60202,7 @@
   - postal clerk
   - mail clerk
   partOfSpeech: n
+  wikidata: Q7234072
 10478778-n:
   definition:
   - someone who rides the near horse of a pair in order to guide the horses pulling
@@ -59630,6 +60233,7 @@
   members:
   - postmaster
   partOfSpeech: n
+  wikidata: Q1416611
 10479253-n:
   definition:
   - a woman postmaster
@@ -59910,6 +60514,7 @@
   - hoaxer
   - practical joker
   partOfSpeech: n
+  wikidata: Q1344569
 10483509-n:
   definition:
   - someone who speaks in a childish way
@@ -59940,6 +60545,7 @@
   - sermonizer
   - sermoniser
   partOfSpeech: n
+  wikidata: Q432386
 10483998-n:
   definition:
   - a canon who receives a prebend for serving the church
@@ -59949,6 +60555,7 @@
   members:
   - prebendary
   partOfSpeech: n
+  wikidata: Q12640328
 10484108-n:
   definition:
   - teacher at a university or college (especially at Cambridge or Oxford)
@@ -60043,6 +60650,7 @@
   members:
   - presbyter
   partOfSpeech: n
+  wikidata: Q831474
 10485488-n:
   definition:
   - a follower of Calvinism as taught in the Presbyterian Church
@@ -60104,6 +60712,7 @@
   members:
   - preservationist
   partOfSpeech: n
+  wikidata: Q7241052
 10486484-n:
   definition:
   - someone who keeps safe from harm or danger
@@ -60131,6 +60740,7 @@
   members:
   - president
   partOfSpeech: n
+  wikidata: Q30461
 10486961-n:
   definition:
   - the person who holds the office of head of state of the United States government
@@ -60177,6 +60787,7 @@
   - chair
   - chairperson
   partOfSpeech: n
+  wikidata: Q140686
 10488931-n:
   definition:
   - the leader of a group meeting
@@ -60204,6 +60815,7 @@
   members:
   - press agent
   partOfSpeech: n
+  wikidata: Q2358549
 10489371-n:
   definition:
   - a powerful newspaper proprietor
@@ -60231,6 +60843,7 @@
   members:
   - pretender
   partOfSpeech: n
+  wikidata: Q845929
 10489717-n:
   definition:
   - a theologian who believes that the Scripture prophecies of the Apocalypse (the
@@ -60300,6 +60913,7 @@
   members:
   - priestess
   partOfSpeech: n
+  wikidata: Q6116659
 10491225-n:
   definition:
   - a leading female ballet dancer
@@ -60320,6 +60934,7 @@
   - prima donna
   - diva
   partOfSpeech: n
+  wikidata: Q693249
 10491444-n:
   definition:
   - a vain and temperamental person
@@ -60399,6 +61014,7 @@
   members:
   - prince
   partOfSpeech: n
+  wikidata: Q2747456
 10492858-n:
   definition:
   - any of the German princes who were entitled to vote in the election of new emperor
@@ -60466,6 +61082,7 @@
   members:
   - princess
   partOfSpeech: n
+  wikidata: Q863048
 10493928-n:
   definition:
   - the eldest daughter of a British sovereign
@@ -60524,6 +61141,7 @@
   - principal investigator
   - PI
   partOfSpeech: n
+  wikidata: Q7245082
 10494882-n:
   definition:
   - someone whose occupation is printing
@@ -60533,6 +61151,7 @@
   members:
   - printer
   partOfSpeech: n
+  wikidata: Q175151
 10495169-n:
   definition:
   - an apprentice in a printing establishment
@@ -60570,6 +61189,7 @@
   members:
   - prior
   partOfSpeech: n
+  wikidata: Q830337
 10495671-n:
   definition:
   - a person who is confined; especially a prisoner of war
@@ -60580,6 +61200,7 @@
   - prisoner
   - captive
   partOfSpeech: n
+  wikidata: Q1862087
 10495916-n:
   definition:
   - a person who surrenders to (or is taken by) the enemy in time of war
@@ -60603,6 +61224,7 @@
   - buck private
   - common soldier
   partOfSpeech: n
+  wikidata: Q158668
 10496256-n:
   definition:
   - someone who can be employed as a detective to collect information and assist in
@@ -60619,6 +61241,7 @@
   - shamus
   - sherlock
   partOfSpeech: n
+  wikidata: Q1058617
 10496513-n:
   definition:
   - an officer or crew member of a privateer
@@ -60630,6 +61253,7 @@
   - privateer
   - privateersman
   partOfSpeech: n
+  wikidata: Q201559
 10496662-n:
   definition:
   - a professional boxer
@@ -60680,6 +61304,7 @@
   members:
   - probation officer
   partOfSpeech: n
+  wikidata: Q13968
 10497540-n:
   definition:
   - someone who processes things (foods or photographs or applicants etc.)
@@ -60710,6 +61335,7 @@
   members:
   - proconsul
   partOfSpeech: n
+  wikidata: Q2912782
 10498047-n:
   definition:
   - an official in a modern colony who has considerable administrative power
@@ -60762,6 +61388,7 @@
   members:
   - procurator
   partOfSpeech: n
+  wikidata: Q499165
 10498913-n:
   definition:
   - someone who obtains or acquires
@@ -60829,6 +61456,7 @@
   - professional
   - professional person
   partOfSpeech: n
+  wikidata: Q702269
 10500168-n:
   definition:
   - an athlete who plays for pay
@@ -60849,6 +61477,7 @@
   - professor
   - prof
   partOfSpeech: n
+  wikidata: Q121594
 10500588-n:
   definition:
   - someone who makes excessive profit (especially on goods in short supply)
@@ -60894,6 +61523,7 @@
   members:
   - projectionist
   partOfSpeech: n
+  wikidata: Q1415369
 10501296-n:
   definition:
   - a member of the working class (not necessarily employed)
@@ -60937,6 +61567,7 @@
   - booster
   - plugger
   partOfSpeech: n
+  wikidata: Q2378505
 10501999-n:
   definition:
   - someone who assists a performer by providing the next words of a forgotten speech
@@ -60947,6 +61578,7 @@
   - prompter
   - theater prompter
   partOfSpeech: n
+  wikidata: Q1126281
 10502172-n:
   definition:
   - (law) one who promulgates laws (announces a law as a way of putting it into execution)
@@ -60968,6 +61600,7 @@
   - proofreader
   - reader
   partOfSpeech: n
+  wikidata: Q356139
 10502506-n:
   definition:
   - a person who disseminates messages calculated to assist some cause or some government
@@ -60977,6 +61610,7 @@
   members:
   - propagandist
   partOfSpeech: n
+  wikidata: Q1685363
 10502723-n:
   definition:
   - someone who spreads the news
@@ -61005,6 +61639,7 @@
   members:
   - property master
   partOfSpeech: n
+  wikidata: Q1430377
 10503115-n:
   definition:
   - an authoritative person who divines the future
@@ -61038,6 +61673,7 @@
   members:
   - prophet
   partOfSpeech: n
+  wikidata: Q42857
 10504111-n:
   definition:
   - (parliamentary procedure) someone who makes a formal motion
@@ -61174,6 +61810,7 @@
   members:
   - provost
   partOfSpeech: n
+  wikidata: Q2114175
 10506146-n:
   definition:
   - the supervisor of the military police
@@ -61276,6 +61913,7 @@
   - head-shrinker
   - shrink
   partOfSpeech: n
+  wikidata: Q211346
 10507894-n:
   definition:
   - a person apparently sensitive to things beyond the natural range of perception
@@ -61285,6 +61923,7 @@
   members:
   - psychic
   partOfSpeech: n
+  wikidata: Q2917466
 10508098-n:
   definition:
   - someone who claims to receive messages from the dead in the form of raps on a
@@ -61306,6 +61945,7 @@
   members:
   - psycholinguist
   partOfSpeech: n
+  wikidata: Q7256360
 10508450-n:
   definition:
   - a scientist trained in psychology
@@ -61315,6 +61955,7 @@
   members:
   - psychologist
   partOfSpeech: n
+  wikidata: Q212980
 10509011-n:
   definition:
   - a psychologist trained in psychophysics
@@ -61402,6 +62043,7 @@
   members:
   - public defender
   partOfSpeech: n
+  wikidata: Q6528049
 10510284-n:
   definition:
   - someone who publicizes
@@ -61434,6 +62076,7 @@
   members:
   - public servant
   partOfSpeech: n
+  wikidata: Q212238
 10510894-n:
   definition:
   - a person engaged in publishing periodicals or books or music
@@ -61443,6 +62086,7 @@
   members:
   - publisher
   partOfSpeech: n
+  wikidata: Q2516866
 10511160-n:
   definition:
   - the proprietor of a newspaper
@@ -61581,6 +62225,7 @@
   members:
   - puppeteer
   partOfSpeech: n
+  wikidata: Q2629392
 10513420-n:
   definition:
   - an inexperienced young person
@@ -61600,6 +62245,7 @@
   members:
   - purchasing agent
   partOfSpeech: n
+  wikidata: Q7260944
 10513622-n:
   definition:
   - someone who insists on great precision and correctness (especially in the use
@@ -61640,6 +62286,7 @@
   members:
   - purser
   partOfSpeech: n
+  wikidata: Q2307407
 10514363-n:
   definition:
   - a person who is being chased
@@ -62003,6 +62650,7 @@
   - queen regnant
   - female monarch
   partOfSpeech: n
+  wikidata: Q19643
 10519216-n:
   definition:
   - the sovereign ruler of England when female
@@ -62192,6 +62840,7 @@
   members:
   - rabbi
   partOfSpeech: n
+  wikidata: Q133485
 10522161-n:
   definition:
   - someone who drives racing cars at high speeds
@@ -62280,6 +62929,7 @@
   members:
   - radiographer
   partOfSpeech: n
+  wikidata: Q2294052
 10523683-n:
   definition:
   - a scientist trained in radiological technology
@@ -62405,6 +63055,7 @@
   - raja
   - rajah
   partOfSpeech: n
+  wikidata: Q684172
 10525409-n:
   definition:
   - a member of the dominant Hindu military caste in northern India
@@ -62469,6 +63120,7 @@
   members:
   - rancher
   partOfSpeech: n
+  wikidata: Q1524582
 10526137-n:
   definition:
   - a hired hand on a ranch
@@ -62551,6 +63203,7 @@
   members:
   - rapper
   partOfSpeech: n
+  wikidata: Q2252262
 10527158-n:
   definition:
   - a recorder appointed by a committee to prepare reports of the meetings
@@ -62778,6 +63431,7 @@
   members:
   - receptionist
   partOfSpeech: n
+  wikidata: Q1722406
 10530832-n:
   definition:
   - someone who lapses into previous undesirable patterns of behavior
@@ -62844,6 +63498,7 @@
   members:
   - recorder
   partOfSpeech: n
+  wikidata: Q2135808
 10531702-n:
   definition:
   - someone who plays the recorder
@@ -63021,6 +63676,7 @@
   - referee
   - ref
   partOfSpeech: n
+  wikidata: Q202648
 10534236-n:
   definition:
   - an attorney appointed by a court to investigate and report on a case
@@ -63086,6 +63742,7 @@
   members:
   - refugee
   partOfSpeech: n
+  wikidata: Q131572
 10535710-n:
   definition:
   - someone who rules during the absence or incapacity or minority of the country's
@@ -63096,6 +63753,7 @@
   members:
   - regent
   partOfSpeech: n
+  wikidata: Q477406
 10535887-n:
   definition:
   - members of a governing board
@@ -63125,6 +63783,7 @@
   - registered nurse
   - RN
   partOfSpeech: n
+  wikidata: Q13608061
 10536285-n:
   definition:
   - a person who is formally entered (along with others) in a register (and who obtains
@@ -63155,6 +63814,7 @@
   members:
   - registrar
   partOfSpeech: n
+  wikidata: Q7309424
 10536730-n:
   definition:
   - a person employed to keep a record of the owners of stocks and bonds issued by
@@ -63274,6 +63934,7 @@
   members:
   - eremite
   partOfSpeech: n
+  wikidata: Q189829
 10538719-n:
   definition:
   - one retired from society for religious reasons
@@ -63284,6 +63945,7 @@
   - anchorite
   - hermit
   partOfSpeech: n
+  wikidata: Q1146843
 10538884-n:
   definition:
   - a member of a religious order living in common
@@ -63385,6 +64047,7 @@
   members:
   - rentier
   partOfSpeech: n
+  wikidata: Q7313543
 10540693-n:
   definition:
   - a skilled worker whose job is to repair things
@@ -63425,6 +64088,7 @@
   - reporter
   - newsperson
   partOfSpeech: n
+  wikidata: Q42909
 10541446-n:
   definition:
   - a female person who investigates and reports or edits news stories
@@ -63527,6 +64191,7 @@
   members:
   - reservist
   partOfSpeech: n
+  wikidata: Q561904
 10543112-n:
   definition:
   - someone who lives at a particular place for a prolonged period or who was born
@@ -63580,6 +64245,7 @@
   members:
   - respondent
   partOfSpeech: n
+  wikidata: Q7315941
 10544462-n:
   definition:
   - the proprietor of a restaurant
@@ -63590,6 +64256,7 @@
   - restaurateur
   - restauranter
   partOfSpeech: n
+  wikidata: Q3427922
 10544566-n:
   definition:
   - a person who rests
@@ -63620,6 +64287,7 @@
   - retailer
   - retail merchant
   partOfSpeech: n
+  wikidata: Q12049274
 10545192-n:
   definition:
   - someone who has retired from active working
@@ -63728,6 +64396,7 @@
   - referee
   - reader
   partOfSpeech: n
+  wikidata: Q10650082
 10546722-n:
   definition:
   - a Communist who tries to rewrite Marxism to justify a retreat from the revolutionary
@@ -63750,6 +64419,7 @@
   - subversive
   - subverter
   partOfSpeech: n
+  wikidata: Q3242115
 10547490-n:
   definition:
   - a person suffering with rheumatism
@@ -63768,6 +64438,7 @@
   members:
   - rheumatologist
   partOfSpeech: n
+  wikidata: Q5997943
 10547723-n:
   definition:
   - a primitive hominid resembling Neanderthal man but living in Africa
@@ -63854,6 +64525,7 @@
   members:
   - millionaire
   partOfSpeech: n
+  wikidata: Q1075912
 10549259-n:
   definition:
   - a very rich person whose material wealth is valued at more than a billion dollars
@@ -63863,6 +64535,7 @@
   members:
   - billionaire
   partOfSpeech: n
+  wikidata: Q1062083
 10549398-n:
   definition:
   - a very rich person whose material wealth is valued at many billions of dollars
@@ -64021,6 +64694,7 @@
   members:
   - ring girl
   partOfSpeech: n
+  wikidata: Q922176
 10551395-n:
   definition:
   - a person who leads (especially in illicit activities)
@@ -64041,6 +64715,7 @@
   members:
   - ringmaster
   partOfSpeech: n
+  wikidata: Q2384944
 10551615-n:
   definition:
   - troublemaker who participates in a violent disturbance of the peace; someone who
@@ -64450,6 +65125,7 @@
   members:
   - roofer
   partOfSpeech: n
+  wikidata: Q552378
 10557955-n:
   definition:
   - a hotel clerk who is responsible for room assignments to guests
@@ -64658,6 +65334,7 @@
   - rover
   - scouter
   partOfSpeech: n
+  wikidata: Q2540793
 10560663-n:
   definition:
   - a person who stares inquisitively
@@ -64680,6 +65357,7 @@
   - ruler
   - swayer
   partOfSpeech: n
+  wikidata: Q1097498
 10561390-n:
   definition:
   - a person who exercises authority over civilian affairs
@@ -64769,6 +65447,7 @@
   members:
   - runner
   partOfSpeech: n
+  wikidata: Q12803959
 10562614-n:
   definition:
   - the competitor who finishes second
@@ -64941,6 +65620,7 @@
   members:
   - saddler
   partOfSpeech: n
+  wikidata: Q1760988
 10565081-n:
   definition:
   - a member of an ancient Jewish sect around the time of Jesus; opposed to the Pharisees
@@ -64962,6 +65642,7 @@
   - sadhu
   - saddhu
   partOfSpeech: n
+  wikidata: Q654776
 10565349-n:
   definition:
   - someone who obtains pleasure from inflicting pain on others
@@ -65015,6 +65696,7 @@
   - sailing master
   - navigator
   partOfSpeech: n
+  wikidata: Q254651
 10566118-n:
   definition:
   - a maker of sails
@@ -65034,6 +65716,7 @@
   members:
   - sailor
   partOfSpeech: n
+  wikidata: Q45199
 10566407-n:
   definition:
   - a person of exceptional holiness
@@ -65170,6 +65853,7 @@
   members:
   - samurai
   partOfSpeech: n
+  wikidata: Q38142
 10569482-n:
   definition:
   - someone who deceives you about their true nature or intent in order to take advantage
@@ -65297,6 +65981,7 @@
   members:
   - sapper
   partOfSpeech: n
+  wikidata: Q1324245
 10571326-n:
   definition:
   - (historically) a Muslim who opposed the Crusades
@@ -65379,6 +66064,7 @@
   - ironist
   - ridiculer
   partOfSpeech: n
+  wikidata: Q9334029
 10572408-n:
   definition:
   - man with strong sexual desires
@@ -65404,6 +66090,7 @@
   members:
   - satrap
   partOfSpeech: n
+  wikidata: Q170305
 10572663-n:
   definition:
   - someone who walks at a leisurely pace
@@ -65474,6 +66161,7 @@
   - saxophonist
   - saxist
   partOfSpeech: n
+  wikidata: Q12800682
 10573883-n:
   definition:
   - someone who works (or provides workers) during a strike
@@ -65882,6 +66570,7 @@
   - schoolteacher
   - school teacher
   partOfSpeech: n
+  wikidata: Q2251335
 10579976-n:
   definition:
   - someone who teaches science
@@ -65900,6 +66589,7 @@
   members:
   - scientist
   partOfSpeech: n
+  wikidata: Q901
 10580650-n:
   definition:
   - a descendant or heir
@@ -66020,6 +66710,7 @@
   - pathfinder
   - guide
   partOfSpeech: n
+  wikidata: Q14290559
 10582396-n:
   definition:
   - someone employed to discover and recruit talented persons (especially in the worlds
@@ -66033,6 +66724,7 @@
   - scout
   - talent scout
   partOfSpeech: n
+  wikidata: Q1339677
 10582611-n:
   definition:
   - a member of the Scouting movement
@@ -66110,6 +66802,7 @@
   - screen actor
   - movie actor
   partOfSpeech: n
+  wikidata: Q10800557
 10583652-n:
   definition:
   - a guard at an airport who checks passengers or their luggage at a security checkpoint
@@ -66129,6 +66822,7 @@
   - screenwriter
   - film writer
   partOfSpeech: n
+  wikidata: Q28389
 10583969-n:
   definition:
   - (baseball) a pitcher who throws screwballs
@@ -66526,6 +67220,7 @@
   - secretary of defense
   - defense secretary
   partOfSpeech: n
+  wikidata: Q2518691
 10590879-n:
   definition:
   - the person who holds the secretaryship of the Department of Education
@@ -66856,6 +67551,7 @@
   members:
   - seismologist
   partOfSpeech: n
+  wikidata: Q12051314
 10596128-n:
   definition:
   - a male elected member of a board of officials who run New England towns
@@ -67115,6 +67811,7 @@
   members:
   - sergeant
   partOfSpeech: n
+  wikidata: Q157696
 10600546-n:
   definition:
   - an officer (as of a legislature or court) who maintains order and executes commands
@@ -67127,6 +67824,7 @@
   - sergeant at arms
   - serjeant-at-arms
   partOfSpeech: n
+  wikidata: Q2611907
 10600730-n:
   definition:
   - a noncommissioned officer serving as chief administrative officer of a headquarters
@@ -67151,6 +67849,7 @@
   - serial killer
   - serial murderer
   partOfSpeech: n
+  wikidata: Q484188
 10601100-n:
   definition:
   - a serial killer whose murders occur within a brief period of time
@@ -67162,6 +67861,7 @@
   members:
   - spree killer
   partOfSpeech: n
+  wikidata: Q1154323
 10601224-n:
   definition:
   - a producer of raw silk
@@ -67202,6 +67902,7 @@
   - servant
   - retainer
   partOfSpeech: n
+  wikidata: Q54128
 10601959-n:
   definition:
   - a girl who is a servant
@@ -67237,6 +67938,7 @@
   members:
   - military personnel
   partOfSpeech: n
+  wikidata: Q47064
 10602702-n:
   definition:
   - someone who performs the duties of an attendant for someone else
@@ -67256,6 +67958,7 @@
   - settler
   - colonist
   partOfSpeech: n
+  wikidata: Q1818899
 10603242-n:
   definition:
   - a clerk in a betting shop who calculates the winnings
@@ -67370,6 +68073,7 @@
   - sexton
   - sacristan
   partOfSpeech: n
+  wikidata: Q1365552
 10604811-n:
   definition:
   - an inseparable companion
@@ -67391,6 +68095,7 @@
   - shah
   - shah of Iran
   partOfSpeech: n
+  wikidata: Q184299
 10605080-n:
   definition:
   - Arabic term for holy martyrs
@@ -67516,6 +68221,7 @@
   members:
   - shearer
   partOfSpeech: n
+  wikidata: Q1569439
 10606635-n:
   definition:
   - a workman who uses shears to cut leather or metal or textiles
@@ -67561,6 +68267,7 @@
   - sheepherder
   - shepherd
   partOfSpeech: n
+  wikidata: Q81710
 10607214-n:
   definition:
   - a man who raises (or tends) sheep
@@ -67620,6 +68327,7 @@
   - tribal sheikh
   - Arab chief
   partOfSpeech: n
+  wikidata: Q185166
 10607927-n:
   definition:
   - the wife of a sheik
@@ -67688,6 +68396,7 @@
   members:
   - sheriff
   partOfSpeech: n
+  wikidata: Q578478
 10608651-n:
   definition:
   - a derogatory term used by Jews to refer to non-Jewish women
@@ -67760,6 +68469,7 @@
   members:
   - ship chandler
   partOfSpeech: n
+  wikidata: Q2235104
 10609554-n:
   definition:
   - an associate on the same ship with you
@@ -67778,6 +68488,7 @@
   members:
   - shipowner
   partOfSpeech: n
+  wikidata: Q500251
 10609747-n:
   definition:
   - someone who ships goods
@@ -67796,6 +68507,7 @@
   members:
   - shipping agent
   partOfSpeech: n
+  wikidata: Q236979
 10609945-n:
   definition:
   - an employee who ships and receives goods
@@ -67825,6 +68537,7 @@
   - shipbuilder
   - ship builder
   partOfSpeech: n
+  wikidata: Q2106711
 10610311-n:
   definition:
   - a maker of shirts
@@ -67856,6 +68569,7 @@
   members:
   - shogun
   partOfSpeech: n
+  wikidata: Q131767
 10610647-n:
   definition:
   - a member of a Bantu tribe living in present-day Zimbabwe
@@ -67942,6 +68656,7 @@
   - storekeeper
   - market keeper
   partOfSpeech: n
+  wikidata: Q7501153
 10611805-n:
   definition:
   - someone who visits stores in search of articles to buy
@@ -68037,6 +68752,7 @@
   - promoter
   - impresario
   partOfSpeech: n
+  wikidata: Q943995
 10613451-n:
   definition:
   - a person skilled at making effective presentations
@@ -68228,6 +68944,7 @@
   - signaler
   - signaller
   partOfSpeech: n
+  wikidata: Q1187287
 10616499-n:
   definition:
   - a railroad employee in charge of signals and point in a railroad yard
@@ -68238,6 +68955,7 @@
   members:
   - signal worker
   partOfSpeech: n
+  wikidata: Q1455706
 10616642-n:
   definition:
   - someone who signs and is bound by a document
@@ -68266,6 +68984,7 @@
   members:
   - sign painter
   partOfSpeech: n
+  wikidata: Q3374324
 10617153-n:
   definition:
   - used as an Italian courtesy title; can be prefixed to the name or used separately
@@ -68351,6 +69070,7 @@
   - silverworker
   - silver-worker
   partOfSpeech: n
+  wikidata: Q2216340
 10618312-n:
   definition:
   - a person with confused ideas; incapable of serious thought
@@ -68407,6 +69127,7 @@
   - vocalizer
   - vocaliser
   partOfSpeech: n
+  wikidata: Q177220
 10620486-n:
   definition:
   - a person who sins (without repenting)
@@ -68536,6 +69257,7 @@
   members:
   - Beguine
   partOfSpeech: n
+  wikidata: Q147618
 10622393-n:
   definition:
   - a female person who has the same parents as another person
@@ -68722,6 +69444,7 @@
   members:
   - ski jumper
   partOfSpeech: n
+  wikidata: Q13382603
 10624918-n:
   definition:
   - a rapid superficial reader
@@ -69462,6 +70185,7 @@
   members:
   - sniper
   partOfSpeech: n
+  wikidata: Q201948
 10636540-n:
   definition:
   - a person regarded as arrogant and annoying
@@ -69622,6 +70346,7 @@
   members:
   - socialite
   partOfSpeech: n
+  wikidata: Q512314
 10639008-n:
   definition:
   - a person who takes part in social activities
@@ -69700,6 +70425,7 @@
   members:
   - sociologist
   partOfSpeech: n
+  wikidata: Q2306091
 10640656-n:
   definition:
   - someone who works at a soda fountain
@@ -69774,6 +70500,7 @@
   members:
   - soldier
   partOfSpeech: n
+  wikidata: Q4991371
 10642537-n:
   definition:
   - a British lawyer who gives legal advice and prepares legal documents
@@ -69785,6 +70512,7 @@
   members:
   - solicitor
   partOfSpeech: n
+  wikidata: Q14284
 10642716-n:
   definition:
   - a petitioner who solicits contributions or trade or votes
@@ -69824,6 +70552,7 @@
   - wine waiter
   - wine steward
   partOfSpeech: n
+  wikidata: Q191493
 10643311-n:
   definition:
   - someone who talks while asleep
@@ -69876,6 +70605,7 @@
   - songster
   - ballad maker
   partOfSpeech: n
+  wikidata: Q753110
 10644277-n:
   definition:
   - the husband of your daughter
@@ -69958,6 +70688,7 @@
   - shaman
   - priest-doctor
   partOfSpeech: n
+  wikidata: Q697405
 10645801-n:
   definition:
   - a Native American shaman
@@ -69967,6 +70698,7 @@
   members:
   - medicine man
   partOfSpeech: n
+  wikidata: Q266750
 10645902-n:
   definition:
   - a woman sorcerer
@@ -70130,6 +70862,7 @@
   - crowned head
   - monarch
   partOfSpeech: n
+  wikidata: Q116
 10648382-n:
   definition:
   - someone who sows
@@ -70234,6 +70967,7 @@
   - verbalizer
   - verbaliser
   partOfSpeech: n
+  wikidata: Q2324479
 10650493-n:
   definition:
   - a speaker of a particular language who has spoken that language since earliest
@@ -70257,6 +70991,7 @@
   members:
   - speaker
   partOfSpeech: n
+  wikidata: Q1758037
 10650874-n:
   definition:
   - someone who leads or initiates an activity (attack or campaign etc.)
@@ -70275,6 +71010,7 @@
   members:
   - speechwriter
   partOfSpeech: n
+  wikidata: Q175301
 10651127-n:
   definition:
   - someone whose authority is limited to the special undertaking they have been instructed
@@ -70285,6 +71021,7 @@
   members:
   - special agent
   partOfSpeech: n
+  wikidata: Q2655853
 10651303-n:
   definition:
   - an expert who is devoted to one occupation or branch of learning
@@ -70306,6 +71043,7 @@
   - specialist
   - medical specialist
   partOfSpeech: n
+  wikidata: Q3332438
 10652696-n:
   definition:
   - someone who draws up specifications giving details (as for obtaining a patent)
@@ -70362,6 +71100,7 @@
   members:
   - speech therapist
   partOfSpeech: n
+  wikidata: Q11762416
 10653994-n:
   definition:
   - a driver who exceeds the safe speed limit
@@ -70391,6 +71130,7 @@
   - speedskater
   - speed skater
   partOfSpeech: n
+  wikidata: Q10866633
 10654388-n:
   definition:
   - an orator who can hold their listeners spellbound
@@ -70754,6 +71494,7 @@
   - sports writer
   - sportswriter
   partOfSpeech: n
+  wikidata: Q11313148
 10659593-n:
   definition:
   - a worker employed to apply spots (as markers or identifiers)
@@ -70849,6 +71590,7 @@
   members:
   - sprinter
   partOfSpeech: n
+  wikidata: Q4009406
 10660949-n:
   definition:
   - a person who rejects (someone or something) with contempt
@@ -70894,6 +71636,7 @@
   members:
   - spymaster
   partOfSpeech: n
+  wikidata: Q7581768
 10661897-n:
   definition:
   - someone who quarrels about a small matter
@@ -71029,6 +71772,7 @@
   members:
   - squire
   partOfSpeech: n
+  wikidata: Q579516
 10663501-n:
   definition:
   - a man who attends or escorts a woman
@@ -71061,6 +71805,7 @@
   - hostler
   - ostler
   partOfSpeech: n
+  wikidata: Q1455520
 10663908-n:
   definition:
   - a laborer who builds up a stack or pile
@@ -71126,6 +71871,7 @@
   - stagehand
   - stage technician
   partOfSpeech: n
+  wikidata: Q2328828
 10665050-n:
   definition:
   - someone who supervises the physical aspects in the production of a show and who
@@ -71244,6 +71990,7 @@
   members:
   - stamp dealer
   partOfSpeech: n
+  wikidata: Q686880
 10666914-n:
   definition:
   - an outstanding leader of a political movement
@@ -71408,6 +72155,7 @@
   - state's attorney
   - state attorney
   partOfSpeech: n
+  wikidata: Q10726370
 10669515-n:
   definition:
   - a member of a state senate
@@ -71466,6 +72214,7 @@
   - stationmaster
   - station agent
   partOfSpeech: n
+  wikidata: Q2962020
 10672393-n:
   definition:
   - someone versed in the collection and interpretation of numerical data (especially
@@ -71479,6 +72228,7 @@
   - statistician
   - actuary
   partOfSpeech: n
+  wikidata: Q2732142
 10672677-n:
   definition:
   - a mathematician who specializes in statistics
@@ -71528,6 +72278,7 @@
   members:
   - steeplejack
   partOfSpeech: n
+  wikidata: Q1097724
 10673342-n:
   definition:
   - a worker who makes or applies stems for artificial flowers
@@ -71548,6 +72299,7 @@
   - amanuensis
   - shorthand typist
   partOfSpeech: n
+  wikidata: Q499134
 10673650-n:
   definition:
   - a speaker with an unusually loud voice
@@ -71640,6 +72392,7 @@
   - dock-walloper
   - lumper
   partOfSpeech: n
+  wikidata: Q1537445
 10674881-n:
   definition:
   - someone who manages property or other affairs for someone else
@@ -71659,6 +72412,7 @@
   - steward
   - flight attendant
   partOfSpeech: n
+  wikidata: Q101539
 10675169-n:
   definition:
   - the ship's officer who is in charge of provisions and dining arrangements
@@ -71788,6 +72542,7 @@
   members:
   - stockbroker
   partOfSpeech: n
+  wikidata: Q4182927
 10676995-n:
   definition:
   - one who deals only with brokers or other jobbers
@@ -71820,6 +72575,7 @@
   members:
   - stock trader
   partOfSpeech: n
+  wikidata: Q3997173
 10677408-n:
   definition:
   - someone who holds shares of stock in a corporation
@@ -71831,6 +72587,7 @@
   - shareholder
   - shareowner
   partOfSpeech: n
+  wikidata: Q381136
 10677561-n:
   definition:
   - the stockholder whose name is registered on the books of the corporation as owning
@@ -71890,6 +72647,7 @@
   members:
   - stoker
   partOfSpeech: n
+  wikidata: Q1147709
 10678627-n:
   definition:
   - someone who breaks up stone
@@ -71911,6 +72669,7 @@
   - stonecutter
   - cutter
   partOfSpeech: n
+  wikidata: Q328325
 10678832-n:
   definition:
   - an attacker who pelts the victim with stones (especially with intent to kill)
@@ -72069,6 +72828,7 @@
   - strategist
   - strategian
   partOfSpeech: n
+  wikidata: Q7621877
 10681171-n:
   definition:
   - a member of a work gang who supervises the other workers
@@ -72206,6 +72966,7 @@
   - stretcher-bearer
   - litter-bearer
   partOfSpeech: n
+  wikidata: Q2923662
 10683098-n:
   definition:
   - someone who leads a strike
@@ -72279,6 +73040,7 @@
   - ecdysiast
   - peeler
   partOfSpeech: n
+  wikidata: Q1141526
 10684095-n:
   definition:
   - a worker who strips the stems from moistened tobacco leaves and binds the leaves
@@ -72323,6 +73085,7 @@
   members:
   - strongman
   partOfSpeech: n
+  wikidata: Q1852228
 10684741-n:
   definition:
   - a person who struggles with difficulties or with great effort
@@ -72363,6 +73126,7 @@
   - pupil
   - educatee
   partOfSpeech: n
+  wikidata: Q48282
 10685698-n:
   definition:
   - a college student who is teaching under the supervision of a certified teacher
@@ -72374,6 +73138,7 @@
   - student teacher
   - practice teacher
   partOfSpeech: n
+  wikidata: Q4405230
 10685903-n:
   definition:
   - someone who memorizes quickly and easily (as the lines for a part in a play)
@@ -72458,6 +73223,7 @@
   members:
   - stylist
   partOfSpeech: n
+  wikidata: Q3610436
 10687035-n:
   definition:
   - an early Christian ascetic who lived on top of high pillars
@@ -72467,6 +73233,7 @@
   members:
   - stylite
   partOfSpeech: n
+  wikidata: Q401642
 10687148-n:
   definition:
   - a British commissioned army officer below the rank of captain
@@ -72574,6 +73341,7 @@
   members:
   - submariner
   partOfSpeech: n
+  wikidata: Q3492027
 10688925-n:
   definition:
   - someone who submits something (as an application for a job or a manuscript for
@@ -72769,6 +73537,7 @@
   - suffragan
   - suffragan bishop
   partOfSpeech: n
+  wikidata: Q13426709
 10692101-n:
   definition:
   - a woman advocate of women's right to vote (especially a militant advocate in the
@@ -72782,6 +73551,7 @@
   members:
   - suffragette
   partOfSpeech: n
+  wikidata: Q322170
 10692347-n:
   definition:
   - an advocate of the extension of voting rights (especially to women)
@@ -72871,6 +73641,7 @@
   - sultan
   - grand Turk
   partOfSpeech: n
+  wikidata: Q43292
 10693910-n:
   definition:
   - a member of a people who inhabited ancient Sumer
@@ -72902,6 +73673,7 @@
   members:
   - sumo wrestler
   partOfSpeech: n
+  wikidata: Q2727289
 10694335-n:
   definition:
   - a person considered as a source of warmth or energy or glory etc
@@ -72949,6 +73721,7 @@
   members:
   - supercargo
   partOfSpeech: n
+  wikidata: Q915830
 10694920-n:
   definition:
   - a police informer who implicates many people
@@ -73019,6 +73792,7 @@
   members:
   - supermodel
   partOfSpeech: n
+  wikidata: Q865851
 10695873-n:
   definition:
   - an informal term for a mother who can combine childcare and full-time employment
@@ -73039,6 +73813,7 @@
   - spear carrier
   - extra
   partOfSpeech: n
+  wikidata: Q658371
 10696121-n:
   definition:
   - a person serving no apparent function
@@ -73059,6 +73834,7 @@
   members:
   - supervisor
   partOfSpeech: n
+  wikidata: Q1240788
 10696710-n:
   definition:
   - someone whose business is to supply a particular service or commodity
@@ -73069,6 +73845,7 @@
   - supplier
   - provider
   partOfSpeech: n
+  wikidata: Q1762621
 10697043-n:
   definition:
   - a commissioned officer responsible for logistics
@@ -73147,6 +73924,7 @@
   - surfer
   - surfboarder
   partOfSpeech: n
+  wikidata: Q13561328
 10698621-n:
   definition:
   - a physician who specializes in surgery
@@ -73158,6 +73936,7 @@
   - operating surgeon
   - sawbones
   partOfSpeech: n
+  wikidata: Q774306
 10698950-n:
   definition:
   - the senior medical officer in an Army or Navy
@@ -73237,6 +74016,7 @@
   members:
   - surveyor
   partOfSpeech: n
+  wikidata: Q294126
 10700243-n:
   definition:
   - someone who conducts a statistical survey
@@ -73413,6 +74193,7 @@
   - natator
   - bather
   partOfSpeech: n
+  wikidata: Q10843402
 10702832-n:
   definition:
   - a trained athlete who participates in swimming meets
@@ -73658,6 +74439,7 @@
   members:
   - syndic
   partOfSpeech: n
+  wikidata: Q1339249
 10706521-n:
   definition:
   - a businessman who forms a syndicate
@@ -73707,6 +74489,7 @@
   members:
   - system administrator
   partOfSpeech: n
+  wikidata: Q327353
 10707224-n:
   definition:
   - a person skilled at systems analysis
@@ -73849,6 +74632,7 @@
   - seamster
   - sartor
   partOfSpeech: n
+  wikidata: Q242468
 10709280-n:
   definition:
   - one who accepts an offer
@@ -74098,6 +74882,7 @@
   - collector of internal revenue
   - internal revenue agent
   partOfSpeech: n
+  wikidata: Q1139055
 10712731-n:
   definition:
   - a bureaucrat who levies taxes
@@ -74127,6 +74912,7 @@
   - animal stuffer
   - stuffer
   partOfSpeech: n
+  wikidata: Q2114844
 10713142-n:
   definition:
   - someone who drives a taxi for a living
@@ -74177,6 +74963,7 @@
   - teacher
   - instructor
   partOfSpeech: n
+  wikidata: Q37226
 10714345-n:
   definition:
   - the teacher's favorite student
@@ -74195,6 +74982,7 @@
   members:
   - teaching fellow
   partOfSpeech: n
+  wikidata: Q7691300
 10714546-n:
   definition:
   - a fellow member of a team
@@ -74218,6 +75006,7 @@
   - trucker
   - truck driver
   partOfSpeech: n
+  wikidata: Q508846
 10714829-n:
   definition:
   - the driver of a team of horses doing hauling
@@ -74227,6 +75016,7 @@
   members:
   - teamster
   partOfSpeech: n
+  wikidata: Q1473046
 10714946-n:
   definition:
   - a reckless and impetuous person
@@ -74293,6 +75083,7 @@
   members:
   - technician
   partOfSpeech: n
+  wikidata: Q5352191
 10716004-n:
   definition:
   - someone known for high skill in some intellectual or artistic technique
@@ -74382,6 +75173,7 @@
   - telegraphist
   - telegraph operator
   partOfSpeech: n
+  wikidata: Q2024200
 10717278-n:
   definition:
   - advocate of teleology
@@ -74469,6 +75261,7 @@
   - cashier
   - bank clerk
   partOfSpeech: n
+  wikidata: Q806805
 10718595-n:
   definition:
   - an official appointed to count the votes (especially in legislative assembly)
@@ -74501,6 +75294,7 @@
   - temporary
   - temporary worker
   partOfSpeech: n
+  wikidata: Q2109535
 10719072-n:
   definition:
   - a worker who moves around and works temporarily in different places
@@ -74592,6 +75386,7 @@
   members:
   - tenant farmer
   partOfSpeech: n
+  wikidata: Q868069
 10720612-n:
   definition:
   - an inexperienced person (especially someone inexperienced in outdoor living)
@@ -74610,6 +75405,7 @@
   members:
   - tennis coach
   partOfSpeech: n
+  wikidata: Q13219424
 10720829-n:
   definition:
   - an athlete who plays tennis
@@ -74620,6 +75416,7 @@
   members:
   - tennis player
   partOfSpeech: n
+  wikidata: Q10833314
 10721293-n:
   definition:
   - someone who earns a living playing or teaching tennis
@@ -74719,6 +75516,7 @@
   members:
   - terrorist
   partOfSpeech: n
+  wikidata: Q12414919
 10722870-n:
   definition:
   - a woman who is pregnant for the third time
@@ -74788,6 +75586,7 @@
   members:
   - test pilot
   partOfSpeech: n
+  wikidata: Q730242
 10723887-n:
   definition:
   - a baby conceived by fertilization that occurs outside the mother's body; the woman's
@@ -74871,6 +75670,7 @@
   members:
   - theatrical producer
   partOfSpeech: n
+  wikidata: Q1759246
 10725264-n:
   definition:
   - someone who is learned in theology or who speculates about theology
@@ -74950,6 +75750,7 @@
   - thief
   - stealer
   partOfSpeech: n
+  wikidata: Q3562775
 10727941-n:
   definition:
   - an important intellectual
@@ -75145,6 +75946,7 @@
   members:
   - tiler
   partOfSpeech: n
+  wikidata: Q878295
 10730654-n:
   definition:
   - someone who tills land (prepares the soil for the planting of crops)
@@ -75224,6 +76026,7 @@
   members:
   - tinker
   partOfSpeech: n
+  wikidata: Q338221
 10731704-n:
   definition:
   - a person who enjoys fixing and experimenting with machines and their parts
@@ -75254,6 +76057,7 @@
   - tinsmith
   - tinner
   partOfSpeech: n
+  wikidata: Q852718
 10732123-n:
   definition:
   - a hairdresser who tints hair
@@ -75449,6 +76253,7 @@
   - bell ringer
   - ringer
   partOfSpeech: n
+  wikidata: Q587524
 10734679-n:
   definition:
   - a girl who behaves in a boyish manner
@@ -75745,6 +76550,7 @@
   members:
   - town clerk
   partOfSpeech: n
+  wikidata: Q883211
 10738781-n:
   definition:
   - (formerly) an official who made public announcements
@@ -75755,6 +76561,7 @@
   - town crier
   - crier
   partOfSpeech: n
+  wikidata: Q1500389
 10738916-n:
   definition:
   - a resident of a town or city
@@ -75980,6 +76787,7 @@
   members:
   - trainer
   partOfSpeech: n
+  wikidata: Q3077353
 10742407-n:
   definition:
   - an employee of a railroad
@@ -76027,6 +76835,7 @@
   - hobo
   - bum
   partOfSpeech: n
+  wikidata: Q1965933
 10743110-n:
   definition:
   - someone who injures by trampling
@@ -76213,6 +77022,7 @@
   - transvestite
   - cross-dresser
   partOfSpeech: n
+  wikidata: Q10384150
 10745885-n:
   definition:
   - someone who sets traps for animals (usually to obtain their furs)
@@ -76222,6 +77032,7 @@
   members:
   - trapper
   partOfSpeech: n
+  wikidata: Q14009165
 10746040-n:
   definition:
   - member of an order of monks noted for austerity and a vow of silence
@@ -76296,6 +77107,7 @@
   - treasurer
   - financial officer
   partOfSpeech: n
+  wikidata: Q388338
 10747110-n:
   definition:
   - the British cabinet minister responsible for economic strategy
@@ -76327,6 +77139,7 @@
   - tree surgeon
   - arborist
   partOfSpeech: n
+  wikidata: Q776268
 10747596-n:
   definition:
   - a traveler who makes a long arduous journey (as hiking through mountainous country)
@@ -76519,6 +77332,7 @@
   - trombonist
   - trombone player
   partOfSpeech: n
+  wikidata: Q544972
 10750194-n:
   definition:
   - a mounted police officer
@@ -76851,6 +77665,7 @@
   - tympanist
   - timpanist
   partOfSpeech: n
+  wikidata: Q3528729
 10754830-n:
   definition:
   - someone paid to operate a typewriter
@@ -76961,6 +77776,7 @@
   members:
   - undersecretary
   partOfSpeech: n
+  wikidata: Q766504
 10756583-n:
   definition:
   - a seller that sells at a lower price than others do
@@ -77080,6 +77896,7 @@
   members:
   - union representative
   partOfSpeech: n
+  wikidata: Q1518641
 10758327-n:
   definition:
   - adherent of Unitarianism
@@ -77349,6 +78166,7 @@
   - usurper
   - supplanter
   partOfSpeech: n
+  wikidata: Q1136723
 10762393-n:
   definition:
   - someone who believes that the value of a thing depends on its utility
@@ -77532,6 +78350,7 @@
   - gentleman's gentleman
   - man
   partOfSpeech: n
+  wikidata: Q13472752
 10765281-n:
   definition:
   - weak or sickly person especially one morbidly concerned with his or her health
@@ -77613,6 +78432,7 @@
   - liege subject
   - feudatory
   partOfSpeech: n
+  wikidata: Q223266
 10766467-n:
   definition:
   - a performer who works in vaudeville
@@ -77802,6 +78622,7 @@
   - veteran
   - vet
   partOfSpeech: n
+  wikidata: Q193891
 10769196-n:
   definition:
   - a serviceman who has seen considerable active service
@@ -77888,6 +78709,7 @@
   members:
   - vicar-general
   partOfSpeech: n
+  wikidata: Q1044528
 10770456-n:
   definition:
   - an admiral ranking below a full admiral and above a rear admiral
@@ -77907,6 +78729,7 @@
   - vice chair
   - vice chairperson
   partOfSpeech: n
+  wikidata: Q1127270
 10770694-n:
   definition:
   - a deputy or assistant to someone bearing the title of chancellor
@@ -77916,6 +78739,7 @@
   members:
   - vice chancellor
   partOfSpeech: n
+  wikidata: Q12416358
 10770820-n:
   definition:
   - someone appointed by a ruler as an administrative deputy
@@ -77936,6 +78760,7 @@
   - vice president
   - V.P.
   partOfSpeech: n
+  wikidata: Q42178
 10771195-n:
   definition:
   - the vice president of the United States who presides over the United States Senate
@@ -77964,6 +78789,7 @@
   members:
   - viceroy
   partOfSpeech: n
+  wikidata: Q244741
 10771688-n:
   definition:
   - wife of a viceroy
@@ -77982,6 +78808,7 @@
   members:
   - victim
   partOfSpeech: n
+  wikidata: Q1851760
 10772148-n:
   definition:
   - a person who is tricked or swindled
@@ -78120,6 +78947,7 @@
   - vintner
   - wine merchant
   partOfSpeech: n
+  wikidata: Q2556132
 10773949-n:
   definition:
   - someone who assaults others sexually
@@ -78156,6 +78984,7 @@
   - violinist
   - fiddler
   partOfSpeech: n
+  wikidata: Q1259917
 10774588-n:
   definition:
   - someone who makes violins
@@ -78174,6 +79003,7 @@
   members:
   - violist
   partOfSpeech: n
+  wikidata: Q899758
 10774832-n:
   definition:
   - a noisy or scolding or domineering woman
@@ -78214,6 +79044,7 @@
   members:
   - virtuoso
   partOfSpeech: n
+  wikidata: Q214970
 10775316-n:
   definition:
   - a member of the most numerous indigenous people of the Philippines
@@ -78234,6 +79065,7 @@
   members:
   - viscount
   partOfSpeech: n
+  wikidata: Q185902
 10775594-n:
   definition:
   - a noblewoman holding the rank of viscount in her own right
@@ -78283,6 +79115,7 @@
   - illusionist
   - seer
   partOfSpeech: n
+  wikidata: Q1658894
 10776309-n:
   definition:
   - a person given to fanciful speculations and enthusiasms with little regard for
@@ -78320,6 +79153,7 @@
   members:
   - visiting professor
   partOfSpeech: n
+  wikidata: Q94084
 10776861-n:
   definition:
   - someone who visits
@@ -78378,6 +79212,7 @@
   members:
   - viticulturist
   partOfSpeech: n
+  wikidata: Q897317
 10777875-n:
   definition:
   - a biologist who cuts open live animals for research
@@ -78409,6 +79244,7 @@
   members:
   - vizier
   partOfSpeech: n
+  wikidata: Q175240
 10778257-n:
   definition:
   - a loud and vehement speaker (usually in protest)
@@ -78481,6 +79317,7 @@
   - military volunteer
   - voluntary
   partOfSpeech: n
+  wikidata: Q1454940
 10779211-n:
   definition:
   - a person addicted to luxury and pleasures of the senses
@@ -78750,6 +79587,7 @@
   - waiter
   - server
   partOfSpeech: n
+  wikidata: Q157195
 10783288-n:
   definition:
   - a woman waiter
@@ -78995,6 +79833,7 @@
   members:
   - war correspondent
   partOfSpeech: n
+  wikidata: Q164236
 10786567-n:
   definition:
   - an offender who violates international law during times of war
@@ -79052,6 +79891,7 @@
   members:
   - warehouser
   partOfSpeech: n
+  wikidata: Q1391362
 10787322-n:
   definition:
   - a god worshipped as giving victory in war
@@ -79081,6 +79921,7 @@
   members:
   - warlord
   partOfSpeech: n
+  wikidata: Q220098
 10787690-n:
   definition:
   - someone who gives a warning to others
@@ -79137,6 +79978,7 @@
   members:
   - warrior
   partOfSpeech: n
+  wikidata: Q1250916
 10788478-n:
   definition:
   - a woman whose husband has died in war
@@ -79230,6 +80072,7 @@
   - horologist
   - horologer
   partOfSpeech: n
+  wikidata: Q157798
 10789727-n:
   definition:
   - a guard who keeps watch
@@ -79367,6 +80210,7 @@
   members:
   - weather forecaster
   partOfSpeech: n
+  wikidata: Q1154500
 10791858-n:
   definition:
   - a craftsman who weaves cloth
@@ -79376,6 +80220,7 @@
   members:
   - weaver
   partOfSpeech: n
+  wikidata: Q437512
 10791957-n:
   definition:
   - a technician who designs or maintains a website
@@ -79385,6 +80230,7 @@
   members:
   - webmaster
   partOfSpeech: n
+  wikidata: Q41674
 10792060-n:
   definition:
   - a guest at a wedding
@@ -79492,6 +80338,7 @@
   members:
   - welder
   partOfSpeech: n
+  wikidata: Q836328
 10793468-n:
   definition:
   - a case for a welfare worker
@@ -79638,6 +80485,7 @@
   - wheelwright
   - wheeler
   partOfSpeech: n
+  wikidata: Q833418
 10795439-n:
   definition:
   - a batter who strikes out by swinging at and missing the third strike
@@ -79760,6 +80608,7 @@
   - whistle-blower
   - whistleblower
   partOfSpeech: n
+  wikidata: Q26102
 10797436-n:
   definition:
   - someone who makes a loud high sound
@@ -79823,6 +80672,7 @@
   - Franciscan
   - Grey Friar
   partOfSpeech: n
+  wikidata: Q165005
 10798379-n:
   definition:
   - a Roman Catholic friar or monk belonging to one of the Augustinian monastic orders
@@ -79975,6 +80825,7 @@
   - wife
   - married woman
   partOfSpeech: n
+  wikidata: Q188830
 10800912-n:
   definition:
   - one who can't stay still (especially a child)
@@ -80127,6 +80978,7 @@
   - window dresser
   - window trimmer
   partOfSpeech: n
+  wikidata: Q874894
 10803028-n:
   definition:
   - someone who washes windows
@@ -80239,6 +81091,7 @@
   members:
   - witch doctor
   partOfSpeech: n
+  wikidata: Q930402
 10804351-n:
   definition:
   - someone who identifies and punishes people for their opinions
@@ -80509,6 +81362,7 @@
   - woodcarver
   - carver
   partOfSpeech: n
+  wikidata: Q6138343
 10809717-n:
   definition:
   - cuts down trees and chops wood as a job
@@ -80538,6 +81392,7 @@
   - woodsman
   - woodman
   partOfSpeech: n
+  wikidata: Q7111941
 10810119-n:
   definition:
   - a person who sorts wool into different grades
@@ -80762,6 +81617,7 @@
   - writer
   - author
   partOfSpeech: n
+  wikidata: Q482980
 10820913-n:
   definition:
   - a person who is able to write and has written something
@@ -80771,6 +81627,7 @@
   members:
   - writer
   partOfSpeech: n
+  wikidata: Q36180
 10821165-n:
   definition:
   - a student enrolled in (or graduated from) Winchester College
@@ -80804,6 +81661,7 @@
   members:
   - yakuza
   partOfSpeech: n
+  wikidata: Q183287
 10821497-n:
   definition:
   - one of a race of brutes resembling men but subject to the Houyhnhnms in a novel
@@ -80974,6 +81832,7 @@
   members:
   - yogi
   partOfSpeech: n
+  wikidata: Q2901587
 10823706-n:
   definition:
   - a person who is not very intelligent or interested in culture
@@ -81115,6 +81974,7 @@
   members:
   - zoo keeper
   partOfSpeech: n
+  wikidata: Q322898
 10825826-n:
   definition:
   - a specialist in the branch of biology dealing with animals

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -29217,6 +29217,7 @@
   - paygrade
   - rating
   partOfSpeech: n
+  wikidata: Q56019
 14455063-n:
   definition:
   - the rank of a flag officer

--- a/src/yaml/noun.substance.yaml
+++ b/src/yaml/noun.substance.yaml
@@ -28278,6 +28278,7 @@
   members:
   - stucco
   partOfSpeech: n
+  wikidata: Q33526
 15086851-n:
   definition:
   - the product of vaporization of a solid


### PR DESCRIPTION
This is a manually reviewed batch of links from OEWN to Wikidata.

It was focused on occupation roles, to provide a better linking of humans in the names