### PR TITLE
Add links for species to Wikidata

### DIFF
--- a/src/yaml/entries-t.yaml
+++ b/src/yaml/entries-t.yaml
@@ -9134,7 +9134,7 @@ Tyrannus tyrannus:
   n:
     sense:
     - id: 'tyrannus_tyrannus%1:05:00::'
-      synset: 01550942-n
+      synset: 01551506-n
 Tyrannus vociferans:
   n:
     sense:

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -1073,6 +1073,7 @@
   members:
   - Lassa virus
   partOfSpeech: n
+  wikidata: Q1806636
 01333607-n:
   definition:
   - the RNA virus that causes lymphocytic choriomeningitis; infects mice and monkeys
@@ -1206,6 +1207,7 @@
   - West Nile virus
   - West Nile encephalitis virus
   partOfSpeech: n
+  wikidata: Q158856
 01335723-n:
   definition:
   - a family of round, pleomorphic arborviruses carried by arthropods
@@ -1910,6 +1912,7 @@
   - Bacillus anthracis
   - anthrax bacillus
   partOfSpeech: n
+  wikidata: Q614156
 01353126-n:
   definition:
   - a species of bacillus found in soil and decomposing organic matter; some strains
@@ -1923,6 +1926,7 @@
   - grass bacillus
   - hay bacillus
   partOfSpeech: n
+  wikidata: Q10424114
 01353342-n:
   definition:
   - a bacillus bacterium that causes the plague; aerosolized bacteria can be used
@@ -1933,6 +1937,7 @@
   members:
   - Yersinia pestis
   partOfSpeech: n
+  wikidata: Q153875
 01353496-n:
   definition:
   - any spherical or nearly spherical bacteria
@@ -1997,6 +2002,7 @@
   - Helicobacter pylori
   - H. pylori
   partOfSpeech: n
+  wikidata: Q180556
 01354600-n:
   definition:
   - an order of bacteria
@@ -2064,6 +2070,7 @@
   members:
   - Aerobacter aerogenes
   partOfSpeech: n
+  wikidata: Q115944464
 01356790-n:
   definition:
   - a small family of rod-shaped bacteria
@@ -2474,6 +2481,7 @@
   - ring rot bacteria
   - Pseudomonas solanacearum
   partOfSpeech: n
+  wikidata: Q22112649
 01363902-n:
   definition:
   - bacteria usually producing greenish fluorescent water-soluble pigment; some pathogenic
@@ -2715,6 +2723,7 @@
   members:
   - Vibrio fetus
   partOfSpeech: n
+  wikidata: Q129574636
 01367228-n:
   definition:
   - family of bacteria living usually in the alimentary canal or on mucous surfaces
@@ -2764,6 +2773,7 @@
   members:
   - Calymmatobacterium granulomatis
   partOfSpeech: n
+  wikidata: Q62895839
 01368115-n:
   definition:
   - a genus of Gram-negative aerobic bacteria that occur as pathogens and parasite
@@ -2788,6 +2798,7 @@
   members:
   - Francisella tularensis
   partOfSpeech: n
+  wikidata: Q1003460
 01368526-n:
   definition:
   - the pus-producing bacterium that causes gonorrhea
@@ -2798,6 +2809,7 @@
   - gonococcus
   - Neisseria gonorrhoeae
   partOfSpeech: n
+  wikidata: Q131129
 01368656-n:
   definition:
   - a large family of mostly Gram-positive and aerobic and nonmotile rod-shaped bacteria
@@ -2948,6 +2960,7 @@
   - Escherichia coli
   - E. coli
   partOfSpeech: n
+  wikidata: Q25419
 01371193-n:
   definition:
   - a genus of non-motile, Gram-negative, oxidase-negative, rod-shaped bacteria with
@@ -3024,6 +3037,7 @@
   - Salmonella typhosa
   - Salmonella typhi
   partOfSpeech: n
+  wikidata: Q22111431
 01372274-n:
   definition:
   - a genus of motile peritrichous bacteria that contain small Gram-negative rod
@@ -3048,6 +3062,7 @@
   members:
   - Serratia marcescens
   partOfSpeech: n
+  wikidata: Q140004
 01372783-n:
   definition:
   - a genus of gram-negative, facultative anaerobic, nonspore-forming, nonmotile,
@@ -3081,6 +3096,7 @@
   - shiga bacillus
   - Shigella dysenteriae
   partOfSpeech: n
+  wikidata: Q265094
 01373222-n:
   definition:
   - a genus of rod-shaped gram-negative bacteria containing mostly plant pathogenic
@@ -3251,6 +3267,7 @@
   - Chlamydia psittaci
   - C. psittaci
   partOfSpeech: n
+  wikidata: Q62869749
 01375731-n:
   definition:
   - bacteria responsible for the sexually transmitted diseases chlamydia and lymphogranuloma
@@ -3477,6 +3494,7 @@
   members:
   - Streptomyces griseus
   partOfSpeech: n
+  wikidata: Q7623385
 01379288-n:
   definition:
   - cause of a potato disease characterized by brownish corky tissue
@@ -3487,6 +3505,7 @@
   - potato scab bacteria
   - Streptomyces scabies
   partOfSpeech: n
+  wikidata: Q12321467
 01379442-n:
   definition:
   - a family of bacteria containing tuberculosis (Mycobacterium tuberculosis) and
@@ -3533,6 +3552,7 @@
   - tubercle bacillus
   - Mycobacterium tuberculosis
   partOfSpeech: n
+  wikidata: Q130971
 01380033-n:
   definition:
   - bacteria that are unaffected by penicillin
@@ -3579,6 +3599,7 @@
   - leprosy bacillus
   - Mycobacterium leprae
   partOfSpeech: n
+  wikidata: Q155891
 01380547-n:
   definition:
   - an order of higher bacteria
@@ -3742,6 +3763,7 @@
   - acidophilus
   - Lactobacillus acidophilus
   partOfSpeech: n
+  wikidata: Q132644
 01383130-n:
   definition:
   - a genus of round bacteria that ordinarily occurs in the form of two joined cells
@@ -5258,6 +5280,7 @@
   - tang
   - Fucus vesiculosus
   partOfSpeech: n
+  wikidata: Q754755
 01408083-n:
   definition:
   - brown algae distinguished by compressed or inflated branchlets along the axis
@@ -5279,6 +5302,7 @@
   - bladderwrack
   - Ascophyllum nodosum
   partOfSpeech: n
+  wikidata: Q1415896
 01408378-n:
   definition:
   - a genus of protoctist containing brown macroalgae (Sargassum)
@@ -5304,6 +5328,7 @@
   - sargasso
   - Sargassum bacciferum
   partOfSpeech: n
+  wikidata: Q68189616
 01408733-n:
   definition:
   - free-swimming flagellate algae
@@ -5907,6 +5932,7 @@
   - carragheen
   - Chondrus crispus
   partOfSpeech: n
+  wikidata: Q4963539
 01417482-n:
   definition:
   - a family of protoctist
@@ -5943,6 +5969,7 @@
   - dulse
   - Rhodymenia palmata
   partOfSpeech: n
+  wikidata: Q104919807
 01417897-n:
   definition:
   - a family of protoctist containing red algae (Bangiaceae)
@@ -6096,6 +6123,7 @@
   - noctiluca
   - Noctiluca miliaris
   partOfSpeech: n
+  wikidata: Q104912737
 01420448-n:
   definition:
   - marine and freshwater dinoflagellates
@@ -6561,9 +6589,7 @@
   - Plasmodium vivax
   - malaria parasite
   partOfSpeech: n
-  wikidata:
-  - Q311376
-  - Q130948
+  wikidata: Q311376
 01427248-n:
   definition:
   - bird parasites
@@ -7066,6 +7092,7 @@
   - European bream
   - Abramis brama
   partOfSpeech: n
+  wikidata: Q144534
 01443296-n:
   definition:
   - tench
@@ -7090,6 +7117,7 @@
   - tench
   - Tinca tinca
   partOfSpeech: n
+  wikidata: Q76280
 01443590-n:
   definition:
   - 'a genus of fish including: dace, chub'
@@ -7114,6 +7142,7 @@
   - dace
   - Leuciscus leuciscus
   partOfSpeech: n
+  wikidata: Q143326
 01443913-n:
   definition:
   - European freshwater game fish with a thick spindle-shaped body
@@ -7124,6 +7153,7 @@
   - chub
   - Leuciscus cephalus
   partOfSpeech: n
+  wikidata: Q189014
 01444066-n:
   definition:
   - any of numerous small silvery North American cyprinid fishes especially of the
@@ -7157,6 +7187,7 @@
   - emerald shiner
   - Notropis atherinoides
   partOfSpeech: n
+  wikidata: Q1979063
 01444551-n:
   definition:
   - the common North American shiner
@@ -7168,6 +7199,7 @@
   - silversides
   - Notropis cornutus
   partOfSpeech: n
+  wikidata: Q106388817
 01444696-n:
   definition:
   - golden shiners
@@ -7213,6 +7245,7 @@
   - roach
   - Rutilus rutilus
   partOfSpeech: n
+  wikidata: Q182976
 01445232-n:
   definition:
   - rudds
@@ -7236,6 +7269,7 @@
   - rudd
   - Scardinius erythrophthalmus
   partOfSpeech: n
+  wikidata: Q200594
 01445496-n:
   definition:
   - minnows
@@ -7259,6 +7293,7 @@
   - minnow
   - Phoxinus phoxinus
   partOfSpeech: n
+  wikidata: Q214278
 01445767-n:
   definition:
   - true gudgeons
@@ -7308,6 +7343,7 @@
   - goldfish
   - Carassius auratus
   partOfSpeech: n
+  wikidata: Q123141
 01446377-n:
   definition:
   - a silvery variety of Carassius auratus
@@ -7328,6 +7364,7 @@
   - Carassius carassius
   - Carassius vulgaris
   partOfSpeech: n
+  wikidata: Q194031
 01446639-n:
   definition:
   - small family comprising the electric eels
@@ -7449,6 +7486,7 @@
   - black buffalo
   - Ictiobus niger
   partOfSpeech: n
+  wikidata: Q136536
 01448359-n:
   definition:
   - a genus of fish in the family Catostomidae, containing 3 species of sucker (Hypentelium)
@@ -7471,6 +7509,7 @@
   - hog molly
   - Hypentelium nigricans
   partOfSpeech: n
+  wikidata: Q3764682
 01448639-n:
   definition:
   - a genus of fish in the family Catostomidae
@@ -7557,6 +7596,7 @@
   - mummichog
   - Fundulus heteroclitus
   partOfSpeech: n
+  wikidata: Q939303
 01449972-n:
   definition:
   - black-barred fish of bays and coastal marshes of the Atlantic and Gulf Coast of
@@ -7570,6 +7610,7 @@
   - may fish
   - Fundulus majalis
   partOfSpeech: n
+  wikidata: Q2186171
 01450192-n:
   definition:
   - a genus of killifish, containing Rivulus cylindraceus, Rivulus formosensis, Rivulus
@@ -7617,6 +7658,7 @@
   - American flagfish
   - Jordanella floridae
   partOfSpeech: n
+  wikidata: Q861774
 01450806-n:
   definition:
   - swordtails
@@ -7742,6 +7784,9 @@
   - platy
   - Platypoecilus maculatus
   partOfSpeech: n
+  wikidata:
+  - Q1162971
+  - Q109540926
 01452498-n:
   definition:
   - mollies
@@ -7828,6 +7873,7 @@
   - reef squirrelfish
   - Holocentrus coruscus
   partOfSpeech: n
+  wikidata: Q106378315
 01453756-n:
   definition:
   - a squirrelfish found from South Carolina to Bermuda and Gulf of Mexico
@@ -7838,6 +7884,7 @@
   - deepwater squirrelfish
   - Holocentrus bullisi
   partOfSpeech: n
+  wikidata: Q106378251
 01453936-n:
   definition:
   - bright red fish of West Indies and Bermuda
@@ -7929,6 +7976,7 @@
   - flashlight fish
   - Photoblepharon palpebratus
   partOfSpeech: n
+  wikidata: Q106377954
 01455137-n:
   definition:
   - dories
@@ -8027,6 +8075,7 @@
   - boarfish
   - Capros aper
   partOfSpeech: n
+  wikidata: Q1278796
 01456232-n:
   definition:
   - a genus of fish in the family Caproidae, commonly known as boarfishes (Antigonia)
@@ -8153,6 +8202,7 @@
   - three-spined stickleback
   - Gasterosteus aculeatus
   partOfSpeech: n
+  wikidata: Q203572
 01458102-n:
   definition:
   - confined to rivers
@@ -8163,6 +8213,9 @@
   - ten-spined stickleback
   - Gasterosteus pungitius
   partOfSpeech: n
+  wikidata:
+  - Q754894
+  - Q109538522
 01458233-n:
   definition:
   - pipefishes
@@ -8212,6 +8265,7 @@
   - dwarf pipefish
   - Syngnathus hildebrandi
   partOfSpeech: n
+  wikidata: Q106436344
 01458937-n:
   definition:
   - a genus of fish in the family Syngnathidae
@@ -8235,6 +8289,7 @@
   - deepwater pipefish
   - Cosmocampus profundus
   partOfSpeech: n
+  wikidata: Q2380746
 01459272-n:
   definition:
   - seahorses
@@ -8343,6 +8398,7 @@
   - trumpetfish
   - Aulostomus maculatus
   partOfSpeech: n
+  wikidata: Q1966255
 01460651-n:
   definition:
   - mouth of a protozoan
@@ -9554,6 +9610,7 @@
   - sea lamprey
   - Petromyzon marinus
   partOfSpeech: n
+  wikidata: Q385764
 01480714-n:
   definition:
   - hagfishes as distinguished from lampreys
@@ -9620,6 +9677,7 @@
   members:
   - Myxine glutinosa
   partOfSpeech: n
+  wikidata: Q780327
 01481707-n:
   definition:
   - a genus of fossil fish of the family Myxinidae
@@ -9802,6 +9860,7 @@
   - rabbitfish
   - Chimaera monstrosa
   partOfSpeech: n
+  wikidata: Q1160972
 01484240-n:
   definition:
   - sharks, rays, dogfishes, skates
@@ -9890,6 +9949,7 @@
   - six-gilled shark
   - Hexanchus griseus
   partOfSpeech: n
+  wikidata: Q312293
 01485829-n:
   definition:
   - oceanic sharks
@@ -9996,6 +10056,7 @@
   - longfin mako
   - Isurus paucus
   partOfSpeech: n
+  wikidata: Q207630
 01487203-n:
   definition:
   - common blue-grey shark of southwest Pacific; sport and food fish
@@ -10033,6 +10094,7 @@
   - man-eating shark
   - Carcharodon carcharias
   partOfSpeech: n
+  wikidata: Q129026
 01487714-n:
   definition:
   - comprising only the basking sharks; in some classifications considered the type
@@ -10069,6 +10131,7 @@
   - basking shark
   - Cetorhinus maximus
   partOfSpeech: n
+  wikidata: Q185260
 01488314-n:
   definition:
   - thresher sharks
@@ -10171,6 +10234,7 @@
   - nurse shark
   - Ginglymostoma cirratum
   partOfSpeech: n
+  wikidata: Q756859
 01489718-n:
   definition:
   - sand sharks; in some classifications coextensive with family Carcharhinidae
@@ -10216,6 +10280,7 @@
   - Carcharias taurus
   - Odontaspis taurus
   partOfSpeech: n
+  wikidata: Q625161
 01490384-n:
   definition:
   - small-toothed sharks comprising only one species
@@ -10253,6 +10318,7 @@
   - whale shark
   - Rhincodon typus
   partOfSpeech: n
+  wikidata: Q80378
 01490875-n:
   definition:
   - small bottom-dwelling sharks
@@ -10333,6 +10399,7 @@
   - cub shark
   - Carcharhinus leucas
   partOfSpeech: n
+  wikidata: Q190469
 01492350-n:
   definition:
   - most common grey shark along coasts of middle Atlantic states; sluggish and occasionally
@@ -10344,6 +10411,7 @@
   - sandbar shark
   - Carcharhinus plumbeus
   partOfSpeech: n
+  wikidata: Q304539
 01492561-n:
   definition:
   - widely distributed shallow-water shark with fins seemingly dipped in ink
@@ -10355,6 +10423,7 @@
   - sandbar shark
   - Carcharhinus limbatus
   partOfSpeech: n
+  wikidata: Q125236
 01492753-n:
   definition:
   - large deep-water shark with white-tipped dorsal fin; worldwide distribution; most
@@ -10380,6 +10449,7 @@
   - dusky shark
   - Carcharhinus obscurus
   partOfSpeech: n
+  wikidata: Q833586
 01493187-n:
   definition:
   - lemon sharks
@@ -10404,6 +10474,7 @@
   - lemon shark
   - Negaprion brevirostris
   partOfSpeech: n
+  wikidata: Q206495
 01493526-n:
   definition:
   - blue sharks
@@ -10429,6 +10500,7 @@
   - great blue shark
   - Prionace glauca
   partOfSpeech: n
+  wikidata: Q26337
 01493876-n:
   definition:
   - tiger sharks
@@ -10536,6 +10608,7 @@
   - smoothhound shark
   - Mustelus mustelus
   partOfSpeech: n
+  wikidata: Q260097
 01495349-n:
   definition:
   - found along the Atlantic coast of the Americas
@@ -10546,6 +10619,7 @@
   - American smooth dogfish
   - Mustelus canis
   partOfSpeech: n
+  wikidata: Q941962
 01495501-n:
   definition:
   - found from the northern Gulf of Mexico to Brazil
@@ -10556,6 +10630,7 @@
   - Florida smoothhound
   - Mustelus norrisi
   partOfSpeech: n
+  wikidata: Q2619358
 01495653-n:
   definition:
   - a genus of Triakidae
@@ -10629,6 +10704,7 @@
   - Atlantic spiny dogfish
   - Squalus acanthias
   partOfSpeech: n
+  wikidata: Q212694
 01496682-n:
   definition:
   - dogfish of Pacific coast of North America
@@ -10698,6 +10774,7 @@
   - smalleye hammerhead
   - Sphyrna tudes
   partOfSpeech: n
+  wikidata: Q1150019
 01497647-n:
   definition:
   - small harmless hammerhead having a spade-shaped head; abundant in bays and estuaries
@@ -10710,6 +10787,7 @@
   - bonnet shark
   - Sphyrna tiburo
   partOfSpeech: n
+  wikidata: Q338891
 01497833-n:
   definition:
   - bottom-dwelling ray-like sharks
@@ -10939,6 +11017,7 @@
   - roughtail stingray
   - Dasyatis centroura
   partOfSpeech: n
+  wikidata: Q137628
 01501218-n:
   definition:
   - butterfly rays
@@ -11010,6 +11089,7 @@
   - spotted ray
   - Aetobatus narinari
   partOfSpeech: n
+  wikidata: Q655565
 01502236-n:
   definition:
   - a genus of Myliobatidae, commonly known as cownose rays (Rhinoptera)
@@ -11034,6 +11114,7 @@
   - cow-nosed ray
   - Rhinoptera bonasus
   partOfSpeech: n
+  wikidata: Q10360338
 01502539-n:
   definition:
   - 'large rays lacking venomous spines: mantas'
@@ -11084,6 +11165,7 @@
   - Atlantic manta
   - Manta birostris
   partOfSpeech: n
+  wikidata: Q321976
 01503362-n:
   definition:
   - type genus of the Mobulidae
@@ -11107,6 +11189,7 @@
   - devil ray
   - Mobula hypostoma
   partOfSpeech: n
+  wikidata: Q4548397
 01503636-n:
   definition:
   - 'bottom-dwelling tropical rays: skates'
@@ -11158,6 +11241,7 @@
   - gray skate
   - Raja batis
   partOfSpeech: n
+  wikidata: Q106445006
 01504418-n:
   definition:
   - most plentiful skate in North American inshore waters in summer; to 21 inches
@@ -11168,7 +11252,9 @@
   - little skate
   - Raja erinacea
   partOfSpeech: n
-  wikidata: Q1913942
+  wikidata:
+  - Q1913942
+  - Q106445138
 01504589-n:
   definition:
   - cold-water bottom fish with spines on the back; to 40 inches
@@ -11190,7 +11276,9 @@
   - barndoor skate
   - Raja laevis
   partOfSpeech: n
-  wikidata: Q9066054
+  wikidata:
+  - Q2718062
+  - Q9066054
 01504903-n:
   definition:
   - (ornithology) the class of birds
@@ -11618,6 +11706,7 @@
   - ostrich
   - Struthio camelus
   partOfSpeech: n
+  wikidata: Q17592
 01521687-n:
   definition:
   - 'a ratite bird order: cassowaries and emus'
@@ -11691,6 +11780,7 @@
   - Dromaius novaehollandiae
   - Emu novaehollandiae
   partOfSpeech: n
+  wikidata: Q93208
 01522699-n:
   definition:
   - 'a ratite bird order: flightless ground birds having vestigial wings and long
@@ -11793,6 +11883,7 @@
   - rhea
   - Rhea americana
   partOfSpeech: n
+  wikidata: Q192044
 01524243-n:
   definition:
   - a genus of birds of the family Rheidae
@@ -11818,6 +11909,7 @@
   - nandu
   - Pterocnemia pennata
   partOfSpeech: n
+  wikidata: Q25006711
 01524621-n:
   definition:
   - 'huge extinct flightless birds: elephant birds'
@@ -12140,6 +12232,7 @@
   - dunnock
   - Prunella modularis
   partOfSpeech: n
+  wikidata: Q26698
 01530121-n:
   definition:
   - larks
@@ -12186,6 +12279,7 @@
   - skylark
   - Alauda arvensis
   partOfSpeech: n
+  wikidata: Q25961
 01530728-n:
   definition:
   - pipits and wagtails
@@ -12258,6 +12352,7 @@
   - meadow pipit
   - Anthus pratensis
   partOfSpeech: n
+  wikidata: Q26956
 01531677-n:
   definition:
   - 'finches: goldfinches, bullfinches, chaffinches, siskins, canaries, cardinals,
@@ -12326,6 +12421,7 @@
   - chaffinch
   - Fringilla coelebs
   partOfSpeech: n
+  wikidata: Q25383
 01533216-n:
   definition:
   - Eurasian finch
@@ -12336,6 +12432,7 @@
   - brambling
   - Fringilla montifringilla
   partOfSpeech: n
+  wikidata: Q188877
 01533332-n:
   definition:
   - used in some classifications for a subgroup of finches
@@ -12374,6 +12471,7 @@
   - goldfinch
   - Carduelis carduelis
   partOfSpeech: n
+  wikidata: Q25418
 01533985-n:
   definition:
   - small Old World finch whose male has a red breast and forehead
@@ -12385,6 +12483,7 @@
   - lintwhite
   - Carduelis cannabina
   partOfSpeech: n
+  wikidata: Q26034
 01534153-n:
   definition:
   - small yellow-and-black Eurasian finch with a sharp beak
@@ -12395,6 +12494,7 @@
   - siskin
   - Carduelis spinus
   partOfSpeech: n
+  wikidata: Q168881
 01534280-n:
   definition:
   - South American species of scarlet finch with black head and wings and tail
@@ -12405,7 +12505,9 @@
   - red siskin
   - Carduelis cucullata
   partOfSpeech: n
-  wikidata: Q1142542
+  wikidata:
+  - Q27075875
+  - Q1142542
 01534452-n:
   definition:
   - small siskin-like finch with a red crown and a rosy breast and rump
@@ -12416,6 +12518,7 @@
   - redpoll
   - Carduelis flammea
   partOfSpeech: n
+  wikidata: Q206701
 01534612-n:
   definition:
   - small siskin-like finch with a red crown
@@ -12426,6 +12529,7 @@
   - redpoll
   - Carduelis hornemanni
   partOfSpeech: n
+  wikidata: Q391412
 01534748-n:
   definition:
   - 'in some classifications considered a subgenus of Carduelis: siskins and New World
@@ -12453,6 +12557,7 @@
   - yellowbird
   - Spinus tristis
   partOfSpeech: n
+  wikidata: Q27075861
 01535152-n:
   definition:
   - small finch of North American coniferous forests
@@ -12464,6 +12569,7 @@
   - pine finch
   - Spinus pinus
   partOfSpeech: n
+  wikidata: Q26847063
 01535305-n:
   definition:
   - house finches and purple finches
@@ -12489,6 +12595,7 @@
   - linnet
   - Carpodacus mexicanus
   partOfSpeech: n
+  wikidata: Q374302
 01535641-n:
   definition:
   - North American finch having a raspberry-red head and breast and rump
@@ -12535,6 +12642,7 @@
   - common canary
   - Serinus canaria
   partOfSpeech: n
+  wikidata: Q192524
 01536292-n:
   definition:
   - any of various brown and yellow finches of parts of Europe
@@ -12591,6 +12699,7 @@
   - bullfinch
   - Pyrrhula pyrrhula
   partOfSpeech: n
+  wikidata: Q25382
 01536962-n:
   definition:
   - American finches
@@ -12624,6 +12733,7 @@
   - slate-colored junco
   - Junco hyemalis
   partOfSpeech: n
+  wikidata: Q525818
 01537403-n:
   definition:
   - sparrow-like North American finches
@@ -12657,6 +12767,7 @@
   - grass finch
   - Pooecetes gramineus
   partOfSpeech: n
+  wikidata: Q776555
 01537951-n:
   definition:
   - large New World sparrows
@@ -12694,6 +12805,7 @@
   - white-crowned sparrow
   - Zonotrichia leucophrys
   partOfSpeech: n
+  wikidata: Q686673
 01538483-n:
   definition:
   - chipping sparrow; field sparrow; tree sparrow
@@ -12719,6 +12831,7 @@
   - chipping sparrow
   - Spizella passerina
   partOfSpeech: n
+  wikidata: Q645203
 01538827-n:
   definition:
   - common North American finch of brushy pasturelands
@@ -12765,6 +12878,7 @@
   - song sparrow
   - Melospiza melodia
   partOfSpeech: n
+  wikidata: Q842599
 01539421-n:
   definition:
   - North American finch of marshy area
@@ -12853,6 +12967,7 @@
   - ortolan bunting
   - Emberiza hortulana
   partOfSpeech: n
+  wikidata: Q206630
 01540700-n:
   definition:
   - European bunting inhabiting marshy areas
@@ -12886,6 +13001,7 @@
   - yellow-breasted bunting
   - Emberiza aureola
   partOfSpeech: n
+  wikidata: Q335535
 01541139-n:
   definition:
   - snow bunting
@@ -13009,6 +13125,7 @@
   - house sparrow
   - Passer domesticus
   partOfSpeech: n
+  wikidata: Q14683
 01542731-n:
   definition:
   - Eurasian sparrow smaller than the house sparrow
@@ -13019,6 +13136,7 @@
   - tree sparrow
   - Passer montanus
   partOfSpeech: n
+  wikidata: Q25968
 01542874-n:
   definition:
   - any of various finches of Europe or America having a massive and powerful bill
@@ -13052,6 +13170,7 @@
   - evening grosbeak
   - Hesperiphona vespertina
   partOfSpeech: n
+  wikidata: Q25167830
 01543338-n:
   definition:
   - large finches
@@ -13075,6 +13194,7 @@
   - hawfinch
   - Coccothraustes coccothraustes
   partOfSpeech: n
+  wikidata: Q174088
 01543610-n:
   definition:
   - a genus of Fringillidae, containing the pine grosbeak and the crimson-browed finch
@@ -13099,6 +13219,7 @@
   - pine grosbeak
   - Pinicola enucleator
   partOfSpeech: n
+  wikidata: Q214571
 01543902-n:
   definition:
   - cardinals
@@ -13125,6 +13246,7 @@
   - Cardinalis cardinalis
   - redbird
   partOfSpeech: n
+  wikidata: Q726389
 01544259-n:
   definition:
   - large showy finches related to cardinals
@@ -13182,6 +13304,7 @@
   - cheewink
   - Pipilo erythrophthalmus
   partOfSpeech: n
+  wikidata: Q1541137
 01544957-n:
   definition:
   - towhees
@@ -13255,6 +13378,7 @@
   - baya
   - Ploceus philippinus
   partOfSpeech: n
+  wikidata: Q1319774
 01545913-n:
   definition:
   - whydahs
@@ -13304,6 +13428,7 @@
   - ricebird
   - Padda oryzivora
   partOfSpeech: n
+  wikidata: Q500278
 01546458-n:
   definition:
   - avadavats
@@ -13622,7 +13747,6 @@
   ili: i43398
   members:
   - kingbird
-  - Tyrannus tyrannus
   partOfSpeech: n
 01551133-n:
   definition:
@@ -13656,6 +13780,7 @@
   ili: i43401
   members:
   - eastern kingbird
+  - Tyrannus tyrannus
   partOfSpeech: n
   wikidata: Q1071571
 01551694-n:
@@ -13709,6 +13834,7 @@
   - western wood pewee
   - Contopus sordidulus
   partOfSpeech: n
+  wikidata: Q941102
 01552410-n:
   definition:
   - phoebes
@@ -13733,6 +13859,7 @@
   - phoebe bird
   - Sayornis phoebe
   partOfSpeech: n
+  wikidata: Q748192
 01552674-n:
   definition:
   - a genus of Tyrannidae including the scarlet flycatcher
@@ -13820,6 +13947,7 @@
   - cock of the rock
   - Rupicola rupicola
   partOfSpeech: n
+  wikidata: Q652466
 01553941-n:
   definition:
   - bird of the Andes similar to Rupicola rupicola
@@ -13913,6 +14041,7 @@
   - umbrella bird
   - Cephalopterus ornatus
   partOfSpeech: n
+  wikidata: Q2469246
 01555164-n:
   definition:
   - e.g. ovenbirds
@@ -14180,6 +14309,7 @@
   - Muscicapa striata
   - Muscicapa grisola
   partOfSpeech: n
+  wikidata: Q26607
 01559009-n:
   definition:
   - arboreal insectivorous birds
@@ -14291,6 +14421,7 @@
   - throstle
   - Turdus philomelos
   partOfSpeech: n
+  wikidata: Q26349
 01560948-n:
   definition:
   - medium-sized Eurasian thrush seen chiefly in winter
@@ -14302,6 +14433,7 @@
   - snowbird
   - Turdus pilaris
   partOfSpeech: n
+  wikidata: Q25777
 01561102-n:
   definition:
   - small European thrush having reddish flanks
@@ -14312,6 +14444,7 @@
   - redwing
   - Turdus iliacus
   partOfSpeech: n
+  wikidata: Q184825
 01561235-n:
   definition:
   - common black European thrush
@@ -14327,6 +14460,7 @@
   - European blackbird
   - Turdus merula
   partOfSpeech: n
+  wikidata: Q25234
 01561406-n:
   definition:
   - European thrush common in rocky areas; the male has blackish plumage with a white
@@ -14340,6 +14474,7 @@
   - ring thrush
   - Turdus torquatus
   partOfSpeech: n
+  wikidata: Q26641
 01561634-n:
   definition:
   - large American thrush having a rust-red breast and abdomen
@@ -14351,6 +14486,7 @@
   - American robin
   - Turdus migratorius
   partOfSpeech: n
+  wikidata: Q460967
 01561801-n:
   definition:
   - robin of Mexico and Central America
@@ -14431,6 +14567,7 @@
   - nightingale
   - Luscinia megarhynchos
   partOfSpeech: n
+  wikidata: Q25393
 01562921-n:
   definition:
   - large nightingale of eastern Europe
@@ -14484,6 +14621,7 @@
   - stonechat
   - Saxicola torquata
   partOfSpeech: n
+  wikidata: Q40658797
 01563576-n:
   definition:
   - brown-and-buff European songbird of grassy meadows
@@ -14494,6 +14632,7 @@
   - whinchat
   - Saxicola rubetra
   partOfSpeech: n
+  wikidata: Q155869
 01563700-n:
   definition:
   - solitaires
@@ -14619,6 +14758,7 @@
   - bluethroat
   - Erithacus svecicus
   partOfSpeech: n
+  wikidata: Q40654550
 01565225-n:
   definition:
   - 'in some classifications considered a subfamily (Sylviinae) of the family Muscicapidae:
@@ -14714,6 +14854,7 @@
   - golden-crested kinglet
   - Regulus regulus
   partOfSpeech: n
+  wikidata: Q26657
 01566742-n:
   definition:
   - American golden-crested kinglet
@@ -14735,6 +14876,7 @@
   - ruby-crowned wren
   - Regulus calendula
   partOfSpeech: n
+  wikidata: Q576050
 01567035-n:
   definition:
   - small active brownish or greyish Old World birds
@@ -14780,6 +14922,7 @@
   - Sylvia communis
   - Curruca communis
   partOfSpeech: n
+  wikidata: Q110257516
 01567719-n:
   definition:
   - Old World warbler similar to the greater whitethroat but smaller
@@ -14791,6 +14934,7 @@
   - whitethroat
   - Sylvia curruca
   partOfSpeech: n
+  wikidata: Q206089
 01567879-n:
   definition:
   - warblers
@@ -14812,6 +14956,7 @@
   - wood warbler
   - Phylloscopus sibilatrix
   partOfSpeech: n
+  wikidata: Q27075477
 01568121-n:
   definition:
   - a genus of Sylviidae, commonly known as marsh warblers and reed warblers (Acrocephalus)
@@ -14882,6 +15027,7 @@
   - tailorbird
   - Orthotomus sutorius
   partOfSpeech: n
+  wikidata: Q795556
 01569027-n:
   definition:
   - babblers
@@ -14984,6 +15130,7 @@
   - Wilson's blackcap
   - Wilsonia pusilla
   partOfSpeech: n
+  wikidata: Q1146827
 01570660-n:
   definition:
   - a genus of Parulidae, containing at least 33 species of New World warblers (Setophaga)
@@ -15016,6 +15163,7 @@
   - redstart
   - Setophaga ruticilla
   partOfSpeech: n
+  wikidata: Q922772
 01571134-n:
   definition:
   - a genus of Parulidae
@@ -15044,6 +15192,7 @@
   - Cape May warbler
   - Dendroica tigrina
   partOfSpeech: n
+  wikidata: Q1586243
 01571533-n:
   definition:
   - yellow-throated American wood warbler
@@ -15056,7 +15205,9 @@
   - yellowbird
   - Dendroica petechia
   partOfSpeech: n
-  wikidata: Q21962227
+  wikidata:
+  - Q21962227
+  - Q754042
 01571701-n:
   definition:
   - black-and-white North American wood warbler having an orange-and-black head and
@@ -15070,8 +15221,8 @@
   - Dendroica fusca
   partOfSpeech: n
   wikidata:
-  - Q1410964
   - Q27075919
+  - Q1410964
 01571903-n:
   definition:
   - common warbler of western North America
@@ -15083,6 +15234,7 @@
   - Audubon warbler
   - Dendroica auduboni
   partOfSpeech: n
+  wikidata: Q40654149
 01572064-n:
   definition:
   - similar to Audubon's warbler
@@ -15094,7 +15246,9 @@
   - myrtle bird
   - Dendroica coronata
   partOfSpeech: n
-  wikidata: Q2192309
+  wikidata:
+  - Q2192309
+  - Q1294154
 01572207-n:
   definition:
   - North American warbler having a black-and-white head
@@ -15138,6 +15292,7 @@
   - yellow-breasted chat
   - Icteria virens
   partOfSpeech: n
+  wikidata: Q787047
 01572753-n:
   definition:
   - ovenbirds and water thrushes
@@ -15162,6 +15317,7 @@
   - ovenbird
   - Seiurus aurocapillus
   partOfSpeech: n
+  wikidata: Q40659522
 01573062-n:
   definition:
   - brownish North American warbler found near streams
@@ -15306,6 +15462,7 @@
   - northern oriole
   - Icterus galbula
   partOfSpeech: n
+  wikidata: Q805774
 01575130-n:
   definition:
   - eastern subspecies of northern oriole
@@ -15339,6 +15496,7 @@
   - orchard oriole
   - Icterus spurius
   partOfSpeech: n
+  wikidata: Q1586976
 01575551-n:
   definition:
   - a genus of passerine birds including the meadowlarks
@@ -15383,6 +15541,7 @@
   - western meadowlark
   - Sturnella neglecta
   partOfSpeech: n
+  wikidata: Q1368136
 01576124-n:
   definition:
   - a genus of tropical American orioles
@@ -15432,6 +15591,7 @@
   - reedbird
   - Dolichonyx oryzivorus
   partOfSpeech: n
+  wikidata: Q591831
 01576686-n:
   definition:
   - any bird of the family Icteridae whose male is black or predominantly black
@@ -15475,6 +15635,7 @@
   - purple grackle
   - Quiscalus quiscula
   partOfSpeech: n
+  wikidata: Q1424486
 01577312-n:
   definition:
   - a genus of Icteridae
@@ -15595,6 +15756,7 @@
   - golden oriole
   - Oriolus oriolus
   partOfSpeech: n
+  wikidata: Q25388
 01578853-n:
   definition:
   - a genus of Old World orioles
@@ -15693,6 +15855,7 @@
   - Pastor sturnus
   - Pastor roseus
   partOfSpeech: n
+  wikidata: Q20823352
 01580300-n:
   definition:
   - tropical Asian starlings
@@ -15730,6 +15893,7 @@
   - crested myna
   - Acridotheres tristis
   partOfSpeech: n
+  wikidata: Q116667
 01580727-n:
   definition:
   - a genus containing the hill mynas (Gracula)
@@ -15753,6 +15917,7 @@
   - grackle
   - Gracula religiosa
   partOfSpeech: n
+  wikidata: Q337416
 01580982-n:
   definition:
   - crow, raven, rook, jackdaw, chough, magpie, jay
@@ -15826,6 +15991,7 @@
   - raven
   - Corvus corax
   partOfSpeech: n
+  wikidata: Q25357
 01582051-n:
   definition:
   - common gregarious Old World bird about the size and color of the American crow
@@ -15836,6 +16002,7 @@
   - rook
   - Corvus frugilegus
   partOfSpeech: n
+  wikidata: Q25386
 01582219-n:
   definition:
   - common black-and-grey Eurasian bird noted for thievery
@@ -15847,6 +16014,9 @@
   - daw
   - Corvus monedula
   partOfSpeech: n
+  wikidata:
+  - Q25345384
+  - Q25394
 01582370-n:
   definition:
   - a European corvine bird of small or medium size with red legs and glossy black
@@ -15946,6 +16116,7 @@
   - jaybird
   - Cyanocitta cristata
   partOfSpeech: n
+  wikidata: Q199758
 01583682-n:
   definition:
   - Canada jays
@@ -15974,6 +16145,7 @@
   - whisker jack
   - Perisoreus canadensis
   partOfSpeech: n
+  wikidata: Q80858
 01584075-n:
   definition:
   - a Canada jay with a white head; widely distributed from Montana to Arizona
@@ -16016,6 +16188,7 @@
   - common nutcracker
   - Nucifraga caryocatactes
   partOfSpeech: n
+  wikidata: Q184820
 01584625-n:
   definition:
   - nutcracker of the western United States
@@ -16026,6 +16199,7 @@
   - Clark's nutcracker
   - Nucifraga columbiana
   partOfSpeech: n
+  wikidata: Q1142785
 01584752-n:
   definition:
   - magpies
@@ -16058,6 +16232,7 @@
   - European magpie
   - Pica pica
   partOfSpeech: n
+  wikidata: Q25307
 01585139-n:
   definition:
   - a magpie of Rocky Mountains in North America
@@ -16093,7 +16268,6 @@
   members:
   - Australian magpie
   partOfSpeech: n
-  wikidata: Q1140949
 01585684-n:
   definition:
   - 'type genus of the Cracticidae: Australian butcherbirds'
@@ -16165,7 +16339,7 @@
   - piping crow-shrike
   - Gymnorhina tibicen
   partOfSpeech: n
-  wikidata: Q1588876
+  wikidata: Q1140949
 01586645-n:
   definition:
   - wrens
@@ -16219,6 +16393,7 @@
   - winter wren
   - Troglodytes troglodytes
   partOfSpeech: n
+  wikidata: Q25740
 01587494-n:
   definition:
   - common American wren that nests around houses
@@ -16262,6 +16437,7 @@
   - long-billed marsh wren
   - Cistothorus palustris
   partOfSpeech: n
+  wikidata: Q1379530
 01588063-n:
   definition:
   - small American wren inhabiting wet sedgy meadows
@@ -16273,6 +16449,7 @@
   - short-billed marsh wren
   - Cistothorus platensis
   partOfSpeech: n
+  wikidata: Q746317
 01588218-n:
   definition:
   - a genus of Troglodytidae
@@ -16296,6 +16473,7 @@
   - rock wren
   - Salpinctes obsoletus
   partOfSpeech: n
+  wikidata: Q935880
 01588531-n:
   definition:
   - Carolina wrens
@@ -16319,6 +16497,7 @@
   - Carolina wren
   - Thryothorus ludovicianus
   partOfSpeech: n
+  wikidata: Q1585636
 01588811-n:
   definition:
   - alternative classifications for the cactus wrens
@@ -16408,6 +16587,7 @@
   - blue mockingbird
   - Melanotis caerulescens
   partOfSpeech: n
+  wikidata: Q1587047
 01590047-n:
   definition:
   - catbirds
@@ -16517,6 +16697,7 @@
   - rock wren
   - Xenicus gilviventris
   partOfSpeech: n
+  wikidata: Q135589
 01591499-n:
   definition:
   - a genus of Xenicidae
@@ -16540,6 +16721,7 @@
   - rifleman bird
   - Acanthisitta chloris
   partOfSpeech: n
+  wikidata: Q646366
 01591766-n:
   definition:
   - creepers
@@ -16590,6 +16772,7 @@
   - American creeper
   - Certhia americana
   partOfSpeech: n
+  wikidata: Q490294
 01592534-n:
   definition:
   - common European brown-and-buff tree creeper with down-curved bill
@@ -16600,6 +16783,7 @@
   - European creeper
   - Certhia familiaris
   partOfSpeech: n
+  wikidata: Q193593
 01592683-n:
   definition:
   - wall creepers; in some classifications placed in family Sittidae
@@ -16675,6 +16859,7 @@
   - European nuthatch
   - Sitta europaea
   partOfSpeech: n
+  wikidata: Q156767
 01593764-n:
   definition:
   - bluish-grey nuthatch with reddish breast; of northern coniferous forests
@@ -16760,6 +16945,9 @@
   - Parus atricapillus
   - Poecile atricapillus
   partOfSpeech: n
+  wikidata:
+  - Q282687
+  - Q22231582
 01595028-n:
   definition:
   - crested titmouse of eastern and midwestern United States
@@ -16771,7 +16959,9 @@
   - Parus bicolor
   - Baeolophus bicolor
   partOfSpeech: n
-  wikidata: Q738534
+  wikidata:
+  - Q738534
+  - Q47456549
 01595181-n:
   definition:
   - southern United States chickadee similar to the blackcap but smaller
@@ -16783,7 +16973,9 @@
   - Parus carolinensis
   - Poecile carolinensis
   partOfSpeech: n
-  wikidata: Q1079441
+  wikidata:
+  - Q1079441
+  - Q22232931
 01595335-n:
   definition:
   - widely distributed European titmouse with bright cobalt blue wings and tail and
@@ -16797,6 +16989,9 @@
   - Parus caeruleus
   - Cyanistes caeruleus
   partOfSpeech: n
+  wikidata:
+  - Q25404
+  - Q25689712
 01595533-n:
   definition:
   - a genus of Paridae, containing the American bushtit (Psaltriparus)
@@ -16843,6 +17038,7 @@
   - wren-tit
   - Chamaea fasciata
   partOfSpeech: n
+  wikidata: Q1048896
 01596064-n:
   definition:
   - a genus of Paridae, containing the verdin (Auriparus)
@@ -16866,6 +17062,7 @@
   - verdin
   - Auriparus flaviceps
   partOfSpeech: n
+  wikidata: Q1300274
 01596346-n:
   definition:
   - a family of birds of the suborder Oscines, comprising the leafbirds, ioras, and
@@ -16956,6 +17153,7 @@
   - chimney swallow
   - Hirundo rustica
   partOfSpeech: n
+  wikidata: Q25429
 01597609-n:
   definition:
   - North American swallow that lives in colonies and builds bottle-shaped mud nests
@@ -16967,6 +17165,9 @@
   - cliff swallow
   - Hirundo pyrrhonota
   partOfSpeech: n
+  wikidata:
+  - Q1591775
+  - Q14624738
 01597809-n:
   definition:
   - of Australia and Polynesia; nests in tree cavities
@@ -16979,6 +17180,9 @@
   - Hirundo nigricans
   - Petrochelidon nigricans
   partOfSpeech: n
+  wikidata:
+  - Q2668013
+  - Q25651097
 01597971-n:
   definition:
   - a genus of Hirundinidae
@@ -17034,6 +17238,7 @@
   - house martin
   - Delichon urbica
   partOfSpeech: n
+  wikidata: Q40654079
 01598783-n:
   definition:
   - a genus of Hirundinidae containing six species, the brown-throated martin, the
@@ -17061,6 +17266,7 @@
   - sand martin
   - Riparia riparia
   partOfSpeech: n
+  wikidata: Q25909
 01599120-n:
   definition:
   - a genus of Hirundinidae containing nine American swallows, the purple martin,
@@ -17087,6 +17293,7 @@
   - purple martin
   - Progne subis
   partOfSpeech: n
+  wikidata: Q1062485
 01599402-n:
   definition:
   - wood swallows
@@ -17198,6 +17405,7 @@
   - summer redbird
   - Piranga rubra
   partOfSpeech: n
+  wikidata: Q1078246
 01600912-n:
   definition:
   - common tanager of southwestern United States and Mexico
@@ -17266,6 +17474,7 @@
   - European shrike
   - Lanius excubitor
   partOfSpeech: n
+  wikidata: Q184508
 01601910-n:
   definition:
   - a butcherbird of northern North America
@@ -17276,6 +17485,7 @@
   - northern shrike
   - Lanius borealis
   partOfSpeech: n
+  wikidata: Q31874734
 01602029-n:
   definition:
   - a butcherbird of western North America; grey with white underparts
@@ -17352,6 +17562,7 @@
   - black-fronted bush shrike
   - Chlorophoneus nigrifrons
   partOfSpeech: n
+  wikidata: Q27075292
 01603121-n:
   definition:
   - bowerbirds
@@ -17402,6 +17613,7 @@
   - satin bird
   - Ptilonorhynchus violaceus
   partOfSpeech: n
+  wikidata: Q585670
 01603909-n:
   definition:
   - a genus of Ptilonorhynchidae
@@ -17475,6 +17687,7 @@
   - European water ouzel
   - Cinclus aquaticus
   partOfSpeech: n
+  wikidata: Q107055630
 01604850-n:
   definition:
   - a water ouzel of western North America
@@ -17485,6 +17698,7 @@
   - American water ouzel
   - Cinclus mexicanus
   partOfSpeech: n
+  wikidata: Q912010
 01604994-n:
   definition:
   - small insectivorous American songbirds
@@ -17540,6 +17754,7 @@
   - solitary vireo
   - Vireo solitarius
   partOfSpeech: n
+  wikidata: Q1586476
 01605793-n:
   definition:
   - common vireo of northeastern North America with bluish slaty-grey head
@@ -17610,6 +17825,7 @@
   - Bohemian waxwing
   - Bombycilla garrulus
   partOfSpeech: n
+  wikidata: Q26135
 01606764-n:
   definition:
   - term used in former classifications; erroneously grouped together birds of the
@@ -17746,6 +17962,7 @@
   - goshawk
   - Accipiter gentilis
   partOfSpeech: n
+  wikidata: Q25353
 01609313-n:
   definition:
   - small hawk of Eurasia and northern Africa
@@ -17756,6 +17973,7 @@
   - sparrow hawk
   - Accipiter nisus
   partOfSpeech: n
+  wikidata: Q25380
 01609450-n:
   definition:
   - bluish-grey North American hawk having a darting flight
@@ -17815,6 +18033,7 @@
   - red-tailed hawk
   - Buteo jamaicensis
   partOfSpeech: n
+  wikidata: Q457471
 01610241-n:
   definition:
   - large hawk of the Northern Hemisphere that feeds chiefly on small rodents and
@@ -17827,6 +18046,7 @@
   - roughleg
   - Buteo lagopus
   partOfSpeech: n
+  wikidata: Q26407
 01610453-n:
   definition:
   - North American hawk with reddish brown shoulders
@@ -17837,6 +18057,7 @@
   - red-shouldered hawk
   - Buteo lineatus
   partOfSpeech: n
+  wikidata: Q1052043
 01610603-n:
   definition:
   - the common European short-winged hawk
@@ -17847,6 +18068,7 @@
   - buzzard
   - Buteo buteo
   partOfSpeech: n
+  wikidata: Q25385
 01610727-n:
   definition:
   - a common European bird of prey; dull brown with white-streaked underparts
@@ -17870,6 +18092,7 @@
   - honey buzzard
   - Pernis apivorus
   partOfSpeech: n
+  wikidata: Q170466
 01611073-n:
   definition:
   - any of several small graceful hawks of the family Accipitridae having long pointed
@@ -17901,6 +18124,7 @@
   - black kite
   - Milvus migrans
   partOfSpeech: n
+  wikidata: Q80362
 01611575-n:
   definition:
   - a genus of kites
@@ -17925,6 +18149,7 @@
   - swallow-tailed hawk
   - Elanoides forficatus
   partOfSpeech: n
+  wikidata: Q430540
 01611877-n:
   definition:
   - a genus of small kites of both Old and New Worlds
@@ -17984,6 +18209,7 @@
   - marsh harrier
   - Circus aeruginosus
   partOfSpeech: n
+  wikidata: Q26431
 01612741-n:
   definition:
   - brownish European harrier
@@ -17994,6 +18220,7 @@
   - Montagu's harrier
   - Circus pygargus
   partOfSpeech: n
+  wikidata: Q26574
 01612867-n:
   definition:
   - common harrier of North America and Europe; nests in marshes and open land
@@ -18006,6 +18233,7 @@
   - hen harrier
   - Circus cyaneus
   partOfSpeech: n
+  wikidata: Q25572
 01613067-n:
   definition:
   - harrier eagles
@@ -18083,6 +18311,7 @@
   - peregrine falcon
   - Falco peregrinus
   partOfSpeech: n
+  wikidata: Q30535
 01614315-n:
   definition:
   - female falcon especially a female peregrine falcon
@@ -18104,6 +18333,7 @@
   - gerfalcon
   - Falco rusticolus
   partOfSpeech: n
+  wikidata: Q177688
 01614610-n:
   definition:
   - small Old World falcon that hovers in the air against a wind
@@ -18114,6 +18344,7 @@
   - kestrel
   - Falco tinnunculus
   partOfSpeech: n
+  wikidata: Q26490
 01614763-n:
   definition:
   - small North American falcon
@@ -18126,6 +18357,7 @@
   - kestrel
   - Falco sparverius
   partOfSpeech: n
+  wikidata: Q651545
 01614916-n:
   definition:
   - small falcon of Europe and America having dark plumage with black-barred tail;
@@ -18138,6 +18370,7 @@
   - merlin
   - Falco columbarius
   partOfSpeech: n
+  wikidata: Q131918
 01615117-n:
   definition:
   - small Old World falcon formerly trained and flown at small birds
@@ -18148,6 +18381,7 @@
   - hobby
   - Falco subbuteo
   partOfSpeech: n
+  wikidata: Q25876
 01615269-n:
   definition:
   - any of various long-legged carrion-eating hawks of South America and Central America
@@ -18193,6 +18427,7 @@
   - carancha
   - Polyborus plancus
   partOfSpeech: n
+  wikidata: Q40657867
 01615935-n:
   definition:
   - any of various large keen-sighted diurnal birds of prey noted for their broad
@@ -18247,6 +18482,7 @@
   - harpy eagle
   - Harpia harpyja
   partOfSpeech: n
+  wikidata: Q53745
 01616836-n:
   definition:
   - a genus of Accipitridae, containing the true eagles (Aquila)
@@ -18272,6 +18508,7 @@
   - golden eagle
   - Aquila chrysaetos
   partOfSpeech: n
+  wikidata: Q41181
 01617197-n:
   definition:
   - brownish eagle of Africa and parts of Asia
@@ -18282,6 +18519,7 @@
   - tawny eagle
   - Aquila rapax
   partOfSpeech: n
+  wikidata: Q374141
 01617331-n:
   definition:
   - an immature golden eagle
@@ -18316,6 +18554,7 @@
   - American eagle
   - Haliaeetus leucocephalus
   partOfSpeech: n
+  wikidata: Q127216
 01617762-n:
   definition:
   - any of various large eagles that usually feed on fish
@@ -18336,6 +18575,7 @@
   - Stellar's sea eagle
   - Haliaeetus pelagicus
   partOfSpeech: n
+  wikidata: Q269896
 01618099-n:
   definition:
   - bulky greyish-brown eagle with a short wedge-shaped white tail; of Europe and
@@ -18459,6 +18699,7 @@
   - griffon
   - Gyps fulvus
   partOfSpeech: n
+  wikidata: Q177856
 01619930-n:
   definition:
   - in some classifications the type genus of the family Aegypiidae
@@ -18482,6 +18723,7 @@
   - lammergeyer
   - Gypaetus barbatus
   partOfSpeech: n
+  wikidata: Q126167
 01620274-n:
   definition:
   - a genus of Accipitridae containing the Egyptian vulture, also known as the white
@@ -18507,6 +18749,7 @@
   - Pharaoh's chicken
   - Neophron percnopterus
   partOfSpeech: n
+  wikidata: Q33504
 01620590-n:
   definition:
   - a genus of Accipitridae, containing the cinereous vulture, also known as the black
@@ -18531,6 +18774,7 @@
   - black vulture
   - Aegypius monachus
   partOfSpeech: n
+  wikidata: Q168677
 01620861-n:
   definition:
   - secretary birds
@@ -18567,6 +18811,7 @@
   - secretary bird
   - Sagittarius serpentarius
   partOfSpeech: n
+  wikidata: Q168748
 01621312-n:
   definition:
   - condors; turkey buzzards; king vultures
@@ -18654,6 +18899,7 @@
   - Andean condor
   - Vultur gryphus
   partOfSpeech: n
+  wikidata: Q170598
 01622644-n:
   definition:
   - containing solely the California condor
@@ -18675,6 +18921,7 @@
   - California condor
   - Gymnogyps californianus
   partOfSpeech: n
+  wikidata: Q194314
 01622923-n:
   definition:
   - a genus of Cathartidae
@@ -18699,6 +18946,7 @@
   - carrion crow
   - Coragyps atratus
   partOfSpeech: n
+  wikidata: Q213366
 01623216-n:
   definition:
   - usually containing only the king vulture
@@ -18804,6 +19052,7 @@
   - little owl
   - Athene noctua
   partOfSpeech: n
+  wikidata: Q129958
 01624871-n:
   definition:
   - a genus of Strigidae containing the American horned owls and the Old World eagle-owls
@@ -18837,6 +19086,7 @@
   - great horned owl
   - Bubo virginianus
   partOfSpeech: n
+  wikidata: Q81515
 01625237-n:
   definition:
   - owls lacking ear tufts
@@ -18864,6 +19114,7 @@
   - great gray owl
   - Strix nebulosa
   partOfSpeech: n
+  wikidata: Q200724
 01625600-n:
   definition:
   - reddish-brown European owl having a round head with black eyes
@@ -18874,6 +19125,7 @@
   - tawny owl
   - Strix aluco
   partOfSpeech: n
+  wikidata: Q25756
 01625751-n:
   definition:
   - large owl of eastern North America having its breast and abdomen streaked with
@@ -18885,6 +19137,7 @@
   - barred owl
   - Strix varia
   partOfSpeech: n
+  wikidata: Q630457
 01625925-n:
   definition:
   - a genus of Strigidae containing the Scops owl (Otus)
@@ -18910,6 +19163,7 @@
   - screech owl
   - Otus asio
   partOfSpeech: n
+  wikidata: Q40657257
 01626256-n:
   definition:
   - any owl that has a screeching cry
@@ -18939,6 +19193,7 @@
   - spotted owl
   - Strix occidentalis
   partOfSpeech: n
+  wikidata: Q748921
 01626756-n:
   definition:
   - European scops owl
@@ -18949,6 +19204,7 @@
   - Old World scops owl
   - Otus scops
   partOfSpeech: n
+  wikidata: Q171563
 01626853-n:
   definition:
   - Asian scops owl
@@ -18959,6 +19215,7 @@
   - Oriental scops owl
   - Otus sunia
   partOfSpeech: n
+  wikidata: Q1260390
 01626946-n:
   definition:
   - any owl that hoots as distinct from screeching
@@ -18991,6 +19248,7 @@
   - hawk owl
   - Surnia ulula
   partOfSpeech: n
+  wikidata: Q193192
 01627348-n:
   definition:
   - a genus of European owls
@@ -19076,6 +19334,7 @@
   - barn owl
   - Tyto alba
   partOfSpeech: n
+  wikidata: Q25317
 01628388-n:
   definition:
   - the class of vertebrates that live on land but breed in water, frogs, toads, newts,
@@ -19256,6 +19515,7 @@
   - European fire salamander
   - Salamandra salamandra
   partOfSpeech: n
+  wikidata: Q26395
 01632603-n:
   definition:
   - European salamander having dark skin with usually yellow spots
@@ -19277,6 +19537,7 @@
   - alpine salamander
   - Salamandra atra
   partOfSpeech: n
+  wikidata: Q259425
 01632925-n:
   definition:
   - small usually bright-colored semiaquatic salamanders of North America and Europe
@@ -19311,6 +19572,7 @@
   - common newt
   - Triturus vulgaris
   partOfSpeech: n
+  wikidata: Q50407527
 01633436-n:
   definition:
   - newts
@@ -19332,6 +19594,7 @@
   - red eft
   - Notophthalmus viridescens
   partOfSpeech: n
+  wikidata: Q1552306
 01633676-n:
   definition:
   - Pacific newts
@@ -19376,6 +19639,7 @@
   - California newt
   - Taricha torosa
   partOfSpeech: n
+  wikidata: Q1358580
 01634304-n:
   definition:
   - a newt in its terrestrial stage of development
@@ -19442,6 +19706,7 @@
   - spotted salamander
   - Ambystoma maculatum
   partOfSpeech: n
+  wikidata: Q2108247
 01635242-n:
   definition:
   - widely distributed brown or black North American salamander with vertical yellowish
@@ -19465,6 +19730,7 @@
   - mud puppy
   - Ambystoma mexicanum
   partOfSpeech: n
+  wikidata: Q22718
 01635593-n:
   definition:
   - any of several large aquatic salamanders
@@ -19512,6 +19778,7 @@
   - mud puppy
   - Cryptobranchus alleganiensis
   partOfSpeech: n
+  wikidata: Q369467
 01636219-n:
   definition:
   - giant salamanders; in some classifications included in the genus Cryptobranchus
@@ -19572,6 +19839,7 @@
   - olm
   - Proteus anguinus
   partOfSpeech: n
+  wikidata: Q15856
 01637033-n:
   definition:
   - a genus of Proteidae
@@ -19668,6 +19936,7 @@
   - olympic salamander
   - Rhyacotriton olympicus
   partOfSpeech: n
+  wikidata: Q786946
 01638300-n:
   definition:
   - small mostly terrestrial New World salamanders having neither lungs nor gills
@@ -19722,6 +19991,7 @@
   - eastern red-backed salamander
   - Plethodon cinereus
   partOfSpeech: n
+  wikidata: Q1092717
 01639151-n:
   definition:
   - salamander of the Pacific coast of North America
@@ -19732,6 +20002,7 @@
   - western red-backed salamander
   - Plethodon vehiculum
   partOfSpeech: n
+  wikidata: Q2510325
 01639316-n:
   definition:
   - an amphibian genus of Plethodontidae
@@ -19855,6 +20126,7 @@
   - limestone salamander
   - Hydromantes brunus
   partOfSpeech: n
+  wikidata: Q308239
 01641123-n:
   definition:
   - the family of congo snakes (Amphiumidae)
@@ -20031,6 +20303,9 @@
   - Rana sylvatica
   - Lithobates sylvaticus
   partOfSpeech: n
+  wikidata:
+  - Q4666317
+  - Q72725
 01644032-n:
   definition:
   - common North American green or brownish frog having white-edged dark oval spots
@@ -20043,6 +20318,9 @@
   - Rana pipiens
   - Lithobates pipiens
   partOfSpeech: n
+  wikidata:
+  - Q1819586
+  - Q26830590
 01644218-n:
   definition:
   - largest North American frog; highly aquatic with a deep-pitched voice
@@ -20054,6 +20332,9 @@
   - Rana catesbeiana
   - Lithobates catesbeianus
   partOfSpeech: n
+  wikidata:
+  - Q4667413
+  - Q159404
 01644380-n:
   definition:
   - similar to bullfrog; found in or near marshes and ponds; of United States and
@@ -20067,6 +20348,9 @@
   - Rana clamitans
   - Lithobates clamitans
   partOfSpeech: n
+  wikidata:
+  - Q4667968
+  - Q159363
 01644571-n:
   definition:
   - mountain frog found near water; of United States Northwest to California
@@ -20100,6 +20384,9 @@
   - Rana palustris
   - Lithobates palustris
   partOfSpeech: n
+  wikidata:
+  - Q28035920
+  - Q469979
 01645032-n:
   definition:
   - Mexican frog found within a jump or two of water
@@ -20111,6 +20398,9 @@
   - Rana tarahumarae
   - Lithobates tarahumarae
   partOfSpeech: n
+  wikidata:
+  - Q4666261
+  - Q3061934
 01645180-n:
   definition:
   - a common semiterrestrial European frog
@@ -20121,6 +20411,7 @@
   - grass frog
   - Rana temporaria
   partOfSpeech: n
+  wikidata: Q27465
 01645312-n:
   definition:
   - New World frogs; in some classifications essentially coextensive with the family
@@ -20219,6 +20510,7 @@
   - South American bullfrog
   - Leptodactylus pentadactylus
   partOfSpeech: n
+  wikidata: Q2136945
 01646745-n:
   definition:
   - Old World tree frogs
@@ -20390,6 +20682,7 @@
   - agua toad
   - Bufo marinus
   partOfSpeech: n
+  wikidata: Q13165156
 01649196-n:
   definition:
   - common toad of Europe
@@ -20400,6 +20693,7 @@
   - European toad
   - Bufo bufo
   partOfSpeech: n
+  wikidata: Q146375
 01649289-n:
   definition:
   - common brownish-yellow short-legged toad of western Europe; runs rather than hops
@@ -20410,6 +20704,9 @@
   - natterjack
   - Bufo calamita
   partOfSpeech: n
+  wikidata:
+  - Q622886
+  - Q50407495
 01649443-n:
   definition:
   - common toad of America
@@ -20421,6 +20718,7 @@
   - Bufo americanus
   - Anaxyrus americanus
   partOfSpeech: n
+  wikidata: Q694496
 01649543-n:
   definition:
   - Eurasian toad with variable chiefly green coloring
@@ -20432,6 +20730,7 @@
   - Bufo viridis
   - Bufotes viridis
   partOfSpeech: n
+  wikidata: Q21245936
 01649674-n:
   definition:
   - small green or yellow-green toad with small black bars and stripes
@@ -20443,6 +20742,9 @@
   - Bufo debilis
   - Anaxyrus debilis
   partOfSpeech: n
+  wikidata:
+  - Q2665299
+  - Q28032129
 01649821-n:
   definition:
   - of high Sierra Nevada meadows and forest borders
@@ -20454,6 +20756,9 @@
   - Bufo canorus
   - Anaxyrus canorus
   partOfSpeech: n
+  wikidata:
+  - Q302397
+  - Q24248378
 01649944-n:
   definition:
   - nocturnal burrowing toad of mesquite woodland and prairies of the United States
@@ -20466,6 +20771,7 @@
   - Bufo speciosus
   - Anaxyrus speciosus
   partOfSpeech: n
+  wikidata: Q28032645
 01650107-n:
   definition:
   - a uniformly warty stocky toad of washes and streams of semiarid southwestern United
@@ -20488,6 +20794,9 @@
   - western toad
   - Bufo boreas
   partOfSpeech: n
+  wikidata:
+  - Q2191167
+  - Q109525827
 01650444-n:
   definition:
   - family of Old World toads having a fixed disklike tongue
@@ -20528,6 +20837,7 @@
   - midwife toad
   - Alytes obstetricans
   partOfSpeech: n
+  wikidata: Q837990
 01650997-n:
   definition:
   - similar in habit to Alytes obstetricians
@@ -20562,6 +20872,7 @@
   - fire-bellied toad
   - Bombina bombina
   partOfSpeech: n
+  wikidata: Q372267
 01651459-n:
   definition:
   - the amphibian family of spadefoot toads
@@ -20612,6 +20923,9 @@
   - western spadefoot
   - Scaphiopus hammondii
   partOfSpeech: n
+  wikidata:
+  - Q3101052
+  - Q109528215
 01652197-n:
   definition:
   - this spadefoot toad lives in the southwestern United States
@@ -20688,6 +21002,9 @@
   - spring peeper
   - Hyla crucifer
   partOfSpeech: n
+  wikidata:
+  - Q135015
+  - Q109526434
 01653542-n:
   definition:
   - the most commonly heard frog on the Pacific coast of America
@@ -20698,6 +21015,9 @@
   - Pacific tree toad
   - Hyla regilla
   partOfSpeech: n
+  wikidata:
+  - Q2336996
+  - Q41083826
 01653700-n:
   definition:
   - a small chiefly ground dweller that stays within easy jumping distance of water;
@@ -20710,6 +21030,9 @@
   - Hyla arenicolor
   - Dryophytes arenicolor
   partOfSpeech: n
+  wikidata:
+  - Q32344826
+  - Q2702096
 01653926-n:
   definition:
   - a form of tree toad
@@ -20751,6 +21074,7 @@
   - northern cricket frog
   - Acris crepitans
   partOfSpeech: n
+  wikidata: Q2673608
 01654419-n:
   definition:
   - a cricket frog of eastern United States
@@ -20850,6 +21174,7 @@
   - western narrow-mouthed toad
   - Gastrophryne olivacea
   partOfSpeech: n
+  wikidata: Q2720420
 01655864-n:
   definition:
   - small toad of southeastern United States
@@ -20860,6 +21185,7 @@
   - eastern narrow-mouthed toad
   - Gastrophryne carolinensis
   partOfSpeech: n
+  wikidata: Q2181155
 01656025-n:
   definition:
   - sheep frogs
@@ -21296,6 +21622,7 @@
   - loggerhead turtle
   - Caretta caretta
   partOfSpeech: n
+  wikidata: Q192095
 01666885-n:
   definition:
   - ridleys
@@ -21330,6 +21657,7 @@
   - bastard turtle
   - Lepidochelys kempii
   partOfSpeech: n
+  wikidata: Q301089
 01667315-n:
   definition:
   - olive-colored sea turtle of tropical Pacific and Indian and the southern Atlantic
@@ -21342,6 +21670,7 @@
   - olive ridley
   - Lepidochelys olivacea
   partOfSpeech: n
+  wikidata: Q282385
 01667503-n:
   definition:
   - hawksbills
@@ -21369,6 +21698,7 @@
   - tortoiseshell turtle
   - Eretmochelys imbricata
   partOfSpeech: n
+  wikidata: Q203538
 01667879-n:
   definition:
   - sea turtles
@@ -21407,6 +21737,7 @@
   - leathery turtle
   - Dermochelys coriacea
   partOfSpeech: n
+  wikidata: Q120043
 01668402-n:
   definition:
   - family of turtles containing two genera, Chelydra and Macrochelys (Chelydridae)
@@ -21456,6 +21787,7 @@
   - snapper
   - Chelydra serpentina
   partOfSpeech: n
+  wikidata: Q289435
 01669072-n:
   definition:
   - includes the alligator snapping turtle
@@ -21633,6 +21965,7 @@
   - yellow-bellied terrapin
   - Pseudemys scripta
   partOfSpeech: n
+  wikidata: Q106448853
 01671533-n:
   definition:
   - large river turtle of the southern United States and northern Mexico
@@ -21679,6 +22012,7 @@
   - Western box turtle
   - Terrapene ornata
   partOfSpeech: n
+  wikidata: Q2302528
 01672168-n:
   definition:
   - painted turtles
@@ -21705,6 +22039,7 @@
   - painted tortoise
   - Chrysemys picta
   partOfSpeech: n
+  wikidata: Q199203
 01672524-n:
   definition:
   - land tortoises
@@ -21756,6 +22091,7 @@
   - European tortoise
   - Testudo graeca
   partOfSpeech: n
+  wikidata: Q504549
 01673314-n:
   definition:
   - giant tortoises
@@ -21826,6 +22162,7 @@
   - desert tortoise
   - Gopherus agassizii
   partOfSpeech: n
+  wikidata: Q914356
 01674346-n:
   definition:
   - close relative to the desert tortoise; may be reclassified as a member of genus
@@ -21885,6 +22222,7 @@
   - spiny softshell
   - Trionyx spiniferus
   partOfSpeech: n
+  wikidata: Q106449030
 01675252-n:
   definition:
   - river turtle of Mississippi basin; prefers running water
@@ -21895,6 +22233,7 @@
   - smooth softshell
   - Trionyx muticus
   partOfSpeech: n
+  wikidata: Q106449022
 01675408-n:
   definition:
   - 'diapsid reptiles: lizards, snakes, tuataras'
@@ -22173,6 +22512,7 @@
   - iguana
   - Iguana iguana
   partOfSpeech: n
+  wikidata: Q215376
 01680254-n:
   definition:
   - marine iguanas
@@ -22196,6 +22536,7 @@
   - marine iguana
   - Amblyrhynchus cristatus
   partOfSpeech: n
+  wikidata: Q208796
 01680554-n:
   definition:
   - desert iguanas
@@ -22220,6 +22561,7 @@
   - desert iguana
   - Dipsosaurus dorsalis
   partOfSpeech: n
+  wikidata: Q912330
 01680878-n:
   definition:
   - chuckwallas
@@ -22268,6 +22610,7 @@
   - gridiron-tailed lizard
   - Callisaurus draconoides
   partOfSpeech: n
+  wikidata: Q169498
 01681528-n:
   definition:
   - fringe-toed lizard
@@ -22455,6 +22798,7 @@
   - sand lizard
   - Uta stansburiana
   partOfSpeech: n
+  wikidata: Q1414026
 01684154-n:
   definition:
   - a reptile genus of Iguanidae, containing the tree and brush lizards (Urosaurus)
@@ -22514,6 +22858,7 @@
   - Texas horned lizard
   - Phrynosoma cornutum
   partOfSpeech: n
+  wikidata: Q748410
 01684934-n:
   definition:
   - a reptile genus of Iguanidae, containing the basilisks (Basiliscus)
@@ -22561,6 +22906,7 @@
   - anole
   - Anolis carolinensis
   partOfSpeech: n
+  wikidata: Q930252
 01685561-n:
   definition:
   - worm lizards
@@ -22791,6 +23137,7 @@
   - six-lined racerunner
   - Cnemidophorus sexlineatus
   partOfSpeech: n
+  wikidata: Q18324831
 01688861-n:
   definition:
   - 'having distinct longitudinal stripes: of Colorado Plateau from Arizona to western
@@ -22802,6 +23149,7 @@
   - plateau striped whiptail
   - Cnemidophorus velox
   partOfSpeech: n
+  wikidata: Q5085972
 01689044-n:
   definition:
   - having longitudinal stripes overlaid with light spots; upland lizard of United
@@ -22813,6 +23161,7 @@
   - Chihuahuan spotted whiptail
   - Cnemidophorus exsanguis
   partOfSpeech: n
+  wikidata: Q43306334
 01689250-n:
   definition:
   - active lizard having a network of dusky dark markings; of semiarid areas from
@@ -22835,6 +23184,7 @@
   - checkered whiptail
   - Cnemidophorus tesselatus
   partOfSpeech: n
+  wikidata: Q43308270
 01689650-n:
   definition:
   - tejus
@@ -22998,6 +23348,7 @@
   - spiny lizard
   - Moloch horridus
   partOfSpeech: n
+  wikidata: Q320665
 01691867-n:
   definition:
   - a family of lizards including slowworms, glass lizards and alligator lizards (Anguidae)
@@ -23072,6 +23423,7 @@
   - slowworm
   - Anguis fragilis
   partOfSpeech: n
+  wikidata: Q183660
 01692980-n:
   definition:
   - glass lizards
@@ -23292,6 +23644,7 @@
   - sand lizard
   - Lacerta agilis
   partOfSpeech: n
+  wikidata: Q148595
 01695975-n:
   definition:
   - a common Eurasian lizard about a foot long
@@ -23302,6 +23655,7 @@
   - green lizard
   - Lacerta viridis
   partOfSpeech: n
+  wikidata: Q307047
 01696113-n:
   definition:
   - Old World chameleons; in some classifications they are considered a superfamily
@@ -23368,6 +23722,9 @@
   - horned chameleon
   - Chamaeleo oweni
   partOfSpeech: n
+  wikidata:
+  - Q3539439
+  - Q29860846
 01697071-n:
   definition:
   - monitor lizards
@@ -23416,6 +23773,7 @@
   - African monitor
   - Varanus niloticus
   partOfSpeech: n
+  wikidata: Q737896
 01697701-n:
   definition:
   - the largest lizard in the world (10 feet); found on Indonesian islands
@@ -23575,6 +23933,7 @@
   - Nile crocodile
   - Crocodylus niloticus
   partOfSpeech: n
+  wikidata: Q168745
 01700252-n:
   definition:
   - estuarine crocodile of eastern Asia and Pacific islands
@@ -23585,6 +23944,7 @@
   - Asian crocodile
   - Crocodylus porosus
   partOfSpeech: n
+  wikidata: Q182599
 01700390-n:
   definition:
   - a variety of crocodile
@@ -23675,6 +24035,7 @@
   - Chinese alligator
   - Alligator sinensis
   partOfSpeech: n
+  wikidata: Q194422
 01701577-n:
   definition:
   - caimans
@@ -23708,6 +24069,7 @@
   - spectacled caiman
   - Caiman sclerops
   partOfSpeech: n
+  wikidata: Q107333250
 01702056-n:
   definition:
   - gavials
@@ -25712,6 +26074,7 @@
   - rough green snake
   - Opheodrys aestivus
   partOfSpeech: n
+  wikidata: Q426062
 01733070-n:
   definition:
   - African green snakes
@@ -25768,6 +26131,7 @@
   - black racer
   - Coluber constrictor
   partOfSpeech: n
+  wikidata: Q1459098
 01733778-n:
   definition:
   - bluish-green blacksnake found from Ohio to Texas
@@ -25788,6 +26152,9 @@
   - horseshoe whipsnake
   - Coluber hippocrepis
   partOfSpeech: n
+  wikidata:
+  - Q540927
+  - Q50824374
 01734059-n:
   definition:
   - whip snakes
@@ -25823,6 +26190,7 @@
   - coachwhip snake
   - Masticophis flagellum
   partOfSpeech: n
+  wikidata: Q43373908
 01734582-n:
   definition:
   - a whipsnake of scrublands and rocky hillsides
@@ -25834,7 +26202,9 @@
   - striped racer
   - Masticophis lateralis
   partOfSpeech: n
-  wikidata: Q2135031
+  wikidata:
+  - Q2135031
+  - Q26849100
 01734734-n:
   definition:
   - both terrestrial and arboreal snake of United States southwest
@@ -25881,6 +26251,7 @@
   - red rat snake
   - Elaphe guttata
   partOfSpeech: n
+  wikidata: Q22915197
 01735430-n:
   definition:
   - large harmless shiny black North American snake
@@ -25894,6 +26265,7 @@
   - mountain blacksnake
   - Elaphe obsoleta
   partOfSpeech: n
+  wikidata: Q18324838
 01735630-n:
   definition:
   - large North American snake
@@ -25949,6 +26321,7 @@
   - glossy snake
   - Arizona elegans
   partOfSpeech: n
+  wikidata: Q670937
 01736275-n:
   definition:
   - bull snakes
@@ -25982,6 +26355,7 @@
   - gopher snake
   - Pituophis melanoleucus
   partOfSpeech: n
+  wikidata: Q1663774
 01736745-n:
   definition:
   - any of several bull snakes of eastern and southeastern United States found chiefly
@@ -26040,6 +26414,7 @@
   - checkered adder
   - Lampropeltis triangulum
   partOfSpeech: n
+  wikidata: Q1257513
 01737703-n:
   definition:
   - garter snakes
@@ -26096,6 +26471,7 @@
   - Western ribbon snake
   - Thamnophis proximus
   partOfSpeech: n
+  wikidata: Q2565456
 01738539-n:
   definition:
   - lined snakes
@@ -26120,6 +26496,7 @@
   - lined snake
   - Tropidoclonion lineatum
   partOfSpeech: n
+  wikidata: Q2156927
 01738897-n:
   definition:
   - a genus of colubrid snakes commonly referred to as ground snakes (Sonora)
@@ -26144,6 +26521,7 @@
   - ground snake
   - Sonora semiannulata
   partOfSpeech: n
+  wikidata: Q3021047
 01739210-n:
   definition:
   - ground snakes
@@ -26171,6 +26549,7 @@
   - Potamophis striatula
   - Haldea striatula
   partOfSpeech: n
+  wikidata: Q3019094
 01739662-n:
   definition:
   - any of various mostly harmless snakes that live in or near water
@@ -26218,6 +26597,7 @@
   - Natrix sipedon
   - Nerodia sipedon
   partOfSpeech: n
+  wikidata: Q2163958
 01740369-n:
   definition:
   - any of numerous North American water snakes inhabiting fresh waters
@@ -26239,6 +26619,7 @@
   - ringed snake
   - Natrix natrix
   partOfSpeech: n
+  wikidata: Q170713
 01740706-n:
   definition:
   - a small harmless grass snake
@@ -26249,6 +26630,7 @@
   - viperine grass snake
   - Natrix maura
   partOfSpeech: n
+  wikidata: Q1541871
 01740816-n:
   definition:
   - a genus of Colubridae containing three species of brown snake and the redbelly
@@ -26407,6 +26789,7 @@
   - night snake
   - Hypsiglena torquata
   partOfSpeech: n
+  wikidata: Q922205
 01742924-n:
   definition:
   - blind snakes
@@ -26490,6 +26873,7 @@
   - gopher snake
   - Drymarchon corais
   partOfSpeech: n
+  wikidata: Q3014273
 01744083-n:
   definition:
   - a variety of indigo snake
@@ -26572,6 +26956,7 @@
   - tow-headed snake
   - Charina bottae
   partOfSpeech: n
+  wikidata: Q302823
 01745321-n:
   definition:
   - boas of western North America
@@ -26619,6 +27004,7 @@
   - anaconda
   - Eunectes murinus
   partOfSpeech: n
+  wikidata: Q207347
 01745864-n:
   definition:
   - 'Old World boas: pythons; in some classifications considered a separate family
@@ -26688,6 +27074,7 @@
   - reticulated python
   - Python reticulatus
   partOfSpeech: n
+  wikidata: Q216136
 01746911-n:
   definition:
   - very large python of southeast Asia
@@ -26698,6 +27085,7 @@
   - Indian python
   - Python molurus
   partOfSpeech: n
+  wikidata: Q245183
 01747042-n:
   definition:
   - very large python of tropical and southern Africa
@@ -26709,6 +27097,7 @@
   - rock snake
   - Python sebae
   partOfSpeech: n
+  wikidata: Q764797
 01747196-n:
   definition:
   - a python having the color of amethyst
@@ -26791,6 +27180,7 @@
   - eastern coral snake
   - Micrurus fulvius
   partOfSpeech: n
+  wikidata: Q1513945
 01748704-n:
   definition:
   - a monotypic genus containing only the western coral snake
@@ -26814,6 +27204,7 @@
   - western coral snake
   - Micruroides euryxanthus
   partOfSpeech: n
+  wikidata: Q167912
 01749000-n:
   definition:
   - any of various venomous elapid snakes of Asia and Africa and Australia
@@ -26872,6 +27263,7 @@
   - African coral snake
   - Aspidelaps lubricus
   partOfSpeech: n
+  wikidata: Q1285063
 01749785-n:
   definition:
   - Australian coral snakes
@@ -26965,6 +27357,7 @@
   - Indian cobra
   - Naja naja
   partOfSpeech: n
+  wikidata: Q192754
 01751030-n:
   definition:
   - cobra used by the Pharaohs as a symbol of their power over life and death
@@ -27002,6 +27395,7 @@
   - spitting cobra
   - Naja nigricollis
   partOfSpeech: n
+  wikidata: Q386619
 01751547-n:
   definition:
   - large cobra of southeastern Asia and the East Indies; the largest venomous snake;
@@ -27015,6 +27409,7 @@
   - Ophiophagus hannah
   - Naja hannah
   partOfSpeech: n
+  wikidata: Q48186
 01751782-n:
   definition:
   - ringhals
@@ -27038,6 +27433,7 @@
   - spitting snake
   - Hemachatus haemachatus
   partOfSpeech: n
+  wikidata: Q169936
 01752069-n:
   definition:
   - mambas
@@ -27105,6 +27501,7 @@
   - death adder
   - Acanthophis antarcticus
   partOfSpeech: n
+  wikidata: Q1454860
 01752956-n:
   definition:
   - tiger snakes
@@ -27128,6 +27525,7 @@
   - tiger snake
   - Notechis scutatus
   partOfSpeech: n
+  wikidata: Q1520949
 01753239-n:
   definition:
   - venomous Australian blacksnakes
@@ -27151,6 +27549,7 @@
   - Australian blacksnake
   - Pseudechis porphyriacus
   partOfSpeech: n
+  wikidata: Q2005433
 01753561-n:
   definition:
   - kraits
@@ -27185,6 +27584,7 @@
   - banded adder
   - Bungarus fasciatus
   partOfSpeech: n
+  wikidata: Q40581
 01753994-n:
   definition:
   - taipans
@@ -27208,6 +27608,7 @@
   - taipan
   - Oxyuranus scutellatus
   partOfSpeech: n
+  wikidata: Q2321476
 01754262-n:
   definition:
   - sea snakes
@@ -27282,6 +27683,7 @@
   - common viper
   - Vipera berus
   partOfSpeech: n
+  wikidata: Q192056
 01755377-n:
   definition:
   - of southern Europe; similar to but smaller than the adder
@@ -27293,6 +27695,7 @@
   - asp viper
   - Vipera aspis
   partOfSpeech: n
+  wikidata: Q572447
 01755530-n:
   definition:
   - a genus of Viperidae
@@ -27317,6 +27720,7 @@
   - puff adder
   - Bitis arietans
   partOfSpeech: n
+  wikidata: Q369667
 01755821-n:
   definition:
   - large heavy-bodied brilliantly marked and extremely venomous west African viper
@@ -27327,6 +27731,7 @@
   - gaboon viper
   - Bitis gabonica
   partOfSpeech: n
+  wikidata: Q371183
 01755995-n:
   definition:
   - horned vipers
@@ -27410,6 +27815,7 @@
   - copperhead
   - Agkistrodon contortrix
   partOfSpeech: n
+  wikidata: Q1248772
 01757174-n:
   definition:
   - venomous semiaquatic snake of swamps in southern United States
@@ -27510,6 +27916,7 @@
   - Western rattlesnake
   - Crotalus viridis
   partOfSpeech: n
+  wikidata: Q1515347
 01758932-n:
   definition:
   - small pale-colored desert rattlesnake of southwestern United States; body moves
@@ -27535,6 +27942,7 @@
   - Western diamondback rattlesnake
   - Crotalus atrox
   partOfSpeech: n
+  wikidata: Q222287
 01759374-n:
   definition:
   - mountain rock dweller of Mexico and most southern parts of United States southwest
@@ -27545,6 +27953,7 @@
   - rock rattlesnake
   - Crotalus lepidus
   partOfSpeech: n
+  wikidata: Q646391
 01759557-n:
   definition:
   - having irregularly cross-banded back; of arid foothills and canyons of southern
@@ -27556,6 +27965,7 @@
   - tiger rattlesnake
   - Crotalus tigris
   partOfSpeech: n
+  wikidata: Q617863
 01759756-n:
   definition:
   - extremely dangerous; most common in areas of scattered scrubby growth; from Mojave
@@ -27579,6 +27989,7 @@
   - speckled rattlesnake
   - Crotalus mitchellii
   partOfSpeech: n
+  wikidata: Q1498023
 01760188-n:
   definition:
   - pygmy rattlesnakes
@@ -27604,6 +28015,7 @@
   - massasauga rattler
   - Sistrurus catenatus
   partOfSpeech: n
+  wikidata: Q1371648
 01760542-n:
   definition:
   - small pygmy rattlesnake
@@ -28012,6 +28424,7 @@
   - vinegarroon
   - Mastigoproctus giganteus
   partOfSpeech: n
+  wikidata: Q3020933
 01774607-n:
   definition:
   - spiders
@@ -28119,6 +28532,7 @@
   - barn spider
   - Araneus cavaticus
   partOfSpeech: n
+  wikidata: Q1306991
 01776438-n:
   definition:
   - a spider common in European gardens
@@ -28177,6 +28591,7 @@
   - black widow
   - Latrodectus mactans
   partOfSpeech: n
+  wikidata: Q113297
 01777236-n:
   definition:
   - large tropical spiders; tarantulas
@@ -28368,6 +28783,7 @@
   - Ixodes dammini
   - deer tick
   partOfSpeech: n
+  wikidata: Q129496515
 01780108-n:
   definition:
   - a tick that usually does not bite humans; transmits Lyme disease spirochete to
@@ -28389,6 +28805,7 @@
   - Ixodes pacificus
   - western black-legged tick
   partOfSpeech: n
+  wikidata: Q2714455
 01780550-n:
   definition:
   - parasitic on mice of genus Peromyscus and bites humans; principal vector for Lyme
@@ -28401,6 +28818,7 @@
   - Ixodes scapularis
   - black-legged tick
   partOfSpeech: n
+  wikidata: Q1497962
 01780858-n:
   definition:
   - parasitic on sheep and cattle as well as humans; can transmit louping ill in sheep
@@ -28434,6 +28852,7 @@
   members:
   - Ixodes dentatus
   partOfSpeech: n
+  wikidata: Q10538610
 01781442-n:
   definition:
   - a species of hard-bodied tick; transmits Lyme disease spirochete to cottontail
@@ -28444,6 +28863,7 @@
   members:
   - Ixodes spinipalpis
   partOfSpeech: n
+  wikidata: Q10538746
 01781625-n:
   definition:
   - vectors of important diseases of man and animals
@@ -28714,6 +29134,7 @@
   - red spider mite
   - Panonychus ulmi
   partOfSpeech: n
+  wikidata: Q640085
 01785316-n:
   definition:
   - used in some classifications to encompass the millipedes (Diplopoda) and centipedes
@@ -28787,6 +29208,7 @@
   - symphilid
   - Scutigerella immaculata
   partOfSpeech: n
+  wikidata: Q6497995
 01786577-n:
   definition:
   - 'in some classifications considered a separate phylum: microscopic arachnid-like
@@ -28907,6 +29329,7 @@
   - house centipede
   - Scutigera coleoptrata
   partOfSpeech: n
+  wikidata: Q367643
 01788472-n:
   definition:
   - small elongate centipedes living in soil and under stones and having more than
@@ -29066,7 +29489,9 @@
   - Limulus polyphemus
   - Xiphosurus polyphemus
   partOfSpeech: n
-  wikidata: Q1329239
+  wikidata:
+  - Q1329239
+  - Q1133152
 01790798-n:
   definition:
   - a genus of Limulidae
@@ -29305,6 +29730,7 @@
   mero_part:
   - 07660576-n
   partOfSpeech: n
+  wikidata: Q184774
 01794595-n:
   definition:
   - any of various small breeds of fowl
@@ -29498,6 +29924,7 @@
   - turkey
   - Meleagris gallopavo
   partOfSpeech: n
+  wikidata: Q26844
 01796985-n:
   definition:
   - male turkey
@@ -29598,6 +30025,7 @@
   - heathfowl
   - Lyrurus tetrix
   partOfSpeech: n
+  wikidata: Q155878
 01798541-n:
   definition:
   - a black grouse of western Asia
@@ -29608,6 +30036,7 @@
   - Asian black grouse
   - Lyrurus mlokosiewiczi
   partOfSpeech: n
+  wikidata: Q845408
 01798660-n:
   definition:
   - male black grouse
@@ -29668,6 +30097,7 @@
   - moorgame
   - Lagopus scoticus
   partOfSpeech: n
+  wikidata: Q40655821
 01799370-n:
   definition:
   - female red grouse
@@ -29735,6 +30165,7 @@
   - spruce grouse
   - Canachites canadensis
   partOfSpeech: n
+  wikidata: Q117253054
 01800113-n:
   definition:
   - sage grouse
@@ -29784,6 +30215,7 @@
   - partridge
   - Bonasa umbellus
   partOfSpeech: n
+  wikidata: Q19058
 01800693-n:
   definition:
   - sharp-tailed grouse
@@ -29840,6 +30272,7 @@
   - greater prairie chicken
   - Tympanuchus cupido
   partOfSpeech: n
+  wikidata: Q19630
 01801480-n:
   definition:
   - a smaller prairie chicken of western Texas
@@ -30044,6 +30477,7 @@
   - lowan
   - Leipoa ocellata
   partOfSpeech: n
+  wikidata: Q901228
 01804313-n:
   definition:
   - adult female mallee fowl
@@ -30076,6 +30510,7 @@
   - brush turkey
   - Alectura lathami
   partOfSpeech: n
+  wikidata: Q632066
 01804674-n:
   definition:
   - maleos
@@ -30099,6 +30534,7 @@
   - maleo
   - Macrocephalon maleo
   partOfSpeech: n
+  wikidata: Q836291
 01804950-n:
   definition:
   - pheasants, quails, partridges
@@ -30170,6 +30606,7 @@
   mero_part:
   - 07663211-n
   partOfSpeech: n
+  wikidata: Q25432
 01806189-n:
   definition:
   - Congo peafowl
@@ -30191,6 +30628,7 @@
   - Congo peafowl
   - Afropavo congensis
   partOfSpeech: n
+  wikidata: Q338996
 01806405-n:
   definition:
   - argus pheasants
@@ -30237,6 +30675,7 @@
   - golden pheasant
   - Chrysolophus pictus
   partOfSpeech: n
+  wikidata: Q335113
 01806981-n:
   definition:
   - the bobwhites (Colinus)
@@ -30271,6 +30710,7 @@
   - northern bobwhite
   - Colinus virginianus
   partOfSpeech: n
+  wikidata: Q142651
 01807437-n:
   definition:
   - Old World quail
@@ -30304,6 +30744,7 @@
   - Coturnix coturnix
   - Coturnix communis
   partOfSpeech: n
+  wikidata: Q28358
 01807840-n:
   definition:
   - monals
@@ -30520,6 +30961,7 @@
   - gray partridge
   - Perdix perdix
   partOfSpeech: n
+  wikidata: Q26106
 01810629-n:
   definition:
   - a genus of Perdicidae
@@ -30556,6 +30998,7 @@
   - rock partridge
   - Alectoris graeca
   partOfSpeech: n
+  wikidata: Q492684
 01811088-n:
   definition:
   - mountain quail of western United States
@@ -30622,6 +31065,7 @@
   mero_part:
   - 07661893-n
   partOfSpeech: n
+  wikidata: Q251842
 01812012-n:
   definition:
   - female guinea fowl
@@ -30670,6 +31114,7 @@
   - stinkbird
   - Opisthocomus hoazin
   partOfSpeech: n
+  wikidata: Q188660
 01812618-n:
   definition:
   - coextensive with the family Tinamidae
@@ -30770,6 +31215,7 @@
   - dodo
   - Raphus cucullatus
   partOfSpeech: n
+  wikidata: Q43502
 01814035-n:
   definition:
   - constituted by the extinct solitaire
@@ -30793,6 +31239,7 @@
   - solitaire
   - Pezophaps solitaria
   partOfSpeech: n
+  wikidata: Q528572
 01814323-n:
   definition:
   - doves and pigeons
@@ -30867,6 +31314,7 @@
   - rock pigeon
   - Columba livia
   partOfSpeech: n
+  wikidata: Q42326
 01815507-n:
   definition:
   - wild pigeon of western North America; often mistaken for the now extinct passenger
@@ -30892,6 +31340,7 @@
   - cushat
   - Columba palumbus
   partOfSpeech: n
+  wikidata: Q26026
 01815897-n:
   definition:
   - turtledoves
@@ -30923,6 +31372,7 @@
   members:
   - Streptopelia turtur
   partOfSpeech: n
+  wikidata: Q168514
 01816299-n:
   definition:
   - greyish Old World turtledove with a black band around the neck; often caged
@@ -31063,6 +31513,7 @@
   - passenger pigeon
   - Ectopistes migratorius
   partOfSpeech: n
+  wikidata: Q191968
 01818072-n:
   definition:
   - sandgrouses
@@ -31113,6 +31564,7 @@
   - painted sandgrouse
   - Pterocles indicus
   partOfSpeech: n
+  wikidata: Q127884
 01818781-n:
   definition:
   - sandgrouse of Europe and Africa having elongated middle tail feathers
@@ -31124,6 +31576,7 @@
   - pin-tailed grouse
   - Pterocles alchata
   partOfSpeech: n
+  wikidata: Q753741
 01818977-n:
   definition:
   - a genus of Pteroclididae
@@ -31147,6 +31600,7 @@
   - pallas's sandgrouse
   - Syrrhaptes paradoxus
   partOfSpeech: n
+  wikidata: Q128002
 01819276-n:
   definition:
   - an order of birds including parrots and amazons and cockatoos and lorikeets and
@@ -31239,6 +31693,7 @@
   - African gray
   - Psittacus erithacus
   partOfSpeech: n
+  wikidata: Q220328
 01820810-n:
   definition:
   - a genus of Psittacidae, containing the Amazon parrots (Amazona)
@@ -31309,6 +31764,7 @@
   - kea
   - Nestor notabilis
   partOfSpeech: n
+  wikidata: Q193337
 01821600-n:
   definition:
   - a genus of Psittacidae containing the cockatoos, found from the Philippines and
@@ -31346,6 +31802,7 @@
   - Kakatoe galerita
   - Cacatua galerita
   partOfSpeech: n
+  wikidata: Q207107
 01822106-n:
   definition:
   - white Australian cockatoo with roseate tinged plumage
@@ -31381,6 +31838,7 @@
   - cockatoo parrot
   - Nymphicus hollandicus
   partOfSpeech: n
+  wikidata: Q514809
 01822559-n:
   definition:
   - a genus of Psittacidae, containing the lovebirds (Agapornis)
@@ -31482,7 +31940,7 @@
   - rainbow lorikeet
   - Trichoglossus moluccanus
   partOfSpeech: n
-  wikidata: Q319545
+  wikidata: Q1809222
 01823844-n:
   definition:
   - any of numerous small slender long-tailed parrots
@@ -31575,6 +32033,7 @@
   - ring-necked parakeet
   - Psittacula krameri
   partOfSpeech: n
+  wikidata: Q208060
 01825064-n:
   definition:
   - cuckoos, touracos, etc.
@@ -31651,6 +32110,7 @@
   - European cuckoo
   - Cuculus canorus
   partOfSpeech: n
+  wikidata: Q18845
 01826251-n:
   definition:
   - a genus of Cuculidae containing cuckoos which live in the Americas (Coccyzus)
@@ -31699,6 +32159,7 @@
   - chaparral cock
   - Geococcyx californianus
   partOfSpeech: n
+  wikidata: Q634804
 01826868-n:
   definition:
   - ani
@@ -31753,6 +32214,7 @@
   - crow pheasant
   - Centropus sinensis
   partOfSpeech: n
+  wikidata: Q767112
 01827503-n:
   definition:
   - Australian bird with a tail like a pheasant
@@ -31764,6 +32226,7 @@
   - pheasant cuckoo
   - Centropus phasianinus
   partOfSpeech: n
+  wikidata: Q369680
 01827650-n:
   definition:
   - touracos
@@ -31888,6 +32351,7 @@
   - European roller
   - Coracias garrulus
   partOfSpeech: n
+  wikidata: Q179367
 01829485-n:
   definition:
   - Madagascan roller with terrestrial and crepuscular habits that feeds on e.g. insects
@@ -31958,6 +32422,7 @@
   - Eurasian kingfisher
   - Alcedo atthis
   partOfSpeech: n
+  wikidata: Q79915
 01830589-n:
   definition:
   - a genus of birds of the family Alcedinidae
@@ -31981,7 +32446,9 @@
   - belted kingfisher
   - Ceryle alcyon
   partOfSpeech: n
-  wikidata: Q736052
+  wikidata:
+  - Q736052
+  - Q41214407
 01830908-n:
   definition:
   - Australasian kingfishers
@@ -32134,6 +32601,7 @@
   - Euopean hoopoe
   - Upupa epops
   partOfSpeech: n
+  wikidata: Q25247
 01832824-n:
   definition:
   - wood hoopoes
@@ -32367,6 +32835,7 @@
   - swiftlet
   - Collocalia inexpectata
   partOfSpeech: n
+  wikidata: Q41214676
 01835924-n:
   definition:
   - tree swifts
@@ -32439,6 +32908,7 @@
   members:
   - Archilochus colubris
   partOfSpeech: n
+  wikidata: Q834843
 01836925-n:
   definition:
   - a genus of thornbills, containing the rainbow-bearded thornbill, bronze-tailed
@@ -32556,6 +33026,7 @@
   - European nightjar
   - Caprimulgus europaeus
   partOfSpeech: n
+  wikidata: Q26717
 01838559-n:
   definition:
   - large whippoorwill-like bird of the southern United States
@@ -32566,6 +33037,9 @@
   - chuck-will's-widow
   - Caprimulgus carolinensis
   partOfSpeech: n
+  wikidata:
+  - Q1262147
+  - Q106447031
 01838728-n:
   definition:
   - American nocturnal goatsucker with grey-and-white plumage
@@ -32576,6 +33050,9 @@
   - whippoorwill
   - Caprimulgus vociferus
   partOfSpeech: n
+  wikidata:
+  - Q1268205
+  - Q25658709
 01838887-n:
   definition:
   - a genus of Caprimulgidae, containing the nighthawks (Chordeiles)
@@ -32623,6 +33100,7 @@
   - poorwill
   - Phalaenoptilus nuttallii
   partOfSpeech: n
+  wikidata: Q930457
 01839450-n:
   definition:
   - frogmouths
@@ -32783,6 +33261,7 @@
   - green woodpecker
   - Picus viridis
   partOfSpeech: n
+  wikidata: Q166171
 01841862-n:
   definition:
   - a genus of Picidae, containing woodpeckers primarily found in North America (Picoides)
@@ -32837,6 +33316,7 @@
   - Colaptes auratus
   - yellowhammer
   partOfSpeech: n
+  wikidata: Q16819
 01842590-n:
   definition:
   - southwestern United States bird like the yellow-shafted flicker but lacking the
@@ -32884,6 +33364,7 @@
   - ivory-billed woodpecker
   - Campephilus principalis
   partOfSpeech: n
+  wikidata: Q756063
 01843284-n:
   definition:
   - a genus of Picidae, containing woodpeckers found in the New World (Melanerpes)
@@ -32908,6 +33389,7 @@
   - redhead
   - Melanerpes erythrocephalus
   partOfSpeech: n
+  wikidata: Q578174
 01843609-n:
   definition:
   - a genus of Picidae, containing the sapsuckers (Sphyrapicus)
@@ -32940,6 +33422,7 @@
   - yellow-bellied sapsucker
   - Sphyrapicus varius
   partOfSpeech: n
+  wikidata: Q934735
 01844082-n:
   definition:
   - western North American sapsucker
@@ -33388,6 +33871,7 @@
   - mallard
   - Anas platyrhynchos
   partOfSpeech: n
+  wikidata: Q25348
 01850619-n:
   definition:
   - a dusky duck of northeastern United States and Canada
@@ -33398,6 +33882,7 @@
   - black duck
   - Anas rubripes
   partOfSpeech: n
+  wikidata: Q845292
 01850764-n:
   definition:
   - any of various small short-necked dabbling river ducks of Europe and America
@@ -33418,7 +33903,7 @@
   - green-winged teal
   - Anas crecca
   partOfSpeech: n
-  wikidata: Q704074
+  wikidata: Q25700
 01851094-n:
   definition:
   - American teal
@@ -33431,6 +33916,9 @@
   - Anas discors
   - Spatula discors
   partOfSpeech: n
+  wikidata:
+  - Q28106778
+  - Q504148
 01851196-n:
   definition:
   - small Eurasian teal
@@ -33442,6 +33930,9 @@
   - Anas querquedula
   - Spatula querquedula
   partOfSpeech: n
+  wikidata:
+  - Q28106902
+  - Q25644
 01851289-n:
   definition:
   - freshwater duck of Eurasia and northern Africa related to mallards and teals
@@ -33454,7 +33945,9 @@
   - Anas penelope
   - Mareca penelope
   partOfSpeech: n
-  wikidata: Q26459
+  wikidata:
+  - Q28106837
+  - Q26459
 01851481-n:
   definition:
   - a widgeon the male of which has a white crown
@@ -33467,7 +33960,9 @@
   - Anas americana
   - Mareca americana
   partOfSpeech: n
-  wikidata: Q703790
+  wikidata:
+  - Q28106685
+  - Q703790
 01851617-n:
   definition:
   - freshwater duck of the Northern Hemisphere having a broad flat bill
@@ -33481,7 +33976,9 @@
   - Anas clypeata
   - Spatula clypeata
   partOfSpeech: n
-  wikidata: Q25940
+  wikidata:
+  - Q28106731
+  - Q25940
 01851798-n:
   definition:
   - long-necked river duck of the Old and New Worlds having elongated central tail
@@ -33494,6 +33991,7 @@
   - pin-tailed duck
   - Anas acuta
   partOfSpeech: n
+  wikidata: Q25450
 01851989-n:
   definition:
   - sheldrakes
@@ -33598,6 +34096,7 @@
   - Barrow's goldeneye
   - Bucephala islandica
   partOfSpeech: n
+  wikidata: Q369767
 01853317-n:
   definition:
   - canvasback, redhead, pochard, etc.
@@ -33625,6 +34124,7 @@
   - canvasback duck
   - Aythya valisineria
   partOfSpeech: n
+  wikidata: Q378533
 01853679-n:
   definition:
   - heavy-bodied Old World diving duck having a grey-and-black body and reddish head
@@ -33635,6 +34135,7 @@
   - pochard
   - Aythya ferina
   partOfSpeech: n
+  wikidata: Q26742
 01853848-n:
   definition:
   - North American diving duck with a grey-and-black body and reddish-brown head
@@ -33645,6 +34146,7 @@
   - redhead
   - Aythya americana
   partOfSpeech: n
+  wikidata: Q692192
 01854016-n:
   definition:
   - diving ducks of North America having a bluish-grey bill
@@ -33668,6 +34170,7 @@
   - greater scaup
   - Aythya marila
   partOfSpeech: n
+  wikidata: Q26635
 01854372-n:
   definition:
   - common scaup of North America; males have purplish heads
@@ -33716,6 +34219,7 @@
   - wood widgeon
   - Aix sponsa
   partOfSpeech: n
+  wikidata: Q322159
 01854970-n:
   definition:
   - male wood duck
@@ -33735,6 +34239,7 @@
   - mandarin duck
   - Aix galericulata
   partOfSpeech: n
+  wikidata: Q200339
 01855185-n:
   definition:
   - a genus of Anatidae containing two species of duck (Cairina)
@@ -33827,6 +34332,7 @@
   - common scoter
   - Melanitta nigra
   partOfSpeech: n
+  wikidata: Q27434
 01856404-n:
   definition:
   - a genus of ducks
@@ -33851,6 +34357,7 @@
   - oldwife
   - Clangula hyemalis
   partOfSpeech: n
+  wikidata: Q26597
 01856688-n:
   definition:
   - mergansers and closely related diving birds
@@ -33904,6 +34411,7 @@
   - goosander
   - Mergus merganser
   partOfSpeech: n
+  wikidata: Q180991
 01857479-n:
   definition:
   - common North American diving duck considered a variety of the European goosander
@@ -33924,6 +34432,7 @@
   - red-breasted merganser
   - Mergus serrator
   partOfSpeech: n
+  wikidata: Q189609
 01857829-n:
   definition:
   - smallest merganser and most expert diver; found in northern Eurasia
@@ -33959,6 +34468,7 @@
   - hooded sheldrake
   - Lophodytes cucullatus
   partOfSpeech: n
+  wikidata: Q241349
 01858313-n:
   definition:
   - web-footed long-necked typically gregarious migratory aquatic birds usually larger
@@ -34015,7 +34525,7 @@
   - Chinese goose
   - Anser cygnoides
   partOfSpeech: n
-  wikidata: Q386047
+  wikidata: Q31354
 01859194-n:
   definition:
   - common grey wild goose of Europe; ancestor of many domestic breeds
@@ -34099,6 +34609,7 @@
   - common brant goose
   - Branta bernicla
   partOfSpeech: n
+  wikidata: Q27050
 01860273-n:
   definition:
   - common greyish-brown wild goose of North America with a loud, trumpeting call
@@ -34111,6 +34622,7 @@
   - Canadian goose
   - Branta canadensis
   partOfSpeech: n
+  wikidata: Q26733
 01860492-n:
   definition:
   - European goose smaller than the brant; breeds in the far north
@@ -34122,6 +34634,7 @@
   - barnacle
   - Branta leucopsis
   partOfSpeech: n
+  wikidata: Q26680
 01860664-n:
   definition:
   - used in some classifications for the swans
@@ -34222,6 +34735,7 @@
   - mute swan
   - Cygnus olor
   partOfSpeech: n
+  wikidata: Q25402
 01861966-n:
   definition:
   - common Old World swan noted for its whooping call
@@ -34244,6 +34758,7 @@
   - tundra swan
   - Cygnus columbianus
   partOfSpeech: n
+  wikidata: Q26603
 01862330-n:
   definition:
   - North American subspecies of tundra swan having a soft whistling note
@@ -34275,6 +34790,7 @@
   - trumpeter swan
   - Cygnus buccinator
   partOfSpeech: n
+  wikidata: Q733375
 01862828-n:
   definition:
   - large Australian swan having black plumage and a red bill
@@ -34285,6 +34801,7 @@
   - black swan
   - Cygnus atratus
   partOfSpeech: n
+  wikidata: Q131044
 01862978-n:
   definition:
   - screamers
@@ -34332,6 +34849,7 @@
   - horned screamer
   - Anhima cornuta
   partOfSpeech: n
+  wikidata: Q732753
 01863666-n:
   definition:
   - crested screamers
@@ -34365,6 +34883,7 @@
   - chaja
   - Chauna torquata
   partOfSpeech: n
+  wikidata: Q602961
 01864106-n:
   definition:
   - warm-blooded vertebrates characterized by mammary glands in the female
@@ -34592,6 +35111,7 @@
   - duck-billed platypus
   - Ornithorhynchus anatinus
   partOfSpeech: n
+  wikidata: Q15343
 01876263-n:
   definition:
   - generalized extinct mammals widespread during the Jurassic; commonly conceded
@@ -34709,6 +35229,7 @@
   - Didelphis virginiana
   - Didelphis marsupialis
   partOfSpeech: n
+  wikidata: Q194663
 01878251-n:
   definition:
   - South American opossum
@@ -34802,6 +35323,7 @@
   - bilby
   - Macrotis lagotis
   partOfSpeech: n
+  wikidata: Q371667
 01879484-n:
   definition:
   - kangaroos; wallabies
@@ -34859,6 +35381,7 @@
   - great grey kangaroo
   - Macropus giganteus
   partOfSpeech: n
+  wikidata: Q270098
 01880453-n:
   definition:
   - any of various small or medium-sized kangaroos; often brightly colored
@@ -35172,6 +35695,7 @@
   - brush-tailed phalanger
   - Trichosurus vulpecula
   partOfSpeech: n
+  wikidata: Q732477
 01884632-n:
   definition:
   - a genus of Phalangeridae containing flying phalangers or wrist-winged gliders
@@ -35245,6 +35769,7 @@
   - native bear
   - Phascolarctos cinereus
   partOfSpeech: n
+  wikidata: Q36101
 01885589-n:
   definition:
   - wombats
@@ -35338,6 +35863,7 @@
   - native cat
   - Dasyurus viverrinus
   partOfSpeech: n
+  wikidata: Q194516
 01886989-n:
   definition:
   - Tasmanian wolf
@@ -35440,6 +35966,7 @@
   - anteater
   - Myrmecobius fasciatus
   partOfSpeech: n
+  wikidata: Q242419
 01888365-n:
   definition:
   - pouched moles
@@ -35697,6 +36224,7 @@
   - star-nosed mole
   - Condylura cristata
   partOfSpeech: n
+  wikidata: Q547663
 01892674-n:
   definition:
   - brewer's moles
@@ -35719,6 +36247,7 @@
   - hair-tailed mole
   - Parascalops breweri
   partOfSpeech: n
+  wikidata: Q1470645
 01892915-n:
   definition:
   - golden moles
@@ -35788,6 +36317,7 @@
   - Asiatic shrew mole
   - Uropsilus soricipes
   partOfSpeech: n
+  wikidata: Q1767402
 01893786-n:
   definition:
   - a genus of shrew moles, containing the American shrew-mole (Neurotrichus)
@@ -35863,6 +36393,7 @@
   - common shrew
   - Sorex araneus
   partOfSpeech: n
+  wikidata: Q591450
 01894786-n:
   definition:
   - commonest shrew of moist habitats in North America
@@ -35873,6 +36404,7 @@
   - masked shrew
   - Sorex cinereus
   partOfSpeech: n
+  wikidata: Q469038
 01894912-n:
   definition:
   - a genus of fairly large shrews with fairly short tails (Blarina)
@@ -35896,6 +36428,7 @@
   - short-tailed shrew
   - Blarina brevicauda
   partOfSpeech: n
+  wikidata: Q1766543
 01895192-n:
   definition:
   - any of several small semiaquatic shrews usually living near swift-flowing streams
@@ -35915,6 +36448,7 @@
   - American water shrew
   - Sorex palustris
   partOfSpeech: n
+  wikidata: Q2043191
 01895517-n:
   definition:
   - a genus of Soricidae
@@ -35939,6 +36473,7 @@
   - European water shrew
   - Neomys fodiens
   partOfSpeech: n
+  wikidata: Q465986
 01895805-n:
   definition:
   - a type of water shrew
@@ -35949,6 +36484,7 @@
   - Mediterranean water shrew
   - Neomys anomalus
   partOfSpeech: n
+  wikidata: Q613721
 01895935-n:
   definition:
   - least shrews
@@ -35970,6 +36506,7 @@
   - least shrew
   - Cryptotis parva
   partOfSpeech: n
+  wikidata: Q1764011
 01896176-n:
   definition:
   - true hedgehogs
@@ -36009,6 +36546,7 @@
   mero_part:
   - 01903478-n
   partOfSpeech: n
+  wikidata: Q6145
 01896681-n:
   definition:
   - tenrecs and extinct related forms
@@ -36055,6 +36593,7 @@
   - tailless tenrec
   - Tenrec ecaudatus
   partOfSpeech: n
+  wikidata: Q852769
 01897311-n:
   definition:
   - otter shrews
@@ -36091,6 +36630,7 @@
   - potamogale
   - Potamogale velox
   partOfSpeech: n
+  wikidata: Q474780
 01897769-n:
   definition:
   - backbone of an animal
@@ -37092,6 +37632,7 @@
   members:
   - Chrysaora quinquecirrha
   partOfSpeech: n
+  wikidata: Q2118900
 01914152-n:
   definition:
   - 'coelenterates typically having alternation of generations; hydroid phase is usually
@@ -37772,6 +38313,7 @@
   - Venus's girdle
   - Cestum veneris
   partOfSpeech: n
+  wikidata: Q2469009
 01923857-n:
   definition:
   - ctenophore having tentacles only in the immature stage; body compressed vertically
@@ -38074,6 +38616,7 @@
   - liver fluke
   - Fasciola hepatica
   partOfSpeech: n
+  wikidata: Q334149
 01929190-n:
   definition:
   - a genus of Fasciolidae containing the trematode Fasciolopsis buski (Fasciolopsis)
@@ -38414,6 +38957,7 @@
   - chicken roundworm
   - Ascaridia galli
   partOfSpeech: n
+  wikidata: Q3503323
 01933918-n:
   definition:
   - a family of nematode worms containing eight genera, including the one consisting
@@ -38502,6 +39046,7 @@
   - Anguillula aceti
   - Turbatrix aceti
   partOfSpeech: n
+  wikidata: Q1368890
 01934999-n:
   definition:
   - a family of Nematoda, containing the subfamilies Atylenchinae, Boleodorinae, Ecphyadophorinae,
@@ -38565,6 +39110,7 @@
   - trichina
   - Trichinella spiralis
   partOfSpeech: n
+  wikidata: Q730937
 01935792-n:
   definition:
   - parasitic bloodsucking roundworms having hooked mouth parts to fasten to the intestinal
@@ -38919,6 +39465,7 @@
   - medicinal leech
   - Hirudo medicinalis
   partOfSpeech: n
+  wikidata: Q30041
 01941259-n:
   definition:
   - leeches
@@ -39124,6 +39671,7 @@
   - sea-ear
   - Haliotis tuberculata
   partOfSpeech: n
+  wikidata: Q1552190
 01945854-n:
   definition:
   - the family of conchs
@@ -39195,6 +39743,9 @@
   - Strombus gigas
   - Lobatus gigas
   partOfSpeech: n
+  wikidata:
+  - Q62603
+  - Q23747451
 01946858-n:
   definition:
   - land snails including the common edible snail and some pests
@@ -39246,6 +39797,7 @@
   mero_substance:
   - 07798451-n
   partOfSpeech: n
+  wikidata: Q245314
 01947596-n:
   definition:
   - any of several inedible snails of the genus Helix; often destructive pests
@@ -39267,6 +39819,9 @@
   - Helix aspersa
   - Cornu aspersum
   partOfSpeech: n
+  wikidata:
+  - Q22019793
+  - Q927080
 01947981-n:
   definition:
   - a kind of garden snail
@@ -39276,6 +39831,7 @@
   members:
   - Helix hortensis
   partOfSpeech: n
+  wikidata: Q40470822
 01948084-n:
   definition:
   - slugs
@@ -39380,6 +39936,7 @@
   - bleeding tooth
   - Nerita peloronta
   partOfSpeech: n
+  wikidata: Q3173997
 01949661-n:
   definition:
   - a genus of Neritidae
@@ -39555,6 +40112,7 @@
   - common limpet
   - Patella vulgata
   partOfSpeech: n
+  wikidata: Q182258
 01951836-n:
   definition:
   - a family of marine limpets, containing the keyhole limpets and slit limpets (Fissurellidae)
@@ -39592,6 +40150,7 @@
   - Fissurella apertura
   - Diodora apertura
   partOfSpeech: n
+  wikidata: Q3739561
 01952325-n:
   definition:
   - freshwater gastropod
@@ -39630,6 +40189,7 @@
   - freshwater limpet
   - Ancylus fluviatilis
   partOfSpeech: n
+  wikidata: Q1434354
 01952836-n:
   definition:
   - 'gastropods having the gills when present posterior to the heart and having no
@@ -39711,6 +40271,7 @@
   - sea hare
   - Aplysia punctata
   partOfSpeech: n
+  wikidata: Q520464
 01954113-n:
   definition:
   - genus of marine sea slugs
@@ -39733,6 +40294,7 @@
   members:
   - Hermissenda crassicornis
   partOfSpeech: n
+  wikidata: Q522625
 01954362-n:
   definition:
   - bubble shells
@@ -39879,6 +40441,7 @@
   - money cowrie
   - Cypraea moneta
   partOfSpeech: n
+  wikidata: Q11176238
 01956403-n:
   definition:
   - cowrie whose shell is used for ornament
@@ -39889,6 +40452,7 @@
   - tiger cowrie
   - Cypraea tigris
   partOfSpeech: n
+  wikidata: Q2664666
 01956518-n:
   definition:
   - comb-like respiratory structure serving as the gill of certain mollusks
@@ -40136,6 +40700,7 @@
   mero_part:
   - 07803405-n
   partOfSpeech: n
+  wikidata: Q20958
 01960232-n:
   definition:
   - hard-shell clams
@@ -40192,6 +40757,7 @@
   mero_part:
   - 07802832-n
   partOfSpeech: n
+  wikidata: Q2279087
 01960987-n:
   definition:
   - a young quahog
@@ -40514,6 +41080,7 @@
   - saddle oyster
   - Anomia ephippium
   partOfSpeech: n
+  wikidata: Q204259
 01965303-n:
   definition:
   - windowpane oysters
@@ -40646,6 +41213,7 @@
   mero_part:
   - 07799526-n
   partOfSpeech: n
+  wikidata: Q27855
 01967082-n:
   definition:
   - bivalve mollusk abundant in rivers of central United States
@@ -40739,6 +41307,7 @@
   - zebra mussel
   - Dreissena polymorpha
   partOfSpeech: n
+  wikidata: Q752130
 01968388-n:
   definition:
   - scallops
@@ -40806,6 +41375,7 @@
   mero_part:
   - 07813889-n
   partOfSpeech: n
+  wikidata: Q106066216
 01969438-n:
   definition:
   - shipworms
@@ -41101,6 +41671,7 @@
   - argonaut
   - Argonauta argo
   partOfSpeech: n
+  wikidata: Q39514
 01973507-n:
   definition:
   - squids and cuttlefishes
@@ -41508,6 +42079,7 @@
   mero_part:
   - 07804706-n
   partOfSpeech: n
+  wikidata: Q5461759
 01980325-n:
   definition:
   - many of the best known edible crabs
@@ -41567,6 +42139,9 @@
   mero_part:
   - 07804585-n
   partOfSpeech: n
+  wikidata:
+  - Q1936093
+  - Q22112422
 01981096-n:
   definition:
   - crab of eastern coast of North America
@@ -41577,6 +42152,7 @@
   - rock crab
   - Cancer irroratus
   partOfSpeech: n
+  wikidata: Q590283
 01981228-n:
   definition:
   - large red deep-water crab of the eastern coast of North America
@@ -41687,6 +42263,7 @@
   mero_part:
   - 07803956-n
   partOfSpeech: n
+  wikidata: Q844839
 01982694-n:
   definition:
   - fiddler crabs
@@ -41757,6 +42334,7 @@
   - oyster crab
   - Pinnotheres ostreum
   partOfSpeech: n
+  wikidata: Q40628380
 01983634-n:
   definition:
   - deep-sea crabs of cold waters
@@ -41873,6 +42451,7 @@
   - giant crab
   - Macrocheira kaempferi
   partOfSpeech: n
+  wikidata: Q273655
 01985123-n:
   definition:
   - lobsters; crabs
@@ -41953,6 +42532,7 @@
   mero_part:
   - 07808902-n
   partOfSpeech: n
+  wikidata: Q37668
 01986315-n:
   definition:
   - lobster of Atlantic coast of Europe
@@ -41975,6 +42555,7 @@
   - Cape lobster
   - Homarus capensis
   partOfSpeech: n
+  wikidata: Q40481921
 01986599-n:
   definition:
   - in some classifications coextensive with the Homaridae
@@ -42011,6 +42592,7 @@
   mero_part:
   - 07809497-n
   partOfSpeech: n
+  wikidata: Q551915
 01987057-n:
   definition:
   - spiny lobsters
@@ -42356,6 +42938,7 @@
   members:
   - Euphausia pacifica
   partOfSpeech: n
+  wikidata: Q992625
 01991612-n:
   definition:
   - opossum shrimp
@@ -42857,6 +43440,7 @@
   - brine shrimp
   - Artemia salina
   partOfSpeech: n
+  wikidata: Q1135229
 01998457-n:
   definition:
   - small freshwater crustaceans with a shield-shaped carapace
@@ -43072,6 +43656,7 @@
   - rock barnacle
   - Balanus balanoides
   partOfSpeech: n
+  wikidata: Q40982388
 02001574-n:
   definition:
   - goose barnacles
@@ -43109,6 +43694,7 @@
   - gooseneck barnacle
   - Lepas fascicularis
   partOfSpeech: n
+  wikidata: Q15896367
 02002028-n:
   definition:
   - enigmatic small elongated wormlike terrestrial invertebrates of damp dark habitats
@@ -43293,6 +43879,7 @@
   - white stork
   - Ciconia ciconia
   partOfSpeech: n
+  wikidata: Q25352
 02005378-n:
   definition:
   - Old World stork that is glossy black above and white below
@@ -43303,6 +43890,7 @@
   - black stork
   - Ciconia nigra
   partOfSpeech: n
+  wikidata: Q25398
 02005529-n:
   definition:
   - adjutant birds and marabous
@@ -43416,6 +44004,7 @@
   - jabiru
   - Ephippiorhynchus senegalensis
   partOfSpeech: n
+  wikidata: Q1219291
 02006997-n:
   definition:
   - East Indian and Australian storks
@@ -43469,6 +44058,7 @@
   - flinthead
   - Mycteria americana
   partOfSpeech: n
+  wikidata: Q990175
 02007756-n:
   definition:
   - shoebills
@@ -43507,6 +44097,7 @@
   - shoebird
   - Balaeniceps rex
   partOfSpeech: n
+  wikidata: Q18700
 02008252-n:
   definition:
   - a family comprising ibises and spoonbills (Threskiornithidae, Ibidiidae)
@@ -43555,6 +44146,7 @@
   - wood stork
   - Ibis ibis
   partOfSpeech: n
+  wikidata: Q11844301
 02008865-n:
   definition:
   - type genus of the Threskiornithidae
@@ -43625,6 +44217,7 @@
   - common spoonbill
   - Platalea leucorodia
   partOfSpeech: n
+  wikidata: Q171360
 02009815-n:
   definition:
   - a genus of Platalea
@@ -43648,6 +44241,7 @@
   - roseate spoonbill
   - Ajaia ajaja
   partOfSpeech: n
+  wikidata: Q107333222
 02010076-n:
   definition:
   - flamingos
@@ -43736,6 +44330,7 @@
   - great white heron
   - Ardea occidentalis
   partOfSpeech: n
+  wikidata: Q110257447
 02011450-n:
   definition:
   - any of various usually white herons having long plumes during breeding season
@@ -43772,6 +44367,7 @@
   - little blue heron
   - Egretta caerulea
   partOfSpeech: n
+  wikidata: Q371028
 02012034-n:
   definition:
   - small New World egret
@@ -43818,6 +44414,7 @@
   - great white heron
   - Casmerodius albus
   partOfSpeech: n
+  wikidata: Q25664280
 02012566-n:
   definition:
   - a common egret of the genus Egretta found in America; it is a variety of the Old
@@ -43912,6 +44509,7 @@
   - yellow-crowned night heron
   - Nyctanassa violacea
   partOfSpeech: n
+  wikidata: Q764282
 02013810-n:
   definition:
   - boatbills
@@ -43937,6 +44535,7 @@
   - broadbill
   - Cochlearius cochlearius
   partOfSpeech: n
+  wikidata: Q210341
 02014114-n:
   definition:
   - relatively small compact tawny-brown heron with nocturnal habits and a booming
@@ -43983,6 +44582,7 @@
   - European bittern
   - Botaurus stellaris
   partOfSpeech: n
+  wikidata: Q25709
 02014717-n:
   definition:
   - a genus of small bitterns (Ixobrychus)
@@ -44006,6 +44606,7 @@
   - least bittern
   - Ixobrychus exilis
   partOfSpeech: n
+  wikidata: Q469586
 02014960-n:
   definition:
   - 'inland marsh-dwelling birds with long legs and necks and bills that wade in water
@@ -44076,6 +44677,7 @@
   - whooper
   - Grus americana
   partOfSpeech: n
+  wikidata: Q457477
 02016016-n:
   definition:
   - 'genus of large brown long-billed wading birds found in warm swampy regions of
@@ -44148,6 +44750,7 @@
   - seriema
   - Cariama cristata
   partOfSpeech: n
+  wikidata: Q903662
 02017060-n:
   definition:
   - a genus of Cariamidae
@@ -44171,6 +44774,7 @@
   - seriema
   - Chunga burmeisteri
   partOfSpeech: n
+  wikidata: Q933531
 02017300-n:
   definition:
   - rails; crakes; gallinules; coots
@@ -44260,6 +44864,7 @@
   - land rail
   - Crex crex
   partOfSpeech: n
+  wikidata: Q26017
 02018598-n:
   definition:
   - spotted crakes
@@ -44283,6 +44888,7 @@
   - spotted crake
   - Porzana porzana
   partOfSpeech: n
+  wikidata: Q194024
 02018852-n:
   definition:
   - gallinules
@@ -44331,6 +44937,7 @@
   - moorhen
   - Gallinula chloropus
   partOfSpeech: n
+  wikidata: Q18847
 02019610-n:
   definition:
   - gallinules with showy purplish plumage
@@ -44361,6 +44968,7 @@
   - European gallinule
   - Porphyrio porphyrio
   partOfSpeech: n
+  wikidata: Q187902
 02019989-n:
   definition:
   - American purple gallinules
@@ -44384,6 +44992,7 @@
   - American gallinule
   - Porphyrula martinica
   partOfSpeech: n
+  wikidata: Q40642457
 02020261-n:
   definition:
   - a genus of Rallidae
@@ -44455,6 +45064,7 @@
   - Old World coot
   - Fulica atra
   partOfSpeech: n
+  wikidata: Q25376
 02021139-n:
   definition:
   - 'terrestrial game birds of the Old World and Australia: bustards'
@@ -44513,6 +45123,7 @@
   - great bustard
   - Otis tarda
   partOfSpeech: n
+  wikidata: Q171655
 02021962-n:
   definition:
   - Australian bustard
@@ -44587,6 +45198,7 @@
   - striped button quail
   - Turnix sylvatica
   partOfSpeech: n
+  wikidata: Q50407554
 02022999-n:
   definition:
   - any of several East Indian birds
@@ -44620,6 +45232,7 @@
   - plain wanderer
   - Pedionomus torquatus
   partOfSpeech: n
+  wikidata: Q665606
 02023431-n:
   definition:
   - trumpeters
@@ -44666,6 +45279,7 @@
   - Brazilian trumpeter
   - Psophia crepitans
   partOfSpeech: n
+  wikidata: Q1275053
 02024092-n:
   definition:
   - 'large diverse order of aquatic birds found along seacoasts and inland waters:
@@ -44805,6 +45419,7 @@
   - killdeer plover
   - Charadrius vociferus
   partOfSpeech: n
+  wikidata: Q755737
 02026839-n:
   definition:
   - rare plover of upland areas of Eurasia
@@ -44817,7 +45432,9 @@
   - Charadrius morinellus
   - Eudromias morinellus
   partOfSpeech: n
-  wikidata: Q202504
+  wikidata:
+  - Q25677554
+  - Q202504
 02027007-n:
   definition:
   - golden plovers
@@ -44898,6 +45515,7 @@
   - ruddy turnstone
   - Arenaria interpres
   partOfSpeech: n
+  wikidata: Q26892
 02028043-n:
   definition:
   - common turnstone of the Pacific coast of North America
@@ -44908,6 +45526,7 @@
   - black turnstone
   - Arenaria melanocephala
   partOfSpeech: n
+  wikidata: Q618751
 02028184-n:
   definition:
   - 'sandpiper family: sandpipers; woodcocks; snipes; tattlers; curlews; godwits;
@@ -44973,8 +45592,8 @@
   - Aphriza virgata
   partOfSpeech: n
   wikidata:
-  - Q1274741
   - Q28070835
+  - Q1274741
 02029452-n:
   definition:
   - a genus of Scolopacidae, comprising the common sandpiper and the spotted sandpiper
@@ -45000,6 +45619,7 @@
   - European sandpiper
   - Actitis hypoleucos
   partOfSpeech: n
+  wikidata: Q18850
 02029729-n:
   definition:
   - common North American sandpiper
@@ -45049,6 +45669,7 @@
   - dunlin
   - Erolia alpina
   partOfSpeech: n
+  wikidata: Q106447283
 02030384-n:
   definition:
   - a genus of Scolopacidae, containing the shanks and the tattlers (Tringa)
@@ -45074,6 +45695,7 @@
   - greenshank
   - Tringa nebularia
   partOfSpeech: n
+  wikidata: Q18840
 02030689-n:
   definition:
   - a common Old World wading bird with long red legs
@@ -45084,6 +45706,7 @@
   - redshank
   - Tringa totanus
   partOfSpeech: n
+  wikidata: Q18859
 02030829-n:
   definition:
   - either of two North American shorebird with yellow legs
@@ -45114,6 +45737,7 @@
   - lesser yellowlegs
   - Tringa flavipes
   partOfSpeech: n
+  wikidata: Q28000
 02031210-n:
   definition:
   - a genus of Scolopacidae, containing the knots and the surfbirds (Calidris)
@@ -45140,6 +45764,7 @@
   - jacksnipe
   - Calidris melanotos
   partOfSpeech: n
+  wikidata: Q260716
 02031554-n:
   definition:
   - a sandpiper that breeds in the Arctic and winters in the Southern Hemisphere
@@ -45152,6 +45777,7 @@
   - grayback
   - Calidris canutus
   partOfSpeech: n
+  wikidata: Q27124
 02031741-n:
   definition:
   - Old World sandpiper with a curved bill like a curlew
@@ -45187,6 +45813,7 @@
   - sanderling
   - Crocethia alba
   partOfSpeech: n
+  wikidata: Q107333207
 02032225-n:
   definition:
   - a genus of Scolopacidae, includes the upland sandpiper (Bartramia)
@@ -45212,6 +45839,7 @@
   - Bartramian sandpiper
   - Bartramia longicauda
   partOfSpeech: n
+  wikidata: Q530194
 02032568-n:
   definition:
   - ruffs
@@ -45277,6 +45905,7 @@
   - Polynesian tattler
   - Heteroscelus incanus
   partOfSpeech: n
+  wikidata: Q1265652
 02033363-n:
   definition:
   - willet
@@ -45300,6 +45929,7 @@
   - willet
   - Catoptrophorus semipalmatus
   partOfSpeech: n
+  wikidata: Q25664334
 02033650-n:
   definition:
   - game bird of the sandpiper family that resembles a snipe
@@ -45332,6 +45962,7 @@
   - Eurasian woodcock
   - Scolopax rusticola
   partOfSpeech: n
+  wikidata: Q26114
 02034109-n:
   definition:
   - American woodcocks
@@ -45393,6 +46024,7 @@
   - whole snipe
   - Gallinago gallinago
   partOfSpeech: n
+  wikidata: Q25692
 02035009-n:
   definition:
   - American snipe
@@ -45473,6 +46105,7 @@
   - grayback
   - Limnodromus griseus
   partOfSpeech: n
+  wikidata: Q371633
 02035978-n:
   definition:
   - a dowitcher with a red breast
@@ -45483,6 +46116,7 @@
   - red-breasted snipe
   - Limnodromus scolopaceus
   partOfSpeech: n
+  wikidata: Q476350
 02036098-n:
   definition:
   - curlews
@@ -45516,6 +46150,7 @@
   - European curlew
   - Numenius arquata
   partOfSpeech: n
+  wikidata: Q18854
 02036536-n:
   definition:
   - New World curlew that breeds in northern North America
@@ -45603,6 +46238,7 @@
   - black-necked stilt
   - Himantopus mexicanus
   partOfSpeech: n
+  wikidata: Q280358
 02037864-n:
   definition:
   - stilt of Europe and Africa and Asia having mostly white plumage but with black
@@ -45614,6 +46250,7 @@
   - black-winged stilt
   - Himantopus himantopus
   partOfSpeech: n
+  wikidata: Q178821
 02038056-n:
   definition:
   - stilt of the southwest Pacific including Australia and New Zealand having mostly
@@ -45815,6 +46452,7 @@
   - Steganopus tricolor
   - Phalaropus tricolor
   partOfSpeech: n
+  wikidata: Q45696
 02041271-n:
   definition:
   - pratincoles and coursers (Glareolidae)
@@ -45888,6 +46526,7 @@
   - cream-colored courser
   - Cursorius cursor
   partOfSpeech: n
+  wikidata: Q219199
 02042314-n:
   definition:
   - a genus of coursers, containing the Egyptian plover (Pluvianus)
@@ -45911,6 +46550,7 @@
   - crocodile bird
   - Pluvianus aegyptius
   partOfSpeech: n
+  wikidata: Q835119
 02042596-n:
   definition:
   - 'large wading birds resembling the plovers: stone curlews'
@@ -45949,6 +46589,7 @@
   - thick-knee
   - Burhinus oedicnemus
   partOfSpeech: n
+  wikidata: Q184834
 02043159-n:
   definition:
   - gull family; skimmer family; jaeger family; auk family
@@ -46037,6 +46678,7 @@
   - sea mew
   - Larus canus
   partOfSpeech: n
+  wikidata: Q26427
 02044529-n:
   definition:
   - white gull having a black back and wings
@@ -46049,6 +46691,7 @@
   - cob
   - Larus marinus
   partOfSpeech: n
+  wikidata: Q26629
 02044700-n:
   definition:
   - large gull of the Northern Hemisphere
@@ -46059,6 +46702,7 @@
   - herring gull
   - Larus argentatus
   partOfSpeech: n
+  wikidata: Q28236
 02044834-n:
   definition:
   - small black-headed European gull
@@ -46072,6 +46716,9 @@
   - pewit gull
   - Larus ridibundus
   partOfSpeech: n
+  wikidata:
+  - Q25634
+  - Q25689558
 02044996-n:
   definition:
   - a genus of Laridae, containing the ivory gull (Pagophila)
@@ -46095,6 +46742,7 @@
   - ivory gull
   - Pagophila eburnea
   partOfSpeech: n
+  wikidata: Q723064
 02045291-n:
   definition:
   - a genus of Laridae, containing the kittiwakes (Rissa)
@@ -46163,6 +46811,7 @@
   - sea swallow
   - Sterna hirundo
   partOfSpeech: n
+  wikidata: Q18875
 02046151-n:
   definition:
   - 'coextensive with the genus Rynchops: skimmers'
@@ -46247,6 +46896,7 @@
   - arctic skua
   - Stercorarius parasiticus
   partOfSpeech: n
+  wikidata: Q203053
 02047313-n:
   definition:
   - skuas
@@ -46280,7 +46930,9 @@
   - great skua
   - Catharacta skua
   partOfSpeech: n
-  wikidata: Q207760
+  wikidata:
+  - Q207760
+  - Q28125238
 02047678-n:
   definition:
   - 'web-footed diving seabirds of northern seas: auks, puffins, guillemots, murres,
@@ -46345,6 +46997,7 @@
   - razor-billed auk
   - Alca torda
   partOfSpeech: n
+  wikidata: Q27102
 02048699-n:
   definition:
   - a genus of Alcidae
@@ -46425,6 +47078,7 @@
   - black guillemot
   - Cepphus grylle
   partOfSpeech: n
+  wikidata: Q212055
 02049699-n:
   definition:
   - northern Pacific guillemot
@@ -46514,6 +47168,7 @@
   - Atlantic puffin
   - Fratercula arctica
   partOfSpeech: n
+  wikidata: Q26685
 02050769-n:
   definition:
   - northern Pacific puffin
@@ -46524,6 +47179,7 @@
   - horned puffin
   - Fratercula corniculata
   partOfSpeech: n
+  wikidata: Q855367
 02050896-n:
   definition:
   - a proposed monotypic genus for tufted puffins
@@ -46547,6 +47203,7 @@
   - tufted puffin
   - Lunda cirrhata
   partOfSpeech: n
+  wikidata: Q50726540
 02051168-n:
   definition:
   - 'large aquatic birds: loons and some extinct forms'
@@ -46681,6 +47338,7 @@
   - great crested grebe
   - Podiceps cristatus
   partOfSpeech: n
+  wikidata: Q25422
 02053096-n:
   definition:
   - large stocky grebe of circumpolar regions having a dark neck
@@ -46691,6 +47349,7 @@
   - red-necked grebe
   - Podiceps grisegena
   partOfSpeech: n
+  wikidata: Q179919
 02053240-n:
   definition:
   - small grebe with yellow ear tufts and a black neck; found in Eurasia and southern
@@ -46703,6 +47362,7 @@
   - eared grebe
   - Podiceps nigricollis
   partOfSpeech: n
+  wikidata: Q185183
 02053463-n:
   definition:
   - small European grebe
@@ -46714,7 +47374,9 @@
   - little grebe
   - Podiceps ruficollis
   partOfSpeech: n
-  wikidata: Q25421
+  wikidata:
+  - Q25421
+  - Q11846961
 02053575-n:
   definition:
   - a genus of Podicipedidae
@@ -46814,6 +47476,7 @@
   - white pelican
   - Pelecanus erythrorhynchos
   partOfSpeech: n
+  wikidata: Q735190
 02055019-n:
   definition:
   - similar to American white pelican
@@ -46824,6 +47487,7 @@
   - Old world white pelican
   - Pelecanus onocrotalus
   partOfSpeech: n
+  wikidata: Q199427
 02055165-n:
   definition:
   - frigate birds
@@ -46910,6 +47574,7 @@
   - solant goose
   - Sula bassana
   partOfSpeech: n
+  wikidata: Q106447807
 02056238-n:
   definition:
   - small tropical gannet having a bright bill or bright feet or both
@@ -46956,6 +47621,7 @@
   - cormorant
   - Phalacrocorax carbo
   partOfSpeech: n
+  wikidata: Q25440
 02056905-n:
   definition:
   - snakebirds
@@ -47003,6 +47669,7 @@
   - water turkey
   - Anhinga anhinga
   partOfSpeech: n
+  wikidata: Q469940
 02057488-n:
   definition:
   - tropicbirds
@@ -47114,6 +47781,7 @@
   - Adelie penguin
   - Pygoscelis adeliae
   partOfSpeech: n
+  wikidata: Q187958
 02059075-n:
   definition:
   - large penguins
@@ -47149,6 +47817,7 @@
   - emperor penguin
   - Aptenodytes forsteri
   partOfSpeech: n
+  wikidata: Q161829
 02059527-n:
   definition:
   - 'type genus of the Spheniscidae: jackass penguins'
@@ -47172,6 +47841,7 @@
   - jackass penguin
   - Spheniscus demersus
   partOfSpeech: n
+  wikidata: Q244813
 02059862-n:
   definition:
   - rock hoppers
@@ -47280,6 +47950,7 @@
   - wandering albatross
   - Diomedea exulans
   partOfSpeech: n
+  wikidata: Q208682
 02061401-n:
   definition:
   - a variety of albatross with black feet
@@ -47294,7 +47965,9 @@
   - goony
   - Diomedea nigripes
   partOfSpeech: n
-  wikidata: Q600319
+  wikidata:
+  - Q600319
+  - Q106447851
 02061587-n:
   definition:
   - petrels; fulmars; shearwaters
@@ -47344,6 +48017,7 @@
   - white-chinned petrel
   - Procellaria aequinoctialis
   partOfSpeech: n
+  wikidata: Q276206
 02062376-n:
   definition:
   - giant petrels
@@ -47393,6 +48067,7 @@
   - fulmar petrel
   - Fulmarus glacialis
   partOfSpeech: n
+  wikidata: Q26896
 02062943-n:
   definition:
   - shearwaters
@@ -47474,6 +48149,7 @@
   - northern storm petrel
   - Hydrobates pelagicus
   partOfSpeech: n
+  wikidata: Q27461
 02064078-n:
   definition:
   - a genus of Hydrobatidae
@@ -47498,6 +48174,7 @@
   - Mother Carey's hen
   - Oceanites oceanicus
   partOfSpeech: n
+  wikidata: Q607024
 02064369-n:
   definition:
   - diving petrels
@@ -47648,6 +48325,7 @@
   - Greenland whale
   - Balaena mysticetus
   partOfSpeech: n
+  wikidata: Q174652
 02066807-n:
   definition:
   - rorquals; blue whales
@@ -47702,6 +48380,7 @@
   - sulfur bottom
   - Balaenoptera musculus
   partOfSpeech: n
+  wikidata: Q42196
 02067679-n:
   definition:
   - large flat-headed whalebone whale having deep furrows along the throat; of Atlantic
@@ -47716,6 +48395,7 @@
   - common rorqual
   - Balaenoptera physalus
   partOfSpeech: n
+  wikidata: Q179020
 02067916-n:
   definition:
   - similar to but smaller than the finback whale
@@ -47726,6 +48406,7 @@
   - sei whale
   - Balaenoptera borealis
   partOfSpeech: n
+  wikidata: Q185097
 02068060-n:
   definition:
   - small finback of coastal waters of Atlantic and Pacific
@@ -47738,6 +48419,7 @@
   - minke whale
   - Balaenoptera acutorostrata
   partOfSpeech: n
+  wikidata: Q201808
 02068252-n:
   definition:
   - humpback whales
@@ -47763,6 +48445,7 @@
   - humpback whale
   - Megaptera novaeangliae
   partOfSpeech: n
+  wikidata: Q132905
 02068585-n:
   definition:
   - comprising only the grey whales
@@ -47868,6 +48551,7 @@
   - black whale
   - Physeter catodon
   partOfSpeech: n
+  wikidata: Q19829408
 02070115-n:
   definition:
   - pygmy sperm whales
@@ -47892,6 +48576,7 @@
   - pygmy sperm whale
   - Kogia breviceps
   partOfSpeech: n
+  wikidata: Q244300
 02070421-n:
   definition:
   - very small (to 8 feet) sperm whale of central coasts of Atlantic and Pacific
@@ -47955,6 +48640,7 @@
   - bottlenose
   - Hyperoodon ampullatus
   partOfSpeech: n
+  wikidata: Q300949
 02071388-n:
   definition:
   - dolphins
@@ -48043,6 +48729,7 @@
   - Atlantic bottlenose dolphin
   - Tursiops truncatus
   partOfSpeech: n
+  wikidata: Q174199
 02072826-n:
   definition:
   - a bottlenose dolphin found in the Pacific Ocean
@@ -48087,6 +48774,7 @@
   - herring hog
   - Phocoena phocoena
   partOfSpeech: n
+  wikidata: Q27027
 02073428-n:
   definition:
   - a short porpoise that lives in the Gulf of California; an endangered species
@@ -48097,6 +48785,7 @@
   - vaquita
   - Phocoena sinus
   partOfSpeech: n
+  wikidata: Q725493
 02073575-n:
   definition:
   - grampus
@@ -48119,6 +48808,7 @@
   - grampus
   - Grampus griseus
   partOfSpeech: n
+  wikidata: Q203897
 02073825-n:
   definition:
   - killer whales
@@ -48147,6 +48837,7 @@
   - sea wolf
   - Orcinus orca
   partOfSpeech: n
+  wikidata: Q26843
 02074158-n:
   definition:
   - pilot whales
@@ -48236,6 +48927,7 @@
   - narwhale
   - Monodon monoceros
   partOfSpeech: n
+  wikidata: Q159426
 02075317-n:
   definition:
   - white whale
@@ -48260,6 +48952,7 @@
   - beluga
   - Delphinapterus leucas
   partOfSpeech: n
+  wikidata: Q132072
 02075605-n:
   definition:
   - a spouting whale
@@ -48332,6 +49025,7 @@
   - manatee
   - Trichechus manatus
   partOfSpeech: n
+  wikidata: Q40261
 02076656-n:
   definition:
   - a family of mammals of order Sirenia including dugongs and Steller's sea cow
@@ -48369,6 +49063,7 @@
   - dugong
   - Dugong dugon
   partOfSpeech: n
+  wikidata: Q129544
 02077194-n:
   definition:
   - a genus of the family Dugongidae comprising only Steller's sea cow
@@ -48393,6 +49088,7 @@
   - Steller's sea cow
   - Hydrodamalis gigas
   partOfSpeech: n
+  wikidata: Q187484
 02077567-n:
   definition:
   - cats, lions, tigers, panthers, dogs, wolves, jackals, bears, cats, lions, tigers,
@@ -48545,6 +49241,7 @@
   - guadalupe fur seal
   - Arctocephalus townsendi
   partOfSpeech: n
+  wikidata: Q221088
 02080185-n:
   definition:
   - a genus of fur seals, containing the northern fur seal (Callorhinus)
@@ -48577,6 +49274,7 @@
   - Alaska fur seal
   - Callorhinus ursinus
   partOfSpeech: n
+  wikidata: Q7966
 02080575-n:
   definition:
   - any of several large eared seals of the northern Pacific related to fur seals
@@ -48610,6 +49308,7 @@
   - South American sea lion
   - Otaria byronia
   partOfSpeech: n
+  wikidata: Q28174380
 02081088-n:
   definition:
   - a genus of sea lions and fur seals (Zalophus)
@@ -48635,6 +49334,7 @@
   - Zalophus californianus
   - Zalophus californicus
   partOfSpeech: n
+  wikidata: Q379732
 02081390-n:
   definition:
   - a variety of sea lion found in Australia
@@ -48724,6 +49424,7 @@
   - common seal
   - Phoca vitulina
   partOfSpeech: n
+  wikidata: Q26913
 02082674-n:
   definition:
   - harp seals
@@ -48797,6 +49498,7 @@
   - squareflipper square flipper
   - Erignathus barbatus
   partOfSpeech: n
+  wikidata: Q149405
 02083586-n:
   definition:
   - hooded seals
@@ -48822,6 +49524,7 @@
   - bladdernose
   - Cystophora cristata
   partOfSpeech: n
+  wikidata: Q214287
 02083934-n:
   definition:
   - walruses and extinct forms
@@ -48870,6 +49573,7 @@
   - Atlantic walrus
   - Odobenus rosmarus
   partOfSpeech: n
+  wikidata: Q40994
 02084579-n:
   definition:
   - a walrus of the Bering Sea and northern Pacific
@@ -48953,6 +49657,7 @@
   - anteater
   - Orycteropus afer
   partOfSpeech: n
+  wikidata: Q46212
 02085690-n:
   definition:
   - dogs, wolves, jackals, foxes
@@ -49037,7 +49742,10 @@
   mero_part:
   - 02161498-n
   partOfSpeech: n
-  wikidata: Q144
+  wikidata:
+  - Q144
+  - Q26972265
+  - Q20717272
 02087384-n:
   definition:
   - informal terms for dogs
@@ -50956,6 +51664,7 @@
   - gray wolf
   - Canis lupus
   partOfSpeech: n
+  wikidata: Q18498
 02117200-n:
   definition:
   - wolf of Arctic North America having white fur and a black-tipped tail
@@ -50980,6 +51689,7 @@
   - Canis rufus
   - Canis niger
   partOfSpeech: n
+  wikidata: Q28196316
 02117507-n:
   definition:
   - small wolf native to western North America
@@ -50992,6 +51702,7 @@
   - brush wolf
   - Canis latrans
   partOfSpeech: n
+  wikidata: Q44299
 02117664-n:
   definition:
   - offspring of a coyote and a dog
@@ -51033,6 +51744,9 @@
   - warragal
   - Canis dingo
   partOfSpeech: n
+  wikidata:
+  - Q5032447
+  - Q117011854
 02118427-n:
   definition:
   - Asiatic wild dog
@@ -51058,6 +51772,7 @@
   - dhole
   - Cuon alpinus
   partOfSpeech: n
+  wikidata: Q132585
 02118731-n:
   definition:
   - crab-eating dog
@@ -51128,6 +51843,7 @@
   - Cape hunting dog
   - Lycaon pictus
   partOfSpeech: n
+  wikidata: Q173651
 02119611-n:
   definition:
   - hyenas
@@ -51177,6 +51893,7 @@
   - striped hyena
   - Hyaena hyaena
   partOfSpeech: n
+  wikidata: Q188657
 02120298-n:
   definition:
   - of southern Africa
@@ -51189,6 +51906,9 @@
   - Hyaena brunnea
   - Parahyaena brunnea
   partOfSpeech: n
+  wikidata:
+  - Q28157482
+  - Q210644
 02120424-n:
   definition:
   - a genus of Hyaenidae
@@ -51237,6 +51957,7 @@
   - aardwolf
   - Proteles cristata
   partOfSpeech: n
+  wikidata: Q185295
 02120985-n:
   definition:
   - alert carnivorous mammal with pointed muzzle and ears and a bushy tail; most are
@@ -51293,6 +52014,7 @@
   - red fox
   - Vulpes vulpes
   partOfSpeech: n
+  wikidata: Q8332
 02121899-n:
   definition:
   - red fox in the color phase when its pelt is mostly black
@@ -51332,6 +52054,7 @@
   - prairie fox
   - Vulpes velox
   partOfSpeech: n
+  wikidata: Q263706
 02122441-n:
   definition:
   - small grey fox of southwestern United States; may be a subspecies of Vulpes velox
@@ -51342,6 +52065,7 @@
   - kit fox
   - Vulpes macrotis
   partOfSpeech: n
+  wikidata: Q745751
 02122613-n:
   definition:
   - arctic foxes
@@ -51366,6 +52090,7 @@
   - white fox
   - Alopex lagopus
   partOfSpeech: n
+  wikidata: Q23729171
 02122930-n:
   definition:
   - a variety of Arctic fox having a pale grey winter coat
@@ -51399,6 +52124,7 @@
   - gray fox
   - Urocyon cinereoargenteus
   partOfSpeech: n
+  wikidata: Q215250
 02123344-n:
   definition:
   - cats, wildcats, lions, leopards, cheetahs, saber-toothed tigers
@@ -51481,6 +52207,9 @@
   - Felis domesticus
   - Felis catus
   partOfSpeech: n
+  wikidata:
+  - Q57818409
+  - Q20980826
 02124950-n:
   definition:
   - informal terms referring to a domestic cat
@@ -51711,6 +52440,7 @@
   - catamountain
   - Felis silvestris
   partOfSpeech: n
+  wikidata: Q43576
 02127963-n:
   definition:
   - large American feline resembling a lion
@@ -51726,6 +52456,9 @@
   - panther
   - Felis concolor
   partOfSpeech: n
+  wikidata:
+  - Q35255
+  - Q109647288
 02128146-n:
   definition:
   - nocturnal wildcat of Central America and South America having a dark-spotted buff-brown
@@ -51739,6 +52472,9 @@
   - Felis pardalis
   - Leopardus pardalis
   partOfSpeech: n
+  wikidata:
+  - Q33261
+  - Q122170181
 02128341-n:
   definition:
   - long-bodied long-tailed tropical American wildcat
@@ -51752,7 +52488,10 @@
   - eyra
   - Felis yagouaroundi
   partOfSpeech: n
-  wikidata: Q182304
+  wikidata:
+  - Q182304
+  - Q27450846
+  - Q27450875
 02128524-n:
   definition:
   - widely distributed wildcat of Africa and Asia Minor
@@ -51764,6 +52503,7 @@
   - caffer cat
   - Felis ocreata
   partOfSpeech: n
+  wikidata: Q47450946
 02128680-n:
   definition:
   - small Asiatic wildcat
@@ -51774,6 +52514,7 @@
   - jungle cat
   - Felis chaus
   partOfSpeech: n
+  wikidata: Q42623
 02128791-n:
   definition:
   - slender long-legged African wildcat having large untufted ears and tawny black-spotted
@@ -51785,6 +52526,9 @@
   - serval
   - Felis serval
   partOfSpeech: n
+  wikidata:
+  - Q42699
+  - Q109647291
 02128969-n:
   definition:
   - small spotted wildcat of southern Asia and Malaysia
@@ -51796,6 +52540,9 @@
   - Felis bengalensis
   - Prionailurus bengalensis
   partOfSpeech: n
+  wikidata:
+  - Q42627
+  - Q122748829
 02129117-n:
   definition:
   - medium-sized wildcat of Central America and South America having a dark-striped
@@ -51807,6 +52554,9 @@
   - tiger cat
   - Felis tigrina
   partOfSpeech: n
+  wikidata:
+  - Q205948
+  - Q122653137
 02129292-n:
   definition:
   - small spotted wildcat found from Texas to Brazil
@@ -51830,6 +52580,9 @@
   - Felis manul
   - Otocolobus manul
   partOfSpeech: n
+  wikidata:
+  - Q166794
+  - Q24006022
 02129603-n:
   definition:
   - lynxes
@@ -51862,6 +52615,7 @@
   - common lynx
   - Lynx lynx
   partOfSpeech: n
+  wikidata: Q43375
 02130033-n:
   definition:
   - of northern North America
@@ -51884,6 +52638,7 @@
   - bay lynx
   - Lynx rufus
   partOfSpeech: n
+  wikidata: Q131907
 02130238-n:
   definition:
   - of southern Europe
@@ -51943,6 +52698,7 @@
   - leopard
   - Panthera pardus
   partOfSpeech: n
+  wikidata: Q34706
 02131250-n:
   definition:
   - female leopard
@@ -51972,6 +52728,7 @@
   - ounce
   - Panthera uncia
   partOfSpeech: n
+  wikidata: Q30197
 02131577-n:
   definition:
   - a large spotted feline of tropical America similar to the leopard; in some classifications
@@ -51985,6 +52742,7 @@
   - Panthera onca
   - Felis onca
   partOfSpeech: n
+  wikidata: Q35694
 02131817-n:
   definition:
   - large gregarious predatory feline of Africa and India having a tawny coat with
@@ -52028,6 +52786,7 @@
   - tiger
   - Panthera tigris
   partOfSpeech: n
+  wikidata: Q19939
 02132489-n:
   definition:
   - southern short-haired tiger
@@ -52090,6 +52849,7 @@
   - chetah
   - Acinonyx jubatus
   partOfSpeech: n
+  wikidata: Q23907
 02133197-n:
   definition:
   - any of many extinct cats of the Old and New Worlds having long swordlike upper
@@ -52199,6 +52959,7 @@
   - bruin
   - Ursus arctos
   partOfSpeech: n
+  wikidata: Q36341
 02134972-n:
   definition:
   - a conventional name for a bear used in tales following usage in the old epic ‘Reynard
@@ -52273,6 +53034,7 @@
   - Ursus americanus
   - Euarctos americanus
   partOfSpeech: n
+  wikidata: Q122783
 02136052-n:
   definition:
   - reddish-brown color phase of the American black bear
@@ -52308,7 +53070,9 @@
   - Selenarctos thibetanus
   - Arcticonus thibetanus
   partOfSpeech: n
-  wikidata: Q124410
+  wikidata:
+  - Q122451771
+  - Q124410
 02136554-n:
   definition:
   - polar bears; in some classifications not a separate genus from Ursus
@@ -52333,6 +53097,7 @@
   - Ursus maritimus
   - Thalarctos maritimus
   partOfSpeech: n
+  wikidata: Q33609
 02136892-n:
   definition:
   - sloth bears; in some classifications not a separate genus from Ursus
@@ -52357,6 +53122,7 @@
   - Melursus ursinus
   - Ursus ursinus
   partOfSpeech: n
+  wikidata: Q145016
 02137241-n:
   definition:
   - genets, civets, mongooses
@@ -52424,6 +53190,7 @@
   - large civet
   - Viverra zibetha
   partOfSpeech: n
+  wikidata: Q757265
 02138378-n:
   definition:
   - a genus of Viverridae
@@ -52446,6 +53213,7 @@
   - Viverricula indica
   - Viverricula malaccensis
   partOfSpeech: n
+  wikidata: Q125705855
 02138633-n:
   definition:
   - binturongs
@@ -52494,6 +53262,7 @@
   - fossa cat
   - Cryptoprocta ferox
   partOfSpeech: n
+  wikidata: Q183330
 02139275-n:
   definition:
   - monotypic genus of Madagascar civets closely related to palm civets
@@ -52540,6 +53309,7 @@
   - genet
   - Genetta genetta
   partOfSpeech: n
+  wikidata: Q261574
 02139824-n:
   definition:
   - banded palm civets
@@ -52606,6 +53376,7 @@
   - ichneumon
   - Herpestes ichneumon
   partOfSpeech: n
+  wikidata: Q649306
 02140694-n:
   definition:
   - palm civets
@@ -52663,6 +53434,7 @@
   - slender-tailed meerkat
   - Suricata suricatta
   partOfSpeech: n
+  wikidata: Q134015
 02141429-n:
   definition:
   - burrowing diurnal meerkat of southern Africa; often kept as a pet
@@ -52768,6 +53540,7 @@
   members:
   - Pteropus hypomelanus
   partOfSpeech: n
+  wikidata: Q583116
 02143009-n:
   definition:
   - East Indian fruit bats
@@ -52816,6 +53589,7 @@
   members:
   - Cynopterus sphinx
   partOfSpeech: n
+  wikidata: Q1340212
 02143622-n:
   definition:
   - most of the bats in the world; all bats except fruit bats; insectivorous bats
@@ -52904,6 +53678,7 @@
   - macrotus
   - Macrotus californicus
   partOfSpeech: n
+  wikidata: Q1834586
 02145227-n:
   definition:
   - type genus of the family Phyllostomatidae
@@ -52935,6 +53710,7 @@
   members:
   - Phyllostomus hastatus
   partOfSpeech: n
+  wikidata: Q1548283
 02145645-n:
   definition:
   - a genus of Phyllostomatidae
@@ -52958,6 +53734,7 @@
   - hognose bat
   - Choeronycteris mexicana
   partOfSpeech: n
+  wikidata: Q309117
 02145945-n:
   definition:
   - Old World leaf-nosed bats
@@ -53144,6 +53921,7 @@
   - frosted bat
   - Vespertilio murinus
   partOfSpeech: n
+  wikidata: Q232644
 02148716-n:
   definition:
   - a genus of Vespertilionidae, containing the hairy-tailed bats (Lasiurus)
@@ -53167,6 +53945,7 @@
   - red bat
   - Lasiurus borealis
   partOfSpeech: n
+  wikidata: Q301708
 02149023-n:
   definition:
   - any of numerous medium to small insectivorous bats found worldwide in caves and
@@ -53237,6 +54016,7 @@
   - big brown bat
   - Eptesicus fuscus
   partOfSpeech: n
+  wikidata: Q301254
 02149980-n:
   definition:
   - common brown bat of Europe
@@ -53248,6 +54028,7 @@
   - European brown bat
   - Eptesicus serotinus
   partOfSpeech: n
+  wikidata: Q214869
 02150104-n:
   definition:
   - a genus of Vespertilionidae, containing the pallid bat (Antrozous)
@@ -53272,6 +54053,7 @@
   - cave bat
   - Antrozous pallidus
   partOfSpeech: n
+  wikidata: Q301105
 02150399-n:
   definition:
   - nearly cosmopolitan genus of very small bats
@@ -53298,6 +54080,7 @@
   - pipistrel
   - Pipistrellus pipistrellus
   partOfSpeech: n
+  wikidata: Q176901
 02150740-n:
   definition:
   - one of the smallest bats of eastern North America
@@ -53308,6 +54091,7 @@
   - eastern pipistrel
   - Pipistrellus subflavus
   partOfSpeech: n
+  wikidata: Q478631
 02150897-n:
   definition:
   - a vespertilian bat of western North America
@@ -53318,6 +54102,7 @@
   - western pipistrel
   - Pipistrellus hesperus
   partOfSpeech: n
+  wikidata: Q786179
 02151029-n:
   definition:
   - a genus of Vespertilionidae, containing the spotted bats (Euderma)
@@ -53425,6 +54210,7 @@
   - Mexican freetail bat
   - Tadarida brasiliensis
   partOfSpeech: n
+  wikidata: Q913930
 02152513-n:
   definition:
   - small brown bat of California and northern Mexico
@@ -53508,6 +54294,7 @@
   members:
   - Desmodus rotundus
   partOfSpeech: n
+  wikidata: Q300981
 02153760-n:
   definition:
   - vampire bats
@@ -53532,6 +54319,7 @@
   - hairy-legged vampire bat
   - Diphylla ecaudata
   partOfSpeech: n
+  wikidata: Q717028
 02154100-n:
   definition:
   - system of fluid-filled tubes used by echinoderms in locomotion and feeding and
@@ -54398,6 +55186,7 @@
   - two-spotted ladybug
   - Adalia bipunctata
   partOfSpeech: n
+  wikidata: Q233024
 02168676-n:
   definition:
   - genus of ladybugs native to Mexico and Central America; both larvae and adults
@@ -54424,6 +55213,7 @@
   - bean beetle
   - Epilachna varivestis
   partOfSpeech: n
+  wikidata: Q1563577
 02169088-n:
   definition:
   - genus of ladybugs, including H. convergens (Hippodamia)
@@ -54471,6 +55261,7 @@
   - vedalia
   - Rodolia cardinalis
   partOfSpeech: n
+  wikidata: Q2235176
 02169638-n:
   definition:
   - ground beetles
@@ -54551,6 +55342,7 @@
   - searcher beetle
   - Calosoma scrutator
   partOfSpeech: n
+  wikidata: Q4035780
 02170773-n:
   definition:
   - fireflies
@@ -54702,6 +55494,7 @@
   - potato beetle
   - Leptinotarsa decemlineata
   partOfSpeech: n
+  wikidata: Q156954
 02172921-n:
   definition:
   - carpet beetles
@@ -54928,6 +55721,7 @@
   - Japanese beetle
   - Popillia japonica
   partOfSpeech: n
+  wikidata: Q1683382
 02176223-n:
   definition:
   - genus of beetles whose grubs feed mainly on roots of plants; includes several
@@ -55013,6 +55807,7 @@
   - May beetle
   - Melolontha melolontha
   partOfSpeech: n
+  wikidata: Q28175
 02177522-n:
   definition:
   - a genus of Melolonthidae
@@ -55038,6 +55833,7 @@
   - rose bug
   - Macrodactylus subspinosus
   partOfSpeech: n
+  wikidata: Q3274895
 02177915-n:
   definition:
   - a subfamily of beetles, commonly known as flower beetles and goliath beetles
@@ -55076,6 +55872,7 @@
   - rose beetle
   - Cetonia aurata
   partOfSpeech: n
+  wikidata: Q731970
 02178443-n:
   definition:
   - stag beetles
@@ -55160,6 +55957,7 @@
   - fire beetle
   - Pyrophorus noctiluca
   partOfSpeech: n
+  wikidata: Q6093621
 02179568-n:
   definition:
   - wormlike larva of various elaterid beetles; feeds on roots of many crop plants
@@ -55239,6 +56037,7 @@
   - deathwatch
   - Xestobium rufovillosum
   partOfSpeech: n
+  wikidata: Q1074662
 02180624-n:
   definition:
   - any of several families of mostly small beetles that feed on plants and plant
@@ -55295,6 +56094,7 @@
   - boll weevil
   - Anthonomus grandis
   partOfSpeech: n
+  wikidata: Q217336
 02181538-n:
   definition:
   - blister beetles
@@ -55546,6 +56346,7 @@
   - pea weevil
   - Bruchus pisorum
   partOfSpeech: n
+  wikidata: Q1310545
 02185150-n:
   definition:
   - a genus of Bruchidae containing the bean weevils (Acanthoscelides)
@@ -55605,6 +56406,7 @@
   - Asian longhorned beetle
   - Anoplophora glabripennis
   partOfSpeech: n
+  wikidata: Q312378
 02186005-n:
   definition:
   - web spinners
@@ -55705,6 +56507,7 @@
   - head louse
   - Pediculus capitis
   partOfSpeech: n
+  wikidata: Q50405403
 02187372-n:
   definition:
   - a parasitic louse that infests the body of human beings
@@ -55807,6 +56610,7 @@
   - Menopon palladum
   - Menopon gallinae
   partOfSpeech: n
+  wikidata: Q11777384
 02188625-n:
   definition:
   - fleas
@@ -55869,6 +56673,7 @@
   members:
   - Pulex irritans
   partOfSpeech: n
+  wikidata: Q989263
 02189486-n:
   definition:
   - an arthropod genus of fleas
@@ -55914,6 +56719,7 @@
   - cat flea
   - Ctenocephalides felis
   partOfSpeech: n
+  wikidata: Q1736901
 02190079-n:
   definition:
   - a genus of Siphonaptera
@@ -55940,6 +56746,7 @@
   - chigoe flea
   - Tunga penetrans
   partOfSpeech: n
+  wikidata: Q133413
 02190411-n:
   definition:
   - a genus of Siphonaptera containing some 21 species occurring in the Palaearctic,
@@ -55965,6 +56772,7 @@
   - sticktight flea
   - Echidnophaga gallinacea
   partOfSpeech: n
+  wikidata: Q5332402
 02190717-n:
   definition:
   - a large order of insects having a single pair of wings and sucking or piercing
@@ -56062,6 +56870,7 @@
   - Hessian fly
   - Mayetiola destructor
   partOfSpeech: n
+  wikidata: Q1615814
 02192474-n:
   definition:
   - 'two-winged flies especially the families: Muscidae, Gasterophilidae, Calliphoridae,
@@ -56346,6 +57155,7 @@
   - horse botfly
   - Gasterophilus intestinalis
   partOfSpeech: n
+  wikidata: Q3098874
 02196451-n:
   definition:
   - New World botflies
@@ -56394,6 +57204,7 @@
   - human botfly
   - Dermatobia hominis
   partOfSpeech: n
+  wikidata: Q941965
 02197066-n:
   definition:
   - warble flies
@@ -56434,6 +57245,7 @@
   - sheep gadfly
   - Oestrus ovis
   partOfSpeech: n
+  wikidata: Q2213119
 02197539-n:
   definition:
   - 'in some classifications considered the type genus of the family Hypodermatidae:
@@ -56617,6 +57429,7 @@
   - medfly
   - Ceratitis capitata
   partOfSpeech: n
+  wikidata: Q250269
 02200065-n:
   definition:
   - fruit flies
@@ -56653,6 +57466,7 @@
   - drosophila
   - Drosophila melanogaster
   partOfSpeech: n
+  wikidata: Q130888
 02200529-n:
   definition:
   - flies whose larvae feed on pickles and imperfectly sealed preserves
@@ -56734,6 +57548,7 @@
   - horsefly
   - Hippobosca equina
   partOfSpeech: n
+  wikidata: Q2302603
 02201648-n:
   definition:
   - an arthropod genus of wingless flies including the sheep ked
@@ -56759,6 +57574,7 @@
   - sheep tick
   - Melophagus ovinus
   partOfSpeech: n
+  wikidata: Q2352863
 02202004-n:
   definition:
   - European genus of bloodsucking flies
@@ -56783,6 +57599,7 @@
   - horn fly
   - Haematobia irritans
   partOfSpeech: n
+  wikidata: Q3125657
 02202364-n:
   definition:
   - mosquitoes, fungus gnats, crane flies, gnats, sand flies
@@ -56943,6 +57760,7 @@
   - common mosquito
   - Culex pipiens
   partOfSpeech: n
+  wikidata: Q27958
 02204776-n:
   definition:
   - widespread tropical mosquito that transmits filarial worms
@@ -57364,6 +58182,7 @@
   - honeybee
   - Apis mellifera
   partOfSpeech: n
+  wikidata: Q30034
 02211150-n:
   definition:
   - a strain of bees that originated in Brazil in the 1950s as a cross between an
@@ -57548,6 +58367,7 @@
   - Nomia melanderi
   - alkali bee
   partOfSpeech: n
+  wikidata: Q2184225
 02213751-n:
   definition:
   - leaf-cutting and mason bees
@@ -57696,6 +58516,7 @@
   - giant hornet
   - Vespa crabro
   partOfSpeech: n
+  wikidata: Q30258
 02216014-n:
   definition:
   - 'sometimes considered a subgenus of Vespa: social wasps'
@@ -57720,6 +58541,7 @@
   - common wasp
   - Vespula vulgaris
   partOfSpeech: n
+  wikidata: Q260482
 02216315-n:
   definition:
   - North American hornet
@@ -57742,6 +58564,7 @@
   - yellow hornet
   - Vespula maculifrons
   partOfSpeech: n
+  wikidata: Q5330640
 02216619-n:
   definition:
   - a genus of Vespidae
@@ -58128,6 +58951,7 @@
   - birch leaf miner
   - Fenusa pusilla
   partOfSpeech: n
+  wikidata: Q14452991
 02221886-n:
   definition:
   - ants
@@ -58196,6 +59020,7 @@
   - little black ant
   - Monomorium minimum
   partOfSpeech: n
+  wikidata: Q6652659
 02223045-n:
   definition:
   - army ants
@@ -58308,6 +59133,7 @@
   members:
   - Formica fusca
   partOfSpeech: n
+  wikidata: Q1543905
 02224472-n:
   definition:
   - an ant that attacks colonies of other ant species and carries off the young to
@@ -58329,6 +59155,7 @@
   - sanguinary ant
   - Formica sanguinea
   partOfSpeech: n
+  wikidata: Q1350298
 02224851-n:
   definition:
   - bulldog ants
@@ -58374,6 +59201,7 @@
   - Amazon ant
   - Polyergus rufescens
   partOfSpeech: n
+  wikidata: Q456474
 02225370-n:
   definition:
   - 'order of social insects that live in colonies, including: termites; often placed
@@ -58520,6 +59348,7 @@
   members:
   - Mastotermes darwiniensis
   partOfSpeech: n
+  wikidata: Q135349
 02227589-n:
   definition:
   - an extinct termite found in amber in southern Mexico
@@ -58587,6 +59416,7 @@
   - powder-post termite
   - Cryptotermes brevis
   partOfSpeech: n
+  wikidata: Q13582607
 02228611-n:
   definition:
   - grasshoppers and locusts; crickets
@@ -58685,6 +59515,7 @@
   - migratory locust
   - Locusta migratoria
   partOfSpeech: n
+  wikidata: Q1059580
 02230082-n:
   definition:
   - New World migratory locusts and common American grasshoppers
@@ -58779,6 +59610,7 @@
   - mormon cricket
   - Anabrus simplex
   partOfSpeech: n
+  wikidata: Q2789177
 02231526-n:
   definition:
   - long-horned grasshoppers
@@ -58817,6 +59649,7 @@
   - Jerusalem cricket
   - Stenopelmatus fuscus
   partOfSpeech: n
+  wikidata: Q10678932
 02232037-n:
   definition:
   - crickets
@@ -58997,6 +59830,7 @@
   - diapheromera
   - Diapheromera femorata
   partOfSpeech: n
+  wikidata: Q5153638
 02234582-n:
   definition:
   - leaf insects
@@ -59166,6 +60000,7 @@
   - American cockroach
   - Periplaneta americana
   partOfSpeech: n
+  wikidata: Q267996
 02237222-n:
   definition:
   - widely distributed in warm countries
@@ -59452,6 +60287,7 @@
   - tarnished plant bug
   - Lygus lineolaris
   partOfSpeech: n
+  wikidata: Q7686422
 02241126-n:
   definition:
   - lace bugs
@@ -59669,6 +60505,7 @@
   - backswimmer
   - Notonecta undulata
   partOfSpeech: n
+  wikidata: Q10603680
 02243836-n:
   definition:
   - true bugs
@@ -59870,6 +60707,7 @@
   - common pond-skater
   - Gerris lacustris
   partOfSpeech: n
+  wikidata: Q20863
 02246659-n:
   definition:
   - assassin bugs
@@ -60085,6 +60923,7 @@
   - citrus whitefly
   - Dialeurodes citri
   partOfSpeech: n
+  wikidata: Q2685673
 02249728-n:
   definition:
   - a genus of whiteflies including the greenhouse whitefly
@@ -60108,6 +60947,7 @@
   - greenhouse whitefly
   - Trialeurodes vaporariorum
   partOfSpeech: n
+  wikidata: Q581988
 02250015-n:
   definition:
   - sweet-potato whitefly
@@ -60144,6 +60984,7 @@
   - Bemisia tabaci
   - poinsettia strain
   partOfSpeech: n
+  wikidata: Q1303946
 02250602-n:
   definition:
   - a strain of bacteria that is resistant to all antibiotics
@@ -60242,6 +61083,7 @@
   - brown soft scale
   - Coccus hesperidum
   partOfSpeech: n
+  wikidata: Q12868312
 02251908-n:
   definition:
   - any of various insects that secrete a waxy substance
@@ -60334,6 +61176,7 @@
   - cochineal
   - Dactylopius coccus
   partOfSpeech: n
+  wikidata: Q244274
 02253116-n:
   definition:
   - 'scalelike insects: mealybugs'
@@ -60397,6 +61240,7 @@
   - Comstock's mealybug
   - Pseudococcus comstocki
   partOfSpeech: n
+  wikidata: Q10642695
 02254104-n:
   definition:
   - a genus of Pseudococcidae
@@ -60420,6 +61264,7 @@
   - citrus mealybug
   - Planococcus citri
   partOfSpeech: n
+  wikidata: Q206556
 02254427-n:
   definition:
   - any of several small insects especially aphids that feed by sucking the juices
@@ -60507,6 +61352,7 @@
   - bean aphid
   - Aphis fabae
   partOfSpeech: n
+  wikidata: Q1532970
 02255779-n:
   definition:
   - greenish aphid; pest on garden and crop plants
@@ -60577,6 +61423,7 @@
   - American blight
   - Eriosoma lanigerum
   partOfSpeech: n
+  wikidata: Q618315
 02256762-n:
   definition:
   - a genus of Aphididae
@@ -60600,6 +61447,7 @@
   - woolly alder aphid
   - Prociphilus tessellatus
   partOfSpeech: n
+  wikidata: Q10639210
 02257022-n:
   definition:
   - a family of wooly conifer aphids, pine aphids, or spruce aphids (Adelgidae)
@@ -60649,6 +61497,7 @@
   - balsam woolly aphid
   - Adelges piceae
   partOfSpeech: n
+  wikidata: Q1382443
 02257675-n:
   definition:
   - a variety of adelgid which is a pest of the Norway spruce and various North American
@@ -60660,6 +61509,7 @@
   - spruce gall aphid
   - Adelges abietis
   partOfSpeech: n
+  wikidata: Q7195442
 02257796-n:
   definition:
   - a genus of Adelgidae
@@ -60684,6 +61534,7 @@
   - pine leaf aphid
   - Pineus pinifoliae
   partOfSpeech: n
+  wikidata: Q10631887
 02258043-n:
   definition:
   - an insect that feeds on hemlocks; its egg sacs are small fuzzy white balls like
@@ -60843,6 +61694,7 @@
   - periodical cicada
   - Magicicada septendecim
   partOfSpeech: n
+  wikidata: Q1949538
 02260188-n:
   definition:
   - froghoppers or spittlebugs
@@ -60936,6 +61788,7 @@
   - Saratoga spittlebug
   - Aphrophora saratogensis
   partOfSpeech: n
+  wikidata: Q13430039
 02261432-n:
   definition:
   - leafhoppers
@@ -61134,6 +61987,7 @@
   - deathwatch
   - Liposcelis divinatorius
   partOfSpeech: n
+  wikidata: Q4224702
 02264282-n:
   definition:
   - a genus of booklice including the common booklouse
@@ -61157,6 +62011,7 @@
   - common booklouse
   - Trogium pulsatorium
   partOfSpeech: n
+  wikidata: Q10717185
 02264535-n:
   definition:
   - the order of mayflies or shadflies (Ephemeroptera, Ephemerida)
@@ -61520,7 +62375,7 @@
   - alder fly
   - Sialis lutaria
   partOfSpeech: n
-  wikidata: Q899799
+  wikidata: Q1316279
 02269671-n:
   definition:
   - a family of arthropods of the suborder Megaloptera, including snakeflies
@@ -61790,6 +62645,7 @@
   - silverfish
   - Lepisma saccharina
   partOfSpeech: n
+  wikidata: Q26842
 02273462-n:
   definition:
   - a genus of Lepismatidae
@@ -61813,6 +62669,7 @@
   - firebrat
   - Thermobia domestica
   partOfSpeech: n
+  wikidata: Q1069416
 02273739-n:
   definition:
   - jumping bristletails
@@ -61913,6 +62770,7 @@
   - tobacco thrips
   - Frankliniella fusca
   partOfSpeech: n
+  wikidata: Q10498532
 02275080-n:
   definition:
   - type genus of the Thripidae
@@ -61996,6 +62854,7 @@
   - common European earwig
   - Forficula auricularia
   partOfSpeech: n
+  wikidata: Q2537221
 02276197-n:
   definition:
   - moths and butterflies
@@ -62108,6 +62967,7 @@
   - Camberwell beauty
   - Nymphalis antiopa
   partOfSpeech: n
+  wikidata: Q503989
 02278425-n:
   definition:
   - brilliantly colored; larvae feed on nettles
@@ -62142,6 +63002,7 @@
   - painted beauty
   - Vanessa virginiensis
   partOfSpeech: n
+  wikidata: Q1590841
 02278910-n:
   definition:
   - any of several brightly colored butterflies
@@ -62161,6 +63022,7 @@
   - red admiral
   - Vanessa atalanta
   partOfSpeech: n
+  wikidata: Q156454
 02279179-n:
   definition:
   - mainly dark northern butterflies with white wing bars
@@ -62199,6 +63061,7 @@
   - white admiral
   - Limenitis arthemis
   partOfSpeech: n
+  wikidata: Q2661300
 02279746-n:
   definition:
   - similar to the banded purple but with red spots on underwing surfaces
@@ -62209,6 +63072,7 @@
   - red-spotted purple
   - Limenitis astyanax
   partOfSpeech: n
+  wikidata: Q13575510
 02279920-n:
   definition:
   - showy American butterfly resembling the monarch but smaller
@@ -62219,6 +63083,7 @@
   - viceroy
   - Limenitis archippus
   partOfSpeech: n
+  wikidata: Q310832
 02280074-n:
   definition:
   - nymphalid butterfly having angular notches on the outer edges of the forewings
@@ -62376,6 +63241,7 @@
   - peacock butterfly
   - Inachis io
   partOfSpeech: n
+  wikidata: Q97378644
 02282094-n:
   definition:
   - 'small family of usually tropical butterflies: monarch butterflies'
@@ -62426,6 +63292,7 @@
   - milkweed butterfly
   - Danaus plexippus
   partOfSpeech: n
+  wikidata: Q212398
 02282875-n:
   definition:
   - arthropod family including cabbage butterflies; sulphur butterflies
@@ -62487,6 +63354,7 @@
   - small white
   - Pieris rapae
   partOfSpeech: n
+  wikidata: Q27653
 02283788-n:
   definition:
   - Old World form of cabbage butterfly
@@ -62497,6 +63365,7 @@
   - large white
   - Pieris brassicae
   partOfSpeech: n
+  wikidata: Q26764
 02283919-n:
   definition:
   - common North American form of cabbage butterfly
@@ -62586,6 +63455,7 @@
   - American copper
   - Lycaena hypophlaeas
   partOfSpeech: n
+  wikidata: Q123966317
 02285368-n:
   definition:
   - large and widely distributed genus of hairstreak butterflies
@@ -62619,6 +63489,7 @@
   members:
   - Strymon melinus
   partOfSpeech: n
+  wikidata: Q3021949
 02285853-n:
   definition:
   - typically crepuscular or nocturnal insect having a stout body and feathery or
@@ -62735,6 +63606,7 @@
   - tortrix
   - Argyrotaenia citrana
   partOfSpeech: n
+  wikidata: Q13394225
 02287704-n:
   definition:
   - codling moths
@@ -62759,6 +63631,7 @@
   - codlin moth
   - Carpocapsa pomonella
   partOfSpeech: n
+  wikidata: Q59155163
 02288011-n:
   definition:
   - tussock moths
@@ -62819,6 +63692,7 @@
   - gipsy moth
   - Lymantria dispar
   partOfSpeech: n
+  wikidata: Q45532
 02288923-n:
   definition:
   - a genus of Lymantriidae
@@ -62845,6 +63719,7 @@
   - brown-tail moth
   - Euproctis phaeorrhoea
   partOfSpeech: n
+  wikidata: Q15657825
 02289306-n:
   definition:
   - white furry-bodied European moth with a yellow tail tuft
@@ -62855,6 +63730,7 @@
   - gold-tail moth
   - Euproctis chrysorrhoea
   partOfSpeech: n
+  wikidata: Q45902
 02289467-n:
   definition:
   - measuring worms
@@ -62904,6 +63780,7 @@
   members:
   - Paleacrita vernata
   partOfSpeech: n
+  wikidata: Q7127086
 02290128-n:
   definition:
   - geometrid moths, known for distinct sexual dimorphism leading to strongly reduced
@@ -62929,6 +63806,7 @@
   members:
   - Alsophila pometaria
   partOfSpeech: n
+  wikidata: Q1370141
 02290451-n:
   definition:
   - green caterpillar of a geometrid moth; pest of various fruit and shade trees
@@ -63035,6 +63913,7 @@
   - wax moth
   - Galleria mellonella
   partOfSpeech: n
+  wikidata: Q761648
 02292118-n:
   definition:
   - moths whose larvae are corn borers
@@ -63109,6 +63988,7 @@
   - cacao moth
   - Ephestia elutella
   partOfSpeech: n
+  wikidata: Q928458
 02293173-n:
   definition:
   - a genus of Pyralidae
@@ -63255,6 +64135,7 @@
   - webbing moth
   - Tineola bisselliella
   partOfSpeech: n
+  wikidata: Q1945889
 02295216-n:
   definition:
   - carpet moths
@@ -63384,6 +64265,7 @@
   - angoumois grain moth
   - Sitotroga cerealella
   partOfSpeech: n
+  wikidata: Q666035
 02296931-n:
   definition:
   - potato moths
@@ -63409,6 +64291,7 @@
   - splitworm
   - Phthorimaea operculella
   partOfSpeech: n
+  wikidata: Q3038703
 02297229-n:
   definition:
   - larva of potato moth; mines in leaves and stems of e.g. potatoes and tobacco
@@ -63506,6 +64389,7 @@
   - red underwing
   - Catocala nupta
   partOfSpeech: n
+  wikidata: Q581524
 02298802-n:
   definition:
   - antler moths
@@ -63530,6 +64414,7 @@
   - antler moth
   - Cerapteryx graminis
   partOfSpeech: n
+  wikidata: Q1258221
 02299132-n:
   definition:
   - a genus of Noctuidae
@@ -63577,6 +64462,7 @@
   - army cutworm
   - Chorizagrotis auxiliaris
   partOfSpeech: n
+  wikidata: Q13466120
 02299779-n:
   definition:
   - moths whose larvae are armyworms
@@ -63601,6 +64487,7 @@
   - armyworm
   - Pseudaletia unipuncta
   partOfSpeech: n
+  wikidata: Q17294983
 02300094-n:
   definition:
   - noctuid moth larvae that travel in multitudes destroying especially grass and
@@ -63637,6 +64524,7 @@
   members:
   - Spodoptera exigua
   partOfSpeech: n
+  wikidata: Q310344
 02300590-n:
   definition:
   - moth larva that eats foliage of beets and other vegetables
@@ -63647,7 +64535,6 @@
   - beet armyworm
   - Spodoptera exigua
   partOfSpeech: n
-  wikidata: Q310344
 02300747-n:
   definition:
   - moth whose larvae are fall armyworms
@@ -63657,6 +64544,7 @@
   members:
   - Spodoptera frugiperda
   partOfSpeech: n
+  wikidata: Q2715913
 02300870-n:
   definition:
   - larva of a migratory American noctuid moth; destroys grasses and small grains
@@ -63720,6 +64608,7 @@
   members:
   - Manduca sexta
   partOfSpeech: n
+  wikidata: Q1366539
 02301809-n:
   definition:
   - large green white-striped hawkmoth larva that feeds on tobacco and related plants;
@@ -63741,6 +64630,7 @@
   members:
   - Manduca quinquemaculata
   partOfSpeech: n
+  wikidata: Q1303141
 02302157-n:
   definition:
   - large green white-striped hawkmoth larva that feeds on tomato and potato plants;
@@ -63776,6 +64666,7 @@
   - death's-head moth
   - Acherontia atropos
   partOfSpeech: n
+  wikidata: Q41524
 02302670-n:
   definition:
   - Chinese silkworm moth
@@ -63827,6 +64718,7 @@
   - domesticated silkworm moth
   - Bombyx mori
   partOfSpeech: n
+  wikidata: Q134747
 02303449-n:
   definition:
   - the commercially bred hairless white caterpillar of the domestic silkworm moth
@@ -63897,6 +64789,7 @@
   - emperor moth
   - Saturnia pavonia
   partOfSpeech: n
+  wikidata: Q30964
 02304776-n:
   definition:
   - imperial moths
@@ -63921,6 +64814,7 @@
   - imperial moth
   - Eacles imperialis
   partOfSpeech: n
+  wikidata: Q1935887
 02305111-n:
   definition:
   - any silkworm moth of the family Saturniidae
@@ -63969,6 +64863,7 @@
   - luna moth
   - Actias luna
   partOfSpeech: n
+  wikidata: Q135289
 02305819-n:
   definition:
   - American silkworm moth
@@ -63991,6 +64886,7 @@
   - cecropia moth
   - Hyalophora cecropia
   partOfSpeech: n
+  wikidata: Q142322
 02306100-n:
   definition:
   - silkworm moths
@@ -64016,6 +64912,7 @@
   - Samia cynthia
   - Samia walkeri
   partOfSpeech: n
+  wikidata: Q13475800
 02306429-n:
   definition:
   - large green silkworm of the cynthia moth
@@ -64050,6 +64947,7 @@
   - io moth
   - Automeris io
   partOfSpeech: n
+  wikidata: Q1766445
 02306881-n:
   definition:
   - large moths whose larvae produce silk of high quality
@@ -64076,6 +64974,7 @@
   - polyphemus moth
   - Antheraea polyphemus
   partOfSpeech: n
+  wikidata: Q1758845
 02307309-n:
   definition:
   - a Chinese moth that produces a brownish silk
@@ -64086,6 +64985,7 @@
   - pernyi moth
   - Antheraea pernyi
   partOfSpeech: n
+  wikidata: Q1074174
 02307449-n:
   definition:
   - oriental moth that produces brownish silk
@@ -64100,6 +65000,7 @@
   - tusser
   - Antheraea mylitta
   partOfSpeech: n
+  wikidata: Q1852236
 02307619-n:
   definition:
   - atlas moth
@@ -64263,6 +65164,7 @@
   - tent-caterpillar moth
   - Malacosoma americana
   partOfSpeech: n
+  wikidata: Q13810025
 02309977-n:
   definition:
   - the larvae of moths that build and live in communal silken webs in orchard and
@@ -64283,6 +65185,7 @@
   - tent-caterpillar moth
   - Malacosoma disstria
   partOfSpeech: n
+  wikidata: Q2121239
 02310333-n:
   definition:
   - larvae of a gregarious North American moth that spins a web resembling a carpet
@@ -64354,6 +65257,7 @@
   members:
   - Hyphantria cunea
   partOfSpeech: n
+  wikidata: Q1333342
 02311387-n:
   definition:
   - a variety of webworm known as the fall webworm (Hyphantria cunea)
@@ -64364,7 +65268,6 @@
   - fall webworm
   - Hyphantria cunea
   partOfSpeech: n
-  wikidata: Q1333342
 02311504-n:
   definition:
   - garden webworms
@@ -64960,6 +65863,7 @@
   members:
   - Astrophyton muricatum
   partOfSpeech: n
+  wikidata: Q3545270
 02321450-n:
   definition:
   - a genus of basket stars found in coldwater environments including the Arctic,
@@ -65006,6 +65910,9 @@
   - edible sea urchin
   - Echinus esculentus
   partOfSpeech: n
+  wikidata:
+  - Q124657158
+  - Q664443
 02322075-n:
   definition:
   - flat sea urchins
@@ -65216,6 +66123,7 @@
   - trepang
   - Holothuria edulis
   partOfSpeech: n
+  wikidata: Q2305882
 02324865-n:
   definition:
   - any of various organs of locomotion or attachment in invertebrates
@@ -65400,6 +66308,7 @@
   mero_part:
   - 07682266-n
   partOfSpeech: n
+  wikidata: Q25851
 02327863-n:
   definition:
   - North American rabbits
@@ -65439,6 +66348,7 @@
   - eastern cottontail
   - Sylvilagus floridanus
   partOfSpeech: n
+  wikidata: Q774716
 02328536-n:
   definition:
   - a wood rabbit of southeastern United States swamps and lowlands
@@ -65451,6 +66361,7 @@
   - swamp hare
   - Sylvilagus aquaticus
   partOfSpeech: n
+  wikidata: Q583901
 02328726-n:
   definition:
   - a wood rabbit of marshy coastal areas from North Carolina to Florida
@@ -65462,6 +66373,7 @@
   - swamp rabbit
   - Sylvilagus palustris
   partOfSpeech: n
+  wikidata: Q138169
 02328889-n:
   definition:
   - 'type genus of the Leporidae: hares'
@@ -65509,6 +66421,7 @@
   - European hare
   - Lepus europaeus
   partOfSpeech: n
+  wikidata: Q26838
 02329680-n:
   definition:
   - large hare of western North America
@@ -65541,6 +66454,7 @@
   - blacktail jackrabbit
   - Lepus californicus
   partOfSpeech: n
+  wikidata: Q640645
 02330308-n:
   definition:
   - a large hare of northern North America; it is almost completely white in winter
@@ -65552,6 +66466,7 @@
   - Arctic hare
   - Lepus arcticus
   partOfSpeech: n
+  wikidata: Q231625
 02330494-n:
   definition:
   - large large-footed North American hare; white in winter
@@ -65637,6 +66552,7 @@
   - little chief hare
   - Ochotona princeps
   partOfSpeech: n
+  wikidata: Q469908
 02331594-n:
   definition:
   - similar to little chief hare and may be same species
@@ -65789,6 +66705,7 @@
   - house mouse
   - Mus musculus
   partOfSpeech: n
+  wikidata: Q83310
 02334967-n:
   definition:
   - Old World harvest mice
@@ -65858,6 +66775,7 @@
   - European wood mouse
   - Apodemus sylvaticus
   partOfSpeech: n
+  wikidata: Q212185
 02336020-n:
   definition:
   - common house rats; upper incisors have a beveled edge
@@ -65885,6 +66803,7 @@
   - Norway rat
   - Rattus norvegicus
   partOfSpeech: n
+  wikidata: Q184224
 02336385-n:
   definition:
   - brown rat that infests wharves
@@ -66143,6 +67062,7 @@
   - deer mouse
   - Peromyscus maniculatus
   partOfSpeech: n
+  wikidata: Q649836
 02339823-n:
   definition:
   - burrowing mouse of desert areas of southwestern United States
@@ -66164,6 +67084,7 @@
   - cotton mouse
   - Peromyscus gossypinus
   partOfSpeech: n
+  wikidata: Q959378
 02340132-n:
   definition:
   - pygmy mice
@@ -66187,6 +67108,7 @@
   - pygmy mouse
   - Baiomys taylori
   partOfSpeech: n
+  wikidata: Q306168
 02340426-n:
   definition:
   - grasshopper mice
@@ -66282,6 +67204,7 @@
   - cotton rat
   - Sigmodon hispidus
   partOfSpeech: n
+  wikidata: Q941564
 02341553-n:
   definition:
   - any of various small short-tailed rodents of the Northern Hemisphere having soft
@@ -66344,6 +67267,7 @@
   - bushytail woodrat
   - Neotoma cinerea
   partOfSpeech: n
+  wikidata: Q1017409
 02342838-n:
   definition:
   - host to Lyme disease tick (Ixodes pacificus) in northern California
@@ -66354,6 +67278,7 @@
   - dusky-footed woodrat
   - Neotoma fuscipes
   partOfSpeech: n
+  wikidata: Q1763729
 02343010-n:
   definition:
   - large greyish-brown wood rat of the southeastern United States
@@ -66364,6 +67289,7 @@
   - eastern woodrat
   - Neotoma floridana
   partOfSpeech: n
+  wikidata: Q1766870
 02343173-n:
   definition:
   - rice rats
@@ -66387,6 +67313,7 @@
   - rice rat
   - Oryzomys palustris
   partOfSpeech: n
+  wikidata: Q1092084
 02343465-n:
   definition:
   - pine mice
@@ -66448,6 +67375,7 @@
   - Richardson vole
   - Microtus richardsoni
   partOfSpeech: n
+  wikidata: Q1768650
 02344268-n:
   definition:
   - typical vole of the extended prairie region of central United States and southern
@@ -66459,6 +67387,7 @@
   - prairie vole
   - Microtus ochrogaster
   partOfSpeech: n
+  wikidata: Q1095135
 02344457-n:
   definition:
   - in some classifications considered synonymous with Microtus
@@ -66483,6 +67412,7 @@
   - water rat
   - Arvicola amphibius
   partOfSpeech: n
+  wikidata: Q27016
 02344761-n:
   definition:
   - a genus of Cricetidae containing the red-backed voles (Clethrionomys)
@@ -66560,6 +67490,7 @@
   - Eurasian hamster
   - Cricetus cricetus
   partOfSpeech: n
+  wikidata: Q208077
 02345839-n:
   definition:
   - golden hamsters
@@ -66654,6 +67585,7 @@
   - tamarisk gerbil
   - Meriones unguiculatus
   partOfSpeech: n
+  wikidata: Q649817
 02347060-n:
   definition:
   - southern European gerbil
@@ -66697,6 +67629,7 @@
   - European lemming
   - Lemmus lemmus
   partOfSpeech: n
+  wikidata: Q819985
 02347730-n:
   definition:
   - of northwestern Canada and Alaska
@@ -66707,6 +67640,7 @@
   - brown lemming
   - Lemmus trimucronatus
   partOfSpeech: n
+  wikidata: Q1769625
 02347865-n:
   definition:
   - a genus of Cricetidae
@@ -66763,6 +67697,7 @@
   - Hudson bay collared lemming
   - Dicrostonyx hudsonius
   partOfSpeech: n
+  wikidata: Q1768611
 02348542-n:
   definition:
   - bog lemmings
@@ -66785,6 +67720,7 @@
   - southern bog lemming
   - Synaptomys cooperi
   partOfSpeech: n
+  wikidata: Q1367837
 02348822-n:
   definition:
   - of wet alpine and subalpine meadows of Canada and Alaska
@@ -66795,6 +67731,7 @@
   - northern bog lemming
   - Synaptomys borealis
   partOfSpeech: n
+  wikidata: Q1762848
 02348967-n:
   definition:
   - 'an order of rodents including: porcupines, guinea pigs, chinchillas, etc.'
@@ -66895,6 +67832,7 @@
   - long-tailed porcupine
   - Trichys lipura
   partOfSpeech: n
+  wikidata: Q40712760
 02350396-n:
   definition:
   - arboreal porcupine
@@ -66999,6 +67937,7 @@
   - silky pocket mouse
   - Perognathus flavus
   partOfSpeech: n
+  wikidata: Q586809
 02352042-n:
   definition:
   - small rodent of open areas of United States plains states
@@ -67021,7 +67960,9 @@
   - Perognathus hispidus
   - Chaetodipus hispidus
   partOfSpeech: n
-  wikidata: Q167053
+  wikidata:
+  - Q167053
+  - Q24808782
 02352382-n:
   definition:
   - pocket mice, containing the Panamanian spiny pocket mouse, Mexican spiny pocket
@@ -67047,6 +67988,7 @@
   - Mexican pocket mouse
   - Liomys irroratus
   partOfSpeech: n
+  wikidata: Q115792
 02352632-n:
   definition:
   - kangaroo rats
@@ -67072,6 +68014,7 @@
   - desert rat
   - Dipodomys phillipsii
   partOfSpeech: n
+  wikidata: Q306215
 02353009-n:
   definition:
   - 'most widely distributed kangaroo rat: plains and mountain areas of central and
@@ -67153,6 +68096,7 @@
   - meadow jumping mouse
   - Zapus hudsonius
   partOfSpeech: n
+  wikidata: Q1761993
 02354170-n:
   definition:
   - Old World jerboas
@@ -67222,6 +68166,7 @@
   members:
   - Jaculus jaculus
   partOfSpeech: n
+  wikidata: Q920382
 02355042-n:
   definition:
   - dormice and other Old World forms
@@ -67271,6 +68216,7 @@
   - loir
   - Glis glis
   partOfSpeech: n
+  wikidata: Q147128
 02355689-n:
   definition:
   - a genus of Gliridae
@@ -67294,6 +68240,7 @@
   - hazel mouse
   - Muscardinus avellanarius
   partOfSpeech: n
+  wikidata: Q207148
 02355949-n:
   definition:
   - lerots
@@ -67378,6 +68325,7 @@
   - southeastern pocket gopher
   - Geomys pinetis
   partOfSpeech: n
+  wikidata: Q1767114
 02357122-n:
   definition:
   - western pocket gophers
@@ -67402,6 +68350,7 @@
   - valley pocket gopher
   - Thomomys bottae
   partOfSpeech: n
+  wikidata: Q1497037
 02357433-n:
   definition:
   - greyish to brown gopher of western and central United States
@@ -67412,6 +68361,7 @@
   - northern pocket gopher
   - Thomomys talpoides
   partOfSpeech: n
+  wikidata: Q1769015
 02357602-n:
   definition:
   - 'large more or less primitive rodents: squirrels, marmots, gophers, beavers, etc.'
@@ -67499,6 +68449,7 @@
   - cat squirrel
   - Sciurus carolinensis
   partOfSpeech: n
+  wikidata: Q468500
 02359264-n:
   definition:
   - large grey squirrel of far western areas of United States
@@ -67510,6 +68461,7 @@
   - western gray squirrel
   - Sciurus griseus
   partOfSpeech: n
+  wikidata: Q1071837
 02359450-n:
   definition:
   - exceptionally large arboreal squirrel of eastern United States
@@ -67566,6 +68518,7 @@
   - Sciurus hudsonicus
   - Tamiasciurus hudsonicus
   partOfSpeech: n
+  wikidata: Q326976
 02360237-n:
   definition:
   - far western United States counterpart of the red squirrel
@@ -67639,6 +68592,7 @@
   - souslik
   - Citellus citellus
   partOfSpeech: n
+  wikidata: Q40653494
 02361364-n:
   definition:
   - of sagebrush and grassland areas of western United States and Canada
@@ -67706,6 +68660,7 @@
   - blacktail prairie dog
   - Cynomys ludovicianus
   partOfSpeech: n
+  wikidata: Q247142
 02362319-n:
   definition:
   - tail is white tipped
@@ -67716,6 +68671,7 @@
   - whitetail prairie dog
   - Cynomys gunnisoni
   partOfSpeech: n
+  wikidata: Q936978
 02362427-n:
   definition:
   - chipmunks of eastern North America
@@ -67742,6 +68698,7 @@
   - ground squirrel
   - Tamias striatus
   partOfSpeech: n
+  wikidata: Q692664
 02362787-n:
   definition:
   - chipmunks of western America and Asia
@@ -67812,6 +68769,7 @@
   - southern flying squirrel
   - Glaucomys volans
   partOfSpeech: n
+  wikidata: Q913350
 02363742-n:
   definition:
   - large flying squirrel; chiefly of Canada
@@ -67822,6 +68780,7 @@
   - northern flying squirrel
   - Glaucomys sabrinus
   partOfSpeech: n
+  wikidata: Q1094722
 02363874-n:
   definition:
   - marmots
@@ -67856,6 +68815,7 @@
   - woodchuck
   - Marmota monax
   partOfSpeech: n
+  wikidata: Q221612
 02364358-n:
   definition:
   - large North American mountain marmot
@@ -67880,6 +68840,7 @@
   - rockchuck
   - Marmota flaviventris
   partOfSpeech: n
+  wikidata: Q838113
 02364677-n:
   definition:
   - Old World flying squirrels
@@ -67976,6 +68937,7 @@
   - Old World beaver
   - Castor fiber
   partOfSpeech: n
+  wikidata: Q181191
 02366003-n:
   definition:
   - a variety of beaver found in almost all areas of North America except Florida
@@ -67986,6 +68948,7 @@
   - New World beaver
   - Castor canadensis
   partOfSpeech: n
+  wikidata: Q81056
 02366163-n:
   definition:
   - extinct beavers of the Pleistocene; of eastern and southern United States
@@ -68035,6 +68998,7 @@
   - sewellel
   - Aplodontia rufa
   partOfSpeech: n
+  wikidata: Q503813
 02366873-n:
   definition:
   - a family of Hystricomorpha
@@ -68082,6 +69046,7 @@
   - guinea pig
   - Cavia cobaya
   partOfSpeech: n
+  wikidata: Q122453942
 02367492-n:
   definition:
   - South American cavy; possibly ancestral to the domestic guinea pig
@@ -68117,6 +69082,7 @@
   - mara
   - Dolichotis patagonum
   partOfSpeech: n
+  wikidata: Q194313
 02367896-n:
   definition:
   - capybara
@@ -68153,6 +69119,7 @@
   - capibara
   - Hydrochoerus hydrochaeris
   partOfSpeech: n
+  wikidata: Q131538
 02368324-n:
   definition:
   - agoutis and pacas
@@ -68192,6 +69159,7 @@
   - agouti
   - Dasyprocta aguti
   partOfSpeech: n
+  wikidata: Q40654026
 02368855-n:
   definition:
   - pacas
@@ -68214,6 +69182,7 @@
   - paca
   - Cuniculus paca
   partOfSpeech: n
+  wikidata: Q33936
 02369105-n:
   definition:
   - mountain pacas
@@ -68272,6 +69241,7 @@
   - nutria
   - Myocastor coypus
   partOfSpeech: n
+  wikidata: Q187704
 02369783-n:
   definition:
   - small bushy-tailed South American burrowing rodents
@@ -68358,6 +69328,7 @@
   - chinchillon
   - Lagostomus maximus
   partOfSpeech: n
+  wikidata: Q1162447
 02370932-n:
   definition:
   - abrocomes
@@ -68700,6 +69671,7 @@
   - rock rabbit
   - Procavia capensis
   partOfSpeech: n
+  wikidata: Q323847
 02375745-n:
   definition:
   - 'nonruminant ungulates: horses, tapirs, rhinoceros, extinct forms'
@@ -68796,6 +69768,9 @@
   - 05546645-n
   - 07682151-n
   partOfSpeech: n
+  wikidata:
+  - Q26644764
+  - Q10758650
 02377954-n:
   definition:
   - a horse having a brownish coat thickly sprinkled with white or gray
@@ -69874,6 +70849,7 @@
   - donkey
   - Equus asinus
   partOfSpeech: n
+  wikidata: Q19829417
 02392431-n:
   definition:
   - small donkey used as a pack animal
@@ -69963,6 +70939,7 @@
   - kiang
   - Equus kiang
   partOfSpeech: n
+  wikidata: Q221380
 02393486-n:
   definition:
   - Asiatic wild ass
@@ -69973,6 +70950,7 @@
   - onager
   - Equus hemionus
   partOfSpeech: n
+  wikidata: Q180960
 02393590-n:
   definition:
   - Mongolian wild ass
@@ -70024,6 +71002,7 @@
   - grevy's zebra
   - Equus grevyi
   partOfSpeech: n
+  wikidata: Q219565
 02394269-n:
   definition:
   - mammal of South Africa that resembled a zebra; extinct since late 19th century
@@ -70034,6 +71013,7 @@
   - quagga
   - Equus quagga
   partOfSpeech: n
+  wikidata: Q245305
 02394434-n:
   definition:
   - rhinoceroses
@@ -70085,6 +71065,7 @@
   - Indian rhinoceros
   - Rhinoceros unicornis
   partOfSpeech: n
+  wikidata: Q47910
 02395207-n:
   definition:
   - extinct thick-haired species of Arctic regions
@@ -70119,6 +71100,7 @@
   - Ceratotherium simum
   - Diceros simus
   partOfSpeech: n
+  wikidata: Q159918
 02395676-n:
   definition:
   - most common species in Africa
@@ -70142,6 +71124,7 @@
   - black rhinoceros
   - Diceros bicornis
   partOfSpeech: n
+  wikidata: Q95036
 02395952-n:
   definition:
   - tapirs and extinct related forms
@@ -70188,6 +71171,7 @@
   - New World tapir
   - Tapirus terrestris
   partOfSpeech: n
+  wikidata: Q220271
 02396592-n:
   definition:
   - a tapir found in Malaya and Sumatra
@@ -70199,7 +71183,9 @@
   - Indian tapir
   - Tapirus indicus
   partOfSpeech: n
-  wikidata: Q192710
+  wikidata:
+  - Q27868283
+  - Q192710
 02396720-n:
   definition:
   - an order of hooved mammals of the subclass Eutheria (including pigs and peccaries
@@ -70290,6 +71276,7 @@
   mero_substance:
   - 07688166-n
   partOfSpeech: n
+  wikidata: Q58697
 02398346-n:
   definition:
   - a young pig
@@ -70389,6 +71376,7 @@
   - babirussa
   - Babyrousa babyrussa
   partOfSpeech: n
+  wikidata: Q629015
 02399622-n:
   definition:
   - warthogs
@@ -70462,6 +71450,7 @@
   - Tayassu tajacu
   - Peccari angulatus
   partOfSpeech: n
+  wikidata: Q24251467
 02400639-n:
   definition:
   - blackish peccary with whitish cheeks; larger than the collared peccary
@@ -70520,6 +71509,7 @@
   - river horse
   - Hippopotamus amphibius
   partOfSpeech: n
+  wikidata: Q34505
 02401384-n:
   definition:
   - cattle, bison, sheep, goats, antelopes, deer, chevrotains, giraffes, camels
@@ -70742,6 +71732,7 @@
   mero_part:
   - 07679337-n
   partOfSpeech: n
+  wikidata: Q19610691
 02405655-n:
   definition:
   - an adult castrated bull of the genus Bos; especially Bos taurus
@@ -70882,6 +71873,7 @@
   - Brahmin
   - Bos indicus
   partOfSpeech: n
+  wikidata: Q20747726
 02407558-n:
   definition:
   - domesticated ox having a humped back and long horns and a large dewlap; used chiefly
@@ -70914,6 +71906,7 @@
   - yak
   - Bos grunniens
   partOfSpeech: n
+  wikidata: Q13408062
 02408092-n:
   definition:
   - wild ox of the Malay Archipelago
@@ -71152,6 +72145,7 @@
   - Asiatic buffalo
   - Bubalus bubalis
   partOfSpeech: n
+  wikidata: Q42710
 02411306-n:
   definition:
   - upland buffalo of eastern Asia where true water buffaloes do not thrive; used
@@ -71194,6 +72188,7 @@
   - dwarf buffalo
   - Anoa depressicornis
   partOfSpeech: n
+  wikidata: Q122849001
 02411848-n:
   definition:
   - small buffalo of Mindoro in the Philippines
@@ -71206,6 +72201,7 @@
   - Bubalus mindorensis
   - Anoa mindorensis
   partOfSpeech: n
+  wikidata: Q622878
 02412015-n:
   definition:
   - Cape buffalo
@@ -71315,6 +72311,7 @@
   mero_part:
   - 07679237-n
   partOfSpeech: n
+  wikidata: Q82728
 02413546-n:
   definition:
   - European bison having a smaller and higher head than the North American bison
@@ -71326,6 +72323,7 @@
   - aurochs
   - Bison bonasus
   partOfSpeech: n
+  wikidata: Q81091
 02413721-n:
   definition:
   - consisting of the musk-ox
@@ -71351,6 +72349,7 @@
   - musk sheep
   - Ovibos moschatus
   partOfSpeech: n
+  wikidata: Q184004
 02414073-n:
   definition:
   - sheep
@@ -71506,6 +72505,7 @@
   - 07682478-n
   - 07682896-n
   partOfSpeech: n
+  wikidata: Q29350771
 02416130-n:
   definition:
   - sheep with long wool originating in the Cotswold Hills
@@ -71612,6 +72612,7 @@
   - argal
   - Ovis ammon
   partOfSpeech: n
+  wikidata: Q186267
 02417550-n:
   definition:
   - Asiatic wild sheep with exceptionally large horns; sometimes considered a variety
@@ -71634,6 +72635,7 @@
   - urial
   - Ovis vignei
   partOfSpeech: n
+  wikidata: Q839513
 02417899-n:
   definition:
   - large white wild sheep of northwestern Canada and Alaska
@@ -71683,6 +72685,7 @@
   - moufflon
   - Ovis musimon
   partOfSpeech: n
+  wikidata: Q24145539
 02418617-n:
   definition:
   - genus of wild sheep
@@ -71710,6 +72713,7 @@
   - maned sheep
   - Ammotragus lervia
   partOfSpeech: n
+  wikidata: Q322141
 02418916-n:
   definition:
   - hairy growth on or near the face of certain mammals
@@ -71789,6 +72793,7 @@
   - domestic goat
   - Capra hircus
   partOfSpeech: n
+  wikidata: Q45320358
 02419888-n:
   definition:
   - Himalayan goat having a silky undercoat highly prized as cashmere wool
@@ -71829,6 +72834,9 @@
   - pasang
   - Capra aegagrus
   partOfSpeech: n
+  wikidata:
+  - Q20908547
+  - Q178228
 02420431-n:
   definition:
   - large Himalayan goat with large spiraled horns
@@ -71840,6 +72848,7 @@
   - markhoor
   - Capra falconeri
   partOfSpeech: n
+  wikidata: Q187927
 02420560-n:
   definition:
   - wild goat of mountain areas of Eurasia and northern Africa having large recurved
@@ -71886,6 +72895,7 @@
   - Rocky Mountain goat
   - Oreamnos americanus
   partOfSpeech: n
+  wikidata: Q242602
 02421294-n:
   definition:
   - gorals
@@ -71909,6 +72919,7 @@
   - goral
   - Naemorhedus goral
   partOfSpeech: n
+  wikidata: Q494436
 02421580-n:
   definition:
   - serows
@@ -71956,6 +72967,7 @@
   - chamois
   - Rupicapra rupicapra
   partOfSpeech: n
+  wikidata: Q131340
 02422161-n:
   definition:
   - gnu goats
@@ -71980,6 +72992,7 @@
   - gnu goat
   - Budorcas taxicolor
   partOfSpeech: n
+  wikidata: Q193469
 02422442-n:
   definition:
   - graceful Old World ruminant with long legs and horns directed upward and backward;
@@ -72061,6 +73074,7 @@
   - addax
   - Addax nasomaculatus
   partOfSpeech: n
+  wikidata: Q190154
 02423954-n:
   definition:
   - gnus (Connochaetes)
@@ -72153,6 +73167,7 @@
   - topi
   - Damaliscus lunatus
   partOfSpeech: n
+  wikidata: Q545071
 02425207-n:
   definition:
   - impalas (Aepyceros)
@@ -72176,6 +73191,7 @@
   - impala
   - Aepyceros melampus
   partOfSpeech: n
+  wikidata: Q132576
 02425506-n:
   definition:
   - typical gazelles
@@ -72219,6 +73235,7 @@
   members:
   - Gazella subgutturosa
   partOfSpeech: n
+  wikidata: Q460977
 02426111-n:
   definition:
   - springboks
@@ -72244,6 +73261,7 @@
   - Antidorcas marsupialis
   - Antidorcas euchore
   partOfSpeech: n
+  wikidata: Q213084
 02426433-n:
   definition:
   - 'African antelopes: kudus, bongos, nyalas, bushbucks'
@@ -72276,6 +73294,7 @@
   - Tragelaphus eurycerus
   - Boocercus eurycerus
   partOfSpeech: n
+  wikidata: Q193400
 02426951-n:
   definition:
   - either of two spiral-horned antelopes of the African bush
@@ -72308,6 +73327,7 @@
   - lesser kudu
   - Tragelaphus imberbis
   partOfSpeech: n
+  wikidata: Q622882
 02427341-n:
   definition:
   - any of several antelopes of the genus Tragelaphus having striped markings resembling
@@ -72351,6 +73371,7 @@
   - guib
   - Tragelaphus scriptus
   partOfSpeech: n
+  wikidata: Q328803
 02428039-n:
   definition:
   - nilgais (Boselaphus)
@@ -72378,6 +73399,7 @@
   - blue bull
   - Boselaphus tragocamelus
   partOfSpeech: n
+  wikidata: Q200444
 02428402-n:
   definition:
   - sable antelopes
@@ -72401,6 +73423,7 @@
   - sable antelope
   - Hippotragus niger
   partOfSpeech: n
+  wikidata: Q239381
 02428700-n:
   definition:
   - saigas (Saiga)
@@ -72423,6 +73446,7 @@
   - saiga
   - Saiga tatarica
   partOfSpeech: n
+  wikidata: Q126683
 02428985-n:
   definition:
   - steenboks (Raphicerus)
@@ -72447,6 +73471,7 @@
   - steinbok
   - Raphicerus campestris
   partOfSpeech: n
+  wikidata: Q368033
 02429280-n:
   definition:
   - elands (Taurotragus)
@@ -72482,6 +73507,7 @@
   - common eland
   - Taurotragus oryx
   partOfSpeech: n
+  wikidata: Q216815
 02429829-n:
   definition:
   - large dark striped eland of western equatorial Africa
@@ -72492,6 +73518,7 @@
   - giant eland
   - Taurotragus derbianus
   partOfSpeech: n
+  wikidata: Q695736
 02429983-n:
   definition:
   - waterbucks (Kobus)
@@ -72515,6 +73542,7 @@
   - kob
   - Kobus kob
   partOfSpeech: n
+  wikidata: Q237267
 02430222-n:
   definition:
   - tawny-colored African antelope inhabiting wet grassy plains; a threatened species
@@ -72525,6 +73553,7 @@
   - lechwe
   - Kobus leche
   partOfSpeech: n
+  wikidata: Q273565
 02430370-n:
   definition:
   - any of several large African antelopes of the genus Kobus having curved ridged
@@ -72658,6 +73687,7 @@
   - American antelope
   - Antilocapra americana
   partOfSpeech: n
+  wikidata: Q187943
 02432341-n:
   definition:
   - 'deer: reindeer, moose or elks, muntjacs, roe deer'
@@ -72763,6 +73793,7 @@
   - wapiti
   - Cervus elaphus
   partOfSpeech: n
+  wikidata: Q79794
 02433983-n:
   definition:
   - a male deer, especially an adult male red deer
@@ -72826,6 +73857,9 @@
   - Cervus nippon
   - Cervus sika
   partOfSpeech: n
+  wikidata:
+  - Q122701031
+  - Q190516
 02434785-n:
   definition:
   - North American deer
@@ -72854,6 +73888,7 @@
   - whitetail deer
   - Odocoileus virginianus
   partOfSpeech: n
+  wikidata: Q215887
 02435157-n:
   definition:
   - long-eared deer of western North America with two-pronged antlers
@@ -72903,6 +73938,7 @@
   - moose
   - Alces alces
   partOfSpeech: n
+  wikidata: Q35517
 02435836-n:
   definition:
   - fallow deer
@@ -72926,6 +73962,7 @@
   - fallow deer
   - Dama dama
   partOfSpeech: n
+  wikidata: Q159857
 02436057-n:
   definition:
   - roe deer
@@ -72949,6 +73986,7 @@
   - roe deer
   - Capreolus capreolus
   partOfSpeech: n
+  wikidata: Q122069
 02436360-n:
   definition:
   - male roe deer
@@ -72984,6 +74022,7 @@
   - Greenland caribou
   - Rangifer tarandus
   partOfSpeech: n
+  wikidata: Q39624
 02436821-n:
   definition:
   - any of several large caribou living in coniferous forests of southern Canada;
@@ -73074,6 +74113,7 @@
   - musk deer
   - Moschus moschiferus
   partOfSpeech: n
+  wikidata: Q190508
 02438017-n:
   definition:
   - a genus of Cervidae
@@ -73098,6 +74138,7 @@
   - elaphure
   - Elaphurus davidianus
   partOfSpeech: n
+  wikidata: Q207906
 02438320-n:
   definition:
   - chevrotains
@@ -73147,6 +74188,7 @@
   - kanchil
   - Tragulus kanchil
   partOfSpeech: n
+  wikidata: Q1059263
 02438984-n:
   definition:
   - chevrotain somewhat larger than the kanchil; found in India and Malaya
@@ -73157,6 +74199,7 @@
   - napu
   - Tragulus javanicus
   partOfSpeech: n
+  wikidata: Q938385
 02439145-n:
   definition:
   - water chevrotains
@@ -73181,6 +74224,7 @@
   - water deer
   - Hyemoschus aquaticus
   partOfSpeech: n
+  wikidata: Q256572
 02439444-n:
   definition:
   - camels and llamas and vicunas
@@ -73229,6 +74273,7 @@
   - dromedary
   - Camelus dromedarius
   partOfSpeech: n
+  wikidata: Q71516
 02440113-n:
   definition:
   - two-humped camel of the cold deserts of central Asia
@@ -73286,6 +74331,7 @@
   - guanaco
   - Lama guanicoe
   partOfSpeech: n
+  wikidata: Q172886
 02440903-n:
   definition:
   - domesticated llama with long silky fleece; believed to be a domesticated variety
@@ -73361,6 +74407,7 @@
   - camelopard
   - Giraffa camelopardalis
   partOfSpeech: n
+  wikidata: Q15083
 02441917-n:
   definition:
   - okapis
@@ -73384,6 +74431,7 @@
   - okapi
   - Okapia johnstoni
   partOfSpeech: n
+  wikidata: Q82037
 02442199-n:
   definition:
   - foot of a pig or sheep especially one used as food
@@ -73536,6 +74584,7 @@
   - shorttail weasel
   - Mustela erminea
   partOfSpeech: n
+  wikidata: Q25345
 02444967-n:
   definition:
   - the ermine in its brown summer coat with black-tipped tail
@@ -73555,6 +74604,7 @@
   - New World least weasel
   - Mustela rixosa
   partOfSpeech: n
+  wikidata: Q121504864
 02445203-n:
   definition:
   - of Europe
@@ -73565,6 +74615,7 @@
   - Old World least weasel
   - Mustela nivalis
   partOfSpeech: n
+  wikidata: Q25311
 02445299-n:
   definition:
   - the common American weasel distinguished by large size and black-tipped tail
@@ -73576,6 +74627,9 @@
   - long-tailed weasel
   - Mustela frenata
   partOfSpeech: n
+  wikidata:
+  - Q125749307
+  - Q720696
 02445476-n:
   definition:
   - slender-bodied semiaquatic mammal having partially webbed feet; valued for its
@@ -73596,6 +74650,9 @@
   - American mink
   - Mustela vison
   partOfSpeech: n
+  wikidata:
+  - Q116910164
+  - Q50407587
 02445745-n:
   definition:
   - dark brown mustelid of woodlands of Eurasia that gives off an unpleasant odor
@@ -73610,6 +74667,7 @@
   - foumart
   - Mustela putorius
   partOfSpeech: n
+  wikidata: Q26582
 02445977-n:
   definition:
   - domesticated albino variety of the European polecat bred for hunting rats and
@@ -73631,6 +74689,7 @@
   - ferret
   - Mustela nigripes
   partOfSpeech: n
+  wikidata: Q402885
 02446314-n:
   definition:
   - muishonds
@@ -73663,6 +74722,7 @@
   - snake muishond
   - Poecilogale albinucha
   partOfSpeech: n
+  wikidata: Q852756
 02446734-n:
   definition:
   - a genus of Mustelidae, containing the Saharan striped polecat and the striped
@@ -73741,6 +74801,7 @@
   - river otter
   - Lutra canadensis
   partOfSpeech: n
+  wikidata: Q61885243
 02447802-n:
   definition:
   - otter found in Europe and Asia
@@ -73751,6 +74812,7 @@
   - Eurasian otter
   - Lutra lutra
   partOfSpeech: n
+  wikidata: Q29995
 02447907-n:
   definition:
   - sea otters
@@ -73774,6 +74836,7 @@
   - sea otter
   - Enhydra lutris
   partOfSpeech: n
+  wikidata: Q41407
 02448195-n:
   definition:
   - 'subdivision not used in some classifications: skunks'
@@ -73820,6 +74883,7 @@
   - striped skunk
   - Mephitis mephitis
   partOfSpeech: n
+  wikidata: Q368495
 02448983-n:
   definition:
   - of Mexico and southernmost parts of southwestern United States
@@ -73830,6 +74894,7 @@
   - hooded skunk
   - Mephitis macroura
   partOfSpeech: n
+  wikidata: Q1068616
 02449143-n:
   definition:
   - a genus of Mustelidae, containing the hog-nosed skunks (Conepatus)
@@ -73882,6 +74947,7 @@
   - little spotted skunk
   - Spilogale putorius
   partOfSpeech: n
+  wikidata: Q307105
 02449851-n:
   definition:
   - 'subdivision not used in some classifications: badgers'
@@ -73949,6 +75015,7 @@
   - Eurasian badger
   - Meles meles
   partOfSpeech: n
+  wikidata: Q27066
 02450831-n:
   definition:
   - ratels
@@ -73973,6 +75040,7 @@
   - honey badger
   - Mellivora capensis
   partOfSpeech: n
+  wikidata: Q173128
 02451133-n:
   definition:
   - a genus of Mustelidae containing the ferret-badgers or fadgers (Melogale)
@@ -74057,6 +75125,7 @@
   - Gulo gulo
   - wolverine
   partOfSpeech: n
+  wikidata: Q14334
 02452095-n:
   definition:
   - a genus of Mustelidae, containing the grisons (Grison)
@@ -74124,6 +75193,7 @@
   - pine marten
   - Martes martes
   partOfSpeech: n
+  wikidata: Q26046
 02453057-n:
   definition:
   - marten of northern Asian forests having luxuriant dark brown fur
@@ -74146,6 +75216,7 @@
   - American sable
   - Martes americana
   partOfSpeech: n
+  wikidata: Q322145
 02453308-n:
   definition:
   - Eurasian marten having a brown coat with pale breast and throat
@@ -74157,6 +75228,7 @@
   - beech marten
   - Martes foina
   partOfSpeech: n
+  wikidata: Q27366
 02453460-n:
   definition:
   - large dark brown North American arboreal carnivorous mammal
@@ -74170,6 +75242,7 @@
   - black cat
   - Martes pennanti
   partOfSpeech: n
+  wikidata: Q584064
 02453623-n:
   definition:
   - a genus of Mustelidae, containing the yellow-throated marten (Charronia)
@@ -74435,6 +75508,7 @@
   - Texas armadillo
   - Dasypus novemcinctus
   partOfSpeech: n
+  wikidata: Q649549
 02457630-n:
   definition:
   - a genus of Dasypodidae, containing the two species of three-banded armadilloes
@@ -74460,6 +75534,7 @@
   - three-banded armadillo
   - Tolypeutes tricinctus
   partOfSpeech: n
+  wikidata: Q111846
 02457941-n:
   definition:
   - solely the tatouay
@@ -74483,6 +75558,7 @@
   - cabassous
   - Cabassous unicinctus
   partOfSpeech: n
+  wikidata: Q1768774
 02458215-n:
   definition:
   - a genus of Dasypodidae, containing Euphractus sexcinctus, commonly known as the
@@ -74508,6 +75584,7 @@
   - poyou
   - Euphractus sexcinctus
   partOfSpeech: n
+  wikidata: Q902876
 02458518-n:
   definition:
   - solely the giant armadillo
@@ -74558,6 +75635,7 @@
   - chlamyphore
   - Chlamyphorus truncatus
   partOfSpeech: n
+  wikidata: Q846337
 02459136-n:
   definition:
   - a genus of Dasypodidae
@@ -74630,7 +75708,7 @@
   - ai
   - Bradypus tridactylus
   partOfSpeech: n
-  wikidata: Q185167
+  wikidata: Q142715
 02460217-n:
   definition:
   - mammal family consisting of the two-toed sloths
@@ -74670,6 +75748,7 @@
   - unai
   - Choloepus didactylus
   partOfSpeech: n
+  wikidata: Q752691
 02460766-n:
   definition:
   - a sloth of Central America that has two long claws on each forefoot and three
@@ -74683,6 +75762,7 @@
   - unai
   - Choloepus hoffmanni
   partOfSpeech: n
+  wikidata: Q1052814
 02460987-n:
   definition:
   - extinct ground sloths
@@ -74843,7 +75923,9 @@
   - tamanoir
   - Myrmecophaga jubata
   partOfSpeech: n
-  wikidata: Q203033
+  wikidata:
+  - Q203033
+  - Q122259133
 02463315-n:
   definition:
   - only the silky anteater
@@ -74868,6 +75950,7 @@
   - two-toed anteater
   - Cyclopes didactylus
   partOfSpeech: n
+  wikidata: Q244043
 02463645-n:
   definition:
   - lesser anteater
@@ -74893,6 +75976,7 @@
   - lesser anteater
   - Tamandua tetradactyla
   partOfSpeech: n
+  wikidata: Q267514
 02464003-n:
   definition:
   - pangolins; in some former classifications included in the order Edentata
@@ -75735,6 +76819,7 @@
   members:
   - Homo sapiens
   partOfSpeech: n
+  wikidata: Q15978631
 02477709-n:
   definition:
   - extinct robust human of Middle Paleolithic in Europe and western Asia
@@ -76098,6 +77183,7 @@
   - orangutang
   - Pongo pygmaeus
   partOfSpeech: n
+  wikidata: Q599672
 02483304-n:
   definition:
   - gorillas
@@ -76127,6 +77213,7 @@
   - gorilla
   - Gorilla gorilla
   partOfSpeech: n
+  wikidata: Q737838
 02483734-n:
   definition:
   - the smallest subspecies of gorilla (Gorilla gorilla gorilla)
@@ -76192,6 +77279,7 @@
   - chimp
   - Pan troglodytes
   partOfSpeech: n
+  wikidata: Q4126704
 02484691-n:
   definition:
   - masked or pale-faced chimpanzees of western Africa; distantly related to the eastern
@@ -76237,6 +77325,7 @@
   - bonobo
   - Pan paniscus
   partOfSpeech: n
+  wikidata: Q19537
 02485451-n:
   definition:
   - used in some classifications for the lesser apes (gibbons and siamangs); sometimes
@@ -76287,6 +77376,7 @@
   - gibbon
   - Hylobates lar
   partOfSpeech: n
+  wikidata: Q208043
 02486195-n:
   definition:
   - used in some classifications for the siamangs
@@ -76310,6 +77400,7 @@
   - Hylobates syndactylus
   - Symphalangus syndactylus
   partOfSpeech: n
+  wikidata: Q46679442
 02486546-n:
   definition:
   - 'Old World monkeys: guenon, baboon, colobus monkey, langur, macaque, mandrill,
@@ -76386,6 +77477,7 @@
   - talapoin
   - Cercopithecus talapoin
   partOfSpeech: n
+  wikidata: Q122311376
 02488002-n:
   definition:
   - white and olive green East African monkey with long white tufts of hair beside
@@ -76397,6 +77489,7 @@
   - grivet
   - Cercopithecus aethiops
   partOfSpeech: n
+  wikidata: Q40652743
 02488167-n:
   definition:
   - South African monkey with black face and hands
@@ -76466,6 +77559,7 @@
   - hussar monkey
   - Erythrocebus patas
   partOfSpeech: n
+  wikidata: Q504496
 02489041-n:
   definition:
   - large terrestrial monkeys having doglike muzzles
@@ -76497,6 +77591,7 @@
   - chacma baboon
   - Papio ursinus
   partOfSpeech: n
+  wikidata: Q257670
 02489418-n:
   definition:
   - a genus containing the mandrill and drill (Mandrillus)
@@ -76520,6 +77615,7 @@
   - mandrill
   - Mandrillus sphinx
   partOfSpeech: n
+  wikidata: Q189868
 02489710-n:
   definition:
   - similar to the mandrill but smaller and less brightly colored
@@ -76530,6 +77626,7 @@
   - drill
   - Mandrillus leucophaeus
   partOfSpeech: n
+  wikidata: Q221434
 02489848-n:
   definition:
   - macaques; rhesus monkeys
@@ -76563,6 +77660,7 @@
   - rhesus monkey
   - Macaca mulatta
   partOfSpeech: n
+  wikidata: Q156606
 02490306-n:
   definition:
   - Indian macaque with a bonnet-like tuft of hair
@@ -76576,6 +77674,7 @@
   - crown monkey
   - Macaca radiata
   partOfSpeech: n
+  wikidata: Q520949
 02490478-n:
   definition:
   - tailless macaque of rocky cliffs and forests of northwestern Africa and Gibraltar
@@ -76668,6 +77767,7 @@
   - guereza
   - Colobus guereza
   partOfSpeech: n
+  wikidata: Q628239
 02491691-n:
   definition:
   - proboscis monkeys
@@ -76787,7 +77887,9 @@
   - pygmy marmoset
   - Cebuella pygmaea
   partOfSpeech: n
-  wikidata: Q244361
+  wikidata:
+  - Q244361
+  - Q14850405
 02493595-n:
   definition:
   - tamarins
@@ -76880,6 +77982,7 @@
   - ringtail
   - Cebus capucinus
   partOfSpeech: n
+  wikidata: Q585189
 02494871-n:
   definition:
   - douroucoulis
@@ -76904,6 +78007,7 @@
   - douroucouli
   - Aotus trivirgatus
   partOfSpeech: n
+  wikidata: Q307153
 02495167-n:
   definition:
   - howler monkeys
@@ -77020,6 +78124,7 @@
   - spider monkey
   - Ateles geoffroyi
   partOfSpeech: n
+  wikidata: Q388032
 02496605-n:
   definition:
   - squirrel monkeys
@@ -77248,6 +78353,7 @@
   - ring-tailed lemur
   - Lemur catta
   partOfSpeech: n
+  wikidata: Q185385
 02500463-n:
   definition:
   - comprising solely the aye-aye
@@ -77286,6 +78392,7 @@
   - aye-aye
   - Daubentonia madagascariensis
   partOfSpeech: n
+  wikidata: Q186778
 02500986-n:
   definition:
   - slow-moving omnivorous nocturnal primates of tropical Asia; usually tailless
@@ -77325,6 +78432,7 @@
   - slender loris
   - Loris gracilis
   partOfSpeech: n
+  wikidata: Q122830509
 02501519-n:
   definition:
   - a genus of Lorisidae, containing the slow lorises (Nycticebus)
@@ -77349,6 +78457,7 @@
   - Nycticebus tardigradua
   - Nycticebus pygmaeus
   partOfSpeech: n
+  wikidata: Q244239
 02501809-n:
   definition:
   - a genus of Lorisidae, containing the potto (Perodicticus)
@@ -77373,6 +78482,7 @@
   - kinkajou
   - Perodicticus potto
   partOfSpeech: n
+  wikidata: Q747610
 02502065-n:
   definition:
   - a genus of Lorisidae, containing the Calabar and golden angwantibos (Arctocebus)
@@ -77397,6 +78507,7 @@
   - golden potto
   - Arctocebus calabarensis
   partOfSpeech: n
+  wikidata: Q1153493
 02502331-n:
   definition:
   - bush babies
@@ -77460,6 +78571,7 @@
   - Indri indri
   - Indri brevicaudatus
   partOfSpeech: n
+  wikidata: Q203868
 02503103-n:
   definition:
   - a genus of Indriidae
@@ -77483,6 +78595,7 @@
   - woolly indris
   - Avahi laniger
   partOfSpeech: n
+  wikidata: Q307262
 02503380-n:
   definition:
   - extinct tiny nocturnal lower primates that fed on fruit and insects; abundant
@@ -77554,6 +78667,7 @@
   members:
   - Tarsius syrichta
   partOfSpeech: n
+  wikidata: Q27334504
 02504637-n:
   definition:
   - a variety of tarsier
@@ -77712,7 +78826,9 @@
   - Indian elephant
   - Elephas maximus
   partOfSpeech: n
-  wikidata: Q591305
+  wikidata:
+  - Q591305
+  - Q133006
 02506827-n:
   definition:
   - albinic Indian elephant; rare and sometimes venerated in east Asia
@@ -77745,6 +78861,7 @@
   - African elephant
   - Loxodonta africana
   partOfSpeech: n
+  wikidata: Q36557
 02507266-n:
   definition:
   - 'extinct genus: mammoths'
@@ -77989,6 +79106,7 @@
   - ringtail
   - Procyon lotor
   partOfSpeech: n
+  wikidata: Q121439
 02510977-n:
   definition:
   - a South American raccoon
@@ -77999,6 +79117,7 @@
   - crab-eating raccoon
   - Procyon cancrivorus
   partOfSpeech: n
+  wikidata: Q405403
 02511089-n:
   definition:
   - in some classifications considered a separate family
@@ -78041,6 +79160,7 @@
   - miner's cat
   - Bassariscus astutus
   partOfSpeech: n
+  wikidata: Q632701
 02511702-n:
   definition:
   - a genus of Procyonidae
@@ -78067,6 +79187,7 @@
   - Potos flavus
   - Potos caudivolvulus
   partOfSpeech: n
+  wikidata: Q254630
 02512036-n:
   definition:
   - coatis
@@ -78093,6 +79214,7 @@
   - coon cat
   - Nasua narica
   partOfSpeech: n
+  wikidata: Q754992
 02512325-n:
   definition:
   - lesser pandas
@@ -78121,6 +79243,7 @@
   - cat bear
   - Ailurus fulgens
   partOfSpeech: n
+  wikidata: Q41960
 02512696-n:
   definition:
   - in some classifications considered the family comprising the giant pandas
@@ -78161,6 +79284,7 @@
   - coon bear
   - Ailuropoda melanoleuca
   partOfSpeech: n
+  wikidata: Q33602
 02513400-n:
   definition:
   - respiratory organ of aquatic animals that breathe oxygen dissolved in water
@@ -78471,6 +79595,7 @@
   - coelacanth
   - Latimeria chalumnae
   partOfSpeech: n
+  wikidata: Q668921
 02518545-n:
   definition:
   - bony fishes of the Southern Hemisphere that breathe by a modified air bladder
@@ -78553,6 +79678,7 @@
   - Queensland lungfish
   - Neoceratodus forsteri
   partOfSpeech: n
+  wikidata: Q782345
 02519800-n:
   definition:
   - an order of fish belonging to the superorder Malacopterygii including catfishes
@@ -78707,6 +79833,7 @@
   - pout
   - Ameiurus melas
   partOfSpeech: n
+  wikidata: Q998380
 02522103-n:
   definition:
   - freshwater catfish of eastern United States
@@ -78739,6 +79866,7 @@
   - channel cat
   - Ictalurus punctatus
   partOfSpeech: n
+  wikidata: Q836957
 02522493-n:
   definition:
   - a large catfish of the Mississippi valley
@@ -78960,6 +80088,7 @@
   - Alaska cod
   - Gadus macrocephalus
   partOfSpeech: n
+  wikidata: Q783575
 02525621-n:
   definition:
   - whitings
@@ -79049,6 +80178,7 @@
   mero_part:
   - 07805517-n
   partOfSpeech: n
+  wikidata: Q202406
 02526712-n:
   definition:
   - pollack
@@ -79076,6 +80206,7 @@
   mero_part:
   - 07805216-n
   partOfSpeech: n
+  wikidata: Q752683
 02527055-n:
   definition:
   - a genus of merluccid hakes containing 16 currently recognized species (Merluccius)
@@ -79109,6 +80240,7 @@
   mero_part:
   - 07794470-n
   partOfSpeech: n
+  wikidata: Q2554744
 02527442-n:
   definition:
   - a genus of phycid hakes, containing 8 currently recognized species (Urophycis)
@@ -79155,6 +80287,7 @@
   - ling
   - Molva molva
   partOfSpeech: n
+  wikidata: Q842406
 02527918-n:
   definition:
   - cusk
@@ -79179,6 +80312,7 @@
   mero_part:
   - 07794786-n
   partOfSpeech: n
+  wikidata: Q850056
 02528174-n:
   definition:
   - grenadiers
@@ -79519,6 +80653,7 @@
   - 07814333-n
   - 07815850-n
   partOfSpeech: n
+  wikidata: Q545697
 02533462-n:
   definition:
   - shad that spawns in streams of the Mississippi drainage; very similar to Alosa
@@ -79558,6 +80693,7 @@
   mero_part:
   - 07801607-n
   partOfSpeech: n
+  wikidata: Q659283
 02533993-n:
   definition:
   - genus to which the alewife is sometimes assigned
@@ -79725,6 +80861,7 @@
   - Pacific sardine
   - Sardinops caerulea
   partOfSpeech: n
+  wikidata: Q106383686
 02536339-n:
   definition:
   - anchovies
@@ -79865,6 +81002,7 @@
   mero_part:
   - 07811981-n
   partOfSpeech: n
+  wikidata: Q188879
 02538390-n:
   definition:
   - Atlantic salmon confined to lakes of New England and southeastern Canada
@@ -79907,6 +81045,7 @@
   mero_part:
   - 07812141-n
   partOfSpeech: n
+  wikidata: Q44064
 02539087-n:
   definition:
   - large Pacific salmon valued as food; adults die after spawning
@@ -79922,6 +81061,7 @@
   mero_part:
   - 07812297-n
   partOfSpeech: n
+  wikidata: Q833503
 02539316-n:
   definition:
   - a large Pacific salmon with small spots on its back; an important food fish
@@ -79950,6 +81090,7 @@
   mero_part:
   - 07812444-n
   partOfSpeech: n
+  wikidata: Q934874
 02539716-n:
   definition:
   - any of various game and food fishes of cool fresh waters mostly smaller than typical
@@ -79974,6 +81115,7 @@
   mero_part:
   - 07810720-n
   partOfSpeech: n
+  wikidata: Q2857311
 02540156-n:
   definition:
   - found in Pacific coastal waters and streams from lower California to Alaska
@@ -79986,6 +81128,7 @@
   mero_part:
   - 07810581-n
   partOfSpeech: n
+  wikidata: Q106428789
 02540347-n:
   definition:
   - silvery marine variety of brown trout that migrates to fresh water to spawn
@@ -80023,6 +81166,7 @@
   mero_part:
   - 07810995-n
   partOfSpeech: n
+  wikidata: Q469946
 02540847-n:
   definition:
   - North American freshwater trout; introduced in Europe
@@ -80036,6 +81180,7 @@
   mero_part:
   - 07810869-n
   partOfSpeech: n
+  wikidata: Q723654
 02541037-n:
   definition:
   - any of several small trout-like fish of the genus Salvelinus
@@ -80057,6 +81202,7 @@
   - Arctic char
   - Salvelinus alpinus
   partOfSpeech: n
+  wikidata: Q421047
 02541361-n:
   definition:
   - soft-finned fishes comprising the freshwater whitefishes; formerly included in
@@ -80109,6 +81255,7 @@
   - lake whitefish
   - Coregonus clupeaformis
   partOfSpeech: n
+  wikidata: Q110577
 02542204-n:
   definition:
   - important food fish of cold deep lakes of North America
@@ -80211,6 +81358,7 @@
   mero_part:
   - 07814704-n
   partOfSpeech: n
+  wikidata: Q2641362
 02543614-n:
   definition:
   - the common smelt of Europe
@@ -80224,6 +81372,7 @@
   mero_part:
   - 07814848-n
   partOfSpeech: n
+  wikidata: Q840795
 02543770-n:
   definition:
   - capelins
@@ -80553,6 +81702,7 @@
   - northern barramundi
   - Scleropages jardinii
   partOfSpeech: n
+  wikidata: Q135567
 02548200-n:
   definition:
   - opahs
@@ -80591,6 +81741,7 @@
   - moonfish
   - Lampris regius
   partOfSpeech: n
+  wikidata: Q106392599
 02548659-n:
   definition:
   - from Nova Scotia to West Indies and Gulf of Mexico
@@ -80687,6 +81838,7 @@
   - ribbonfish
   - Regalecus glesne
   partOfSpeech: n
+  wikidata: Q310390
 02549844-n:
   definition:
   - anglers and batfishes; spiny-finned marine fishes having pectoral fins at the
@@ -80796,6 +81948,7 @@
   - toadfish
   - Opsanus tau
   partOfSpeech: n
+  wikidata: Q1524360
 02551515-n:
   definition:
   - a variety of toadfish
@@ -80998,6 +82151,7 @@
   - billfish
   - Scomberesox saurus
   partOfSpeech: n
+  wikidata: Q1886478
 02554455-n:
   definition:
   - teleost fishes having fins with sharp bony rays
@@ -81068,6 +82222,7 @@
   mero_part:
   - 07800967-n
   partOfSpeech: n
+  wikidata: Q81964
 02555827-n:
   definition:
   - 'one of the largest natural groups of fishes of both marine and fresh water: true
@@ -81211,6 +82366,7 @@
   - Anabas testudineus
   - A. testudineus
   partOfSpeech: n
+  wikidata: Q10540515
 02559254-n:
   definition:
   - active freshwater fishes; true perches and pike perches
@@ -81262,6 +82418,7 @@
   mero_part:
   - 07796149-n
   partOfSpeech: n
+  wikidata: Q469754
 02559949-n:
   definition:
   - a perch native to Europe
@@ -81274,6 +82431,7 @@
   mero_part:
   - 07796149-n
   partOfSpeech: n
+  wikidata: Q166812
 02560092-n:
   definition:
   - pike-perches
@@ -81310,6 +82468,7 @@
   - dory
   - Stizostedion vitreum
   partOfSpeech: n
+  wikidata: Q107329229
 02560540-n:
   definition:
   - variety inhabiting the Great Lakes
@@ -81573,6 +82732,7 @@
   - northern pike
   - Esox lucius
   partOfSpeech: n
+  wikidata: Q165278
 02564145-n:
   definition:
   - large (60 to 80 pounds) sport fish of North America
@@ -81585,6 +82745,7 @@
   mero_part:
   - 07795511-n
   partOfSpeech: n
+  wikidata: Q917705
 02564292-n:
   definition:
   - any of several North American species of small pike
@@ -81605,6 +82766,7 @@
   - chain pike
   - Esox niger
   partOfSpeech: n
+  wikidata: Q93596
 02564568-n:
   definition:
   - small but gamy pickerel of Atlantic coastal states
@@ -81616,6 +82778,7 @@
   - barred pickerel
   - Esox americanus
   partOfSpeech: n
+  wikidata: Q93675
 02564716-n:
   definition:
   - sunfish family
@@ -81682,6 +82845,7 @@
   - black crappie
   - Pomoxis nigromaculatus
   partOfSpeech: n
+  wikidata: Q3006347
 02565710-n:
   definition:
   - a crappie that is white
@@ -81692,6 +82856,7 @@
   - white crappie
   - Pomoxis annularis
   partOfSpeech: n
+  wikidata: Q7995596
 02565813-n:
   definition:
   - any of various usually edible freshwater percoid fishes having compressed bodies
@@ -81789,6 +82954,7 @@
   - rock sunfish
   - Ambloplites rupestris
   partOfSpeech: n
+  wikidata: Q2093287
 02567203-n:
   definition:
   - American freshwater black basses
@@ -81839,6 +83005,7 @@
   mero_part:
   - 07793816-n
   partOfSpeech: n
+  wikidata: Q536224
 02567955-n:
   definition:
   - a large black bass; the angle of the jaw falls behind the eye
@@ -81855,6 +83022,7 @@
   mero_part:
   - 07793711-n
   partOfSpeech: n
+  wikidata: Q755105
 02568204-n:
   definition:
   - nontechnical name for any of numerous edible marine and freshwater spiny-finned
@@ -81924,6 +83092,7 @@
   - silver perch
   - Morone americana
   partOfSpeech: n
+  wikidata: Q2337531
 02569296-n:
   definition:
   - North American freshwater bass resembling the larger marine striped bass
@@ -81971,6 +83140,7 @@
   - blackmouth bass
   - Synagrops bellus
   partOfSpeech: n
+  wikidata: Q2181894
 02570115-n:
   definition:
   - sea basses
@@ -81996,6 +83166,7 @@
   - rock bass
   - Centropristis philadelphica
   partOfSpeech: n
+  wikidata: Q3542000
 02570403-n:
   definition:
   - bluish black-striped sea bass of the Atlantic coast of the United States
@@ -82081,6 +83252,7 @@
   - belted sandfish
   - Serranus subligarius
   partOfSpeech: n
+  wikidata: Q1562068
 02571590-n:
   definition:
   - usually solitary bottom sea basses of warm seas
@@ -82117,6 +83289,7 @@
   - coney
   - Epinephelus fulvus
   partOfSpeech: n
+  wikidata: Q106418886
 02572115-n:
   definition:
   - any of several mostly spotted fishes that resemble groupers
@@ -82160,6 +83333,7 @@
   - creole-fish
   - Paranthias furcifer
   partOfSpeech: n
+  wikidata: Q2605826
 02572669-n:
   definition:
   - groupers
@@ -82183,6 +83357,7 @@
   - jewfish
   - Mycteroperca bonaci
   partOfSpeech: n
+  wikidata: Q2912602
 02572943-n:
   definition:
   - a genus of fish of the family Serranidae, including soapfishes
@@ -82349,6 +83524,7 @@
   - flamefish
   - Apogon maculatus
   partOfSpeech: n
+  wikidata: Q2374278
 02575259-n:
   definition:
   - a genus of fish of the family Apogonidae
@@ -82406,6 +83582,7 @@
   - tilefish
   - Lopholatilus chamaeleonticeps
   partOfSpeech: n
+  wikidata: Q198572
 02576037-n:
   definition:
   - food and game fishes related to pompanos
@@ -82445,6 +83622,7 @@
   mero_part:
   - 07801759-n
   partOfSpeech: n
+  wikidata: Q461432
 02576549-n:
   definition:
   - family of pelagic fishes containing solely the cobia
@@ -82483,6 +83661,7 @@
   - Rachycentron canadum
   - sergeant fish
   partOfSpeech: n
+  wikidata: Q833940
 02577120-n:
   definition:
   - small order of fishes comprising the remoras
@@ -82546,6 +83725,7 @@
   - sharksucker
   - Echeneis naucrates
   partOfSpeech: n
+  wikidata: Q1156517
 02578086-n:
   definition:
   - a genus of Echeneididae
@@ -82570,7 +83750,9 @@
   - whalesucker
   - Remilegia australis
   partOfSpeech: n
-  wikidata: Q850041
+  wikidata:
+  - Q850041
+  - Q107328425
 02578397-n:
   definition:
   - large family of narrow-bodied marine food fishes with widely forked tails; chiefly
@@ -82652,6 +83834,9 @@
   - yellow jack
   - Caranx bartholomaei
   partOfSpeech: n
+  wikidata:
+  - Q1995094
+  - Q60594032
 02579795-n:
   definition:
   - 'fish of western Atlantic: Cape Cod to Brazil'
@@ -82663,6 +83848,7 @@
   - blue runner
   - Caranx crysos
   partOfSpeech: n
+  wikidata: Q2288528
 02579922-n:
   definition:
   - a genus of Carangidae, containing the rainbow runner (Elagatis)
@@ -82684,6 +83870,7 @@
   - rainbow runner
   - Elagatis bipinnulata
   partOfSpeech: n
+  wikidata: Q1807925
 02580163-n:
   definition:
   - leatherjackets
@@ -82731,6 +83918,7 @@
   - thread-fish
   - Alectis ciliaris
   partOfSpeech: n
+  wikidata: Q2802649
 02580756-n:
   definition:
   - a genus of Carangidae, containing the lookdowns and moonfishes (Selene)
@@ -82757,6 +83945,7 @@
   - dollarfish
   - Selene setapinnis
   partOfSpeech: n
+  wikidata: Q649336
 02581085-n:
   definition:
   - similar to moonfish but with eyes high on the truncated forehead
@@ -82768,6 +83957,7 @@
   - lookdown fish
   - Selene vomer
   partOfSpeech: n
+  wikidata: Q889541
 02581235-n:
   definition:
   - a genus of Carangidae, containing the amberjacks (Seriola)
@@ -82803,6 +83993,7 @@
   - yellowtail
   - Seriola dorsalis
   partOfSpeech: n
+  wikidata: Q21297408
 02581722-n:
   definition:
   - fish having the habit of following ships; found in North American and South American
@@ -82826,6 +84017,7 @@
   - kingfish
   - Seriola grandis
   partOfSpeech: n
+  wikidata: Q106413580
 02582051-n:
   definition:
   - a genus of Carangidae, containing the jacks and pompanos (Trachinotus)
@@ -82860,6 +84052,7 @@
   - Florida pompano
   - Trachinotus carolinus
   partOfSpeech: n
+  wikidata: Q2601525
 02582559-n:
   definition:
   - large game fish; found in waters of the West Indies
@@ -82870,6 +84063,7 @@
   - permit
   - Trachinotus falcatus
   partOfSpeech: n
+  wikidata: Q972376
 02582686-n:
   definition:
   - a genus of Carangidae
@@ -82893,6 +84087,7 @@
   - pilotfish
   - Naucrates ductor
   partOfSpeech: n
+  wikidata: Q223289
 02582967-n:
   definition:
   - any of a number of fishes of the family Carangidae
@@ -82926,6 +84121,7 @@
   - saurel
   - Trachurus symmetricus
   partOfSpeech: n
+  wikidata: Q2626960
 02583461-n:
   definition:
   - large elongated compressed food fish of the Atlantic waters of Europe
@@ -82937,6 +84133,7 @@
   - saurel
   - Trachurus trachurus
   partOfSpeech: n
+  wikidata: Q842956
 02583622-n:
   definition:
   - big-eyed scad
@@ -83001,6 +84198,7 @@
   - quiaquia
   - Decapterus punctatus
   partOfSpeech: n
+  wikidata: Q1964494
 02584434-n:
   definition:
   - large active pelagic percoid fish
@@ -83039,6 +84237,7 @@
   members:
   - Coryphaena hippurus
   partOfSpeech: n
+  wikidata: Q14443
 02584980-n:
   definition:
   - a kind of dolphinfish
@@ -83190,6 +84389,7 @@
   - cardinal tetra
   - Paracheirodon axelrodi
   partOfSpeech: n
+  wikidata: Q590731
 02586956-n:
   definition:
   - piranhas
@@ -83312,6 +84512,7 @@
   - bolti
   - Tilapia nilotica
   partOfSpeech: n
+  wikidata: Q106405737
 02589013-n:
   definition:
   - the family of snappers (Lutjanidae)
@@ -83403,6 +84604,7 @@
   - schoolmaster
   - Lutjanus apodus
   partOfSpeech: n
+  wikidata: Q2542507
 02590391-n:
   definition:
   - a genus of snappers (Ocyurus)
@@ -83428,6 +84630,7 @@
   - yellowtail snapper
   - Ocyurus chrysurus
   partOfSpeech: n
+  wikidata: Q928985
 02590738-n:
   definition:
   - grunts
@@ -83491,6 +84694,7 @@
   - Spanish grunt
   - Haemulon macrostomum
   partOfSpeech: n
+  wikidata: Q3758334
 02591692-n:
   definition:
   - found off the West Indies and Florida
@@ -83501,6 +84705,7 @@
   - tomtate
   - Haemulon aurolineatum
   partOfSpeech: n
+  wikidata: Q2482811
 02591826-n:
   definition:
   - of warm Atlantic waters
@@ -83522,6 +84727,7 @@
   - sailors choice
   - Haemulon parra
   partOfSpeech: n
+  wikidata: Q968535
 02592116-n:
   definition:
   - a genus of Haemulidae, containing grunts native to the eastern Pacific and western
@@ -83547,6 +84753,7 @@
   - pork-fish
   - Anisotremus virginicus
   partOfSpeech: n
+  wikidata: Q1733218
 02592426-n:
   definition:
   - dusky grey food fish found from Louisiana and Florida southward
@@ -83710,6 +84917,7 @@
   - Atlantic sea bream
   - Archosargus rhomboidalis
   partOfSpeech: n
+  wikidata: Q2700401
 02594685-n:
   definition:
   - large (up to 20 lbs) food fish of the eastern coast of the United States and Mexico
@@ -83720,6 +84928,7 @@
   - sheepshead
   - Archosargus probatocephalus
   partOfSpeech: n
+  wikidata: Q744187
 02594874-n:
   definition:
   - a genus of Sparidae, containing the pinfish (Lagodon)
@@ -83746,6 +84955,7 @@
   - squirrelfish
   - Lagodon rhomboides
   partOfSpeech: n
+  wikidata: Q1870535
 02595237-n:
   definition:
   - a genus of Sparidae, containing porgies (Calamus)
@@ -83769,6 +84979,7 @@
   - sheepshead porgy
   - Calamus penna
   partOfSpeech: n
+  wikidata: Q969159
 02595496-n:
   definition:
   - Australian snapper
@@ -83795,6 +85006,7 @@
   mero_part:
   - 07813165-n
   partOfSpeech: n
+  wikidata: Q111127408
 02595821-n:
   definition:
   - important dark-colored edible food and game fish of Australia
@@ -83805,6 +85017,7 @@
   - black bream
   - Chrysophrys australis
   partOfSpeech: n
+  wikidata: Q106420509
 02595983-n:
   definition:
   - scups
@@ -83831,6 +85044,7 @@
   mero_part:
   - 07806222-n
   partOfSpeech: n
+  wikidata: Q2151537
 02596309-n:
   definition:
   - porgy of southern Atlantic coastal waters of North America
@@ -83914,6 +85128,7 @@
   - striped drum
   - Equetus pulcher
   partOfSpeech: n
+  wikidata: Q106417247
 02597686-n:
   definition:
   - black-and-white drumfish with an erect elongated dorsal fin
@@ -83924,6 +85139,7 @@
   - jackknife-fish
   - Equetus lanceolatus
   partOfSpeech: n
+  wikidata: Q1497325
 02597847-n:
   definition:
   - a genus of fish in the family Sciaenidae, comprising the armed croaker, the silver
@@ -83951,6 +85167,7 @@
   - mademoiselle
   - Bairdiella chrysoura
   partOfSpeech: n
+  wikidata: Q2514677
 02598199-n:
   definition:
   - a genus of Sciaenidae, containing the fish known as the red drum, the channel
@@ -83977,6 +85194,7 @@
   - redfish
   - Sciaenops ocellatus
   partOfSpeech: n
+  wikidata: Q2168496
 02598532-n:
   definition:
   - 'type genus of the Sciaenidae: croakers'
@@ -84002,6 +85220,7 @@
   - jewfish
   - Sciaena antarctica
   partOfSpeech: n
+  wikidata: Q106417781
 02598882-n:
   definition:
   - large European marine food fish
@@ -84123,6 +85342,7 @@
   - king whiting
   - Menticirrhus americanus
   partOfSpeech: n
+  wikidata: Q2177693
 02600602-n:
   definition:
   - whiting of the east coast of United States; closely resembles king whiting
@@ -84133,6 +85353,7 @@
   - northern whiting
   - Menticirrhus saxatilis
   partOfSpeech: n
+  wikidata: Q2765403
 02600764-n:
   definition:
   - bluish-grey whiting of California coast
@@ -84143,6 +85364,7 @@
   - corbina
   - Menticirrhus undulatus
   partOfSpeech: n
+  wikidata: Q692017
 02600882-n:
   definition:
   - a dull silvery whiting of southern Atlantic and Gulf Coasts of the United States
@@ -84242,6 +85464,7 @@
   mero_part:
   - 07808446-n
   partOfSpeech: n
+  wikidata: Q136887
 02602187-n:
   definition:
   - weakfish of southern Atlantic and Gulf Coasts of United States
@@ -84308,6 +85531,7 @@
   - surmullet
   - Mullus surmuletus
   partOfSpeech: n
+  wikidata: Q7119
 02603133-n:
   definition:
   - body bright scarlet with 2 yellow to reddish strips on side
@@ -84342,6 +85566,7 @@
   - yellow goatfish
   - Mulloidichthys martinicus
   partOfSpeech: n
+  wikidata: Q1941836
 02603583-n:
   definition:
   - 'fishes distinguished by abdominal pelvic fins: families Mugilidae; Atherinidae;
@@ -84409,6 +85634,7 @@
   - striped mullet
   - Mugil cephalus
   partOfSpeech: n
+  wikidata: Q234014
 02604551-n:
   definition:
   - silvery mullet of Atlantic and Pacific coasts
@@ -84419,6 +85645,7 @@
   - white mullet
   - Mugil curema
   partOfSpeech: n
+  wikidata: Q1818649
 02604689-n:
   definition:
   - similar to the striped mullet and takes its place in the Caribbean region
@@ -84429,6 +85656,7 @@
   - liza
   - Mugil liza
   partOfSpeech: n
+  wikidata: Q1911764
 02604845-n:
   definition:
   - small spiny-finned fishes of both salt and fresh water
@@ -84478,6 +85706,7 @@
   - jacksmelt
   - Atherinopsis californiensis
   partOfSpeech: n
+  wikidata: Q939626
 02605600-n:
   definition:
   - 'monotypic family of large active fishes of tropical and subtropical waters: barracuda'
@@ -84523,6 +85752,7 @@
   - great barracuda
   - Sphyraena barracuda
   partOfSpeech: n
+  wikidata: Q2306485
 02606367-n:
   definition:
   - sweepers
@@ -84631,6 +85861,7 @@
   - angelfish
   - Chaetodipterus faber
   partOfSpeech: n
+  wikidata: Q756961
 02607769-n:
   definition:
   - butterfly fishes
@@ -84760,6 +85991,9 @@
   - beaugregory
   - Pomacentrus leucostictus
   partOfSpeech: n
+  wikidata:
+  - Q738910
+  - Q106410671
 02609556-n:
   definition:
   - a genus of clownfishes or anemone fishes (Amphiprion)
@@ -84793,6 +86027,7 @@
   - clown anemone fish
   - Amphiprion percula
   partOfSpeech: n
+  wikidata: Q926234
 02609975-n:
   definition:
   - a genus of sergeant-majors (Abudefduf)
@@ -84816,6 +86051,7 @@
   - sergeant major
   - Abudefduf saxatilis
   partOfSpeech: n
+  wikidata: Q2070648
 02610260-n:
   definition:
   - wrasses
@@ -84869,6 +86105,7 @@
   - giant pigfish
   - Achoerodus gouldii
   partOfSpeech: n
+  wikidata: Q935046
 02611059-n:
   definition:
   - a genus of Labridae containing the hogfish (Lachnolaimus)
@@ -84891,6 +86128,7 @@
   - hog snapper
   - Lachnolaimus maximus
   partOfSpeech: n
+  wikidata: Q1278753
 02611338-n:
   definition:
   - a genus of Labridae containing 81 species of wrasses (Halicoeres)
@@ -84949,6 +86187,7 @@
   - bluehead
   - Thalassoma bifasciatum
   partOfSpeech: n
+  wikidata: Q1971551
 02612096-n:
   definition:
   - razor fish
@@ -85008,6 +86247,7 @@
   - blackfish
   - Tautoga onitis
   partOfSpeech: n
+  wikidata: Q2299834
 02612864-n:
   definition:
   - a genus of Labridae, containing the bergall (Tautogolabrus)
@@ -85032,6 +86272,7 @@
   - bergall
   - Tautogolabrus adspersus
   partOfSpeech: n
+  wikidata: Q1884642
 02613171-n:
   definition:
   - parrotfishes
@@ -85383,6 +86624,7 @@
   mero_part:
   - 07801981-n
   partOfSpeech: n
+  wikidata: Q640454
 02618124-n:
   definition:
   - pricklebacks
@@ -85576,6 +86818,7 @@
   - fish doctor
   - Gymnelus viridis
   partOfSpeech: n
+  wikidata: Q2584636
 02620586-n:
   definition:
   - a genus of eelpouts including the ocean pout
@@ -85599,7 +86842,9 @@
   - ocean pout
   - Macrozoarces americanus
   partOfSpeech: n
-  wikidata: Q218024
+  wikidata:
+  - Q218024
+  - Q107331225
 02620874-n:
   definition:
   - sand lances
@@ -85864,6 +87109,7 @@
   - doctor-fish
   - Acanthurus chirurgus
   partOfSpeech: n
+  wikidata: Q2355866
 02624351-n:
   definition:
   - snake mackerels
@@ -85911,6 +87157,7 @@
   - snake mackerel
   - Gempylus serpens
   partOfSpeech: n
+  wikidata: Q1817179
 02625038-n:
   definition:
   - a genus of Gempylidae
@@ -85934,6 +87181,7 @@
   - escolar
   - Lepidocybium flavobrunneum
   partOfSpeech: n
+  wikidata: Q1367312
 02625342-n:
   definition:
   - very large deep-water snake mackerel
@@ -86056,6 +87304,7 @@
   mero_part:
   - 07797295-n
   partOfSpeech: n
+  wikidata: Q30153
 02627437-n:
   definition:
   - medium-sized mackerel of temperate Atlantic and Gulf of Mexico
@@ -86068,6 +87317,7 @@
   mero_part:
   - 07797473-n
   partOfSpeech: n
+  wikidata: Q1934719
 02627617-n:
   definition:
   - small mackerel found nearly worldwide
@@ -86079,6 +87329,7 @@
   - tinker
   - Scomber japonicus
   partOfSpeech: n
+  wikidata: Q815837
 02627762-n:
   definition:
   - wahoos
@@ -86154,6 +87405,7 @@
   members:
   - Scomberomorus maculatus
   partOfSpeech: n
+  wikidata: Q311047
 02628895-n:
   definition:
   - large edible mackerel of temperate United States coastal Atlantic waters
@@ -86168,6 +87420,7 @@
   mero_part:
   - 07800786-n
   partOfSpeech: n
+  wikidata: Q1796427
 02629101-n:
   definition:
   - a Spanish mackerel of western North America
@@ -86178,6 +87431,7 @@
   - sierra
   - Scomberomorus sierra
   partOfSpeech: n
+  wikidata: Q613384
 02629220-n:
   definition:
   - 'tunas: warm-blooded fishes'
@@ -86221,6 +87475,7 @@
   mero_part:
   - 07796850-n
   partOfSpeech: n
+  wikidata: Q239977
 02629922-n:
   definition:
   - 'largest tuna; to 1500 pounds; of mostly temperate seas: feed in polar regions
@@ -86236,6 +87491,7 @@
   mero_part:
   - 07797183-n
   partOfSpeech: n
+  wikidata: Q214415
 02630162-n:
   definition:
   - may reach 400 pounds; worldwide in tropics
@@ -86247,6 +87503,7 @@
   - yellowfin tuna
   - Thunnus albacares
   partOfSpeech: n
+  wikidata: Q269781
 02630316-n:
   definition:
   - bonitos
@@ -86286,6 +87543,7 @@
   - Atlantic bonito
   - Sarda sarda
   partOfSpeech: n
+  wikidata: Q910363
 02630889-n:
   definition:
   - common bonito of Pacific coast of the Americas; its dark oily flesh cans well
@@ -86298,6 +87556,7 @@
   - Pacific bonito
   - Sarda chiliensis
   partOfSpeech: n
+  wikidata: Q18560367
 02631097-n:
   definition:
   - a genus of Scombridae
@@ -86399,6 +87658,7 @@
   mero_part:
   - 07801863-n
   partOfSpeech: n
+  wikidata: Q164327
 02632682-n:
   definition:
   - sailfishes, spearfishes, marlins
@@ -86449,6 +87709,7 @@
   - Atlantic sailfish
   - Istiophorus albicans
   partOfSpeech: n
+  wikidata: Q1064635
 02633369-n:
   definition:
   - giant warm-water game fish having a prolonged and rounded toothless upper jaw
@@ -86491,6 +87752,7 @@
   - blue marlin
   - Makaira nigricans
   partOfSpeech: n
+  wikidata: Q882668
 02634105-n:
   definition:
   - large game fish in the Pacific Ocean; may reach 1000 pounds
@@ -86502,6 +87764,7 @@
   - Makaira mazara
   - Makaira marlina
   partOfSpeech: n
+  wikidata: Q106426463
 02634258-n:
   definition:
   - Pacific food and game fish marked with dark blue vertical stripes
@@ -86512,6 +87775,7 @@
   - striped marlin
   - Makaira mitsukurii
   partOfSpeech: n
+  wikidata: Q106426464
 02634405-n:
   definition:
   - small marlin (to 180 pounds) of western Atlantic
@@ -86522,6 +87786,7 @@
   - white marlin
   - Makaira albida
   partOfSpeech: n
+  wikidata: Q106426240
 02634529-n:
   definition:
   - a genus of Istiophoridae
@@ -86582,6 +87847,7 @@
   - louvar
   - Luvarus imperialis
   partOfSpeech: n
+  wikidata: Q1208946
 02635324-n:
   definition:
   - 'butterfishes: harvest fishes; dollar fishes'
@@ -86623,6 +87889,7 @@
   - dollarfish
   - Poronotus triacanthus
   partOfSpeech: n
+  wikidata: Q107330934
 02636307-n:
   definition:
   - smaller than Florida pompano; common in West Indies
@@ -86634,6 +87901,7 @@
   - California pompano
   - Palometa simillima
   partOfSpeech: n
+  wikidata: Q107330919
 02636474-n:
   definition:
   - a genus of Stromateidae
@@ -86843,6 +88111,7 @@
   - Atlantic tripletail
   - Lobotes surinamensis
   partOfSpeech: n
+  wikidata: Q2168666
 02639180-n:
   definition:
   - tripletail found in the Pacific
@@ -86853,6 +88122,7 @@
   - Pacific tripletail
   - Lobotes pacificus
   partOfSpeech: n
+  wikidata: Q2462078
 02639296-n:
   definition:
   - mojarras
@@ -87153,6 +88423,7 @@
   - Sacramento sturgeon
   - Acipenser transmontanus
   partOfSpeech: n
+  wikidata: Q592876
 02643487-n:
   definition:
   - valuable source of caviar and isinglass; found in Black and Caspian seas
@@ -87167,6 +88438,7 @@
   mero_part:
   - 07815714-n
   partOfSpeech: n
+  wikidata: Q106373169
 02643693-n:
   definition:
   - comprises the genus Lepisosteus
@@ -87207,6 +88479,7 @@
   - billfish
   - Lepisosteus osseus
   partOfSpeech: n
+  wikidata: Q1431272
 02644238-n:
   definition:
   - scorpionfishes, sculpins, gurnards, greenlings, flying gurnards
@@ -87313,6 +88586,7 @@
   - plumed scorpionfish
   - Scorpaena grandicornis
   partOfSpeech: n
+  wikidata: Q2197411
 02646078-n:
   definition:
   - lionfishes
@@ -87417,6 +88691,7 @@
   mero_part:
   - 07813494-n
   partOfSpeech: n
+  wikidata: Q4847126
 02647447-n:
   definition:
   - large fish of northern Atlantic coasts of America and Europe
@@ -87428,6 +88703,7 @@
   - ocean perch
   - Sebastes marinus
   partOfSpeech: n
+  wikidata: Q1753710
 02647597-n:
   definition:
   - sculpins
@@ -87570,6 +88846,7 @@
   - lumpfish
   - Cyclopterus lumpus
   partOfSpeech: n
+  wikidata: Q30066
 02649522-n:
   definition:
   - any of several very small lumpfishes
@@ -87620,6 +88897,7 @@
   - sea snail
   - Liparis liparis
   partOfSpeech: n
+  wikidata: Q2125926
 02650133-n:
   definition:
   - poachers
@@ -87671,6 +88949,7 @@
   - armed bullhead
   - Agonus cataphractus
   partOfSpeech: n
+  wikidata: Q2143094
 02650804-n:
   definition:
   - alligatorfishes
@@ -87844,7 +89123,9 @@
   - yellow gurnard
   - Trigla lucerna
   partOfSpeech: n
-  wikidata: Q630618
+  wikidata:
+  - Q630618
+  - Q106430314
 02653171-n:
   definition:
   - American gurnard; mostly found in bays and estuaries
@@ -87889,6 +89170,7 @@
   - northern sea robin
   - Prionotus carolinus
   partOfSpeech: n
+  wikidata: Q2045269
 02653845-n:
   definition:
   - in some classifications considered a subfamily of Triglidae comprising the armored
@@ -88047,6 +89329,7 @@
   - oldwife
   - Balistes vetula
   partOfSpeech: n
+  wikidata: Q302151
 02656285-n:
   definition:
   - filefishes
@@ -88141,6 +89424,7 @@
   - cowfish
   - Lactophrys quadricornis
   partOfSpeech: n
+  wikidata: Q106443279
 02657520-n:
   definition:
   - puffers
@@ -88219,7 +89503,7 @@
   - porcupine fish
   - Diodon hystrix
   partOfSpeech: n
-  wikidata: Q329334
+  wikidata: Q1328265
 02658662-n:
   definition:
   - similar to but smaller than porcupinefish
@@ -88230,6 +89514,7 @@
   - balloonfish
   - Diodon holocanthus
   partOfSpeech: n
+  wikidata: Q1329475
 02658801-n:
   definition:
   - burrfishes
@@ -88302,6 +89587,7 @@
   - sharptail mola
   - Mola lanceolata
   partOfSpeech: n
+  wikidata: Q106441405
 02659713-n:
   definition:
   - 'flatfishes: halibut; sole; flounder; plaice; turbot; tonguefishes'
@@ -88394,6 +89680,7 @@
   mero_part:
   - 07806911-n
   partOfSpeech: n
+  wikidata: Q27098
 02661300-n:
   definition:
   - a genus of Pleuronectidae containing the starry flounders (Platichthys)
@@ -88417,6 +89704,7 @@
   - European flatfish
   - Platichthys flesus
   partOfSpeech: n
+  wikidata: Q214034
 02661574-n:
   definition:
   - a genus of Pleuronectidae; righteye flounders having a humped nose and small scales;
@@ -88443,6 +89731,7 @@
   mero_part:
   - 07806776-n
   partOfSpeech: n
+  wikidata: Q1499442
 02661972-n:
   definition:
   - a genus of Pleuronectidae containing the righteye flounders, most of which are
@@ -88470,6 +89759,7 @@
   mero_part:
   - 07807639-n
   partOfSpeech: n
+  wikidata: Q1071815
 02662297-n:
   definition:
   - a genus of Pleuronectidae containing the righteye flounders native to the North
@@ -88496,6 +89786,7 @@
   mero_part:
   - 07807511-n
   partOfSpeech: n
+  wikidata: Q127463
 02662591-n:
   definition:
   - a genus of Pleuronectidae containing the righteye flounders native to the North
@@ -88627,6 +89918,7 @@
   - summer flounder
   - Paralichthys dentatus
   partOfSpeech: n
+  wikidata: Q2536162
 02664395-n:
   definition:
   - a genus of Bothidae, containing the large-tooth flounders native to the coastal
@@ -88652,6 +89944,7 @@
   - gray flounder
   - Etropus rimosus
   partOfSpeech: n
+  wikidata: Q2403988
 02664711-n:
   definition:
   - a genus of Bothidae, containing some of the large-tooth flounders, sanddabs, whiffs,
@@ -88686,6 +89979,7 @@
   - horned whiff
   - Citharichthys cornutus
   partOfSpeech: n
+  wikidata: Q5904261
 02665189-n:
   definition:
   - small food fishes of the Pacific coast of North America
@@ -88718,6 +90012,7 @@
   - windowpane
   - Scophthalmus aquosus
   partOfSpeech: n
+  wikidata: Q2045179
 02665623-n:
   definition:
   - European food fish
@@ -88728,6 +90023,7 @@
   - brill
   - Scophthalmus rhombus
   partOfSpeech: n
+  wikidata: Q1122881
 02665716-n:
   definition:
   - a genus of Bothidae
@@ -88753,6 +90049,7 @@
   mero_part:
   - 07807015-n
   partOfSpeech: n
+  wikidata: Q21097700
 02665982-n:
   definition:
   - tonguefishes
@@ -88831,6 +90128,7 @@
   - European sole
   - Solea solea
   partOfSpeech: n
+  wikidata: Q27773
 02667029-n:
   definition:
   - small European sole
@@ -88841,6 +90139,7 @@
   - lemon sole
   - Solea lascaris
   partOfSpeech: n
+  wikidata: Q126890724
 02667141-n:
   definition:
   - a genus of Soleidae, containing the English sole (Parophrys)
@@ -88911,6 +90210,7 @@
   - hogchoker
   - Trinectes maculatus
   partOfSpeech: n
+  wikidata: Q2057479
 02668043-n:
   definition:
   - skin that is very thick (as an elephant or rhinoceros)
@@ -88967,6 +90267,7 @@
   - Canis aureus
   - golden jackal
   partOfSpeech: n
+  wikidata: Q128098
 82475871-n:
   definition:
   - a canid living in the deserts of Northern Africa related to the golden jackal
@@ -88980,7 +90281,7 @@
   - Egyptian jackal
   - grey jackal
   partOfSpeech: n
-  wikidata: Q728631
+  wikidata: Q20744349
 83443092-n:
   definition:
   - a jackal native to Africa with a black back
@@ -88991,6 +90292,9 @@
   - Canis mesomelas
   - black-backed jackal
   partOfSpeech: n
+  wikidata:
+  - Q125814326
+  - Q188944
 84660288-n:
   definition:
   - a dinosaur that is not a bird
@@ -89017,7 +90321,9 @@
   - Canis adustus
   - side-striped jackal
   partOfSpeech: n
-  wikidata: Q208079
+  wikidata:
+  - Q125815593
+  - Q208079
 85444389-n:
   definition:
   - an animal with congenital albinism

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -38717,8 +38717,8 @@
   wikidata: Q7902619
 06928089-n:
   definition:
-  - a non-standard subfamily of Uto-Aztecan languages spoken mainly in the southwestern United
-    States
+  - a non-standard subfamily of Uto-Aztecan languages spoken mainly in the southwestern
+    United States
   hypernym:
   - 06931172-n
   ili: i72876
@@ -40149,7 +40149,8 @@
   wikidata: Q35103
 06944501-n:
   definition:
-  - a non-standard subfamily of the Tibeto-Burman languages including Tibetan and Newari
+  - a non-standard subfamily of the Tibeto-Burman languages including Tibetan and
+    Newari
   hypernym:
   - 06943976-n
   ili: i72998
@@ -40159,7 +40160,8 @@
   partOfSpeech: n
 06944668-n:
   definition:
-  - a non-standard subfamily of the Tibeto-Burman languages including languages spoken in India, Burma and Bangladesh
+  - a non-standard subfamily of the Tibeto-Burman languages including languages spoken
+    in India, Burma and Bangladesh
   hypernym:
   - 06943976-n
   ili: i72999
@@ -41596,8 +41598,8 @@
   - the accent of English spoken at Oxford University and regarded by many as affected
     and pretentious
   example:
-  - text: Not the upper-crusty Oxford English that the English themselves would hear
-    source: http://blogs.suntimes.com/ebert/2011/05/_i_didnt_attend_the.html
+  - source: http://blogs.suntimes.com/ebert/2011/05/_i_didnt_attend_the.html
+    text: Not the upper-crusty Oxford English that the English themselves would hear
   hypernym:
   - 82423757-n
   ili: i73122

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -824,6 +824,9 @@
   - hepatica
   - Marchantia polymorpha
   partOfSpeech: n
+  wikidata:
+  - Q15348827
+  - Q992846
 11564582-n:
   definition:
   - small order sometimes included in the order Jungermanniales
@@ -1742,6 +1745,7 @@
   - welwitschia
   - Welwitschia mirabilis
   partOfSpeech: n
+  wikidata: Q156926
 11620145-n:
   definition:
   - 'palmlike gymnosperms: includes the surviving order Cycadales and several extinct
@@ -1896,6 +1900,7 @@
   - Seminole bread
   - Zamia pumila
   partOfSpeech: n
+  wikidata: Q2252144
 11622755-n:
   definition:
   - small genus of Mexican cycads; sometimes classified in family Cycadaceae
@@ -1974,6 +1979,7 @@
   - kaffir bread
   - Encephalartos caffer
   partOfSpeech: n
+  wikidata: Q3724957
 11624081-n:
   definition:
   - genus of large evergreen Australian cycads; sometimes classified in family Cycadaceae
@@ -2010,8 +2016,8 @@
   - Macrozamia spiralis
   partOfSpeech: n
   wikidata:
-  - Q5402509
   - Q5472958
+  - Q5402509
 11624676-n:
   definition:
   - fossil gymnospermous plants of the Carboniferous
@@ -2345,6 +2351,7 @@
   - Rocky mountain pinon
   - Pinus edulis
   partOfSpeech: n
+  wikidata: Q133096
 11630666-n:
   definition:
   - pinon of southwestern United States having solitary needles and often many stems;
@@ -2358,6 +2365,7 @@
   - single-leaf pinyon
   - Pinus monophylla
   partOfSpeech: n
+  wikidata: Q583885
 11630888-n:
   definition:
   - two-needled or three-needled pinon mostly of northwestern California coast
@@ -2381,6 +2389,9 @@
   - California single-leaf pinyon
   - Pinus californiarum
   partOfSpeech: n
+  wikidata:
+  - Q21384176
+  - Q106918872
 11631274-n:
   definition:
   - five-needled pinon of southern California and northern Baja California having
@@ -2393,6 +2404,9 @@
   - Pinus quadrifolia
   - Pinus parryana
   partOfSpeech: n
+  wikidata:
+  - Q93383212
+  - Q3506492
 11631538-n:
   definition:
   - large two-needled pine of southeastern United States with light soft wood
@@ -2414,6 +2428,7 @@
   - black pine
   - Pinus nigra
   partOfSpeech: n
+  wikidata: Q145954
 11631807-n:
   definition:
   - large three-needled pine of the eastern United States and southeastern Canada;
@@ -2470,6 +2485,7 @@
   mero_part:
   - 11632686-n
   partOfSpeech: n
+  wikidata: Q147278
 11632686-n:
   definition:
   - the seed of the Swiss pine
@@ -2495,6 +2511,7 @@
   - mugo pine
   - Pinus mugo
   partOfSpeech: n
+  wikidata: Q147475
 11633026-n:
   definition:
   - small slow-growing pine of western United States similar to the bristlecone pine;
@@ -2534,6 +2551,7 @@
   - weymouth pine
   - Pinus strobus
   partOfSpeech: n
+  wikidata: Q157230
 11633910-n:
   definition:
   - tall pine of western North America with stout blue-green needles; bark is grey-brown
@@ -2559,6 +2577,7 @@
   - southwestern white pine
   - Pinus strobiformis
   partOfSpeech: n
+  wikidata: Q2746153
 11634318-n:
   definition:
   - western North American pine with long needles and very flexible limbs and dark-grey
@@ -2570,6 +2589,7 @@
   - limber pine
   - Pinus flexilis
   partOfSpeech: n
+  wikidata: Q594993
 11634490-n:
   definition:
   - small pine of western North America; having smooth grey-white bark and soft brittle
@@ -2582,6 +2602,7 @@
   - whitebarked pine
   - Pinus albicaulis
   partOfSpeech: n
+  wikidata: Q761480
 11634701-n:
   definition:
   - any of various pines having yellow wood
@@ -2608,6 +2629,7 @@
   - bull pine
   - Pinus ponderosa
   partOfSpeech: n
+  wikidata: Q460523
 11635164-n:
   definition:
   - tall symmetrical pine of western North America having long blue-green needles
@@ -2622,6 +2644,7 @@
   - black pine
   - Pinus jeffreyi
   partOfSpeech: n
+  wikidata: Q251370
 11635477-n:
   definition:
   - shrubby two-needled pine of coastal northwestern United States; red to yellow-brown
@@ -2636,6 +2659,7 @@
   - spruce pine
   - Pinus contorta
   partOfSpeech: n
+  wikidata: Q165091
 11635710-n:
   definition:
   - tall subspecies of lodgepole pine
@@ -2658,6 +2682,7 @@
   - frankincense pine
   - Pinus taeda
   partOfSpeech: n
+  wikidata: Q368248
 11636058-n:
   definition:
   - slender medium-sized two-needled pine of eastern North America; with yellow-green
@@ -2695,9 +2720,7 @@
   - Georgia pine
   - Pinus palustris
   partOfSpeech: n
-  wikidata:
-  - Q3300799
-  - Q148542
+  wikidata: Q148542
 11636711-n:
   definition:
   - large pine of southern United States having short needles in bunches of 2-3 and
@@ -2711,6 +2734,7 @@
   - shortleaf yellow pine
   - Pinus echinata
   partOfSpeech: n
+  wikidata: Q3237846
 11636937-n:
   definition:
   - pine of eastern North America having long needles in bunches of two and reddish
@@ -2723,6 +2747,7 @@
   - Canadian red pine
   - Pinus resinosa
   partOfSpeech: n
+  wikidata: Q2045958
 11637113-n:
   definition:
   - medium large two-needled pine of northern Europe and Asia having flaking red-brown
@@ -2736,6 +2761,7 @@
   - Scotch fir
   - Pinus sylvestris
   partOfSpeech: n
+  wikidata: Q133128
 11637303-n:
   definition:
   - common small shrubby pine of the eastern United States having straggling often
@@ -2749,6 +2775,7 @@
   - Jersey pine
   - Pinus virginiana
   partOfSpeech: n
+  wikidata: Q3505749
 11637541-n:
   definition:
   - tall California pine with long needles in bunches of 3, a dense crown, and dark
@@ -2760,6 +2787,7 @@
   - Monterey pine
   - Pinus radiata
   partOfSpeech: n
+  wikidata: Q748888
 11637723-n:
   definition:
   - small slow-growing upland pine of western United States (Rocky Mountains) having
@@ -2774,6 +2802,7 @@
   - Rocky Mountain bristlecone pine
   - Pinus aristata
   partOfSpeech: n
+  wikidata: Q936888
 11638082-n:
   definition:
   - a small two-needled upland pine of the eastern United States (Appalachians) having
@@ -2787,6 +2816,7 @@
   - hickory pine
   - Pinus pungens
   partOfSpeech: n
+  wikidata: Q3087592
 11638329-n:
   definition:
   - medium-sized three-needled pine of the Pacific coast of the United States having
@@ -2798,6 +2828,7 @@
   - knobcone pine
   - Pinus attenuata
   partOfSpeech: n
+  wikidata: Q2703208
 11638530-n:
   definition:
   - pine native to Japan and Korea having a wide-spreading irregular crown when mature;
@@ -2823,6 +2854,7 @@
   - black pine
   - Pinus thunbergii
   partOfSpeech: n
+  wikidata: Q854884
 11638976-n:
   definition:
   - medium-sized five-needled pine of southwestern California having long cylindrical
@@ -2886,6 +2918,7 @@
   - black larch
   - Larix laricina
   partOfSpeech: n
+  wikidata: Q734085
 11639906-n:
   definition:
   - tall larch of western North America have pale green sharply pointed leaves and
@@ -2899,6 +2932,7 @@
   - Oregon larch
   - Larix occidentalis
   partOfSpeech: n
+  wikidata: Q576585
 11640138-n:
   definition:
   - medium-sized larch of the Rocky Mountains; closely related to Larix occidentalis
@@ -2909,6 +2943,7 @@
   - subalpine larch
   - Larix lyallii
   partOfSpeech: n
+  wikidata: Q1404234
 11640296-n:
   definition:
   - tall European tree having a slender conic crown, flat needlelike leaves, and hairy
@@ -2920,6 +2955,7 @@
   - European larch
   - Larix decidua
   partOfSpeech: n
+  wikidata: Q146048
 11640467-n:
   definition:
   - medium-sized larch of northeastern Russia and Siberia having narrowly conic crown
@@ -2955,6 +2991,7 @@
   - golden larch
   - Pseudolarix amabilis
   partOfSpeech: n
+  wikidata: Q1458175
 11641011-n:
   definition:
   - true firs
@@ -3029,6 +3066,7 @@
   - Christmas tree
   - Abies alba
   partOfSpeech: n
+  wikidata: Q146992
 11642178-n:
   definition:
   - medium to tall fir of central to western United States having a narrow erect crown
@@ -3043,9 +3081,7 @@
   - Abies concolor
   - Abies lowiana
   partOfSpeech: n
-  wikidata:
-  - Q967962
-  - Q145939
+  wikidata: Q145939
 11642401-n:
   definition:
   - medium-sized fir of northeastern North America; leaves smell of balsam when crushed;
@@ -3071,6 +3107,7 @@
   - Fraser fir
   - Abies fraseri
   partOfSpeech: n
+  wikidata: Q1451343
 11642819-n:
   definition:
   - lofty fir of the Pacific coast of northwestern America having long curving branches
@@ -3085,6 +3122,7 @@
   - grand fir
   - Abies grandis
   partOfSpeech: n
+  wikidata: Q147434
 11643042-n:
   definition:
   - medium-tall timber tree of the Rocky Mountains having a narrowly conic to columnar
@@ -3097,6 +3135,7 @@
   - subalpine fir
   - Abies lasiocarpa
   partOfSpeech: n
+  wikidata: Q978755
 11643222-n:
   definition:
   - a pyramidal fir of southwestern California having spiny pointed leaves and cone
@@ -3176,6 +3215,9 @@
   - cedar of Lebanon
   - Cedrus libani
   partOfSpeech: n
+  wikidata:
+  - Q93301790
+  - Q61105
 11644418-n:
   definition:
   - tall East Indian cedar having spreading branches with nodding tips; highly valued
@@ -3201,6 +3243,7 @@
   - Atlas cedar
   - Cedrus atlantica
   partOfSpeech: n
+  wikidata: Q623489
 11644818-n:
   definition:
   - a genus of temperate and Arctic evergreen trees (see spruce)
@@ -3246,6 +3289,7 @@
   - Norway spruce
   - Picea abies
   partOfSpeech: n
+  wikidata: Q145992
 11645674-n:
   definition:
   - medium-sized spruce of California and Oregon having pendulous branches
@@ -3270,6 +3314,7 @@
   - Engelmann's spruce
   - Picea engelmannii
   partOfSpeech: n
+  wikidata: Q165387
 11646083-n:
   definition:
   - medium-sized spruce of northeastern North America having short blue-green leaves
@@ -3294,6 +3339,7 @@
   - Picea mariana
   - spruce pine
   partOfSpeech: n
+  wikidata: Q218425
 11646461-n:
   definition:
   - tall spruce of northern Europe and Asia; resembles Norway spruce
@@ -3304,6 +3350,7 @@
   - Siberian spruce
   - Picea obovata
   partOfSpeech: n
+  wikidata: Q1137607
 11646603-n:
   definition:
   - a large spruce that grows only along the northwestern coast of the United States
@@ -3342,6 +3389,7 @@
   - silver spruce
   - Picea pungens
   partOfSpeech: n
+  wikidata: Q146025
 11647277-n:
   definition:
   - medium-sized spruce of eastern North America; chief lumber spruce of the area;
@@ -3355,6 +3403,7 @@
   - yellow spruce
   - Picea rubens
   partOfSpeech: n
+  wikidata: Q469151
 11647479-n:
   definition:
   - hemlock; hemlock fir; hemlock spruce
@@ -3414,6 +3463,7 @@
   - Carolina hemlock
   - Tsuga caroliniana
   partOfSpeech: n
+  wikidata: Q1044374
 11648359-n:
   definition:
   - large evergreen of western United States; wood much harder than Canadian hemlock
@@ -3425,6 +3475,7 @@
   - black hemlock
   - Tsuga mertensiana
   partOfSpeech: n
+  wikidata: Q593894
 11648538-n:
   definition:
   - tall evergreen of western North America; commercially important timber tree
@@ -3488,6 +3539,7 @@
   - Oregon pine
   - Pseudotsuga menziesii
   partOfSpeech: n
+  wikidata: Q156687
 11649498-n:
   definition:
   - douglas fir of California having cones 4-8 inches long
@@ -3499,6 +3551,7 @@
   - big-cone douglas fir
   - Pseudotsuga macrocarpa
   partOfSpeech: n
+  wikidata: Q1425070
 11649662-n:
   definition:
   - one species; related to Pseudotsuga and Larix
@@ -3612,6 +3665,9 @@
   - gowen cypress
   - Cupressus goveniana
   partOfSpeech: n
+  wikidata:
+  - Q65944114
+  - Q287544
 11651856-n:
   definition:
   - rare small cypress native to northern California; sometimes considered the same
@@ -3636,7 +3692,9 @@
   - Cupressus abramsiana
   - Cupressus goveniana abramsiana
   partOfSpeech: n
-  wikidata: Q5194570
+  wikidata:
+  - Q28192849
+  - Q5194570
 11652305-n:
   definition:
   - Arizona timber tree with bluish silvery foliage
@@ -3647,6 +3705,9 @@
   - Arizona cypress
   - Cupressus arizonica
   partOfSpeech: n
+  wikidata:
+  - Q65944113
+  - Q670040
 11652436-n:
   definition:
   - relatively low wide-spreading endemic on Guadalupe Island; cultivated for its
@@ -3658,6 +3719,9 @@
   - Guadalupe cypress
   - Cupressus guadalupensis
   partOfSpeech: n
+  wikidata:
+  - Q92734748
+  - Q1552597
 11652618-n:
   definition:
   - tall California cypress endemic on Monterey Bay; widely used for ornament as well
@@ -3669,7 +3733,9 @@
   - Monterey cypress
   - Cupressus macrocarpa
   partOfSpeech: n
-  wikidata: Q1137183
+  wikidata:
+  - Q65944117
+  - Q1137183
 11652827-n:
   definition:
   - tall spreading evergreen found in Mexico having drooping branches; believed to
@@ -3683,7 +3749,9 @@
   - Portuguese cypress
   - Cupressus lusitanica
   partOfSpeech: n
-  wikidata: Q1308561
+  wikidata:
+  - Q65944116
+  - Q1308561
 11653070-n:
   definition:
   - tall Eurasian cypress with thin grey bark and ascending branches
@@ -3695,6 +3763,7 @@
   - Mediterranean cypress
   - Cupressus sempervirens
   partOfSpeech: n
+  wikidata: Q147513
 11653245-n:
   definition:
   - a genus of gymnosperm
@@ -3742,6 +3811,7 @@
   - Chilean cedar
   - Austrocedrus chilensis
   partOfSpeech: n
+  wikidata: Q12981787
 11653910-n:
   definition:
   - 'evergreen monoecious coniferous trees or shrubs: cypress pines'
@@ -3765,6 +3835,7 @@
   - Port Jackson pine
   - Callitris cupressiformis
   partOfSpeech: n
+  wikidata: Q87597486
 11654450-n:
   definition:
   - Australian tree with small flattened scales as leaves and numerous dark brown
@@ -3778,6 +3849,7 @@
   - Callitris endlicheri
   - Callitris calcarata
   partOfSpeech: n
+  wikidata: Q2934277
 11654694-n:
   definition:
   - small tree or shrub of southern Australia
@@ -3789,6 +3861,7 @@
   - Callitris glaucophylla
   - Callitris glauca
   partOfSpeech: n
+  wikidata: Q87597525
 11654844-n:
   definition:
   - Australian cypress pine with fibrous inner bark
@@ -3826,6 +3899,7 @@
   - Calocedrus decurrens
   - Libocedrus decurrens
   partOfSpeech: n
+  wikidata: Q1399164
 11655421-n:
   definition:
   - a genus of Chamaecyparis
@@ -3856,6 +3930,7 @@
   - white cedar
   - Chamaecyparis thyoides
   partOfSpeech: n
+  wikidata: Q1744650
 11655884-n:
   definition:
   - large timber tree of western North America with trunk diameter to 12 feet and
@@ -3872,6 +3947,7 @@
   mero_substance:
   - 11656160-n
   partOfSpeech: n
+  wikidata: Q161360
 11656160-n:
   definition:
   - the wood of the Port Orford cedar tree
@@ -3894,6 +3970,7 @@
   - Alaska cedar
   - Chamaecyparis nootkatensis
   partOfSpeech: n
+  wikidata: Q15043561
 11656519-n:
   definition:
   - Japanese cedar; sugi
@@ -3919,6 +3996,7 @@
   - sugi
   - Cryptomeria japonica
   partOfSpeech: n
+  wikidata: Q147388
 11656840-n:
   definition:
   - junipers
@@ -3981,6 +4059,7 @@
   - Bermuda cedar
   - Juniperus bermudiana
   partOfSpeech: n
+  wikidata: Q822052
 11658110-n:
   definition:
   - tropical African timber tree with fragrant wood
@@ -3991,6 +4070,7 @@
   - east African cedar
   - Juniperus procera
   partOfSpeech: n
+  wikidata: Q577041
 11658261-n:
   definition:
   - juniper of swampy coastal regions of southeastern United States; similar to eastern
@@ -4002,6 +4082,7 @@
   - southern red cedar
   - Juniperus silicicola
   partOfSpeech: n
+  wikidata: Q41777820
 11658442-n:
   definition:
   - procumbent or spreading juniper
@@ -4013,6 +4094,7 @@
   - savin
   - Juniperus sabina
   partOfSpeech: n
+  wikidata: Q148630
 11658560-n:
   definition:
   - densely branching shrub or small tree having pungent blue berries used to flavor
@@ -4027,6 +4109,7 @@
   mero_part:
   - 07843106-n
   partOfSpeech: n
+  wikidata: Q26325
 11658829-n:
   definition:
   - a procumbent variety of the common juniper
@@ -4049,6 +4132,7 @@
   - creeping juniper
   - Juniperus horizontalis
   partOfSpeech: n
+  wikidata: Q121427
 11659149-n:
   definition:
   - small tree of western Texas and mountains of Mexico having spreading branches
@@ -4061,6 +4145,7 @@
   - drooping juniper
   - Juniperus flaccida
   partOfSpeech: n
+  wikidata: Q311965
 11659353-n:
   definition:
   - cypresses that resemble cedars
@@ -4182,6 +4267,7 @@
   - coast redwood
   - Sequoia sempervirens
   partOfSpeech: n
+  wikidata: Q150129
 11661726-n:
   definition:
   - giant sequoias; sometimes included in the genus Sequoia; until recently placed
@@ -4268,6 +4354,7 @@
   - 11663805-n
   - 11663957-n
   partOfSpeech: n
+  wikidata: Q50838983
 11663805-n:
   definition:
   - a brittle and faintly aromatic translucent resin used in varnishes
@@ -4339,6 +4426,7 @@
   - white cedar
   - Thuja occidentalis
   partOfSpeech: n
+  wikidata: Q147468
 11664913-n:
   definition:
   - Asiatic shrub or small tree widely planted in United States and Europe; in some
@@ -4351,7 +4439,9 @@
   - Thuja orientalis
   - Platycladus orientalis
   partOfSpeech: n
-  wikidata: Q33482
+  wikidata:
+  - Q33482
+  - Q15041676
 11665163-n:
   definition:
   - one species; has close similarity to genus Thuja
@@ -4457,6 +4547,7 @@
   - chile pine
   - Araucaria araucana
   partOfSpeech: n
+  wikidata: Q158780
 11666795-n:
   definition:
   - evergreen of Australia and Norfolk Island in the South Pacific
@@ -4468,6 +4559,7 @@
   - Araucaria heterophylla
   - Araucaria excelsa
   partOfSpeech: n
+  wikidata: Q87611094
 11666968-n:
   definition:
   - very tall evergreen of New Caledonia and the New Hebrides similar to Norfolk Island
@@ -4479,6 +4571,7 @@
   - new caledonian pine
   - Araucaria columnaris
   partOfSpeech: n
+  wikidata: Q134045
 11667145-n:
   definition:
   - Australian conifer bearing two-inch seeds tasting like roasted chestnuts; among
@@ -4493,6 +4586,9 @@
   mero_part:
   - 07753570-n
   partOfSpeech: n
+  wikidata:
+  - Q65934672
+  - Q782275
 11667406-n:
   definition:
   - pine of Australia and New Guinea; yields a valuable light even-textured wood
@@ -4566,6 +4662,7 @@
   - Agathis dammara
   - Agathis alba
   partOfSpeech: n
+  wikidata: Q17164898
 11668490-n:
   definition:
   - Australian timber tree resembling the kauri but having wood much lighter in weight
@@ -4579,6 +4676,7 @@
   - smooth bark kauri
   - Agathis robusta
   partOfSpeech: n
+  wikidata: Q144112
 11668719-n:
   definition:
   - New Zealand tree with glossy leaves and scaly reddish-brown bark
@@ -4654,6 +4752,7 @@
   - nutmeg-yew
   - Torreya californica
   partOfSpeech: n
+  wikidata: Q1440975
 11669810-n:
   definition:
   - rare small evergreen of northern Florida; its glossy green leaves have an unpleasant
@@ -4725,6 +4824,7 @@
   - tanekaha
   - Phyllocladus trichomanoides
   partOfSpeech: n
+  wikidata: Q5409426
 11670881-n:
   definition:
   - small shrubby celery pine of New Zealand
@@ -4735,6 +4835,9 @@
   - Alpine celery pine
   - Phyllocladus alpinus
   partOfSpeech: n
+  wikidata:
+  - Q33125492
+  - Q7188675
 11671009-n:
   definition:
   - any of various trees having yellowish wood or yielding a yellow extract
@@ -4842,6 +4945,7 @@
   - yacca podocarp
   - Podocarpus coriaceus
   partOfSpeech: n
+  wikidata: Q5410614
 11672827-n:
   definition:
   - large Australian tree with straight-grained yellow wood that turns brown on exposure
@@ -4853,6 +4957,9 @@
   - Rockingham podocarp
   - Podocarpus elatus
   partOfSpeech: n
+  wikidata:
+  - Q65943052
+  - Q2504953
 11673029-n:
   definition:
   - South African tree or shrub having a rounded crown
@@ -4864,6 +4971,7 @@
   - African yellowwood
   - Podocarpus elongatus
   partOfSpeech: n
+  wikidata: Q5410640
 11673204-n:
   definition:
   - erect or shrubby tree of Africa having ridged dark grey bark and rigid glossy
@@ -4875,6 +4983,7 @@
   - South-African yellowwood
   - Podocarpus latifolius
   partOfSpeech: n
+  wikidata: Q164767
 11673417-n:
   definition:
   - low wide-spreading coniferous shrub of New Zealand mountains
@@ -4897,6 +5006,7 @@
   - totara
   - Podocarpus totara
   partOfSpeech: n
+  wikidata: Q164276
 11673774-n:
   definition:
   - 'dioecious evergreen trees or shrubs; equatorial to southern and southeastern
@@ -4946,6 +5056,9 @@
   - Dacrycarpus dacrydioides
   - Podocarpus dacrydioides
   partOfSpeech: n
+  wikidata:
+  - Q1981615
+  - Q14947698
 11674575-n:
   definition:
   - Australasian evergreen trees or shrubs
@@ -4985,6 +5098,9 @@
   - tar-wood
   - Dacrydium colensoi
   partOfSpeech: n
+  wikidata:
+  - Q138261
+  - Q17363786
 11675118-n:
   definition:
   - 'sickle pines: dioecious evergreen tropical trees and shrubs having sickle-shaped
@@ -5023,6 +5139,7 @@
   - yellow-leaf sickle pine
   - Falcatifolium taxoides
   partOfSpeech: n
+  wikidata: Q3544675
 11675858-n:
   definition:
   - dioecious trees or shrubs of New Zealand; similar in habit to Dacrydium
@@ -5086,6 +5203,9 @@
   - Lagarostrobus franklinii
   - Dacrydium franklinii
   partOfSpeech: n
+  wikidata:
+  - Q137400
+  - Q17363776
 11676831-n:
   definition:
   - small usually shrubby conifers
@@ -5174,6 +5294,7 @@
   - nagi
   - Nageia nagi
   partOfSpeech: n
+  wikidata: Q3274110
 11678214-n:
   definition:
   - 'one species: parasite yew'
@@ -5225,6 +5346,7 @@
   - Prumnopitys ferruginea
   - Podocarpus ferruginea
   partOfSpeech: n
+  wikidata: Q311628
 11678995-n:
   definition:
   - conifer of Australia and New Zealand
@@ -5237,6 +5359,7 @@
   - Prumnopitys taxifolia
   - Podocarpus spicata
   partOfSpeech: n
+  wikidata: Q1127677
 11679160-n:
   definition:
   - South American evergreen tree or shrub
@@ -5248,6 +5371,7 @@
   - Prumnopitys andina
   - Prumnopitys elegans
   partOfSpeech: n
+  wikidata: Q50851707
 11679323-n:
   definition:
   - small genus of tropical evergreen dioecious shrubs or trees of Oceania and tropical
@@ -5312,6 +5436,7 @@
   - Prumnopitys amara
   - Podocarpus amara
   partOfSpeech: n
+  wikidata: Q20671985
 11680360-n:
   definition:
   - family comprising a single genus that until recently was considered part of Taxodiaceae
@@ -5349,6 +5474,7 @@
   - Japanese umbrella pine
   - Sciadopitys verticillata
   partOfSpeech: n
+  wikidata: Q161648
 11680988-n:
   definition:
   - 'yews: in some systems classified as a class (Taxopsida) and in others as a subdivision
@@ -5441,6 +5567,9 @@
   - English yew
   - Taxus baccata
   partOfSpeech: n
+  wikidata:
+  - Q92968108
+  - Q179729
 11682579-n:
   definition:
   - small or medium irregularly branched tree of the Pacific coast of North America;
@@ -5466,6 +5595,7 @@
   - Japanese yew
   - Taxus cuspidata
   partOfSpeech: n
+  wikidata: Q1144815
 11683036-n:
   definition:
   - small bushy yew of northern Florida having spreading branches and very narrow
@@ -5477,7 +5607,9 @@
   - Florida yew
   - Taxus floridana
   partOfSpeech: n
-  wikidata: Q1430041
+  wikidata:
+  - Q92968239
+  - Q1430041
 11683215-n:
   definition:
   - 'a gymnosperm genus having one species: New Caledonian yew'
@@ -5526,6 +5658,7 @@
   - white-berry yew
   - Pseudotaxus chienii
   partOfSpeech: n
+  wikidata: Q136195
 11683900-n:
   definition:
   - 'ginkgos: in some systems classified as a class and in others as a subdivision;
@@ -5595,6 +5728,7 @@
   - maidenhair tree
   - Ginkgo biloba
   partOfSpeech: n
+  wikidata: Q43284
 11685128-n:
   definition:
   - used in former classifications to include all ferns and flowering plants and divided
@@ -7151,6 +7285,7 @@
   mero_part:
   - 07777117-n
   partOfSpeech: n
+  wikidata: Q158986
 11714938-n:
   definition:
   - tropical American tree grown in southern United States having a whitish pink-tinged
@@ -7165,6 +7300,7 @@
   mero_part:
   - 07777753-n
   partOfSpeech: n
+  wikidata: Q24849787
 11715133-n:
   definition:
   - small tropical American tree bearing large succulent slightly acid fruit
@@ -7224,6 +7360,7 @@
   mero_part:
   - 07777930-n
   partOfSpeech: n
+  wikidata: Q2353550
 11715954-n:
   definition:
   - pawpaw
@@ -7252,6 +7389,7 @@
   mero_part:
   - 07778090-n
   partOfSpeech: n
+  wikidata: Q948827
 11716282-n:
   definition:
   - a genus of Malayan tree
@@ -7279,6 +7417,7 @@
   - ylang-ylang
   - Cananga odorata
   partOfSpeech: n
+  wikidata: Q220963
 11716680-n:
   definition:
   - oil distilled from flowers of the ilang-ilang tree; used in perfumery
@@ -7312,6 +7451,7 @@
   mero_substance:
   - 11717075-n
   partOfSpeech: n
+  wikidata: Q15363939
 11717075-n:
   definition:
   - durable straight-grained wood of the lacewood tree; used for building and cabinetwork
@@ -7400,6 +7540,7 @@
   - American barberry
   - Berberis canadensis
   partOfSpeech: n
+  wikidata: Q1723503
 11718511-n:
   definition:
   - upright deciduous European shrub widely naturalized in United States having clusters
@@ -7412,6 +7553,7 @@
   - European barberry
   - Berberis vulgaris
   partOfSpeech: n
+  wikidata: Q158563
 11718714-n:
   definition:
   - compact deciduous shrub having persistent red berries; widespread in cultivation
@@ -7423,6 +7565,7 @@
   - Japanese barberry
   - Berberis thunbergii
   partOfSpeech: n
+  wikidata: Q158397
 11718902-n:
   definition:
   - blue cohosh
@@ -7479,6 +7622,7 @@
   - bishop's hat
   - Epimedium grandiflorum
   partOfSpeech: n
+  wikidata: Q2617435
 11719752-n:
   definition:
   - evergreen shrubs and small trees of North and Central America and Asia
@@ -7505,6 +7649,7 @@
   - holly-leaves barberry
   - Mahonia aquifolium
   partOfSpeech: n
+  wikidata: Q158303
 11720220-n:
   definition:
   - small shrub with grey-green leaves and yellow flowers followed by glaucous blue
@@ -7516,6 +7661,7 @@
   - Oregon grape
   - Mahonia nervosa
   partOfSpeech: n
+  wikidata: Q647429
 11720384-n:
   definition:
   - perennial rhizomatous herbs
@@ -7543,6 +7689,7 @@
   mero_part:
   - 11720748-n
   partOfSpeech: n
+  wikidata: Q1572090
 11720748-n:
   definition:
   - edible but insipid fruit of the May apple plant
@@ -7619,6 +7766,7 @@
   - California allspice
   - Calycanthus occidentalis
   partOfSpeech: n
+  wikidata: Q10786205
 11721961-n:
   definition:
   - 'small genus of Asian deciduous or evergreen shrubs having fragrant flowers: winter
@@ -7645,6 +7793,7 @@
   - winter sweet
   - Chimonanthus praecox
   partOfSpeech: n
+  wikidata: Q2566375
 11722372-n:
   definition:
   - 'coextensive with the genus Ceratophyllum: hornworts'
@@ -7830,6 +7979,7 @@
   - camphor tree
   - Cinnamomum camphora
   partOfSpeech: n
+  wikidata: Q158722
 11725260-n:
   definition:
   - tropical Asian tree with aromatic yellowish-brown bark; source of the spice cinnamon
@@ -7845,6 +7995,7 @@
   - 07830179-n
   - 11725521-n
   partOfSpeech: n
+  wikidata: Q12892282
 11725521-n:
   definition:
   - aromatic bark used as a spice
@@ -7869,6 +8020,7 @@
   mero_part:
   - 11725856-n
   partOfSpeech: n
+  wikidata: Q204148
 11725856-n:
   definition:
   - aromatic bark of the cassia-bark tree; less desirable as a spice than Ceylon cinnamon
@@ -7942,6 +8094,7 @@
   - Lindera benzoin
   - Benzoin odoriferum
   partOfSpeech: n
+  wikidata: Q3024124
 11727098-n:
   definition:
   - avocado
@@ -7980,6 +8133,7 @@
   - red bay
   - Persea borbonia
   partOfSpeech: n
+  wikidata: Q4351742
 11727578-n:
   definition:
   - a genus of sassafras
@@ -8008,6 +8162,7 @@
   mero_substance:
   - 11727980-n
   partOfSpeech: n
+  wikidata: Q584469
 11727980-n:
   definition:
   - oil from root bark of sassafras trees; used in perfumery and as a disinfectant
@@ -8177,6 +8332,7 @@
   - bull bay
   - Magnolia grandiflora
   partOfSpeech: n
+  wikidata: Q161116
 11730862-n:
   definition:
   - small deciduous tree of eastern North America having creamy white flowers and
@@ -8191,6 +8347,7 @@
   - elk-wood
   - Magnolia tripetala
   partOfSpeech: n
+  wikidata: Q990982
 11731127-n:
   definition:
   - small erect deciduous tree with large leaves in coiled formations at branch tips
@@ -8201,6 +8358,7 @@
   - earleaved umbrella tree
   - Magnolia fraseri
   partOfSpeech: n
+  wikidata: Q819208
 11731296-n:
   definition:
   - American deciduous magnolia having large leaves and fruit like a small cucumber
@@ -8211,6 +8369,9 @@
   - cucumber tree
   - Magnolia acuminata
   partOfSpeech: n
+  wikidata:
+  - Q93448763
+  - Q1249099
 11731456-n:
   definition:
   - large deciduous shrub or tree of southeastern United States having huge leaves
@@ -8248,6 +8409,7 @@
   - star magnolia
   - Magnolia stellata
   partOfSpeech: n
+  wikidata: Q839507
 11732233-n:
   definition:
   - shrub or small tree having rather small fragrant white flowers; abundant in southeastern
@@ -8304,6 +8466,7 @@
   mero_substance:
   - 11733090-n
   partOfSpeech: n
+  wikidata: Q158783
 11733090-n:
   definition:
   - light easily worked wood of a tulip tree; used for furniture and veneer
@@ -8394,6 +8557,7 @@
   - Carolina moonseed
   - Cocculus carolinus
   partOfSpeech: n
+  wikidata: Q5139267
 11734429-n:
   definition:
   - family of aromatic tropical trees with arillate seeds
@@ -8436,6 +8600,7 @@
   mero_part:
   - 07831400-n
   partOfSpeech: n
+  wikidata: Q2724976
 11735087-n:
   definition:
   - dicot aquatic plants
@@ -8493,6 +8658,9 @@
   - pond lily
   - Nymphaea odorata
   partOfSpeech: n
+  wikidata:
+  - Q87635472
+  - Q635853
 11736147-n:
   definition:
   - a water lily with white flowers
@@ -8518,6 +8686,7 @@
   - white lily
   - Nymphaea lotus
   partOfSpeech: n
+  wikidata: Q161111
 11736510-n:
   definition:
   - 'blue Egyptian lotus: held sacred by the Egyptians'
@@ -8528,6 +8697,9 @@
   - blue lotus
   - Nymphaea caerulea
   partOfSpeech: n
+  wikidata:
+  - Q50897106
+  - Q148880
 11736636-n:
   definition:
   - blue lotus of India and southeastern Asia
@@ -8538,6 +8710,7 @@
   - blue lotus
   - Nymphaea stellata
   partOfSpeech: n
+  wikidata: Q87581437
 11736754-n:
   definition:
   - spatterdocks
@@ -8565,6 +8738,7 @@
   - yellow pond lily
   - Nuphar advena
   partOfSpeech: n
+  wikidata: Q2651986
 11737167-n:
   definition:
   - of flowing waters of the southeastern United States; may form obstructive mats
@@ -8586,6 +8760,7 @@
   - yellow water lily
   - Nuphar lutea
   partOfSpeech: n
+  wikidata: Q146406
 11737476-n:
   definition:
   - in some classifications considered an independent family of water lilies; comprises
@@ -8625,6 +8800,7 @@
   - sacred lotus
   - Nelumbo nucifera
   partOfSpeech: n
+  wikidata: Q16528
 11738046-n:
   definition:
   - water lily of eastern North America having pale yellow blossoms and edible globular
@@ -8640,6 +8816,7 @@
   mero_part:
   - 07788607-n
   partOfSpeech: n
+  wikidata: Q468996
 11738289-n:
   definition:
   - in some classifications considered an independent family of water lilies; comprises
@@ -8682,6 +8859,7 @@
   - fanwort
   - Cabomba caroliniana
   partOfSpeech: n
+  wikidata: Q786072
 11738990-n:
   definition:
   - alternatively, a member of the family Nymphaeaceae
@@ -8707,6 +8885,7 @@
   - Brasenia schreberi
   - water-target
   partOfSpeech: n
+  wikidata: Q10913294
 11739380-n:
   definition:
   - perennial rhizomatous herbs and shrubs; of temperate Europe and North America
@@ -8829,6 +9008,9 @@
   - tall field buttercup
   - Ranunculus acris
   partOfSpeech: n
+  wikidata:
+  - Q42711363
+  - Q157563
 11741360-n:
   definition:
   - plant of ponds and slow streams having submerged and floating leaves and white
@@ -8841,7 +9023,9 @@
   - water buttercup
   - Ranunculus aquatilis
   partOfSpeech: n
-  wikidata: Q162818
+  wikidata:
+  - Q58814094
+  - Q162818
 11741593-n:
   definition:
   - perennial Old World buttercup with golden to sulphur yellow flowers in late spring
@@ -8867,6 +9051,7 @@
   - pilewort
   - Ranunculus ficaria
   partOfSpeech: n
+  wikidata: Q19796483
 11742111-n:
   definition:
   - semiaquatic Eurasian perennial crowfoot with leaves shaped like spears; naturalized
@@ -8878,6 +9063,7 @@
   - lesser spearwort
   - Ranunculus flammula
   partOfSpeech: n
+  wikidata: Q161737
 11742313-n:
   definition:
   - small early-flowering buttercup with shiny yellow flowers of western North America
@@ -8888,6 +9074,7 @@
   - sagebrush buttercup
   - Ranunculus glaberrimus
   partOfSpeech: n
+  wikidata: Q4117731
 11742505-n:
   definition:
   - semiaquatic European crowfoot with leaves shaped like spears
@@ -8932,6 +9119,7 @@
   - creeping crowfoot
   - Ranunculus repens
   partOfSpeech: n
+  wikidata: Q213356
 11743090-n:
   definition:
   - annual herb growing in marshy places
@@ -8943,6 +9131,7 @@
   - celery-leaved buttercup
   - Ranunculus sceleratus
   partOfSpeech: n
+  wikidata: Q1339284
 11743238-n:
   definition:
   - genus of poisonous plants of temperate regions of Northern Hemisphere with a vaulted
@@ -8980,6 +9169,7 @@
   - helmet flower
   - Aconitum napellus
   partOfSpeech: n
+  wikidata: Q159218
 11743921-n:
   definition:
   - poisonous Eurasian perennial herb with broad rounded leaves and yellow flowers
@@ -8993,6 +9183,7 @@
   - wolf's bane
   - Aconitum lycoctonum
   partOfSpeech: n
+  wikidata: Q158040
 11744124-n:
   definition:
   - baneberry
@@ -9056,6 +9247,7 @@
   - doll's eyes
   - Actaea alba
   partOfSpeech: n
+  wikidata: Q116886712
 11744998-n:
   definition:
   - annual or perennial herbs
@@ -9079,6 +9271,7 @@
   - pheasant's-eye
   - Adonis annua
   partOfSpeech: n
+  wikidata: Q148907
 11745291-n:
   definition:
   - perennial herbs with tuberous roots and beautiful flowers; of north and south
@@ -9114,6 +9307,7 @@
   - mountain anemone
   - Anemone tetonensis
   partOfSpeech: n
+  wikidata: Q15365673
 11745949-n:
   definition:
   - common summer-flowering woodland herb of Labrador to Colorado
@@ -9124,6 +9318,9 @@
   - Canada anemone
   - Anemone canadensis
   partOfSpeech: n
+  wikidata:
+  - Q91249630
+  - Q2198861
 11746092-n:
   definition:
   - a common North American anemone with cylindrical fruit clusters resembling thimbles
@@ -9134,6 +9331,7 @@
   - thimbleweed
   - Anemone cylindrica
   partOfSpeech: n
+  wikidata: Q4115564
 11746290-n:
   definition:
   - European anemone with solitary white flowers common in deciduous woodlands
@@ -9144,7 +9342,9 @@
   - wood anemone
   - Anemone nemorosa
   partOfSpeech: n
-  wikidata: Q161056
+  wikidata:
+  - Q55813553
+  - Q161056
 11746442-n:
   definition:
   - common anemone of eastern North America with solitary pink-tinged white flowers
@@ -9156,6 +9356,7 @@
   - snowdrop
   - Anemone quinquefolia
   partOfSpeech: n
+  wikidata: Q2208329
 11746614-n:
   definition:
   - thimbleweed of northern North America
@@ -9178,6 +9379,9 @@
   - snowdrop windflower
   - Anemone sylvestris
   partOfSpeech: n
+  wikidata:
+  - Q93124828
+  - Q157358
 11746902-n:
   definition:
   - thimbleweed of central and eastern North America
@@ -9188,6 +9392,7 @@
   - Virginia thimbleweed
   - Anemone virginiana
   partOfSpeech: n
+  wikidata: Q4117342
 11747038-n:
   definition:
   - 'one species: rue anemone'
@@ -9212,6 +9417,7 @@
   - rue anemone
   - Anemonella thalictroides
   partOfSpeech: n
+  wikidata: Q159600
 11747394-n:
   definition:
   - columbine
@@ -9250,6 +9456,7 @@
   - honeysuckle
   - Aquilegia canadensis
   partOfSpeech: n
+  wikidata: Q2846008
 11748009-n:
   definition:
   - columbine of the Rocky Mountains having long-spurred blue flowers
@@ -9261,6 +9468,7 @@
   - Aquilegia caerulea
   - Aquilegia scopulorum calcarea
   partOfSpeech: n
+  wikidata: Q22113514
 11748207-n:
   definition:
   - common European columbine having variously colored (white or blue to purple or
@@ -9272,6 +9480,7 @@
   - granny's bonnets
   - Aquilegia vulgaris
   partOfSpeech: n
+  wikidata: Q148929
 11748445-n:
   definition:
   - a genus of Caltha
@@ -9301,6 +9510,7 @@
   - water dragon
   - Caltha palustris
   partOfSpeech: n
+  wikidata: Q147192
 11748819-n:
   definition:
   - 'small genus of perennial herbs of north temperate regions: bugbane'
@@ -9335,6 +9545,7 @@
   - summer cohosh
   - Cimicifuga americana
   partOfSpeech: n
+  wikidata: Q19847498
 11749414-n:
   definition:
   - North American bugbane found from Maine and Ontario to Wisconsin and south to
@@ -9348,6 +9559,7 @@
   - rattle-top
   - Cimicifuga racemosa
   partOfSpeech: n
+  wikidata: Q19847513
 11749611-n:
   definition:
   - bugbane of Siberia and eastern Asia having ill-smelling green-white flowers
@@ -9359,6 +9571,7 @@
   - foetid bugbane
   - Cimicifuga foetida
   partOfSpeech: n
+  wikidata: Q10905072
 11749784-n:
   definition:
   - large genus of deciduous or evergreen woody vines or erect herbs
@@ -9392,6 +9605,7 @@
   - Clematis baldwinii
   - Viorna baldwinii
   partOfSpeech: n
+  wikidata: Q15366837
 11750484-n:
   definition:
   - climber of southern United States having bluish-purple flowers
@@ -9416,6 +9630,7 @@
   - pipestem clematis
   - Clematis lasiantha
   partOfSpeech: n
+  wikidata: Q5131214
 11750781-n:
   definition:
   - shrubby clematis of the eastern United States having curly foliage
@@ -9447,6 +9662,7 @@
   - scarlet clematis
   - Clematis texensis
   partOfSpeech: n
+  wikidata: Q5131225
 11751219-n:
   definition:
   - woody vine of the southern United States having purple or blue flowers with leathery
@@ -9458,6 +9674,7 @@
   - leather flower
   - Clematis versicolor
   partOfSpeech: n
+  wikidata: Q15369316
 11751402-n:
   definition:
   - scandent subshrub of southeastern United States having large red-purple bell-shaped
@@ -9471,6 +9688,7 @@
   - vase vine
   - Clematis viorna
   partOfSpeech: n
+  wikidata: Q15369586
 11751626-n:
   definition:
   - common climber of eastern North America that sprawls over other plants and bears
@@ -9498,6 +9716,7 @@
   - old man's beard
   - Clematis vitalba
   partOfSpeech: n
+  wikidata: Q160100
 11752128-n:
   definition:
   - climber of northeastern North America having waxy purplish-blue flowers
@@ -9510,6 +9729,7 @@
   - mountain clematis
   - Clematis verticillaris
   partOfSpeech: n
+  wikidata: Q110469357
 11752330-n:
   definition:
   - small genus of low perennial herbs having yellow rhizomes and white or yellow
@@ -9537,6 +9757,7 @@
   - Coptis groenlandica
   - Coptis trifolia groenlandica
   partOfSpeech: n
+  wikidata: Q85197594
 11752778-n:
   definition:
   - plants having flowers resembling the larkspur's but differing from larkspur's
@@ -9563,6 +9784,7 @@
   - Consolida ambigua
   - Delphinium ajacis
   partOfSpeech: n
+  wikidata: Q50839091
 11753326-n:
   definition:
   - large genus of chiefly perennial erect branching herbs of north temperate regions
@@ -9681,6 +9903,7 @@
   - black hellebore
   - Helleborus orientalis
   partOfSpeech: n
+  wikidata: Q937300
 11755167-n:
   definition:
   - deciduous plant with large deep green pedate leaves and nodding saucer-shaped
@@ -9692,6 +9915,7 @@
   - green hellebore
   - Helleborus viridis
   partOfSpeech: n
+  wikidata: Q149328
 11755341-n:
   definition:
   - small genus of perennial herbs of north temperate regions; allied to genus Anemone
@@ -9744,6 +9968,7 @@
   - turmeric root
   - Hydrastis canadensis
   partOfSpeech: n
+  wikidata: Q1051710
 11756291-n:
   definition:
   - tufted perennial herbs of Northern Hemisphere
@@ -9769,6 +9994,7 @@
   - false rue
   - Isopyrum biternatum
   partOfSpeech: n
+  wikidata: Q110470586
 11756685-n:
   definition:
   - 'one species: giant buttercup'
@@ -9793,6 +10019,7 @@
   - giant buttercup
   - Laccopetalum giganteum
   partOfSpeech: n
+  wikidata: Q15374155
 11757038-n:
   definition:
   - erect annual Eurasian herbs
@@ -9824,6 +10051,7 @@
   - love-in-a-mist
   - Nigella damascena
   partOfSpeech: n
+  wikidata: Q158338
 11757478-n:
   definition:
   - nigella of Spain and southern France
@@ -9834,6 +10062,7 @@
   - fennel flower
   - Nigella hispanica
   partOfSpeech: n
+  wikidata: Q4514226
 11757594-n:
   definition:
   - herb of the Mediterranean region having pungent seeds used like those of caraway
@@ -9846,6 +10075,7 @@
   - Roman coriander
   - Nigella sativa
   partOfSpeech: n
+  wikidata: Q160575
 11757785-n:
   definition:
   - 'includes a group of plants that in some classifications are included in the genus
@@ -9888,6 +10118,7 @@
   - Pulsatilla patens
   - Anemone ludoviciana
   partOfSpeech: n
+  wikidata: Q149341
 11758532-n:
   definition:
   - A herbaceous plant species of western North America (Anemone occidentalis, Pulsatilla
@@ -9900,6 +10131,7 @@
   - Pulsatilla occidentalis
   - Anemone occidentalis
   partOfSpeech: n
+  wikidata: Q17813765
 11758672-n:
   definition:
   - European perennial having usually violet or white spring flowers
@@ -9911,6 +10143,7 @@
   - Pulsatilla vulgaris
   - Anemone pulsatilla
   partOfSpeech: n
+  wikidata: Q148623
 11758847-n:
   definition:
   - 'widely distributed genus of perennial herbs: meadow rue'
@@ -9959,6 +10192,7 @@
   - false bugbane
   - Trautvetteria carolinensis
   partOfSpeech: n
+  wikidata: Q17847344
 11759668-n:
   definition:
   - 'perennial herbs of north temperate regions: globeflowers'
@@ -10025,6 +10259,7 @@
   mero_part:
   - 13183713-n
   partOfSpeech: n
+  wikidata: Q775529
 11760677-n:
   definition:
   - evergreen shrubs or small trees of Australia and New Zealand
@@ -10052,6 +10287,7 @@
   - Pseudowintera colorata
   - Wintera colorata
   partOfSpeech: n
+  wikidata: Q5854145
 11761124-n:
   definition:
   - coextensive with the family Myricaceae
@@ -10106,6 +10342,7 @@
   - Scotch gale
   - Myrica gale
   partOfSpeech: n
+  wikidata: Q161681
 11761819-n:
   definition:
   - any shrub or small tree of the genus Myrica with aromatic foliage and small wax-coated
@@ -10130,6 +10367,9 @@
   - puckerbush
   - Myrica cerifera
   partOfSpeech: n
+  wikidata:
+  - Q1109693
+  - Q15377365
 11762266-n:
   definition:
   - deciduous aromatic shrub of eastern North America with grey-green wax-coated berries
@@ -10143,6 +10383,9 @@
   - waxberry
   - Myrica pensylvanica
   partOfSpeech: n
+  wikidata:
+  - Q3331585
+  - Q12331270
 11762472-n:
   definition:
   - a fragrant green wax obtained from the wax myrtle and used in making candles
@@ -10271,6 +10514,7 @@
   - soft rush
   - Juncus effusus
   partOfSpeech: n
+  wikidata: Q161677
 11764480-n:
   definition:
   - rush of Australia
@@ -10281,6 +10525,7 @@
   - jointed rush
   - Juncus articulatus
   partOfSpeech: n
+  wikidata: Q159141
 11764577-n:
   definition:
   - low-growing annual rush of damp low-lying ground; nearly cosmopolitan
@@ -10291,6 +10536,7 @@
   - toad rush
   - Juncus bufonius
   partOfSpeech: n
+  wikidata: Q159152
 11764720-n:
   definition:
   - tall rush of temperate regions
@@ -10301,6 +10547,7 @@
   - hard rush
   - Juncus inflexus
   partOfSpeech: n
+  wikidata: Q161332
 11764824-n:
   definition:
   - rush of the Pacific coast of North America
@@ -10486,6 +10733,7 @@
   - 07753721-n
   - 11769280-n
   partOfSpeech: n
+  wikidata: Q37383
 11769280-n:
   definition:
   - underground pod of the peanut vine
@@ -10522,6 +10770,7 @@
   mero_substance:
   - 11769742-n
   partOfSpeech: n
+  wikidata: Q10741417
 11769742-n:
   definition:
   - wood of the granadilla tree used for making musical instruments especially clarinets
@@ -10556,6 +10805,7 @@
   - arariba
   - Centrolobium robustum
   partOfSpeech: n
+  wikidata: Q15528519
 11770211-n:
   definition:
   - 'tropical American trees: tonka beans'
@@ -10584,6 +10834,7 @@
   - Coumarouna odorata
   - Dipteryx odorata
   partOfSpeech: n
+  wikidata: Q901484
 11770642-n:
   definition:
   - fragrant black nutlike seeds of the tonka bean tree; used in perfumes and medicines
@@ -10712,6 +10963,7 @@
   - smooth darling pea
   - Swainsona galegifolia
   partOfSpeech: n
+  wikidata: Q7653034
 11772637-n:
   definition:
   - shrubby perennial of southern Australia having downy or woolly stems and undersides
@@ -10724,6 +10976,7 @@
   - Swainsona greyana
   - Swainsona grandiflora
   partOfSpeech: n
+  wikidata: Q65950237
 11772873-n:
   definition:
   - any leguminous plant having leaves divided into three leaflets
@@ -10757,6 +11010,7 @@
   - alpine clover
   - Trifolium alpinum
   partOfSpeech: n
+  wikidata: Q159593
 11773406-n:
   definition:
   - clover native to Ireland with yellowish flowers; often considered the true or
@@ -10783,6 +11037,7 @@
   - Italian clover
   - Trifolium incarnatum
   partOfSpeech: n
+  wikidata: Q161361
 11773824-n:
   definition:
   - erect to decumbent short-lived perennial having red-purple to pink flowers; the
@@ -10795,7 +11050,9 @@
   - purple clover
   - Trifolium pratense
   partOfSpeech: n
-  wikidata: Q156635
+  wikidata:
+  - Q21381394
+  - Q156635
 11774031-n:
   definition:
   - clover of western United States
@@ -10807,6 +11064,7 @@
   - Trifolium reflexum
   - Trifolium stoloniferum
   partOfSpeech: n
+  wikidata: Q15546026
 11774169-n:
   definition:
   - creeping European clover having white to pink flowers and bright green leaves;
@@ -10820,6 +11078,7 @@
   - shamrock
   - Trifolium repens
   partOfSpeech: n
+  wikidata: Q148675
 11774405-n:
   definition:
   - family of spiny woody plants (usually shrubs or small trees) whose leaves mimic
@@ -10893,6 +11152,7 @@
   - sensitive plant
   - Mimosa sensitiva
   partOfSpeech: n
+  wikidata: Q5558576
 11775788-n:
   definition:
   - prostrate or semi-erect subshrub of tropical America, and Australia; heavily armed
@@ -10910,6 +11170,7 @@
   - action plant
   - Mimosa pudica
   partOfSpeech: n
+  wikidata: Q148532
 11776163-n:
   definition:
   - 'large genus of shrubs and trees and some woody vines of Central and South America,
@@ -10984,6 +11245,9 @@
   - black wattle
   - Acacia auriculiformis
   partOfSpeech: n
+  wikidata:
+  - Q43375010
+  - Q2673522
 11777486-n:
   definition:
   - scrubby Australian acacia having extremely foul-smelling blossoms
@@ -11009,6 +11273,7 @@
   mero_substance:
   - 11777902-n
   partOfSpeech: n
+  wikidata: Q15535916
 11777902-n:
   definition:
   - extract of the heartwood of Acacia catechu used for dyeing and tanning and preserving
@@ -11032,6 +11297,9 @@
   - mimosa
   - Acacia dealbata
   partOfSpeech: n
+  wikidata:
+  - Q50892032
+  - Q757123
 11778320-n:
   definition:
   - tropical American thorny shrub or small tree; fragrant yellow flowers used in
@@ -11049,6 +11317,9 @@
   - flame tree
   - Acacia farnesiana
   partOfSpeech: n
+  wikidata:
+  - Q67453964
+  - Q932729
 11778591-n:
   definition:
   - tall Australian acacia yielding highly valued black timber
@@ -11059,7 +11330,9 @@
   - lightwood
   - Acacia melanoxylon
   partOfSpeech: n
-  wikidata: Q386585
+  wikidata:
+  - Q43375057
+  - Q386585
 11778745-n:
   definition:
   - shrubby Australian tree having clusters of fragrant golden yellow flowers; widely
@@ -11071,6 +11344,9 @@
   - golden wattle
   - Acacia pycnantha
   partOfSpeech: n
+  wikidata:
+  - Q15531407
+  - Q516233
 11778952-n:
   definition:
   - African tree supposed to mark healthful regions
@@ -11081,6 +11357,9 @@
   - fever tree
   - Acacia xanthophloea
   partOfSpeech: n
+  wikidata:
+  - Q15525187
+  - Q1499421
 11779097-n:
   definition:
   - small genus of trees of tropical Asia and Pacific areas
@@ -11108,6 +11387,7 @@
   - peacock flower fence
   - Adenanthera pavonina
   partOfSpeech: n
+  wikidata: Q2717414
 11779518-n:
   definition:
   - large genus of unarmed trees and shrubs of Old World tropics
@@ -11143,6 +11423,7 @@
   - Albizia julibrissin
   - Albizzia julibrissin
   partOfSpeech: n
+  wikidata: Q750307
 11780078-n:
   definition:
   - large spreading Old World tree having large leaves and globose clusters of greenish-yellow
@@ -11173,6 +11454,7 @@
   - zamang
   - Albizia saman
   partOfSpeech: n
+  wikidata: Q15283786
 11780597-n:
   definition:
   - 2 species of tropical American shrubs or trees
@@ -11282,6 +11564,7 @@
   - ice-cream bean
   - Inga edulis
   partOfSpeech: n
+  wikidata: Q138183
 11782487-n:
   definition:
   - tropical tree of Central America and West Indies and Puerto Rico having spikes
@@ -11293,6 +11576,7 @@
   - guama
   - Inga laurina
   partOfSpeech: n
+  wikidata: Q15538172
 11782706-n:
   definition:
   - small genus of tropical evergreen trees or shrubs having pods like those of the
@@ -11320,6 +11604,7 @@
   - Leucaena glauca
   - Leucaena leucocephala
   partOfSpeech: n
+  wikidata: Q65941858
 11783175-n:
   definition:
   - small genus of tropical American trees and shrubs with pinnate leaves and flat
@@ -11360,6 +11645,7 @@
   mero_substance:
   - 11783809-n
   partOfSpeech: n
+  wikidata: Q15531794
 11783809-n:
   definition:
   - the wood of the sabicu which resembles mahogany
@@ -11446,6 +11732,7 @@
   - wild tamarind
   - Pithecellobium dulce
   partOfSpeech: n
+  wikidata: Q15248750
 11785283-n:
   definition:
   - erect shrub with small if any spines having racemes of white to yellow flowers
@@ -11459,6 +11746,7 @@
   - black bead
   - Pithecellobium unguis-cati
   partOfSpeech: n
+  wikidata: Q2097212
 11785568-n:
   definition:
   - 'genus of tropical or subtropical branching shrubs or trees: mesquite'
@@ -11496,7 +11784,9 @@
   - Western honey mesquite
   - Prosopis glandulosa
   partOfSpeech: n
-  wikidata: Q3013277
+  wikidata:
+  - Q50890820
+  - Q3013277
 11786328-n:
   definition:
   - mesquite of Gulf Coast and Caribbean Islands from Mexico to Venezuela
@@ -11642,6 +11932,7 @@
   - Rocky Mountain dogbane
   - Apocynum pumilum
   partOfSpeech: n
+  wikidata: Q109577313
 11788711-n:
   definition:
   - small genus of trees and shrubs containing strongly toxic cardiac glycosides;
@@ -11712,6 +12003,7 @@
   - Adenium obesum
   - Adenium multiflorum
   partOfSpeech: n
+  wikidata: Q4682225
 11789952-n:
   definition:
   - genus of tropical American woody vines
@@ -11774,6 +12066,7 @@
   - devil tree
   - Alstonia scholaris
   partOfSpeech: n
+  wikidata: Q135307
 11790995-n:
   definition:
   - genus of herbs and subshrubs with milky juice and showy bluish flowers; Europe
@@ -11825,6 +12118,7 @@
   - Easter lily vine
   - Beaumontia grandiflora
   partOfSpeech: n
+  wikidata: Q11895343
 11791852-n:
   definition:
   - Old World genus of tropical evergreen usually spiny shrubs
@@ -11859,6 +12153,7 @@
   - natal plum
   - Carissa bispinosa
   partOfSpeech: n
+  wikidata: Q12234248
 11792393-n:
   definition:
   - very large closely branched South African shrub having forked bright green spines
@@ -11906,6 +12201,7 @@
   - Catharanthus roseus
   - Vinca rosea
   partOfSpeech: n
+  wikidata: Q161093
 11793171-n:
   definition:
   - genus of deciduous trees and shrubs of tropical Africa and Asia
@@ -11934,6 +12230,7 @@
   - Holarrhena pubescens
   - Holarrhena antidysenterica
   partOfSpeech: n
+  wikidata: Q87605530
 11793607-n:
   definition:
   - genus of tropical South American tuberous perennial woody vines with large racemose
@@ -11963,6 +12260,7 @@
   - Mandevilla boliviensis
   - Dipladenia boliviensis
   partOfSpeech: n
+  wikidata: Q6747992
 11794097-n:
   definition:
   - woody vine of Argentina grown as an ornamental for its glossy leaves and racemes
@@ -11974,6 +12272,7 @@
   - Chilean jasmine
   - Mandevilla laxa
   partOfSpeech: n
+  wikidata: Q10475326
 11794329-n:
   definition:
   - 'one species: oleander'
@@ -12000,6 +12299,7 @@
   - rose bay
   - Nerium oleander
   partOfSpeech: n
+  wikidata: Q155833
 11794748-n:
   definition:
   - deciduous shrubs and trees of tropical America having branches like candelabra
@@ -12037,6 +12337,7 @@
   - temple tree
   - Plumeria acutifolia
   partOfSpeech: n
+  wikidata: Q50847406
 11795441-n:
   definition:
   - tall sparingly branched conical tree having large fragrant yellow flowers with
@@ -12117,6 +12418,7 @@
   members:
   - Strophanthus kombe
   partOfSpeech: n
+  wikidata: Q4444247
 11796806-n:
   definition:
   - evergreen tropical trees and shrubs with milky sap
@@ -12174,6 +12476,7 @@
   - Thevetia peruviana
   - Thevetia neriifolia
   partOfSpeech: n
+  wikidata: Q104921330
 11797834-n:
   definition:
   - genus of Asiatic woody vines with milky sap in leaves and stems
@@ -12233,6 +12536,7 @@
   - myrtle
   - Vinca minor
   partOfSpeech: n
+  wikidata: Q161777
 11798726-n:
   definition:
   - plant having variegated foliage and used for window boxes
@@ -12243,6 +12547,7 @@
   - large periwinkle
   - Vinca major
   partOfSpeech: n
+  wikidata: Q161746
 11798860-n:
   definition:
   - Araceae; Lemnaceae
@@ -12361,6 +12666,7 @@
   - black calla
   - Arum palaestinum
   partOfSpeech: n
+  wikidata: Q2866021
 11801058-n:
   definition:
   - sweet flags; sometimes placed in subfamily Acoraceae
@@ -12403,6 +12709,7 @@
   mero_substance:
   - 11801770-n
   partOfSpeech: n
+  wikidata: Q158008
 11801645-n:
   definition:
   - the aromatic root of the sweet flag used medicinally
@@ -12446,6 +12753,7 @@
   - Japanese leaf
   - Aglaonema modestum
   partOfSpeech: n
+  wikidata: Q4056964
 11802319-n:
   definition:
   - tropical Asiatic herbs similar to Colocasia but distinguished by a large sterile
@@ -12524,6 +12832,9 @@
   - Amorphophallus paeonifolius
   - Amorphophallus campanulatus
   partOfSpeech: n
+  wikidata:
+  - Q9248988
+  - Q37247507
 11803631-n:
   definition:
   - foul-smelling somewhat fleshy tropical plant of southeastern Asia cultivated for
@@ -12538,6 +12849,7 @@
   - umbrella arum
   - Amorphophallus rivieri
   partOfSpeech: n
+  wikidata: Q41777258
 11803957-n:
   definition:
   - malodorous tropical plant having a spathe that resembles the corolla of a morning
@@ -12550,6 +12862,7 @@
   - titan arum
   - Amorphophallus titanum
   partOfSpeech: n
+  wikidata: Q431224
 11804192-n:
   definition:
   - large genus of often epiphytic evergreen tropical American plants often cultivated
@@ -12617,6 +12930,7 @@
   - Arisaema triphyllum
   - Arisaema atrorubens
   partOfSpeech: n
+  wikidata: Q50827206
 11805294-n:
   definition:
   - early spring-flowering plant of eastern North America resembling the related jack-in-the-pulpit
@@ -12628,6 +12942,7 @@
   - green dragon
   - Arisaema dracontium
   partOfSpeech: n
+  wikidata: Q2861311
 11805569-n:
   definition:
   - tuberous or rhizomatous perennial herbs; mainly Mediterranean area
@@ -12652,6 +12967,7 @@
   - friar's-cowl
   - Arisarum vulgare
   partOfSpeech: n
+  wikidata: Q1644587
 11805944-n:
   definition:
   - small genus of tropical South American tuberous perennials with large variously
@@ -12684,6 +13000,7 @@
   members:
   - Caladium bicolor
   partOfSpeech: n
+  wikidata: Q10296092
 11806486-n:
   definition:
   - water arum
@@ -12740,6 +13057,7 @@
   - 07752789-n
   - 11807312-n
   partOfSpeech: n
+  wikidata: Q227997
 11807312-n:
   definition:
   - edible starchy tuberous root of taro plants
@@ -12876,6 +13194,7 @@
   - Epipremnum aureum
   - Scindapsus aureus
   partOfSpeech: n
+  wikidata: Q161809
 11809395-n:
   definition:
   - skunk cabbage
@@ -12934,6 +13253,7 @@
   mero_part:
   - 07762725-n
   partOfSpeech: n
+  wikidata: Q161077
 11810265-n:
   definition:
   - small genus of tropical western African creeping or twining herbs
@@ -12965,6 +13285,7 @@
   members:
   - Nephthytis afzelii
   partOfSpeech: n
+  wikidata: Q15339700
 11810708-n:
   definition:
   - 'one species of aquatic plant: golden club'
@@ -12989,6 +13310,7 @@
   - golden club
   - Orontium aquaticum
   partOfSpeech: n
+  wikidata: Q2700676
 11811093-n:
   definition:
   - small genus of North American marsh or aquatic herbs
@@ -13023,6 +13345,7 @@
   - tuckahoe
   - Peltandra virginica
   partOfSpeech: n
+  wikidata: Q7161742
 11811624-n:
   definition:
   - any of several tropical American climbing plants with smooth shiny evergreen leaves
@@ -13144,6 +13467,7 @@
   - foetid pothos
   - Symplocarpus foetidus
   partOfSpeech: n
+  wikidata: Q1195489
 11813501-n:
   definition:
   - epiphytic or terrestrial climbing shrubs of Central and South America; used as
@@ -13184,7 +13508,9 @@
   - Xanthosoma sagittifolium
   - Xanthosoma atrovirens
   partOfSpeech: n
-  wikidata: Q279280
+  wikidata:
+  - Q279280
+  - Q49629862
 11814120-n:
   definition:
   - calla lily
@@ -13211,6 +13537,7 @@
   - arum lily
   - Zantedeschia aethiopica
   partOfSpeech: n
+  wikidata: Q1945905
 11814493-n:
   definition:
   - calla having a rose-colored spathe
@@ -13284,6 +13611,7 @@
   - lesser duckweed
   - Lemna minor
   partOfSpeech: n
+  wikidata: Q26875
 11815685-n:
   definition:
   - cosmopolitan in temperate regions except North America
@@ -13294,6 +13622,7 @@
   - star-duckweed
   - Lemna trisulca
   partOfSpeech: n
+  wikidata: Q158194
 11815835-n:
   definition:
   - minute aquatic herbs floating on the water surface consisting of a shiny leaflike
@@ -13353,6 +13682,7 @@
   - common wolffia
   - Wolffia columbiana
   partOfSpeech: n
+  wikidata: Q13962206
 11816787-n:
   definition:
   - minute rootless aquatic herbs having flat fronds floating on or below the water
@@ -13378,6 +13708,7 @@
   - bogmat
   - Wolffiella gladiata
   partOfSpeech: n
+  wikidata: Q15334855
 11817213-n:
   definition:
   - 'mostly tropical trees and shrubs and lianas: genera Panax and Hedera'
@@ -13450,6 +13781,7 @@
   - wild sarsparilla
   - Aralia nudicaulis
   partOfSpeech: n
+  wikidata: Q2859483
 11818450-n:
   definition:
   - unarmed woody rhizomatous perennial plant distinguished from wild sarsaparilla
@@ -13463,6 +13795,7 @@
   - life-of-man
   - Aralia racemosa
   partOfSpeech: n
+  wikidata: Q3926761
 11818739-n:
   definition:
   - bristly herb of eastern and central North America having black fruit and medicinal
@@ -13476,6 +13809,7 @@
   - dwarf elder
   - Aralia hispida
   partOfSpeech: n
+  wikidata: Q4068485
 11818965-n:
   definition:
   - deciduous clump-forming Asian shrub or small tree; adventive in the eastern United
@@ -13487,6 +13821,7 @@
   - Japanese angelica tree
   - Aralia elata
   partOfSpeech: n
+  wikidata: Q284736
 11819157-n:
   definition:
   - similar to American angelica tree but less prickly; China
@@ -13524,6 +13859,7 @@
   - English ivy
   - Hedera helix
   partOfSpeech: n
+  wikidata: Q26354
 11819627-n:
   definition:
   - 'small to medium evergreen dioecious trees of oceanic climates: puka'
@@ -13548,6 +13884,7 @@
   - puka
   - Meryta sinclairii
   partOfSpeech: n
+  wikidata: Q5459044
 11819989-n:
   definition:
   - 'perennial herbs of eastern North America and Asia having aromatic tuberous roots:
@@ -13579,6 +13916,7 @@
   mero_part:
   - 11820705-n
   partOfSpeech: n
+  wikidata: Q10888482
 11820489-n:
   definition:
   - North American woodland herb similar to and used as substitute for the Chinese
@@ -13593,6 +13931,9 @@
   mero_part:
   - 11820705-n
   partOfSpeech: n
+  wikidata:
+  - Q19833747
+  - Q2737217
 11820705-n:
   definition:
   - aromatic root of ginseng plants
@@ -13628,6 +13969,7 @@
   - Schefflera actinophylla
   - Brassaia actinophylla
   partOfSpeech: n
+  wikidata: Q134943
 11821268-n:
   definition:
   - order of plants distinguished by tubular petaloid perianth and inferior ovary
@@ -13682,6 +14024,7 @@
   - birthwort
   - Aristolochia clematitis
   partOfSpeech: n
+  wikidata: Q158273
 11822134-n:
   definition:
   - hardy deciduous vine having large leaves and flowers with the calyx tube curved
@@ -13695,6 +14038,7 @@
   - Aristolochia macrophylla
   - Aristolochia durior
   partOfSpeech: n
+  wikidata: Q159506
 11822360-n:
   definition:
   - birthwort of the eastern United States woodlands
@@ -13707,6 +14051,9 @@
   - Virginia serpentary
   - Aristolochia serpentaria
   partOfSpeech: n
+  wikidata:
+  - Q58380413
+  - Q4791037
 11822545-n:
   definition:
   - wild ginger
@@ -13754,6 +14101,7 @@
   - heart-leaf
   - Asarum virginicum
   partOfSpeech: n
+  wikidata: Q15593811
 11823269-n:
   definition:
   - wild ginger having persistent heart-shaped pungent leaves; West Virginia to Alabama
@@ -13765,6 +14113,9 @@
   - heart-leaf
   - Asarum shuttleworthii
   partOfSpeech: n
+  wikidata:
+  - Q15295890
+  - Q15593271
 11823464-n:
   definition:
   - thick creeping evergreen herb of western Europe
@@ -13921,6 +14272,7 @@
   - crown-of-the-field
   - Agrostemma githago
   partOfSpeech: n
+  wikidata: Q147852
 11826306-n:
   definition:
   - sandworts
@@ -13955,6 +14307,7 @@
   - mountain daisy
   - Arenaria groenlandica
   partOfSpeech: n
+  wikidata: Q110414985
 11826838-n:
   definition:
   - deep-rooted perennial of southeastern United States
@@ -13966,6 +14319,9 @@
   - longroot
   - Arenaria caroliniana
   partOfSpeech: n
+  wikidata:
+  - Q15571189
+  - Q38617331
 11826990-n:
   definition:
   - perennial succulent herb with small solitary axillary or terminal flowers
@@ -13976,6 +14332,9 @@
   - seabeach sandwort
   - Arenaria peploides
   partOfSpeech: n
+  wikidata:
+  - Q157949
+  - Q21870734
 11827148-n:
   definition:
   - low perennial tufted plant of southeastern North America
@@ -13986,6 +14345,7 @@
   - rock sandwort
   - Arenaria stricta
   partOfSpeech: n
+  wikidata: Q110415161
 11827283-n:
   definition:
   - Eurasian annual sprawling plant naturalized throughout North America
@@ -13996,6 +14356,7 @@
   - thyme-leaved sandwort
   - Arenaria serpyllifolia
   partOfSpeech: n
+  wikidata: Q937450
 11827444-n:
   definition:
   - mouse-eared chickweed
@@ -14033,6 +14394,7 @@
   - field mouse-ear
   - Cerastium arvense
   partOfSpeech: n
+  wikidata: Q1370878
 11827994-n:
   definition:
   - chickweed with hairy silver-grey leaves and rather large white flowers
@@ -14044,6 +14406,7 @@
   - love-in-a-mist
   - Cerastium tomentosum
   partOfSpeech: n
+  wikidata: Q114430
 11828165-n:
   definition:
   - widespread in the Arctic and on mountains in Europe
@@ -14118,6 +14481,7 @@
   - rainbow pink
   - Dianthus chinensis
   partOfSpeech: n
+  wikidata: Q159013
 11829401-n:
   definition:
   - a flowering variety of China pink distinguished by jagged-edged petals
@@ -14160,6 +14524,7 @@
   - button pink
   - Dianthus latifolius
   partOfSpeech: n
+  wikidata: Q110416287
 11830063-n:
   definition:
   - European pink cultivated for its very fragrant pink or rosy flowers
@@ -14171,6 +14536,7 @@
   - grass pink
   - Dianthus plumarius
   partOfSpeech: n
+  wikidata: Q159590
 11830223-n:
   definition:
   - Eurasian perennial pink having fragrant lilac or rose flowers with deeply fringed
@@ -14229,6 +14595,7 @@
   - babies'-breath
   - Gypsophila paniculata
   partOfSpeech: n
+  wikidata: Q162134
 11831028-n:
   definition:
   - low-growing Old World herbs with minute bright green leaves
@@ -14312,6 +14679,9 @@
   - Lychnis flos-cuculi
   - Lychins floscuculi
   partOfSpeech: n
+  wikidata:
+  - Q19849678
+  - Q21038
 11832390-n:
   definition:
   - Eurasian garden perennial having scarlet flowers in dense terminal heads
@@ -14337,6 +14707,7 @@
   - dusty miller
   - Lychnis coronaria
   partOfSpeech: n
+  wikidata: Q59420260
 11832827-n:
   definition:
   - 'mostly perennial herbs of Northern Hemisphere often with mat-forming habit; most
@@ -14375,6 +14746,7 @@
   - sandwort
   - Moehringia lateriflora
   partOfSpeech: n
+  wikidata: Q12583230
 11833546-n:
   definition:
   - loosely matted plant with moss-like foliage studded with tiny starry four-petaled
@@ -14475,6 +14847,7 @@
   - bouncing Bess
   - Saponaria officinalis
   partOfSpeech: n
+  wikidata: Q156841
 11835293-n:
   definition:
   - 'small genus of Old World weedy prostrate annuals: knawel'
@@ -14500,6 +14873,7 @@
   - knawe
   - Scleranthus annuus
   partOfSpeech: n
+  wikidata: Q159192
 11835663-n:
   definition:
   - 'large widely distributed genus of plants having mostly showy flowers of various
@@ -14540,6 +14914,7 @@
   - moss campion
   - Silene acaulis
   partOfSpeech: n
+  wikidata: Q1339103
 11836387-n:
   definition:
   - perennial of eastern and central North America having short-stalked pink or white
@@ -14551,6 +14926,7 @@
   - wild pink
   - Silene caroliniana
   partOfSpeech: n
+  wikidata: Q12902117
 11836590-n:
   definition:
   - biennial European catchfly having red or pink flowers; sometimes placed in genus
@@ -14580,6 +14956,7 @@
   - Silene latifolia
   - Lychnis alba
   partOfSpeech: n
+  wikidata: Q27624
 11837118-n:
   definition:
   - perennial herb of eastern North America, having red flowers with narrow notched
@@ -14591,6 +14968,7 @@
   - fire pink
   - Silene virginica
   partOfSpeech: n
+  wikidata: Q951243
 11837298-n:
   definition:
   - perennial of Arctic Europe having large white flowers with inflated calyx
@@ -14602,6 +14980,7 @@
   - Silene uniflora
   - Silene vulgaris
   partOfSpeech: n
+  wikidata: Q951322
 11837469-n:
   definition:
   - 'small genus of Old World annual herbs: corn spurry'
@@ -14626,6 +15005,7 @@
   - corn spurrey
   - Spergula arvensis
   partOfSpeech: n
+  wikidata: Q162826
 11837798-n:
   definition:
   - 'chiefly maritime Eurasian herbs: sand spurry; sea spurry'
@@ -14652,6 +15032,7 @@
   - sea spurry
   - Spergularia rubra
   partOfSpeech: n
+  wikidata: Q1474695
 11838243-n:
   definition:
   - common chickweed; stitchwort
@@ -14699,7 +15080,9 @@
   - starwort
   - Stellaria holostea
   partOfSpeech: n
-  wikidata: Q157452
+  wikidata:
+  - Q94303275
+  - Q157452
 11838984-n:
   definition:
   - cow-cockles
@@ -14727,6 +15110,9 @@
   - Vaccaria pyramidata
   - Saponaria vaccaria
   partOfSpeech: n
+  wikidata:
+  - Q94409869
+  - Q50877763
 11839414-n:
   definition:
   - 'succulent herbs or small shrubs mostly of South Africa but also New Zealand and
@@ -14777,6 +15163,7 @@
   - Carpobrotus edulis
   - Mesembryanthemum edule
   partOfSpeech: n
+  wikidata: Q1368577
 11840220-n:
   definition:
   - a caryophyllaceous genus of Dorotheanthus
@@ -14802,6 +15189,7 @@
   - livingstone daisy
   - Dorotheanthus bellidiformis
   partOfSpeech: n
+  wikidata: Q3268918
 11840660-n:
   definition:
   - (botany) a tiny outgrowth on the surface of a petal or leaf
@@ -14878,6 +15266,7 @@
   - icicle plant
   - Mesembryanthemum crystallinum
   partOfSpeech: n
+  wikidata: Q161473
 11841884-n:
   definition:
   - carpetweeds
@@ -14953,6 +15342,7 @@
   - Tetragonia tetragonioides
   - Tetragonia expansa
   partOfSpeech: n
+  wikidata: Q28936712
 11843026-n:
   definition:
   - cosmopolitan family of herbs and shrubs
@@ -15018,8 +15408,8 @@
   - Amaranthus graecizans
   partOfSpeech: n
   wikidata:
-  - Q164118
   - Q162295
+  - Q164118
 11844041-n:
   definition:
   - young leaves widely used as leaf vegetables; seeds used as cereal
@@ -15032,6 +15422,9 @@
   - tassel flower
   - Amaranthus caudatus
   partOfSpeech: n
+  wikidata:
+  - Q90405797
+  - Q162791
 11844225-n:
   definition:
   - tall showy tropical American annual having hairy stems and long spikes of usually
@@ -15049,6 +15442,9 @@
   - Amaranthus hybridus hypochondriacus
   - Amaranthus hybridus erythrostachys
   partOfSpeech: n
+  wikidata:
+  - Q50914214
+  - Q159191
 11844615-n:
   definition:
   - leaves sometimes used as potherbs; seeds used as cereal; southern United States
@@ -15060,6 +15456,7 @@
   - pigweed
   - Amaranthus hypochondriacus
   partOfSpeech: n
+  wikidata: Q159611
 11844813-n:
   definition:
   - erect annual of tropical central Asia and Africa having a pair of divergent spines
@@ -15071,6 +15468,7 @@
   - thorny amaranth
   - Amaranthus spinosus
   partOfSpeech: n
+  wikidata: Q2881023
 11845017-n:
   definition:
   - genus of low herbs of tropical America and Australia; includes genus Telanthera
@@ -15121,6 +15519,7 @@
   - red fox
   - Celosia argentea
   partOfSpeech: n
+  wikidata: Q161816
 11845820-n:
   definition:
   - garden annual with featherlike spikes of red or yellow flowers
@@ -15133,7 +15532,9 @@
   - Celosia cristata
   - Celosia argentea cristata
   partOfSpeech: n
-  wikidata: Q1186867
+  wikidata:
+  - Q5058425
+  - Q1186867
 11846004-n:
   definition:
   - 'genus of erect or procumbent herbs of the Americas having spikes of woolly white
@@ -15184,6 +15585,7 @@
   - bachelor's button
   - Gomphrena globosa
   partOfSpeech: n
+  wikidata: Q1200680
 11846885-n:
   definition:
   - genus of tropical American herbs or subshrubs
@@ -15220,6 +15622,9 @@
   - Iresine herbstii
   - Iresine reticulata
   partOfSpeech: n
+  wikidata:
+  - Q69537690
+  - Q310558
 11847468-n:
   definition:
   - used in former classifications systems; now included in genus Alternanthera
@@ -15270,6 +15675,7 @@
   - saltwort
   - Batis maritima
   partOfSpeech: n
+  wikidata: Q4869290
 11848244-n:
   definition:
   - includes spinach and beets
@@ -15343,6 +15749,9 @@
   - wormseed
   - Chenopodium ambrosioides
   partOfSpeech: n
+  wikidata:
+  - Q640032
+  - Q15251066
 11849442-n:
   definition:
   - European plant naturalized in North America; often collected from the wild as
@@ -15359,6 +15768,9 @@
   mero_part:
   - 07749823-n
   partOfSpeech: n
+  wikidata:
+  - Q163805
+  - Q19849736
 11849674-n:
   definition:
   - Eurasian aromatic oak-leaved goosefoot with many yellow-green flowers; naturalized
@@ -15373,6 +15785,9 @@
   - Chenopodium botrys
   - Atriplex mexicana
   partOfSpeech: n
+  wikidata:
+  - Q1746114
+  - Q21872302
 11849904-n:
   definition:
   - European annual with clusters of greenish flowers followed by red pulpy berrylike
@@ -15386,6 +15801,7 @@
   - Indian paint
   - Chenopodium capitatum
   partOfSpeech: n
+  wikidata: Q254669
 11850141-n:
   definition:
   - annual European plant with spikes of greenish flowers and leaves that are white
@@ -15398,6 +15814,9 @@
   - oakleaf goosefoot
   - Chenopodium glaucum
   partOfSpeech: n
+  wikidata:
+  - Q17271799
+  - Q1543836
 11850391-n:
   definition:
   - herb considered fatal to swine
@@ -15409,6 +15828,9 @@
   - red goosefoot
   - Chenopodium hybridum
   partOfSpeech: n
+  wikidata:
+  - Q17398481
+  - Q810563
 11850514-n:
   definition:
   - European annual with coarsely dentate leaves; widespread in United States and
@@ -15421,7 +15843,9 @@
   - nettleleaf goosefoot
   - Chenopodium murale
   partOfSpeech: n
-  wikidata: Q1911022
+  wikidata:
+  - Q17271937
+  - Q1911022
 11850721-n:
   definition:
   - common Eurasian weed; naturalized in United States
@@ -15433,6 +15857,9 @@
   - French spinach
   - Chenopodium rubrum
   partOfSpeech: n
+  wikidata:
+  - Q17271894
+  - Q1477103
 11850869-n:
   definition:
   - European goosefoot with strong-scented foliage; adventive in eastern North America
@@ -15491,6 +15918,7 @@
   - mountain spinach
   - Atriplex hortensis
   partOfSpeech: n
+  wikidata: Q158505
 11851766-n:
   definition:
   - handsome low saltbush of arid southwestern United States and Mexico having blue-green
@@ -15502,6 +15930,7 @@
   - desert holly
   - Atriplex hymenelytra
   partOfSpeech: n
+  wikidata: Q4817592
 11851990-n:
   definition:
   - spiny shrub with silvery-scurfy foliage of alkaline plains of southwestern United
@@ -15515,6 +15944,7 @@
   - white thistle
   - Atriplex lentiformis
   partOfSpeech: n
+  wikidata: Q4817590
 11852199-n:
   definition:
   - summer cypress
@@ -15650,6 +16080,7 @@
   - tumbleweed
   - Cycloloma atriplicifolium
   partOfSpeech: n
+  wikidata: Q15591153
 11854046-n:
   definition:
   - a caryophyllaceous genus of the family Chenopodiaceae, its name is derived from
@@ -15675,7 +16106,7 @@
   - halogeton
   - Halogeton glomeratus
   partOfSpeech: n
-  wikidata: Q1024025
+  wikidata: Q15709475
 11854468-n:
   definition:
   - Algerian plant formerly burned to obtain calcium carbonate
@@ -15711,6 +16142,9 @@
   - samphire
   - Salicornia europaea
   partOfSpeech: n
+  wikidata:
+  - Q91347795
+  - Q27943
 11854990-n:
   definition:
   - 'chiefly Old World herbs or shrubs: saltworts'
@@ -15777,6 +16211,7 @@
   - black greasewood
   - Sarcobatus vermiculatus
   partOfSpeech: n
+  wikidata: Q17252862
 11855920-n:
   definition:
   - spinach
@@ -15851,6 +16286,9 @@
   - scarlet musk flower
   - Nyctaginia capitata
   partOfSpeech: n
+  wikidata:
+  - Q17239383
+  - Q18228263
 11857025-n:
   definition:
   - genus of western North American herbs having showy flowers
@@ -15886,6 +16324,7 @@
   - sweet sand verbena
   - Abronia elliptica
   partOfSpeech: n
+  wikidata: Q17233520
 11857673-n:
   definition:
   - taller than Abronia elliptica and having night-blooming flowers
@@ -15896,6 +16335,7 @@
   - sweet sand verbena
   - Abronia fragrans
   partOfSpeech: n
+  wikidata: Q2821956
 11857820-n:
   definition:
   - plant having hemispherical heads of yellow trumpet-shaped flowers; found in coastal
@@ -15907,6 +16347,7 @@
   - yellow sand verbena
   - Abronia latifolia
   partOfSpeech: n
+  wikidata: Q4669573
 11858031-n:
   definition:
   - plant having hemispherical heads of wine-red flowers; found in coastal dunes from
@@ -15918,6 +16359,7 @@
   - beach pancake
   - Abronia maritima
   partOfSpeech: n
+  wikidata: Q4669577
 11858212-n:
   definition:
   - prostrate herb having heads of deep pink to white flowers; found in coastal dunes
@@ -15943,6 +16385,7 @@
   - desert sand verbena
   - Abronia villosa
   partOfSpeech: n
+  wikidata: Q2821975
 11858735-n:
   definition:
   - small genus of chiefly American herbs
@@ -15969,6 +16412,7 @@
   - trailing windmills
   - Allionia incarnata
   partOfSpeech: n
+  wikidata: Q2838315
 11859210-n:
   definition:
   - ornamental tropical woody vines
@@ -16003,6 +16447,7 @@
   - paper flower
   - Bougainvillea glabra
   partOfSpeech: n
+  wikidata: Q159984
 11859766-n:
   definition:
   - four o'clocks
@@ -16050,6 +16495,7 @@
   - Mirabilis jalapa
   - Mirabilis uniflora
   partOfSpeech: n
+  wikidata: Q13710
 11860536-n:
   definition:
   - California four o'clock with purple-red flowers
@@ -16061,7 +16507,10 @@
   - Mirabilis laevis
   - Mirabilis californica
   partOfSpeech: n
-  wikidata: Q4295494
+  wikidata:
+  - Q4295494
+  - Q50859393
+  - Q95945753
 11860715-n:
   definition:
   - leafy wildflower having fragrant slender white or pale pink trumpet-shaped flowers;
@@ -16089,6 +16538,7 @@
   - maravilla
   - Mirabilis multiflora
   partOfSpeech: n
+  wikidata: Q2623355
 11861233-n:
   definition:
   - leafy wildflower with lavender-pink flowers that open in the evening and remain
@@ -16101,6 +16551,7 @@
   - mountain four o'clock
   - Mirabilis oblongifolia
   partOfSpeech: n
+  wikidata: Q85205625
 11861530-n:
   definition:
   - genus of often thorny tropical trees and shrubs and some vines; mainly America
@@ -16124,6 +16575,7 @@
   - cockspur
   - Pisonia aculeata
   partOfSpeech: n
+  wikidata: Q15238862
 11861837-n:
   definition:
   - 'coextensive with the family Cactaceae: cactuses'
@@ -16215,7 +16667,9 @@
   mero_part:
   - 07767256-n
   partOfSpeech: n
-  wikidata: Q149401
+  wikidata:
+  - Q149401
+  - Q41793314
 11863754-n:
   definition:
   - small genus of epiphytic cacti of Mexico
@@ -16241,6 +16695,7 @@
   - rat's-tail cactus
   - Aporocactus flagelliformis
   partOfSpeech: n
+  wikidata: Q41793383
 11864178-n:
   definition:
   - slow-growing geophytic cacti; northern and eastern Mexico; southern Texas
@@ -16293,6 +16748,7 @@
   - sahuaro
   - Carnegiea gigantea
   partOfSpeech: n
+  wikidata: Q275573
 11865120-n:
   definition:
   - genus of much-branched treelike or shrubby cacti with pronounced ribs and rounded
@@ -16381,6 +16837,9 @@
   - golden barrel cactus
   - Echinocactus grusonii
   partOfSpeech: n
+  wikidata:
+  - Q42751825
+  - Q131270
 11866556-n:
   definition:
   - large genus of low-growing shrubby ribbed cacti of Mexico and southwestern United
@@ -16513,7 +16972,9 @@
   - Hatiora gaertneri
   - Schlumbergera gaertneri
   partOfSpeech: n
-  wikidata: Q3153249
+  wikidata:
+  - Q3153249
+  - Q138282
 11868722-n:
   definition:
   - genus of climbing or epiphytic tropical American cacti with angular stems and
@@ -16561,6 +17022,7 @@
   - chichipe
   - Lemaireocereus chichipe
   partOfSpeech: n
+  wikidata: Q41793280
 11869486-n:
   definition:
   - 'two species of small cacti of northeastern Mexico and southwestern United States
@@ -16635,6 +17097,9 @@
   - feather ball
   - Mammillaria plumosa
   partOfSpeech: n
+  wikidata:
+  - Q15339901
+  - Q283486
 11870605-n:
   definition:
   - genus of strongly ribbed globose or spheroid cacti of tropical South and Central
@@ -16673,6 +17138,7 @@
   mero_part:
   - 07784981-n
   partOfSpeech: n
+  wikidata: Q287064
 11871217-n:
   definition:
   - low-growing cacti of the Great Plains of North America
@@ -16696,7 +17162,9 @@
   - Knowlton's cactus
   - Pediocactus knowltonii
   partOfSpeech: n
-  wikidata: Q150706
+  wikidata:
+  - Q94384402
+  - Q150706
 11871570-n:
   definition:
   - a genus of the cactus family with scarlet flowers
@@ -16757,6 +17225,9 @@
   - cholla
   - Opuntia cholla
   partOfSpeech: n
+  wikidata:
+  - Q1147788
+  - Q14946481
 11872497-n:
   definition:
   - cactus having yellow flowers and purple fruits
@@ -16767,6 +17238,9 @@
   - nopal
   - Opuntia lindheimeri
   partOfSpeech: n
+  wikidata:
+  - Q93313162
+  - Q14955003
 11872617-n:
   definition:
   - tropical American prickly pear of Jamaica
@@ -16808,6 +17282,7 @@
   mero_part:
   - 07785078-n
   partOfSpeech: n
+  wikidata: Q134422
 11873283-n:
   definition:
   - large genus of epiphytic or lithophytic unarmed cacti with usually segmented stems
@@ -16856,6 +17331,7 @@
   - Schlumbergera buckleyi
   - Schlumbergera baridgesii
   partOfSpeech: n
+  wikidata: Q104924393
 11874113-n:
   definition:
   - mostly epiphytic climbing cacti that bloom at night
@@ -16889,6 +17365,7 @@
   - queen of the night
   - Selenicereus grandiflorus
   partOfSpeech: n
+  wikidata: Q137139
 11874701-n:
   definition:
   - small genus of Brazilian cacti having flat fleshy usually branched joints and
@@ -16916,6 +17393,7 @@
   - Zygocactus truncatus
   - Schlumbergera truncatus
   partOfSpeech: n
+  wikidata: Q15336358
 11875229-n:
   definition:
   - 'chiefly tropical herbaceous plants (including shrubs and trees) with racemose
@@ -17048,6 +17526,7 @@
   - rouge plant
   - Rivina humilis
   partOfSpeech: n
+  wikidata: Q886492
 11877284-n:
   definition:
   - a genus of erect or climbing shrubs found in tropical South America
@@ -17141,6 +17620,7 @@
   - verdolagas
   - Portulaca oleracea
   partOfSpeech: n
+  wikidata: Q158015
 11878875-n:
   definition:
   - large genus of low-growing herbs; widespread throughout tropical and warm temperate
@@ -17205,6 +17685,7 @@
   - Carolina spring beauty
   - Claytonia caroliniana
   partOfSpeech: n
+  wikidata: Q2978736
 11879941-n:
   definition:
   - small slender plant having one pair of succulent leaves at the middle of the stem
@@ -17228,6 +17709,7 @@
   - Virginia spring beauty
   - Claytonia virginica
   partOfSpeech: n
+  wikidata: Q671939
 11880450-n:
   definition:
   - genus of western North American low-growing herbs having linear woolly leaves
@@ -17267,6 +17749,7 @@
   - bitterroot
   - Lewisia rediviva
   partOfSpeech: n
+  wikidata: Q4113860
 11881270-n:
   definition:
   - small genus of densely tufted annual herbs; north temperate regions and South
@@ -17301,6 +17784,7 @@
   - broad-leaved montia
   - Montia cordifolia
   partOfSpeech: n
+  wikidata: Q111699640
 11881956-n:
   definition:
   - small Indian lettuce of northern regions
@@ -17313,6 +17797,7 @@
   - water chickweed
   - Montia lamprosperma
   partOfSpeech: n
+  wikidata: Q98105970
 11882110-n:
   definition:
   - a floating or creeping Indian lettuce having terminal racemes of pale rose flowers;
@@ -17324,6 +17809,7 @@
   - toad lily
   - Montia chamissoi
   partOfSpeech: n
+  wikidata: Q6905917
 11882322-n:
   definition:
   - succulent herb sometimes grown as a salad or pot herb; grows on dunes and waste
@@ -17337,6 +17823,7 @@
   - Cuban spinach
   - Montia perfoliata
   partOfSpeech: n
+  wikidata: Q65943855
 11882558-n:
   definition:
   - small genus of usually perennial herbs having deep woody taproots and flower heads
@@ -17365,6 +17852,7 @@
   - Spraguea umbellatum
   - Calyptridium umbellatum
   partOfSpeech: n
+  wikidata: Q32855932
 11883067-n:
   definition:
   - genus of mainly American more-or-less succulent herbs
@@ -17396,6 +17884,9 @@
   - flameflower
   - Talinum aurantiacum
   partOfSpeech: n
+  wikidata:
+  - Q17244256
+  - Q41778381
 11883711-n:
   definition:
   - similar to Talinum aurantiacum but with narrower leaves and yellow-orange flowers;
@@ -17418,6 +17909,7 @@
   - pigmy talinum
   - Talinum brevifolium
   partOfSpeech: n
+  wikidata: Q112066025
 11884186-n:
   definition:
   - pink-flowered perennial of rocky regions of western United States
@@ -17428,6 +17920,7 @@
   - rock pink
   - Talinum calycinum
   partOfSpeech: n
+  wikidata: Q112066004
 11884346-n:
   definition:
   - erect plant with tuberous roots and terminal panicles of red to yellow flowers;
@@ -17451,6 +17944,7 @@
   - spiny talinum
   - Talinum spinescens
   partOfSpeech: n
+  wikidata: Q50875909
 11884833-n:
   definition:
   - an order of dicotyledonous plants, containing the families Capparidaceae, Cruciferae,
@@ -17520,6 +18014,7 @@
   - native pomegranate
   - Capparis arborea
   partOfSpeech: n
+  wikidata: Q5036113
 11885898-n:
   definition:
   - shrub of southern Florida to West Indies
@@ -17531,6 +18026,9 @@
   - Jamaica caper tree
   - Capparis cynophallophora
   partOfSpeech: n
+  wikidata:
+  - Q22114345
+  - Q5036115
 11886043-n:
   definition:
   - shrub or small tree of southern Florida to Central and South America
@@ -17542,6 +18040,7 @@
   - bay-leaved caper
   - Capparis flexuosa
   partOfSpeech: n
+  wikidata: Q15544693
 11886207-n:
   definition:
   - small Australian tree bearing edible dark purple fruit
@@ -17566,6 +18065,7 @@
   mero_part:
   - 07838029-n
   partOfSpeech: n
+  wikidata: Q156251
 11886547-n:
   definition:
   - tropical and subtropical annual or perennial herbs or low shrubs
@@ -17602,7 +18102,9 @@
   - spider plant
   - Cleome hassleriana
   partOfSpeech: n
-  wikidata: Q5131678
+  wikidata:
+  - Q17467629
+  - Q5131678
 11887175-n:
   definition:
   - plant of western North America having trifoliate leaves and white or pink spider-shaped
@@ -17615,6 +18117,9 @@
   - stinking clover
   - Cleome serrulata
   partOfSpeech: n
+  wikidata:
+  - Q19849781
+  - Q5131677
 11887411-n:
   definition:
   - tropical genus of small trees or shrubs
@@ -17803,6 +18308,7 @@
   - jack-by-the-hedge
   - Alliaria officinalis
   partOfSpeech: n
+  wikidata: Q50826504
 11891076-n:
   definition:
   - a genus of the family Cruciferae, containing annual and perennial herbaceous plants
@@ -17879,6 +18385,7 @@
   - Arabidopsis thaliana
   - mouse-ear cress
   partOfSpeech: n
+  wikidata: Q158695
 11892217-n:
   definition:
   - a small noninvasive cross-pollinating plant with white flowers; closely related
@@ -17937,6 +18444,9 @@
   - tower mustard
   - Arabis turrita
   partOfSpeech: n
+  wikidata:
+  - Q17235405
+  - Q163451
 11893127-n:
   definition:
   - 'or genus Arabis: erect cress widely distributed throughout Europe'
@@ -17949,6 +18459,9 @@
   - Turritis glabra
   - Arabis glabra
   partOfSpeech: n
+  wikidata:
+  - Q158993
+  - Q18182668
 11893319-n:
   definition:
   - horseradish
@@ -18034,6 +18547,7 @@
   - Barbarea verna
   - Barbarea praecox
   partOfSpeech: n
+  wikidata: Q164056
 11894550-n:
   definition:
   - noxious cress with yellow flowers; sometimes placed in genus Sisymbrium
@@ -18047,6 +18561,7 @@
   - Barbarea vulgaris
   - Sisymbrium barbarea
   partOfSpeech: n
+  wikidata: Q157285
 11894769-n:
   definition:
   - hoary alyssum
@@ -18135,6 +18650,7 @@
   - wild cabbage
   - Brassica oleracea
   partOfSpeech: n
+  wikidata: Q146212
 11896160-n:
   definition:
   - any of various cultivars of the genus Brassica oleracea grown for their edible
@@ -18276,6 +18792,9 @@
   - 07751957-n
   - 07752232-n
   partOfSpeech: n
+  wikidata:
+  - Q3337246
+  - Q3384
 11898329-n:
   definition:
   - a cruciferous plant with a thick bulbous edible yellow root
@@ -18338,6 +18857,7 @@
   - gai choi
   - Brassica juncea
   partOfSpeech: n
+  wikidata: Q504781
 11899277-n:
   definition:
   - plant with an elongated head of broad stalked leaves resembling celery; used as
@@ -18378,6 +18898,7 @@
   - Brassica perviridis
   - Brassica rapa perviridis
   partOfSpeech: n
+  wikidata: Q50828168
 11899974-n:
   definition:
   - widespread Eurasian annual plant cultivated for its pungent seeds; a principal
@@ -18405,6 +18926,9 @@
   mero_substance:
   - 11900364-n
   partOfSpeech: n
+  wikidata:
+  - Q50914900
+  - Q177932
 11900364-n:
   definition:
   - seed of rape plants; source of an edible oil
@@ -18453,6 +18977,7 @@
   - sea-rocket
   - Cakile maritima
   partOfSpeech: n
+  wikidata: Q589913
 11901079-n:
   definition:
   - annual and biennial herbs of Mediterranean to central Asia
@@ -18479,6 +19004,7 @@
   - gold of pleasure
   - Camelina sativa
   partOfSpeech: n
+  wikidata: Q163958
 11901532-n:
   definition:
   - shepherd's purse
@@ -18504,6 +19030,7 @@
   - shepherd's pouch
   - Capsella bursa-pastoris
   partOfSpeech: n
+  wikidata: Q27264
 11901895-n:
   definition:
   - bittercress, bitter cress
@@ -18553,6 +19080,7 @@
   - meadow cress
   - Cardamine pratensis
   partOfSpeech: n
+  wikidata: Q27490
 11902706-n:
   definition:
   - European bittercress having a knotted white rootstock
@@ -18566,6 +19094,7 @@
   - Cardamine bulbifera
   - Dentaria bulbifera
   partOfSpeech: n
+  wikidata: Q244583
 11902895-n:
   definition:
   - North American herb with pungent scaly or toothed roots
@@ -18581,6 +19110,7 @@
   - Cardamine diphylla
   - Dentaria diphylla
   partOfSpeech: n
+  wikidata: Q2938024
 11903105-n:
   definition:
   - mat-forming perennial found in cold springs of the eastern United States
@@ -18592,6 +19122,7 @@
   - mountain watercress
   - Cardamine rotundifolia
   partOfSpeech: n
+  wikidata: Q15538152
 11903290-n:
   definition:
   - small white-flowered cress common in wet places in eastern North America
@@ -18640,7 +19171,9 @@
   - Cheiranthus cheiri
   - Erysimum cheiri
   partOfSpeech: n
-  wikidata: Q159370
+  wikidata:
+  - Q159370
+  - Q11111735
 11904097-n:
   definition:
   - any of several western American plants of the genus Cheiranthus having large yellow
@@ -18703,6 +19236,7 @@
   - sea cole
   - Crambe maritima
   partOfSpeech: n
+  wikidata: Q165299
 11905136-n:
   definition:
   - includes annual or biennial herbs of America and Europe very similar to and often
@@ -18728,6 +19262,7 @@
   - tansy mustard
   - Descurainia pinnata
   partOfSpeech: n
+  wikidata: Q5263816
 11905617-n:
   definition:
   - wall rocket
@@ -18754,6 +19289,7 @@
   - Diplotaxis muralis
   - Diplotaxis tenuifolia
   partOfSpeech: n
+  wikidata: Q159643
 11905993-n:
   definition:
   - from Mediterranean region; a naturalized weed throughout southern Europe
@@ -18764,6 +19300,7 @@
   - white rocket
   - Diplotaxis erucoides
   partOfSpeech: n
+  wikidata: Q3029029
 11906166-n:
   definition:
   - large genus of low tufted herbs of temperate and Arctic regions
@@ -18800,6 +19337,9 @@
   - shad-flower
   - Draba verna
   partOfSpeech: n
+  wikidata:
+  - Q15543679
+  - Q164032
 11906849-n:
   definition:
   - annual to perennial herbs of the Mediterranean region
@@ -18829,6 +19369,9 @@
   - Eruca sativa
   - Eruca vesicaria sativa
   partOfSpeech: n
+  wikidata:
+  - Q156884
+  - Q25694275
 11907257-n:
   definition:
   - large genus of annual or perennial herbs some grown for their flowers and some
@@ -18892,6 +19435,7 @@
   - Cheiranthus asperus
   - Erysimum arkansanum
   partOfSpeech: n
+  wikidata: Q5600924
 11908530-n:
   definition:
   - slender yellow-flowered European mustard often troublesome as a weed; formerly
@@ -18952,6 +19496,7 @@
   - sweet rocket
   - Hesperis matronalis
   partOfSpeech: n
+  wikidata: Q1857886
 11909547-n:
   definition:
   - 'one species: tansy-leaved rocket'
@@ -18977,6 +19522,7 @@
   - Hugueninia tanacetifolia
   - Sisymbrium tanacetifolia
   partOfSpeech: n
+  wikidata: Q15624085
 11909942-n:
   definition:
   - candytuft (Iberis)
@@ -19062,6 +19608,7 @@
   mero_part:
   - 07748981-n
   partOfSpeech: n
+  wikidata: Q27033
 11911192-n:
   definition:
   - 'genus of low-growing hairy herbs: bladderpods'
@@ -19139,6 +19686,7 @@
   - satinpod
   - Lunaria annua
   partOfSpeech: n
+  wikidata: Q240620
 11912307-n:
   definition:
   - genus of plants usually found in coastal habitats; Mediterranean to Afghanistan
@@ -19211,6 +19759,7 @@
   - brompton stock
   - Matthiola incana
   partOfSpeech: n
+  wikidata: Q30063
 11913473-n:
   definition:
   - a genus of seven plant species in the family Brassicaceae (Nasturtium)
@@ -19237,6 +19786,7 @@
   - Rorippa nasturtium-aquaticum
   - Nasturtium officinale
   partOfSpeech: n
+  wikidata: Q150452
 11913920-n:
   definition:
   - 'small genus of western North American herbs similar to Lesquerella: bladderpods'
@@ -19283,6 +19833,7 @@
   - Pritzelago alpina
   - Lepidium alpina
   partOfSpeech: n
+  wikidata: Q42350193
 11914642-n:
   definition:
   - radish
@@ -19324,6 +19875,7 @@
   - runch
   - Raphanus raphanistrum
   partOfSpeech: n
+  wikidata: Q28017
 11915239-n:
   definition:
   - Eurasian plant widely cultivated for its edible pungent root usually eaten raw
@@ -19336,6 +19888,9 @@
   mero_substance:
   - 15057934-n
   partOfSpeech: n
+  wikidata:
+  - Q65956553
+  - Q7224565
 11915427-n:
   definition:
   - pungent edible root of any of various cultivated radish plants
@@ -19383,6 +19938,7 @@
   - yellow watercress
   - Rorippa islandica
   partOfSpeech: n
+  wikidata: Q15249950
 11916183-n:
   definition:
   - perennial herb found on streams and riversides throughout Europe except extreme
@@ -19419,6 +19975,7 @@
   - schizopetalon
   - Schizopetalon walkeri
   partOfSpeech: n
+  wikidata: Q15549014
 11916834-n:
   definition:
   - small genus of Old World herbs usually included in genus Brassica
@@ -19444,7 +20001,9 @@
   mero_part:
   - 07835279-n
   partOfSpeech: n
-  wikidata: Q146202
+  wikidata:
+  - Q146202
+  - Q50838947
 11917191-n:
   definition:
   - weedy Eurasian plant often a pest in grain fields
@@ -19459,6 +20018,7 @@
   - Brassica kaber
   - Sinapis arvensis
   partOfSpeech: n
+  wikidata: Q87644934
 11917373-n:
   definition:
   - genus of Old World annual or biennial or perennial herbs with racemose flowers;
@@ -19560,6 +20120,7 @@
   - awlwort
   - Subularia aquatica
   partOfSpeech: n
+  wikidata: Q164046
 11918943-n:
   definition:
   - 'herbs of temperate regions: pennycress'
@@ -19736,6 +20297,9 @@
   - Iceland poppy
   - Papaver alpinum
   partOfSpeech: n
+  wikidata:
+  - Q119149737
+  - Q149346
 11921921-n:
   definition:
   - showy annual of California with red flowers
@@ -19746,6 +20310,7 @@
   - western poppy
   - Papaver californicum
   partOfSpeech: n
+  wikidata: Q5666712
 11922066-n:
   definition:
   - annual Old World poppy with orange-red flowers and bristly fruit
@@ -19756,6 +20321,7 @@
   - prickly poppy
   - Papaver argemone
   partOfSpeech: n
+  wikidata: Q149951
 11922228-n:
   definition:
   - subarctic perennial poppy of both hemispheres having fragrant white or yellow
@@ -19768,7 +20334,9 @@
   - arctic poppy
   - Papaver nudicaule
   partOfSpeech: n
-  wikidata: Q148824
+  wikidata:
+  - Q119150816
+  - Q148824
 11922446-n:
   definition:
   - commonly cultivated Asiatic perennial poppy having stiff heavily haired leaves
@@ -19807,6 +20375,7 @@
   mero_part:
   - 07843726-n
   partOfSpeech: n
+  wikidata: Q131584
 11923064-n:
   definition:
   - prickly poppies
@@ -19868,6 +20437,7 @@
   - tree celandine
   - Bocconia frutescens
   partOfSpeech: n
+  wikidata: Q5730997
 11923994-n:
   definition:
   - 'one species: greater celandine'
@@ -19894,6 +20464,7 @@
   - swallow wort
   - Chelidonium majus
   partOfSpeech: n
+  wikidata: Q156807
 11924350-n:
   definition:
   - annual or perennial herbs of Himalayan China and South Africa
@@ -19928,6 +20499,7 @@
   - Corydalis claviculata
   - Fumaria claviculata
   partOfSpeech: n
+  wikidata: Q111208575
 11924946-n:
   definition:
   - glaucous herb of northeastern United States and Canada having loose racemes of
@@ -19941,7 +20513,10 @@
   - Corydalis sempervirens
   - Fumaria sempervirens
   partOfSpeech: n
-  wikidata: Q1478395
+  wikidata:
+  - Q1478395
+  - Q15324515
+  - Q21874304
 11925212-n:
   definition:
   - herb of northern Europe and Asia having erect racemes of red flowers
@@ -19953,6 +20528,7 @@
   - fumeroot
   - Corydalis solida
   partOfSpeech: n
+  wikidata: Q1074622
 11925365-n:
   definition:
   - 'one species: bush poppy'
@@ -20027,6 +20603,7 @@
   - sea poppy
   - Glaucium flavum
   partOfSpeech: n
+  wikidata: Q157916
 11926458-n:
   definition:
   - 'one species: golden cup'
@@ -20077,9 +20654,7 @@
   - bocconia
   - Macleaya cordata
   partOfSpeech: n
-  wikidata:
-  - Q159327
-  - Q1974044
+  wikidata: Q159327
 11927182-n:
   definition:
   - herbs almost entirely of mountains of China and Tibet; often monocarpic
@@ -20104,6 +20679,9 @@
   - blue poppy
   - Meconopsis betonicifolia
   partOfSpeech: n
+  wikidata:
+  - Q89185886
+  - Q3083496
 11927569-n:
   definition:
   - widely cultivated west European plant with showy pale yellow flowers
@@ -20114,6 +20692,7 @@
   - Welsh poppy
   - Meconopsis cambrica
   partOfSpeech: n
+  wikidata: Q1578328
 11927736-n:
   definition:
   - 'one species: creamcups'
@@ -20137,6 +20716,7 @@
   - creamcups
   - Platystemon californicus
   partOfSpeech: n
+  wikidata: Q15321448
 11928023-n:
   definition:
   - 'one species: matilija poppy'
@@ -20162,6 +20742,7 @@
   - California tree poppy
   - Romneya coulteri
   partOfSpeech: n
+  wikidata: Q3018989
 11928408-n:
   definition:
   - 'one species: bloodroot'
@@ -20190,6 +20771,7 @@
   - tetterwort
   - Sanguinaria canadensis
   partOfSpeech: n
+  wikidata: Q2724394
 11928900-n:
   definition:
   - 'one species: wind poppy'
@@ -20213,6 +20795,7 @@
   - Stylomecon heterophyllum
   - Papaver heterophyllum
   partOfSpeech: n
+  wikidata: Q25407894
 11929187-n:
   definition:
   - wood poppies
@@ -20333,6 +20916,7 @@
   - lyre-flower
   - Dicentra spectabilis
   partOfSpeech: n
+  wikidata: Q50828764
 11930929-n:
   definition:
   - delicate spring-flowering plant of the eastern United States having white flowers
@@ -20654,6 +21238,9 @@
   - milfoil
   - Achillea millefolium
   partOfSpeech: n
+  wikidata:
+  - Q90395482
+  - Q25408
 11937434-n:
   definition:
   - Eurasian herb having loose heads of button-shaped white flowers and long grey-green
@@ -20666,6 +21253,7 @@
   - sneezewort
   - Achillea ptarmica
   partOfSpeech: n
+  wikidata: Q1335122
 11937655-n:
   definition:
   - 'genus of herbs and shrubs of Australia and South Africa: everlasting flower;
@@ -20692,6 +21280,9 @@
   - pink paper daisy
   - Acroclinium roseum
   partOfSpeech: n
+  wikidata:
+  - Q3429583
+  - Q96012655
 11938102-n:
   definition:
   - annual to perennial herbs or shrubs of eastern United States and Central and South
@@ -20752,6 +21343,7 @@
   - common ageratum
   - Ageratum houstonianum
   partOfSpeech: n
+  wikidata: Q280807
 11939100-n:
   definition:
   - herbs of Mediterranean to central Asia cultivated for their flowers
@@ -20883,6 +21475,7 @@
   - winged everlasting
   - Ammobium alatum
   partOfSpeech: n
+  wikidata: Q2001235
 11941336-n:
   definition:
   - a Spanish pellitory
@@ -20907,6 +21500,7 @@
   - pellitory-of-Spain
   - Anacyclus pyrethrum
   partOfSpeech: n
+  wikidata: Q1855185
 11941669-n:
   definition:
   - 'a genus of herbs of north temperate regions having hoary leaves: pearly everlasting'
@@ -20981,6 +21575,7 @@
   - lady's tobacco
   - Antennaria plantaginifolia
   partOfSpeech: n
+  wikidata: Q15524973
 11942843-n:
   definition:
   - low-growing perennial herb having leaves with whitish down and clusters of small
@@ -20994,6 +21589,7 @@
   - pussytoes
   - Antennaria dioica
   partOfSpeech: n
+  wikidata: Q847898
 11943130-n:
   definition:
   - a variety of pussytoes, with leaves resembling a plantain
@@ -21058,6 +21654,7 @@
   - stinking chamomile
   - Anthemis cotula
   partOfSpeech: n
+  wikidata: Q571357
 11943866-n:
   definition:
   - Eurasian perennial herb with hairy divided leaves and yellow flowers; naturalized
@@ -21071,6 +21668,7 @@
   - dyers' chamomile
   - Anthemis tinctoria
   partOfSpeech: n
+  wikidata: Q925164
 11944106-n:
   definition:
   - European white-flowered weed naturalized in North America
@@ -21083,6 +21681,7 @@
   - corn mayweed
   - Anthemis arvensis
   partOfSpeech: n
+  wikidata: Q20778
 11944296-n:
   definition:
   - small genus of North American herbs often included in genus Eriophyllum
@@ -21110,6 +21709,7 @@
   - Antheropeas wallacei
   - Eriophyllum wallacei
   partOfSpeech: n
+  wikidata: Q2852739
 11944799-n:
   definition:
   - burdock
@@ -21197,6 +21797,7 @@
   - Arctotis stoechadifolia
   - Arctotis venusta
   partOfSpeech: n
+  wikidata: Q15591812
 11946189-n:
   definition:
   - comprises plants often included in the genus Chrysanthemum, endemic to Macaronesia
@@ -21286,6 +21887,7 @@
   - heartleaf arnica
   - Arnica cordifolia
   partOfSpeech: n
+  wikidata: Q2863306
 11947684-n:
   definition:
   - herb of pasture and open woodland throughout most of Europe and western Asia having
@@ -21333,6 +21935,7 @@
   - dwarf nipplewort
   - Arnoseris minima
   partOfSpeech: n
+  wikidata: Q202219
 11948370-n:
   definition:
   - 'usually aromatic shrubs or herbs of north temperate regions and South Africa
@@ -21406,6 +22009,7 @@
   - southernwood
   - Artemisia abrotanum
   partOfSpeech: n
+  wikidata: Q157976
 11949946-n:
   definition:
   - aromatic herb of temperate Eurasia and North Africa having a bitter taste used
@@ -21443,6 +22047,7 @@
   - California sage
   - Artemisia californica
   partOfSpeech: n
+  wikidata: Q4797496
 11950507-n:
   definition:
   - European wormwood similar to common wormwood in its properties
@@ -21453,6 +22058,7 @@
   - field wormwood
   - Artemisia campestris
   partOfSpeech: n
+  wikidata: Q783863
 11950672-n:
   definition:
   - aromatic perennial of southeastern Russia
@@ -21466,6 +22072,7 @@
   mero_part:
   - 07837586-n
   partOfSpeech: n
+  wikidata: Q155814
 11950822-n:
   definition:
   - silver-haired shrub of central and southern United States and Mexico; a troublesome
@@ -21478,6 +22085,7 @@
   - silvery wormwood
   - Artemisia filifolia
   partOfSpeech: n
+  wikidata: Q582243
 11951040-n:
   definition:
   - silky-leaved aromatic perennial of dry northern parts of the Northern Hemisphere;
@@ -21490,6 +22098,7 @@
   - prairie sagewort
   - Artemisia frigida
   partOfSpeech: n
+  wikidata: Q606606
 11951257-n:
   definition:
   - perennial cottony-white herb of southwestern United States
@@ -21504,7 +22113,10 @@
   - Artemisia ludoviciana
   - Artemisia gnaphalodes
   partOfSpeech: n
-  wikidata: Q2716821
+  wikidata:
+  - Q2716821
+  - Q42681972
+  - Q95983836
 11951463-n:
   definition:
   - European wormwood; minor source of absinthe
@@ -21539,6 +22151,7 @@
   - old woman
   - Artemisia stelleriana
   partOfSpeech: n
+  wikidata: Q2862331
 11952009-n:
   definition:
   - European tufted aromatic perennial herb having hairy red or purple stems and dark
@@ -21593,6 +22206,9 @@
   - whorled aster
   - Aster acuminatus
   partOfSpeech: n
+  wikidata:
+  - Q15548303
+  - Q38761572
 11953568-n:
   definition:
   - common North American perennial with heathlike foliage and small white flower
@@ -21604,6 +22220,7 @@
   - heath aster
   - Aster arenosus
   partOfSpeech: n
+  wikidata: Q21246984
 11953726-n:
   definition:
   - perennial wood aster of eastern North America
@@ -21614,6 +22231,9 @@
   - heart-leaved aster
   - Aster cordifolius
   partOfSpeech: n
+  wikidata:
+  - Q4050493
+  - Q21871600
 11953856-n:
   definition:
   - rhizomatous perennial wood aster of eastern North America with white flowers
@@ -21624,6 +22244,9 @@
   - white wood aster
   - Aster divaricatus
   partOfSpeech: n
+  wikidata:
+  - Q19848818
+  - Q13911606
 11954015-n:
   definition:
   - stiff perennial of the eastern United States having small linear leaves and numerous
@@ -21635,7 +22258,9 @@
   - bushy aster
   - Aster dumosus
   partOfSpeech: n
-  wikidata: Q7061674
+  wikidata:
+  - Q4050490
+  - Q7061674
 11954197-n:
   definition:
   - common much-branched North American perennial with heathlike foliage and small
@@ -21647,6 +22272,9 @@
   - heath aster
   - Aster ericoides
   partOfSpeech: n
+  wikidata:
+  - Q7160573
+  - Q21871614
 11954372-n:
   definition:
   - perennial of western North America having white flowers
@@ -21657,6 +22285,9 @@
   - white prairie aster
   - Aster falcatus
   partOfSpeech: n
+  wikidata:
+  - Q13955505
+  - Q38782261
 11954510-n:
   definition:
   - wiry tufted perennial of the eastern United States with stiff erect rough stems,
@@ -21681,6 +22312,9 @@
   - Aster linosyris
   - Linosyris vulgaris
   partOfSpeech: n
+  wikidata:
+  - Q80691167
+  - Q15630423
 11954932-n:
   definition:
   - tufted perennial wood aster of North America; naturalized in Europe
@@ -21691,6 +22325,9 @@
   - large-leaved aster
   - Aster macrophyllus
   partOfSpeech: n
+  wikidata:
+  - Q19848825
+  - Q174445
 11955085-n:
   definition:
   - common perennial of eastern North America having showy purplish flowers; a parent
@@ -21702,6 +22339,9 @@
   - New England aster
   - Aster novae-angliae
   partOfSpeech: n
+  wikidata:
+  - Q1894641
+  - Q21871639
 11955276-n:
   definition:
   - North American perennial herb having small autumn-blooming purple or pink or white
@@ -21714,6 +22354,9 @@
   - New York aster
   - Aster novi-belgii
   partOfSpeech: n
+  wikidata:
+  - Q1537333
+  - Q15708990
 11955496-n:
   definition:
   - tufted rigid North American perennial with loose clusters of white flowers
@@ -21724,6 +22367,9 @@
   - upland white aster
   - Aster ptarmicoides
   partOfSpeech: n
+  wikidata:
+  - Q15567718
+  - Q38780016
 11955656-n:
   definition:
   - perennial of southeastern United States having usually blue flowers
@@ -21734,6 +22380,9 @@
   - Short's aster
   - Aster shortii
   partOfSpeech: n
+  wikidata:
+  - Q15555506
+  - Q38783181
 11955799-n:
   definition:
   - a common European aster that grows in salt marshes
@@ -21745,6 +22394,9 @@
   - sea starwort
   - Aster tripolium
   partOfSpeech: n
+  wikidata:
+  - Q26808337
+  - Q19796604
 11955938-n:
   definition:
   - violet-flowered perennial aster of central United States having solitary heads
@@ -22031,6 +22683,7 @@
   - mule fat
   - Baccharis viminea
   partOfSpeech: n
+  wikidata: Q50840238
 11959201-n:
   definition:
   - widely spreading evergreen shrub of southwestern United States with flower heads
@@ -22045,6 +22698,7 @@
   - kidney wort
   - Baccharis pilularis
   partOfSpeech: n
+  wikidata: Q1028765
 11959446-n:
   definition:
   - genus of coarse western American herbs with large roots containing an aromatic
@@ -22144,6 +22798,7 @@
   - Spanish needles
   - Bidens bipinnata
   partOfSpeech: n
+  wikidata: Q15251279
 11960947-n:
   definition:
   - the seed of bur marigolds
@@ -22165,6 +22820,7 @@
   - Bidens coronata
   - Bidens trichosperma
   partOfSpeech: n
+  wikidata: Q21252466
 11961219-n:
   definition:
   - bur marigold of temperate Eurasia
@@ -22189,6 +22845,7 @@
   - swampy beggar-ticks
   - Bidens connata
   partOfSpeech: n
+  wikidata: Q1668987
 11961563-n:
   definition:
   - a variety of knapweed, widespread across England
@@ -22302,6 +22959,7 @@
   - woodland oxeye
   - Buphthalmum salicifolium
   partOfSpeech: n
+  wikidata: Q1363283
 11963344-n:
   definition:
   - genus of tall smooth herbs of forested mountains of Europe and Asia minor; in
@@ -22360,6 +23018,9 @@
   - Scotch marigold
   - Calendula officinalis
   partOfSpeech: n
+  wikidata:
+  - Q35587197
+  - Q145930
 11964293-n:
   definition:
   - 'one species: erect Asiatic herb with large flowers'
@@ -22384,6 +23045,7 @@
   - China aster
   - Callistephus chinensis
   partOfSpeech: n
+  wikidata: Q312441
 11964665-n:
   definition:
   - any of numerous plants of the family Compositae and especially of the genera Carduus
@@ -22419,6 +23081,7 @@
   - welted thistle
   - Carduus crispus
   partOfSpeech: n
+  wikidata: Q926838
 11965423-n:
   definition:
   - Eurasian perennial naturalized in eastern North America having very spiny white
@@ -22507,6 +23170,7 @@
   mero_substance:
   - 11966902-n
   partOfSpeech: n
+  wikidata: Q156625
 11966782-n:
   definition:
   - seed of the safflower
@@ -22560,6 +23224,7 @@
   - cupid's dart
   - Catananche caerulea
   partOfSpeech: n
+  wikidata: Q514545
 11967548-n:
   definition:
   - knapweed; star thistle
@@ -22595,6 +23260,9 @@
   - basket flower
   - Centaurea americana
   partOfSpeech: n
+  wikidata:
+  - Q468566
+  - Q87598685
 11968098-n:
   definition:
   - a plant having leaves and stems covered with down that resembles dust
@@ -22620,6 +23288,7 @@
   - bluebottle
   - Centaurea cyanus
   partOfSpeech: n
+  wikidata: Q156921
 11968513-n:
   definition:
   - Mediterranean annual or biennial herb having pinkish to purple flowers surrounded
@@ -22652,6 +23321,7 @@
   - sweet sultan
   - Centaurea imperialis
   partOfSpeech: n
+  wikidata: Q15567609
 11969125-n:
   definition:
   - a weedy perennial with tough wiry stems and purple flowers; native to Europe but
@@ -22665,6 +23335,7 @@
   - hardheads
   - Centaurea nigra
   partOfSpeech: n
+  wikidata: Q1851639
 11969333-n:
   definition:
   - tall European perennial having purple flower heads
@@ -22676,6 +23347,7 @@
   - greater knapweed
   - Centaurea scabiosa
   partOfSpeech: n
+  wikidata: Q1569852
 11969484-n:
   definition:
   - European weed having a winged stem and hairy leaves; adventive in the eastern
@@ -22688,6 +23360,7 @@
   - yellow star-thistle
   - Centaurea solstitialis
   partOfSpeech: n
+  wikidata: Q2068262
 11969686-n:
   definition:
   - 'small genus of plants sometimes included in genus Anthemis: chamomile'
@@ -22714,6 +23387,9 @@
   - Chamaemelum nobilis
   - Anthemis nobilis
   partOfSpeech: n
+  wikidata:
+  - Q5723577
+  - Q15281388
 11970176-n:
   definition:
   - genus of flowering herbs of western United States
@@ -22777,6 +23453,9 @@
   - field marigold
   - Chrysanthemum segetum
   partOfSpeech: n
+  wikidata:
+  - Q28242
+  - Q15627858
 11971346-n:
   definition:
   - shrubby annual of the Mediterranean region with yellowish-white flowers
@@ -22787,6 +23466,9 @@
   - crown daisy
   - Chrysanthemum coronarium
   partOfSpeech: n
+  wikidata:
+  - Q6585129
+  - Q15627835
 11971521-n:
   definition:
   - grown for its succulent edible leaves used in Asian cooking
@@ -22844,6 +23526,7 @@
   - Maryland golden aster
   - Chrysopsis mariana
   partOfSpeech: n
+  wikidata: Q5114924
 11972430-n:
   definition:
   - a variety of golden aster (Chrysopsis graminifolia)
@@ -22899,6 +23582,7 @@
   - rabbit bush
   - Chrysothamnus nauseosus
   partOfSpeech: n
+  wikidata: Q15629521
 11973369-n:
   definition:
   - chicory
@@ -22929,6 +23613,7 @@
   - 07746831-n
   - 11974079-n
   partOfSpeech: n
+  wikidata: Q2544599
 11973808-n:
   definition:
   - widely cultivated herb with leaves valued as salad green; either curly serrated
@@ -22944,6 +23629,7 @@
   - 07747563-n
   - 07747743-n
   partOfSpeech: n
+  wikidata: Q178547
 11974079-n:
   definition:
   - 'the dried root of the chicory plant: used as a coffee substitute'
@@ -23001,6 +23687,7 @@
   - field thistle
   - Cirsium discolor
   partOfSpeech: n
+  wikidata: Q5122056
 11974953-n:
   definition:
   - thistle of western North America having white woolly leaves
@@ -23011,6 +23698,7 @@
   - woolly thistle
   - Cirsium flodmanii
   partOfSpeech: n
+  wikidata: Q15593859
 11975111-n:
   definition:
   - woolly thistle of western and central Europe and Balkan Peninsula
@@ -23021,6 +23709,7 @@
   - European woolly thistle
   - Cirsium eriophorum
   partOfSpeech: n
+  wikidata: Q1029175
 11975267-n:
   definition:
   - perennial stoloniferous thistle of northern Europe with lanceolate basal leaves
@@ -23033,6 +23722,7 @@
   - Cirsium heterophylum
   - Cirsium helenioides
   partOfSpeech: n
+  wikidata: Q15546864
 11975509-n:
   definition:
   - of central and southwestern Europe
@@ -23043,6 +23733,7 @@
   - brook thistle
   - Cirsium rivulare
   partOfSpeech: n
+  wikidata: Q588939
 11975622-n:
   definition:
   - European thistle with rather large heads and prickly leaves; extensively naturalized
@@ -23057,6 +23748,7 @@
   - Cirsium vulgare
   - Cirsium lanceolatum
   partOfSpeech: n
+  wikidata: Q15630402
 11975867-n:
   definition:
   - 'one species: blessed thistle'
@@ -23082,6 +23774,9 @@
   - sweet sultan
   - Cnicus benedictus
   partOfSpeech: n
+  wikidata:
+  - Q792835
+  - Q15548577
 11976239-n:
   definition:
   - mistflower
@@ -23109,6 +23804,7 @@
   - Conoclinium coelestinum
   - Eupatorium coelestinum
   partOfSpeech: n
+  wikidata: Q15548876
 11976677-n:
   definition:
   - common American weed or wildflower
@@ -23185,6 +23881,7 @@
   - giant coreopsis
   - Coreopsis gigantea
   partOfSpeech: n
+  wikidata: Q4232929
 11977983-n:
   definition:
   - stout herb with flowers one to a stalk; ornamental developed from a Mexican wildflower
@@ -23195,6 +23892,7 @@
   - sea dahlia
   - Coreopsis maritima
   partOfSpeech: n
+  wikidata: Q4232932
 11978147-n:
   definition:
   - North American annual widely cultivated for its yellow flowers with purple-red
@@ -23206,6 +23904,7 @@
   - calliopsis
   - Coreopsis tinctoria
   partOfSpeech: n
+  wikidata: Q2631259
 11978381-n:
   definition:
   - genus of tropical American plants cultivated for their colorful flowers
@@ -23253,6 +23952,7 @@
   - brass buttons
   - Cotula coronopifolia
   partOfSpeech: n
+  wikidata: Q2998623
 11979211-n:
   definition:
   - herbs of Australia and New Zealand
@@ -23329,7 +24029,9 @@
   mero_part:
   - 07734492-n
   partOfSpeech: n
-  wikidata: Q134609
+  wikidata:
+  - Q23044189
+  - Q134609
 11980331-n:
   definition:
   - southern European plant having spiny leaves and purple flowers cultivated for
@@ -23343,6 +24045,7 @@
   mero_part:
   - 07746009-n
   partOfSpeech: n
+  wikidata: Q7186137
 11980553-n:
   definition:
   - genus of perennial tuberous plants of Mexico and Central America
@@ -23366,6 +24069,7 @@
   - dahlia
   - Dahlia pinnata
   partOfSpeech: n
+  wikidata: Q1549236
 11981009-n:
   definition:
   - 'one species: German ivy'
@@ -23391,6 +24095,7 @@
   - Delairea odorata
   - Senecio milkanioides
   partOfSpeech: n
+  wikidata: Q2702202
 11981412-n:
   definition:
   - comprises plants often included in the genus Chrysanthemum, including the economically
@@ -23416,6 +24121,9 @@
   - Dendranthema grandifloruom
   - Chrysanthemum morifolium
   partOfSpeech: n
+  wikidata:
+  - Q15571979
+  - Q15530181
 11981735-n:
   definition:
   - South African herbs or subshrubs with usually yellow flowers
@@ -23562,6 +24270,7 @@
   - Cacalia javanica
   - Cacalia lutea
   partOfSpeech: n
+  wikidata: Q15587313
 11984041-n:
   definition:
   - tropical Asiatic annual cultivated for its small tassel-shaped heads of scarlet
@@ -23625,6 +24334,7 @@
   - sunray
   - Enceliopsis nudicaulis
   partOfSpeech: n
+  wikidata: Q3053763
 11985157-n:
   definition:
   - 'one species: North American herbs that resemble sunflowers'
@@ -23669,6 +24379,7 @@
   - fireweed
   - Erechtites hieracifolia
   partOfSpeech: n
+  wikidata: Q15588334
 11985847-n:
   definition:
   - cosmopolitan genus of usually perennial herbs with flowers that resemble asters;
@@ -23774,6 +24485,7 @@
   - robin's plantain
   - Erigeron pulchellus
   partOfSpeech: n
+  wikidata: Q5388423
 11987784-n:
   definition:
   - plant having branching leafy stems each branch with an especially showy solitary
@@ -23820,6 +24532,7 @@
   - golden yarrow
   - Eriophyllum lanatum
   partOfSpeech: n
+  wikidata: Q2592617
 11988573-n:
   definition:
   - large genus of chiefly tropical herbs having heads of white or purplish flowers
@@ -23871,6 +24584,9 @@
   - spotted Joe-Pye weed
   - Eupatorium maculatum
   partOfSpeech: n
+  wikidata:
+  - Q1951405
+  - Q38732209
 11989400-n:
   definition:
   - perennial herb of southeastern United States having white-rayed flower heads;
@@ -23899,6 +24615,9 @@
   - marsh milkweed
   - Eupatorium purpureum
   partOfSpeech: n
+  wikidata:
+  - Q19848832
+  - Q2716731
 11989879-n:
   definition:
   - genus of tropical African herbs or subshrubs with usually blue flowers
@@ -23925,6 +24644,7 @@
   - blue marguerite
   - Felicia amelloides
   partOfSpeech: n
+  wikidata: Q354211
 11990275-n:
   definition:
   - softly hairy South African herb having flowers with bright blue rays
@@ -23935,6 +24655,7 @@
   - kingfisher daisy
   - Felicia bergeriana
   partOfSpeech: n
+  wikidata: Q15598583
 11990446-n:
   definition:
   - genus of small woolly herbs
@@ -23969,6 +24690,7 @@
   - herba impia
   - Filago germanica
   partOfSpeech: n
+  wikidata: Q108746821
 11990898-n:
   definition:
   - genus of western American hairy herbs with showy flowers
@@ -24005,6 +24727,7 @@
   - fire-wheel
   - Gaillardia pulchella
   partOfSpeech: n
+  wikidata: Q2701210
 11991563-n:
   definition:
   - genus of tomentose tropical African herbs with milky sap
@@ -24038,6 +24761,7 @@
   - treasure flower
   - Gazania rigens
   partOfSpeech: n
+  wikidata: Q775301
 11992069-n:
   definition:
   - 'genus of South African or Asiatic herbs: African daisies'
@@ -24134,7 +24858,9 @@
   - wood cudweed
   - Gnaphalium sylvaticum
   partOfSpeech: n
-  wikidata: Q1848151
+  wikidata:
+  - Q7089517
+  - Q1848151
 11993628-n:
   definition:
   - large genus of coarse gummy herbs of western North and Central America
@@ -24170,6 +24896,7 @@
   members:
   - Grindelia robusta
   partOfSpeech: n
+  wikidata: Q5609419
 11994218-n:
   definition:
   - perennial gumweed of western and central North America
@@ -24218,6 +24945,7 @@
   - little-head snakeweed
   - Gutierrezia microcephala
   partOfSpeech: n
+  wikidata: Q5621812
 11995026-n:
   definition:
   - low-growing sticky subshrub of southwestern United States having narrow linear
@@ -24234,6 +24962,7 @@
   - turpentine weed
   - Gutierrezia sarothrae
   partOfSpeech: n
+  wikidata: Q15553359
 11995357-n:
   definition:
   - annual of southwestern United States having rigid woody branches with sticky foliage
@@ -24246,6 +24975,7 @@
   - broom-weed
   - Gutierrezia texana
   partOfSpeech: n
+  wikidata: Q19570453
 11995569-n:
   definition:
   - 'genus of Old World tropical herbs: velvet plants'
@@ -24272,6 +25002,7 @@
   - royal velvet plant
   - Gynura aurantiaca
   partOfSpeech: n
+  wikidata: Q9268236
 11995951-n:
   definition:
   - 'genus of New Zealand mat-forming herbs or subshrubs: vegetable sheep'
@@ -24296,6 +25027,7 @@
   - sheep plant
   - Haastia pulvinaris
   partOfSpeech: n
+  wikidata: Q15556408
 11996322-n:
   definition:
   - genus of North and South American perennial herbs or shrubs with yellow flowers;
@@ -24332,6 +25064,9 @@
   - camphor daisy
   - Haplopappus phyllocephalus
   partOfSpeech: n
+  wikidata:
+  - Q15601199
+  - Q38774941
 11996980-n:
   definition:
   - slender perennial of western North America having weakly bristly leaves and yellow
@@ -24343,6 +25078,7 @@
   - yellow spiny daisy
   - Haplopappus spinulosus
   partOfSpeech: n
+  wikidata: Q41777651
 11997184-n:
   definition:
   - small genus of shrubs and subshrubs of western United States having flowers that
@@ -24414,6 +25150,9 @@
   - owlclaws
   - Helenium hoopesii
   partOfSpeech: n
+  wikidata:
+  - Q5956675
+  - Q38742382
 11998356-n:
   definition:
   - a sneezeweed of southwestern United States especially southern California
@@ -24424,6 +25163,7 @@
   - rosilla
   - Helenium puberulum
   partOfSpeech: n
+  wikidata: Q5703947
 11998504-n:
   definition:
   - 'genus of tall erect or branched American annual or perennial herbs with showy
@@ -24459,6 +25199,7 @@
   - swamp sunflower
   - Helianthus angustifolius
   partOfSpeech: n
+  wikidata: Q12212025
 11999182-n:
   definition:
   - annual sunflower grown for silage and for its seeds which are a source of oil;
@@ -24473,6 +25214,7 @@
   mero_part:
   - 07791173-n
   partOfSpeech: n
+  wikidata: Q171497
 11999430-n:
   definition:
   - very tall American perennial of central and the eastern United States to Canada
@@ -24486,6 +25228,7 @@
   - Indian potato
   - Helianthus giganteus
   partOfSpeech: n
+  wikidata: Q12212017
 11999656-n:
   definition:
   - tall rough-leaved perennial with a few large flower heads; central United States
@@ -24533,6 +25276,7 @@
   mero_part:
   - 12000433-n
   partOfSpeech: n
+  wikidata: Q146190
 12000433-n:
   definition:
   - edible tuber of the Jerusalem artichoke
@@ -24567,6 +25311,7 @@
   - yellow paper daisy
   - Helichrysum bracteatum
   partOfSpeech: n
+  wikidata: Q159089
 12001046-n:
   definition:
   - oxeye
@@ -24641,6 +25386,7 @@
   - Heterotheca villosa
   - Chrysopsis villosa
   partOfSpeech: n
+  wikidata: Q15562549
 12002286-n:
   definition:
   - large genus of perennial hairy herbs of Europe to western Asia to northwestern
@@ -24679,7 +25425,10 @@
   - yellow hawkweed
   - Hieracium praealtum
   partOfSpeech: n
-  wikidata: Q8051739
+  wikidata:
+  - Q8051739
+  - Q25362844
+  - Q15575765
 12003014-n:
   definition:
   - a hawkweed with a rosette of purple-veined basal leaves; Canada to northern Georgia
@@ -24691,6 +25440,7 @@
   - rattlesnake weed
   - Hieracium venosum
   partOfSpeech: n
+  wikidata: Q13919553
 12003193-n:
   definition:
   - small genus of low perennial herbs of montane Europe; in some classifications
@@ -24717,6 +25467,7 @@
   - Homogyne alpina
   - Tussilago alpina
   partOfSpeech: n
+  wikidata: Q1815404
 12003629-n:
   definition:
   - small genus of erect balsam-scented herbs; Pacific coast of the northwestern United
@@ -24755,6 +25506,7 @@
   - dwarf hulsea
   - Hulsea nana
   partOfSpeech: n
+  wikidata: Q5936274
 12004208-n:
   definition:
   - genus of herbs of temperate Australia including some from genus Helipterum
@@ -24796,6 +25548,7 @@
   - gosmore
   - Hypochaeris radicata
   partOfSpeech: n
+  wikidata: Q421057
 12004866-n:
   definition:
   - 'genus of Old World herbs or subshrubs: elecampane'
@@ -24828,6 +25581,7 @@
   - elecampane
   - Inula helenium
   partOfSpeech: n
+  wikidata: Q697416
 12005323-n:
   definition:
   - small genus of American herbs or shrubs; in some classifications placed in a separate
@@ -24898,6 +25652,7 @@
   - Krigia dandelion
   - Krigia bulbosa
   partOfSpeech: n
+  wikidata: Q15601446
 12006560-n:
   definition:
   - 'an herb with milky juice: lettuce; prickly lettuce'
@@ -24937,6 +25692,7 @@
   mero_part:
   - 07739304-n
   partOfSpeech: n
+  wikidata: Q83193
 12007198-n:
   definition:
   - lettuce with long dark-green spoon-shaped leaves
@@ -25001,7 +25757,9 @@
   - Lactuca serriola
   - Lactuca scariola
   partOfSpeech: n
-  wikidata: Q533481
+  wikidata:
+  - Q90471886
+  - Q533481
 12008191-n:
   definition:
   - small genus of herbs of Australia and South America having small solitary white
@@ -25039,6 +25797,7 @@
   - goldfields
   - Lasthenia chrysostoma
   partOfSpeech: n
+  wikidata: Q50845411
 12008888-n:
   definition:
   - genus of western United States annuals with showy yellow or white flowers
@@ -25063,6 +25822,7 @@
   - tidy tips
   - Layia platyglossa
   partOfSpeech: n
+  wikidata: Q6505577
 12009243-n:
   definition:
   - hawkbit
@@ -25097,6 +25857,9 @@
   - arnica bud
   - Leontodon autumnalis
   partOfSpeech: n
+  wikidata:
+  - Q43064408
+  - Q717067
 12009735-n:
   definition:
   - edelweiss
@@ -25121,6 +25884,9 @@
   - edelweiss
   - Leontopodium alpinum
   partOfSpeech: n
+  wikidata:
+  - Q22111554
+  - Q15584175
 12010105-n:
   definition:
   - comprises plants often included in the genus Chrysanthemum, mainly distributed
@@ -25154,6 +25920,7 @@
   - Leucanthemum vulgare
   - Chrysanthemum leucanthemum
   partOfSpeech: n
+  wikidata: Q27164
 12010636-n:
   definition:
   - similar to oxeye daisy
@@ -25165,6 +25932,7 @@
   - Leucanthemum maximum
   - Chrysanthemum maximum
   partOfSpeech: n
+  wikidata: Q3020526
 12010782-n:
   definition:
   - hybrid garden flower derived from Chrysanthemum maximum and Chrysanthemum lacustre
@@ -25189,6 +25957,7 @@
   - Leucanthemum lacustre
   - Chrysanthemum lacustre
   partOfSpeech: n
+  wikidata: Q19848891
 12011273-n:
   definition:
   - New Zealand edelweiss
@@ -25210,6 +25979,7 @@
   - north island edelweiss
   - Leucogenes leontopodium
   partOfSpeech: n
+  wikidata: Q15549862
 12011549-n:
   definition:
   - genus of perennial North American herbs with aromatic usually cormous roots
@@ -25248,6 +26018,7 @@
   - dotted gayfeather
   - Liatris punctata
   partOfSpeech: n
+  wikidata: Q6540315
 12012246-n:
   definition:
   - perennial of southeastern and central United States having very dense spikes of
@@ -25259,6 +26030,7 @@
   - dense blazing star
   - Liatris pycnostachya
   partOfSpeech: n
+  wikidata: Q12061156
 12012462-n:
   definition:
   - 'genus of Old World herbs resembling groundsel: leopard plants'
@@ -25372,6 +26144,7 @@
   - sticky aster
   - Machaeranthera bigelovii
   partOfSpeech: n
+  wikidata: Q21327846
 12014144-n:
   definition:
   - wild aster having greyish leafy stems and flower heads with narrow pale lavender
@@ -25434,6 +26207,7 @@
   mero_substance:
   - 12015187-n
   partOfSpeech: n
+  wikidata: Q6727680
 12015187-n:
   definition:
   - used as a substitute for olive oil
@@ -25472,9 +26246,7 @@
   - Matricaria recutita
   - Matricaria chamomilla
   partOfSpeech: n
-  wikidata:
-  - Q3978815
-  - Q28437
+  wikidata: Q28437
 12015865-n:
   definition:
   - annual aromatic weed of Pacific coastal areas (United States and northeastern
@@ -25489,6 +26261,7 @@
   - rayless chamomile
   - Matricaria matricarioides
   partOfSpeech: n
+  wikidata: Q24851007
 12016152-n:
   definition:
   - herbs and subshrubs of warm North America
@@ -25602,6 +26375,9 @@
   - Nabalus alba
   - Prenanthes alba
   partOfSpeech: n
+  wikidata:
+  - Q41778118
+  - Q7995681
 12017878-n:
   definition:
   - common perennial herb widely distributed in the southern and eastern United States
@@ -25616,6 +26392,7 @@
   - Nabalus serpentarius
   - Prenanthes serpentaria
   partOfSpeech: n
+  wikidata: Q41778123
 12018244-n:
   definition:
   - large genus of Australian evergreen shrubs or small trees with large daisylike
@@ -25654,6 +26431,7 @@
   - muskwood
   - Olearia argophylla
   partOfSpeech: n
+  wikidata: Q2160632
 12018961-n:
   definition:
   - bushy New Zealand shrub cultivated for its fragrant white flower heads
@@ -25664,6 +26442,7 @@
   - New Zealand daisybush
   - Olearia haastii
   partOfSpeech: n
+  wikidata: Q15586910
 12019117-n:
   definition:
   - a genus of Eurasian herbs of the family Compositae with prickly foliage and large
@@ -25694,6 +26473,7 @@
   - Onopordum acanthium
   - Onopordon acanthium
   partOfSpeech: n
+  wikidata: Q30166
 12019609-n:
   definition:
   - genus of western African herbs or shrubs
@@ -25742,6 +26522,7 @@
   - Ozothamnus secundiflorus
   - Helichrysum secundiflorum
   partOfSpeech: n
+  wikidata: Q7116673
 12020427-n:
   definition:
   - genus of American of east Asian perennial herbs with yellow to orange or red flower
@@ -25819,6 +26600,7 @@
   - bastard feverfew
   - Parthenium hysterophorus
   partOfSpeech: n
+  wikidata: Q3595850
 12021763-n:
   definition:
   - stout perennial herb of the eastern United States with whitish flowers; leaves
@@ -25832,6 +26614,7 @@
   - prairie dock
   - Parthenium integrifolium
   partOfSpeech: n
+  wikidata: Q7140245
 12022034-n:
   definition:
   - cineraria
@@ -25858,6 +26641,7 @@
   - Pericallis cruenta
   - Senecio cruentus
   partOfSpeech: n
+  wikidata: Q14954851
 12022393-n:
   definition:
   - herb derived from Pericallis cruenta and widely cultivated in a variety of profusely
@@ -25870,6 +26654,7 @@
   - florest's cineraria
   - Pericallis hybrida
   partOfSpeech: n
+  wikidata: Q1494593
 12022666-n:
   definition:
   - 'genus of rhizomatous herbs of north temperate regions: butterbur; sweet coltsfoot'
@@ -25898,6 +26683,7 @@
   - Petasites hybridus
   - Petasites vulgaris
   partOfSpeech: n
+  wikidata: Q375620
 12023120-n:
   definition:
   - European herb with vanilla-scented white-pink flowers
@@ -25909,6 +26695,7 @@
   - sweet coltsfoot
   - Petasites fragrans
   partOfSpeech: n
+  wikidata: Q4082537
 12023295-n:
   definition:
   - American sweet-scented herb
@@ -25947,6 +26734,9 @@
   - bugloss
   - Picris echioides
   partOfSpeech: n
+  wikidata:
+  - Q1764432
+  - Q21876251
 12023876-n:
   definition:
   - genus of hairy perennial herbs with horizontal rhizomes and leafy or underground
@@ -25984,7 +26774,9 @@
   - Pilosella aurantiaca
   - Hieracium aurantiacum
   partOfSpeech: n
-  wikidata: Q159107
+  wikidata:
+  - Q159107
+  - Q20757547
 12024589-n:
   definition:
   - European hawkweed having soft hairy leaves; sometimes placed in genus Hieracium
@@ -25996,6 +26788,7 @@
   - Pilosella officinarum
   - Hieracium pilocella
   partOfSpeech: n
+  wikidata: Q15593797
 12024779-n:
   definition:
   - small genus of tropical American perennial herbs or subshrubs with white to pale
@@ -26044,6 +26837,7 @@
   - rattlesnake root
   - Prenanthes purpurea
   partOfSpeech: n
+  wikidata: Q849890
 12025617-n:
   definition:
   - genus of Australian and South African herbs including some from genus Helipterum
@@ -26091,6 +26885,7 @@
   - feabane mullet
   - Pulicaria dysenterica
   partOfSpeech: n
+  wikidata: Q743794
 12026338-n:
   definition:
   - used in former classifications for plants later placed in genus Chrysanthemum
@@ -26129,6 +26924,7 @@
   - Raoulia lutescens
   - Raoulia australis
   partOfSpeech: n
+  wikidata: Q49615863
 12026972-n:
   definition:
   - genus of perennial wildflowers of North American plains and prairies; often cultivated
@@ -26166,6 +26962,7 @@
   - Mexican hat
   - Ratibida columnaris
   partOfSpeech: n
+  wikidata: Q50864117
 12027665-n:
   definition:
   - plant similar to the Mexican hat coneflower; from British Columbia to New Mexico
@@ -26177,6 +26974,7 @@
   - prairie coneflower
   - Ratibida columnifera
   partOfSpeech: n
+  wikidata: Q7295703
 12027875-n:
   definition:
   - coneflower of central to southwestern United States
@@ -26187,6 +26985,7 @@
   - prairie coneflower
   - Ratibida tagetes
   partOfSpeech: n
+  wikidata: Q15601027
 12028029-n:
   definition:
   - genus of xerophytic herbs and shrubs of South Africa and Australia; sometimes
@@ -26252,6 +27051,7 @@
   - Rudbeckia hirta
   - Rudbeckia serotina
   partOfSpeech: n
+  wikidata: Q104247213
 12029218-n:
   definition:
   - tall leafy plant with erect branches ending in large yellow flower heads with
@@ -26301,6 +27101,7 @@
   - lavender cotton
   - Santolina chamaecyparissus
   partOfSpeech: n
+  wikidata: Q1543811
 12030085-n:
   definition:
   - 'small genus of tropical American annual herbs: creeping zinnia'
@@ -26351,6 +27152,7 @@
   - Saussurea costus
   - Saussurea lappa
   partOfSpeech: n
+  wikidata: Q18774030
 12030927-n:
   definition:
   - small genus of thistlelike herbs of the Mediterranean region
@@ -26386,6 +27188,7 @@
   - Spanish oyster plant
   - Scolymus hispanicus
   partOfSpeech: n
+  wikidata: Q1403748
 12031536-n:
   definition:
   - enormous and diverse cosmopolitan genus of trees and shrubs and vines and herbs
@@ -26416,6 +27219,7 @@
   - nodding groundsel
   - Senecio bigelovii
   partOfSpeech: n
+  wikidata: Q15592098
 12032089-n:
   definition:
   - stiff much-branched perennial of the Mediterranean region having very white woolly
@@ -26428,6 +27232,9 @@
   - Senecio cineraria
   - Cineraria maritima
   partOfSpeech: n
+  wikidata:
+  - Q20061216
+  - Q15591639
 12032307-n:
   definition:
   - bluish-green bushy leafy plant covered with close white wool and bearing branched
@@ -26450,6 +27257,9 @@
   - ragwort
   - Senecio glabellus
   partOfSpeech: n
+  wikidata:
+  - Q7122962
+  - Q15598537
 12032722-n:
   definition:
   - widespread European weed having yellow daisylike flowers; sometimes an obnoxious
@@ -26464,6 +27274,7 @@
   - benweed
   - Senecio jacobaea
   partOfSpeech: n
+  wikidata: Q1144724
 12032979-n:
   definition:
   - perennial with sharply toothed triangular leaves on leafy stems bearing a cluster
@@ -26475,6 +27286,7 @@
   - arrowleaf groundsel
   - Senecio triangularis
   partOfSpeech: n
+  wikidata: Q2465957
 12033224-n:
   definition:
   - Eurasian weed with heads of small yellow flowers
@@ -26485,6 +27297,7 @@
   - groundsel
   - Senecio vulgaris
   partOfSpeech: n
+  wikidata: Q504256
 12033366-n:
   definition:
   - genus of narrow-leaved European herbs
@@ -26512,6 +27325,7 @@
   mero_part:
   - 07751270-n
   partOfSpeech: n
+  wikidata: Q385259
 12033792-n:
   definition:
   - 'small genus of herbs of the eastern United States: white-topped asters'
@@ -26576,8 +27390,9 @@
   - Artemisia cana
   partOfSpeech: n
   wikidata:
-  - Q583160
   - Q1431474
+  - Q583160
+  - Q15562485
 12034824-n:
   definition:
   - plants of western and northern European coasts
@@ -26589,6 +27404,7 @@
   - Seriphidium maritimum
   - Artemisia maritima
   partOfSpeech: n
+  wikidata: Q15562228
 12034993-n:
   definition:
   - aromatic shrub of arid regions of western North America having hoary leaves
@@ -26625,6 +27441,7 @@
   - sawwort
   - Serratula tinctoria
   partOfSpeech: n
+  wikidata: Q7215753
 12035545-n:
   definition:
   - tall North American perennial herbs
@@ -26648,6 +27465,7 @@
   - rosinweed
   - Silphium laciniatum
   partOfSpeech: n
+  wikidata: Q1780806
 12035853-n:
   definition:
   - small genus of east African herbs
@@ -26710,6 +27528,7 @@
   - silverrod
   - Solidago bicolor
   partOfSpeech: n
+  wikidata: Q3489400
 12037036-n:
   definition:
   - large North American goldenrod having showy clusters of yellow flowers on arching
@@ -26722,6 +27541,7 @@
   - Canadian goldenrod
   - Solidago canadensis
   partOfSpeech: n
+  wikidata: Q254436
 12037246-n:
   definition:
   - similar to meadow goldenrod but usually smaller
@@ -26732,6 +27552,7 @@
   - Missouri goldenrod
   - Solidago missouriensis
   partOfSpeech: n
+  wikidata: Q7557954
 12037383-n:
   definition:
   - goldenrod similar to narrow goldenrod but having bristly hairs on edges of leaf
@@ -26743,6 +27564,7 @@
   - alpine goldenrod
   - Solidago multiradiata
   partOfSpeech: n
+  wikidata: Q13953922
 12037596-n:
   definition:
   - a dyer's weed of Canada and the eastern United States having yellow flowers sometimes
@@ -26768,6 +27590,7 @@
   - sweet goldenrod
   - Solidago odora
   partOfSpeech: n
+  wikidata: Q15566381
 12037980-n:
   definition:
   - eastern North American herb whose yellow flowers are (or were) used in dyeing
@@ -26778,6 +27601,7 @@
   - dyer's weed
   - Solidago rugosa
   partOfSpeech: n
+  wikidata: Q3020839
 12038133-n:
   definition:
   - vigorous showy goldenrod common along eastern coast and Gulf Coast of North America
@@ -26789,6 +27613,7 @@
   - beach goldenrod
   - Solidago sempervirens
   partOfSpeech: n
+  wikidata: Q7557963
 12038322-n:
   definition:
   - western American goldenrod with long narrow clusters of small yellow flowers
@@ -26799,6 +27624,9 @@
   - narrow goldenrod
   - Solidago spathulata
   partOfSpeech: n
+  wikidata:
+  - Q67197476
+  - Q15567522
 12038483-n:
   definition:
   - a variety of goldenrod (solidago arguta var. bootii)
@@ -26898,6 +27726,7 @@
   - milkweed
   - Sonchus oleraceus
   partOfSpeech: n
+  wikidata: Q331676
 12039659-n:
   definition:
   - genus of western North American low evergreen shrubs growing in dense tufts
@@ -26972,6 +27801,7 @@
   - cornflower aster
   - Stokesia laevis
   partOfSpeech: n
+  wikidata: Q1436235
 12040857-n:
   definition:
   - marigolds
@@ -27020,6 +27850,7 @@
   - French marigold
   - Tagetes patula
   partOfSpeech: n
+  wikidata: Q644934
 12041589-n:
   definition:
   - a large genus of plants resembling chrysanthemums; comprises some plants often
@@ -27060,6 +27891,7 @@
   mero_part:
   - 07833575-n
   partOfSpeech: n
+  wikidata: Q1451844
 12042351-n:
   definition:
   - densely hairy plant with rayless flowers; San Francisco Bay area
@@ -27070,6 +27902,7 @@
   - camphor dune tansy
   - Tanacetum camphoratum
   partOfSpeech: n
+  wikidata: Q7682196
 12042523-n:
   definition:
   - spring-flowering garden perennial of Asiatic origin having finely divided aromatic
@@ -27084,6 +27917,7 @@
   - Tanacetum coccineum
   - Chrysanthemum coccineum
   partOfSpeech: n
+  wikidata: Q852073
 12042851-n:
   definition:
   - white-flowered pyrethrum of Balkan area whose pinnate leaves are white and silky-hairy
@@ -27120,6 +27954,7 @@
   - northern dune tansy
   - Tanacetum douglasii
   partOfSpeech: n
+  wikidata: Q59262587
 12043577-n:
   definition:
   - bushy aromatic European perennial herb having clusters of buttonlike white-rayed
@@ -27148,6 +27983,7 @@
   - Tanacetum ptarmiciflorum
   - Chrysanthemum ptarmiciflorum
   partOfSpeech: n
+  wikidata: Q7682199
 12044195-n:
   definition:
   - common perennial aromatic herb native to Eurasia having buttonlike yellow flower
@@ -27161,6 +27997,9 @@
   - scented fern
   - Tanacetum vulgare
   partOfSpeech: n
+  wikidata:
+  - Q87647183
+  - Q27079
 12044465-n:
   definition:
   - an asterid dicot genus of the family Compositae including dandelions
@@ -27200,6 +28039,7 @@
   - 07749193-n
   - 12045159-n
   partOfSpeech: n
+  wikidata: Q131219
 12045159-n:
   definition:
   - the foliage of the dandelion plant
@@ -27249,6 +28089,7 @@
   - Tetraneuris acaulis
   - Hymenoxys acaulis
   partOfSpeech: n
+  wikidata: Q7706616
 12045976-n:
   definition:
   - whitish hairy plant with featherlike leaves and a few stout stems each bearing
@@ -27263,6 +28104,7 @@
   - Tetraneuris grandiflora
   - Hymenoxys grandiflora
   partOfSpeech: n
+  wikidata: Q67193838
 12046318-n:
   definition:
   - 'genus of robust herbs of Mexico and Central America: Mexican sunflower'
@@ -27340,6 +28182,7 @@
   - yellow salsify
   - Tragopogon dubius
   partOfSpeech: n
+  wikidata: Q1548650
 12047691-n:
   definition:
   - Mediterranean biennial herb with long-stemmed heads of purple ray flowers and
@@ -27356,6 +28199,7 @@
   - 07751155-n
   - 12048007-n
   partOfSpeech: n
+  wikidata: Q941639
 12048007-n:
   definition:
   - edible root of the salsify plant
@@ -27378,6 +28222,7 @@
   - shepherd's clock
   - Tragopogon pratensis
   partOfSpeech: n
+  wikidata: Q1345772
 12048333-n:
   definition:
   - genus of herbs of southern United States
@@ -27401,6 +28246,7 @@
   - wild vanilla
   - Trilisa odoratissima
   partOfSpeech: n
+  wikidata: Q21307444
 12048665-n:
   definition:
   - small genus comprising plants often included in genus Matricaria
@@ -27433,6 +28279,7 @@
   - Tripleurospermum inodorum
   - Matricaria inodorum
   partOfSpeech: n
+  wikidata: Q19848986
 12049287-n:
   definition:
   - mat-forming perennial herb of Asia Minor; sometimes included in genus Matricaria
@@ -27444,6 +28291,7 @@
   - Tripleurospermum oreades tchihatchewii
   - Matricaria oreades
   partOfSpeech: n
+  wikidata: Q109732821
 12049508-n:
   definition:
   - low densely tufted perennial herb of Turkey having small white flowers; used as
@@ -27456,6 +28304,7 @@
   - Tripleurospermum tchihatchewii
   - Matricaria tchihatchewii
   partOfSpeech: n
+  wikidata: Q50874346
 12049795-n:
   definition:
   - 'genus of low creeping yellow-flowered perennial herbs of north temperate regions:
@@ -27557,6 +28406,7 @@
   - Verbesina alternifolia
   - Actinomeris alternifolia
   partOfSpeech: n
+  wikidata: Q11933237
 12051608-n:
   definition:
   - coarse greyish-green annual yellow-flowered herb; southwestern United States to
@@ -27583,6 +28433,7 @@
   - gravelweed
   - Verbesina helianthoides
   partOfSpeech: n
+  wikidata: Q15563301
 12052016-n:
   definition:
   - tall perennial herb having clusters of white flowers; the eastern United States
@@ -27595,6 +28446,7 @@
   - frost-weed
   - Verbesina virginica
   partOfSpeech: n
+  wikidata: Q15564201
 12052208-n:
   definition:
   - genus of New World tropical herbs or shrubs with terminal cymose heads of tubular
@@ -27645,6 +28497,7 @@
   - mule's ears
   - Wyethia amplexicaulis
   partOfSpeech: n
+  wikidata: Q15571724
 12053155-n:
   definition:
   - herb with basal leaves and leafy hairy stems bearing solitary flower heads with
@@ -27656,6 +28509,7 @@
   - white-rayed mule's ears
   - Wyethia helianthoides
   partOfSpeech: n
+  wikidata: Q15572520
 12053408-n:
   definition:
   - coarse herbs having small heads of greenish flowers followed by burrs with hooked
@@ -27716,6 +28570,7 @@
   - immortelle
   - Xeranthemum annuum
   partOfSpeech: n
+  wikidata: Q2054752
 12054408-n:
   definition:
   - genus of annual or perennial plants of tropical America having solitary heads
@@ -27752,6 +28607,7 @@
   - white zinnia
   - Zinnia acerosa
   partOfSpeech: n
+  wikidata: Q979508
 12055063-n:
   definition:
   - subshrub having short leafy stems and numerous small flower heads with nearly
@@ -27763,6 +28619,7 @@
   - little golden zinnia
   - Zinnia grandiflora
   partOfSpeech: n
+  wikidata: Q3025716
 12055297-n:
   definition:
   - family of bristly hairy sometimes climbing plants; America and Africa and southern
@@ -27930,6 +28787,7 @@
   - creeping bellflower
   - Campanula rapunculoides
   partOfSpeech: n
+  wikidata: Q341547
 12058160-n:
   definition:
   - European biennial widely cultivated for its blue or violet or white flowers
@@ -27953,6 +28811,7 @@
   - southern harebell
   - Campanula divaricata
   partOfSpeech: n
+  wikidata: Q15600342
 12058507-n:
   definition:
   - annual or perennial of eastern North America with long spikes of blue or white
@@ -27976,6 +28835,9 @@
   - marsh bellflower
   - Campanula aparinoides
   partOfSpeech: n
+  wikidata:
+  - Q110059553
+  - Q15596433
 12058875-n:
   definition:
   - bellflower of Europe to temperate Asia having dense spikes of violet-blue to white
@@ -27987,6 +28849,7 @@
   - clustered bellflower
   - Campanula glomerata
   partOfSpeech: n
+  wikidata: Q158045
 12059054-n:
   definition:
   - perennial European bellflower with racemose white or blue flowers
@@ -27999,6 +28862,7 @@
   - willow bell
   - Campanula persicifolia
   partOfSpeech: n
+  wikidata: Q790170
 12059229-n:
   definition:
   - bellflower of southeastern Europe
@@ -28010,6 +28874,7 @@
   - chimney bellflower
   - Campanula pyramidalis
   partOfSpeech: n
+  wikidata: Q2119769
 12059367-n:
   definition:
   - bellflower of Europe and Asia and North Africa having bluish flowers and an edible
@@ -28022,6 +28887,7 @@
   - rampion bellflower
   - Campanula rapunculus
   partOfSpeech: n
+  wikidata: Q547186
 12059591-n:
   definition:
   - European bellflower with blue-purple to lilac flowers formerly used to treat sore
@@ -28034,6 +28900,7 @@
   - nettle-leaved bellflower
   - Campanula trachelium
   partOfSpeech: n
+  wikidata: Q776583
 12059786-n:
   definition:
   - European perennial bellflower that grows in clumps with spreading stems and blue
@@ -28200,6 +29067,9 @@
   - early purple orchid
   - Orchis mascula
   partOfSpeech: n
+  wikidata:
+  - Q92740849
+  - Q157435
 12064305-n:
   definition:
   - Mediterranean orchid having usually purple flowers with a fan-shaped spotted or
@@ -28225,7 +29095,9 @@
   - purple-hooded orchis
   - Orchis spectabilis
   partOfSpeech: n
-  wikidata: Q1596744
+  wikidata:
+  - Q1596744
+  - Q21977702
 12064738-n:
   definition:
   - epiphytic orchids of tropical Asia having stiff leaves and fragrant white flowers
@@ -28356,6 +29228,7 @@
   - dragon's mouth
   - Arethusa bulbosa
   partOfSpeech: n
+  wikidata: Q15111652
 12066720-n:
   definition:
   - genus of tropical American terrestrial orchids with large purple or pink flowers
@@ -28463,6 +29336,7 @@
   - spider orchid
   - Brassia lawrenceana
   partOfSpeech: n
+  wikidata: Q109509683
 12068525-n:
   definition:
   - Central American orchid having spiderlike flowers with prominent green warts
@@ -28473,6 +29347,7 @@
   - spider orchid
   - Brassia verrucosa
   partOfSpeech: n
+  wikidata: Q4957942
 12068700-n:
   definition:
   - terrestrial orchids of Australia to New Caledonia
@@ -28506,7 +29381,9 @@
   - zebra orchid
   - Caladenia cairnsiana
   partOfSpeech: n
-  wikidata: Q9673398
+  wikidata:
+  - Q65932938
+  - Q9673398
 12069241-n:
   definition:
   - large and widely distributed genus of terrestrial orchids
@@ -28575,6 +29452,7 @@
   - fairy-slipper
   - Calypso bulbosa
   partOfSpeech: n
+  wikidata: Q1141063
 12070265-n:
   definition:
   - genus of tropical American orchids having showy male and female flowers usually
@@ -28601,6 +29479,7 @@
   - jumping orchid
   - Catasetum macrocarpum
   partOfSpeech: n
+  wikidata: Q1595747
 12070764-n:
   definition:
   - large and highly valued genus of beautiful tropical American epiphytic or lithophytic
@@ -28657,6 +29536,7 @@
   - red helleborine
   - Cephalanthera rubra
   partOfSpeech: n
+  wikidata: Q157431
 12071754-n:
   definition:
   - terrestrial orchids of North and South America having slender fibrous roots; allied
@@ -28685,6 +29565,7 @@
   - Cleistes divaricata
   - Pogonia divaricata
   partOfSpeech: n
+  wikidata: Q15287920
 12072261-n:
   definition:
   - orchid of central and northern South America having 1- to 3-blossomed racemes
@@ -28722,6 +29603,7 @@
   - satyr orchid
   - Coeloglossum bracteatum
   partOfSpeech: n
+  wikidata: Q49426376
 12072916-n:
   definition:
   - orchid having hooded long-bracted green to yellow-green flowers suffused with
@@ -28733,6 +29615,7 @@
   - frog orchid
   - Coeloglossum viride
   partOfSpeech: n
+  wikidata: Q22782964
 12073099-n:
   definition:
   - large diverse genus of tropical Asiatic epiphytic orchids
@@ -28793,6 +29676,7 @@
   - spotted coral root
   - Corallorhiza maculata
   partOfSpeech: n
+  wikidata: Q2996998
 12074431-n:
   definition:
   - nearly leafless wildflower with erect reddish-purple stems bearing racemes of
@@ -28804,6 +29688,7 @@
   - striped coral root
   - Corallorhiza striata
   partOfSpeech: n
+  wikidata: Q5169619
 12074664-n:
   definition:
   - plant having clumps of nearly leafless pale yellowish to greenish stems bearing
@@ -28817,6 +29702,7 @@
   - pale coral root
   - Corallorhiza trifida
   partOfSpeech: n
+  wikidata: Q157971
 12074968-n:
   definition:
   - small genus of tropical American epiphytic or lithophytic orchids
@@ -28957,6 +29843,7 @@
   - Cypripedium reginae
   - Cypripedium album
   partOfSpeech: n
+  wikidata: Q977605
 12077491-n:
   definition:
   - orchid of northern North America having a brownish-green flower and red-and-white
@@ -28969,6 +29856,7 @@
   - ram's-head lady's slipper
   - Cypripedium arietinum
   partOfSpeech: n
+  wikidata: Q1306340
 12077712-n:
   definition:
   - maroon to purple-brown orchid with yellow lip; Europe, North America and Japan
@@ -29018,6 +29906,7 @@
   - clustered lady's slipper
   - Cypripedium fasciculatum
   partOfSpeech: n
+  wikidata: Q1021762
 12078693-n:
   definition:
   - leafy plant having a few stems in a clump with 1 white and dull purple flower
@@ -29066,6 +29955,7 @@
   - Dactylorhiza fuchsii
   - Dactylorhiza maculata fuchsii
   partOfSpeech: n
+  wikidata: Q637526
 12079591-n:
   definition:
   - large genus and variable genus of chiefly epiphytic or lithophytic orchids of
@@ -29190,6 +30080,7 @@
   - Encyclia citrina
   - Cattleya citrina
   partOfSpeech: n
+  wikidata: Q5375639
 12081881-n:
   definition:
   - orchid of Florida and the Bahamas having showy brightly colored flowers; sometimes
@@ -29216,6 +30107,7 @@
   - Epidendrum venosum
   - Encyclia venosa
   partOfSpeech: n
+  wikidata: Q109521235
 12082350-n:
   definition:
   - large and variable genus of terrestrial or epiphytic or lithophytic orchids of
@@ -29273,6 +30165,7 @@
   members:
   - Epipactis helleborine
   partOfSpeech: n
+  wikidata: Q157426
 12083282-n:
   definition:
   - orchid growing along streams or ponds of western North America having leafy stems
@@ -29286,6 +30179,9 @@
   - giant helleborine
   - Epipactis gigantea
   partOfSpeech: n
+  wikidata:
+  - Q93296656
+  - Q2221912
 12083567-n:
   definition:
   - small genus of Australian orchids, mostly purple (Glossodia)
@@ -29373,6 +30269,9 @@
   - fragrant orchid
   - Gymnadenia conopsea
   partOfSpeech: n
+  wikidata:
+  - Q93377046
+  - Q157442
 12085092-n:
   definition:
   - similar to Gymnadenia conopsea but with smaller flowers on shorter stems and having
@@ -29384,6 +30283,7 @@
   - short-spurred fragrant orchid
   - Gymnadenia odoratissima
   partOfSpeech: n
+  wikidata: Q161314
 12085315-n:
   definition:
   - genus of North American terrestrial orchids usually included in genus Habenaria
@@ -29475,6 +30375,7 @@
   - elegant Habenaria
   - Habenaria elegans
   partOfSpeech: n
+  wikidata: Q41474510
 12087131-n:
   definition:
   - North American orchid similar to Habenaria psycodes with larger paler flowers
@@ -29497,6 +30398,7 @@
   - coastal rein orchid
   - Habenaria greenei
   partOfSpeech: n
+  wikidata: Q109524690
 12087530-n:
   definition:
   - a long-spurred orchid with base leaves and petals converging under the upper sepal
@@ -29507,6 +30409,9 @@
   - Hooker's orchid
   - Habenaria hookeri
   partOfSpeech: n
+  wikidata:
+  - Q15435811
+  - Q39369033
 12087694-n:
   definition:
   - fringed orchid of the eastern United States having a greenish flower with the
@@ -29533,6 +30438,7 @@
   - prairie white-fringed orchis
   - Habenaria leucophaea
   partOfSpeech: n
+  wikidata: Q109524758
 12088173-n:
   definition:
   - slender fringed orchid of eastern North America having white flowers
@@ -29543,6 +30449,7 @@
   - snowy orchid
   - Habenaria nivea
   partOfSpeech: n
+  wikidata: Q109524901
 12088318-n:
   definition:
   - orchid having a raceme of large greenish-white flowers on a single flower stalk
@@ -29555,6 +30462,7 @@
   - round-leaved rein orchid
   - Habenaria orbiculata
   partOfSpeech: n
+  wikidata: Q115861488
 12088639-n:
   definition:
   - orchid of northeastern and alpine eastern North America closely related to the
@@ -29568,6 +30476,9 @@
   - purple fringeless orchis
   - Habenaria peramoena
   partOfSpeech: n
+  wikidata:
+  - Q15436673
+  - Q39369293
 12088933-n:
   definition:
   - North American orchid with clusters of fragrant purple fringed flowers
@@ -29616,6 +30527,7 @@
   - crested coral root
   - Hexalectris spicata
   partOfSpeech: n
+  wikidata: Q15467564
 12089718-n:
   definition:
   - orchid with slender nearly leafless reddish-brown stems with loose racemes of
@@ -29628,6 +30540,9 @@
   - Texas purple spike
   - Hexalectris warnockii
   partOfSpeech: n
+  wikidata:
+  - Q106899649
+  - Q15467896
 12089989-n:
   definition:
   - small genus of terrestrial orchids of Europe and Mediterranean region
@@ -29651,6 +30566,7 @@
   - lizard orchid
   - Himantoglossum hircinum
   partOfSpeech: n
+  wikidata: Q159296
 12090322-n:
   definition:
   - large genus of mostly epiphytic or lithophytic Central and South American orchids
@@ -29746,6 +30662,7 @@
   - broad-leaved twayblade
   - Listera convallarioides
   partOfSpeech: n
+  wikidata: Q15502015
 12091978-n:
   definition:
   - orchid having two triangular leaves and a short lax raceme of green to rust-colored
@@ -29757,6 +30674,7 @@
   - lesser twayblade
   - Listera cordata
   partOfSpeech: n
+  wikidata: Q157891
 12092245-n:
   definition:
   - orchid having a pair of ovate leaves and a long slender raceme of green flowers
@@ -29794,6 +30712,7 @@
   - Malaxis ophioglossoides
   - Malaxis unifolia
   partOfSpeech: n
+  wikidata: Q109476478
 12092920-n:
   definition:
   - large genus of tropical American mostly epiphytic orchids whose flowers have sepals
@@ -29939,6 +30858,7 @@
   - bee orchid
   - Ophrys apifera
   partOfSpeech: n
+  wikidata: Q159291
 12095511-n:
   definition:
   - European orchid whose flowers resemble flies
@@ -29971,6 +30891,7 @@
   - early spider orchid
   - Ophrys sphegodes
   partOfSpeech: n
+  wikidata: Q161476
 12095996-n:
   definition:
   - horticulturally important genus of mainly terrestrial orchids including many hybrids;
@@ -30120,6 +31041,7 @@
   - Platanthera bifolia
   - Habenaria bifolia
   partOfSpeech: n
+  wikidata: Q157433
 12098673-n:
   definition:
   - south European orchid with dark green flowers that are larger and less fragrant
@@ -30132,6 +31054,7 @@
   - Platanthera chlorantha
   - Habenaria chlorantha
   partOfSpeech: n
+  wikidata: Q157889
 12098952-n:
   definition:
   - of central North America; a threatened species
@@ -30454,6 +31377,7 @@
   - screw augur
   - Spiranthes cernua
   partOfSpeech: n
+  wikidata: Q1152261
 12104659-n:
   definition:
   - orchid having dense clusters of gently spiraling creamy white flowers with 2 upper
@@ -30487,6 +31411,7 @@
   - European ladies' tresses
   - Spiranthes spiralis
   partOfSpeech: n
+  wikidata: Q159283
 12105263-n:
   definition:
   - genus of tropical American epiphytic orchids
@@ -30624,6 +31549,7 @@
   mero_part:
   - 07844618-n
   partOfSpeech: n
+  wikidata: Q7224923
 12107549-n:
   definition:
   - a crystalline compound found in vanilla beans and some balsam resins; used in
@@ -30722,6 +31648,7 @@
   - water yam
   - Dioscorea alata
   partOfSpeech: n
+  wikidata: Q1932852
 12109012-n:
   definition:
   - hardy Chinese vine naturalized in United States and cultivated as an ornamental
@@ -30782,6 +31709,7 @@
   - wild yam
   - Dioscorea paniculata
   partOfSpeech: n
+  wikidata: Q50839860
 12110013-n:
   definition:
   - tropical American yam with small yellow edible tubers
@@ -30792,6 +31720,7 @@
   - cush-cush
   - Dioscorea trifida
   partOfSpeech: n
+  wikidata: Q5279597
 12110142-n:
   definition:
   - a genus of tuberous vines of the family Dioscoreaceae; has twining stems and heart-shaped
@@ -30817,6 +31746,9 @@
   - black bindweed
   - Tamus communis
   partOfSpeech: n
+  wikidata:
+  - Q161378
+  - Q21877561
 12110558-n:
   definition:
   - Primulaceae, Theophrastaceae, Myrsinaceae, and (in some classifications) Plumbaginaceae
@@ -30890,6 +31822,7 @@
   - English primrose
   - Primula vulgaris
   partOfSpeech: n
+  wikidata: Q159537
 12111894-n:
   definition:
   - early spring flower common in British isles having fragrant yellow or sometimes
@@ -30902,6 +31835,7 @@
   - paigle
   - Primula veris
   partOfSpeech: n
+  wikidata: Q157552
 12112067-n:
   definition:
   - Eurasian primrose with yellow flowers clustered in a one-sided umbel
@@ -30913,6 +31847,7 @@
   - paigle
   - Primula elatior
   partOfSpeech: n
+  wikidata: Q157842
 12112214-n:
   definition:
   - cultivated Asiatic primrose
@@ -30982,6 +31917,9 @@
   - poor man's weatherglass
   - Anagallis arvensis
   partOfSpeech: n
+  wikidata:
+  - Q21327968
+  - Q160573
 12113146-n:
   definition:
   - small creeping European herb having delicate pink flowers
@@ -31043,6 +31981,7 @@
   - cyclamen
   - Cyclamen purpurascens
   partOfSpeech: n
+  wikidata: Q149344
 12114117-n:
   definition:
   - common wild European cyclamen with pink flowers
@@ -31054,6 +31993,7 @@
   - Cyclamen hederifolium
   - Cyclamen neopolitanum
   partOfSpeech: n
+  wikidata: Q1965935
 12114286-n:
   definition:
   - sea milkwort
@@ -31080,6 +32020,9 @@
   - black saltwort
   - Glaux maritima
   partOfSpeech: n
+  wikidata:
+  - Q2720092
+  - Q157851
 12114638-n:
   definition:
   - a genus of aquatic herbs, comprising hottonia palustris and hottonia inflata (Hottonia)
@@ -31115,6 +32058,7 @@
   - American featherfoil
   - Hottonia inflata
   partOfSpeech: n
+  wikidata: Q3141217
 12115129-n:
   definition:
   - featherfoil of Europe and western Asia having submerged and floating leaves and
@@ -31126,6 +32070,7 @@
   - water violet
   - Hottonia palustris
   partOfSpeech: n
+  wikidata: Q157882
 12115303-n:
   definition:
   - 'loosestrife: a cosmopolitan genus found in damp or swampy terrain having usually
@@ -31169,6 +32114,9 @@
   - yellow pimpernel
   - Lysimachia nemorum
   partOfSpeech: n
+  wikidata:
+  - Q92620183
+  - Q162496
 12116060-n:
   definition:
   - of North America
@@ -31191,6 +32139,7 @@
   - creeping Charlie
   - Lysimachia nummularia
   partOfSpeech: n
+  wikidata: Q147305
 12116298-n:
   definition:
   - frequently considered a weed; Europe and Asia
@@ -31213,6 +32162,7 @@
   - swamp candles
   - Lysimachia terrestris
   partOfSpeech: n
+  wikidata: Q15325082
 12116606-n:
   definition:
   - common North American yellow-flowered plant
@@ -31223,6 +32173,7 @@
   - whorled loosestrife
   - Lysimachia quadrifolia
   partOfSpeech: n
+  wikidata: Q6710201
 12116740-n:
   definition:
   - 'genus of herbs usually growing in salt marshes: water pimpernels'
@@ -31255,6 +32206,7 @@
   - brookweed
   - Samolus valerandii
   partOfSpeech: n
+  wikidata: Q111528911
 12117191-n:
   definition:
   - American water pimpernel
@@ -31266,6 +32218,7 @@
   - Samolus parviflorus
   - Samolus floribundus
   partOfSpeech: n
+  wikidata: Q19847450
 12117315-n:
   definition:
   - family of Old World tropical trees and shrubs; some in Florida
@@ -31331,6 +32284,7 @@
   - Ardisia escallonoides
   - Ardisia paniculata
   partOfSpeech: n
+  wikidata: Q49426613
 12118263-n:
   definition:
   - coextensive with the family Plumbaginaceae; usually included in order Primulales
@@ -31391,6 +32345,7 @@
   - leadwort
   - Plumbago europaea
   partOfSpeech: n
+  wikidata: Q1418304
 12119182-n:
   definition:
   - shrubby or herbaceous low-growing evergreen perennials
@@ -31491,6 +32446,7 @@
   - bracelet wood
   - Jacquinia armillaris
   partOfSpeech: n
+  wikidata: Q15345112
 12120704-n:
   definition:
   - West Indian shrub or small tree having leathery saponaceous leaves and extremely
@@ -31503,6 +32459,7 @@
   - joewood
   - Jacquinia keyensis
   partOfSpeech: n
+  wikidata: Q15345269
 12120899-n:
   definition:
   - grasses, sedges, rushes
@@ -31769,6 +32726,7 @@
   - witchgrass
   - Agropyron repens
   partOfSpeech: n
+  wikidata: Q87622596
 12126345-n:
   definition:
   - a wheatgrass with straight terminal awns on the flowering glumes
@@ -31779,6 +32737,7 @@
   - bearded wheatgrass
   - Agropyron subsecundum
   partOfSpeech: n
+  wikidata: Q85191663
 12126498-n:
   definition:
   - valuable forage grass of western United States
@@ -31790,6 +32749,9 @@
   - bluestem wheatgrass
   - Agropyron smithii
   partOfSpeech: n
+  wikidata:
+  - Q15510778
+  - Q39551241
 12126651-n:
   definition:
   - Asiatic grass introduced into United States rangelands for pasture and fodder
@@ -31801,6 +32763,7 @@
   - Agropyron intermedium
   - Elymus hispidus
   partOfSpeech: n
+  wikidata: Q15510647
 12126840-n:
   definition:
   - North American grass cultivated in western United States as excellent forage crop
@@ -31813,6 +32776,7 @@
   - Agropyron pauciflorum
   - Elymus trachycaulos
   partOfSpeech: n
+  wikidata: Q87622248
 12127057-n:
   definition:
   - 'annual or perennial grasses cosmopolitan in Northern Hemisphere: bent grass (so
@@ -31852,6 +32816,7 @@
   - dog bent
   - Agrostis canina
   partOfSpeech: n
+  wikidata: Q159182
 12127708-n:
   definition:
   - Spanish grass with light feathery panicles grown for dried bouquets
@@ -31862,6 +32827,7 @@
   - cloud grass
   - Agrostis nebulosa
   partOfSpeech: n
+  wikidata: Q4694285
 12127853-n:
   definition:
   - common pasture or lawn grass spread by long runners
@@ -31873,6 +32839,7 @@
   - creeping bentgrass
   - Agrostis palustris
   partOfSpeech: n
+  wikidata: Q9591119
 12128006-n:
   definition:
   - annual or perennial grasses including decorative and meadow species as well as
@@ -31898,6 +32865,7 @@
   - meadow foxtail
   - Alopecurus pratensis
   partOfSpeech: n
+  wikidata: Q157346
 12128487-n:
   definition:
   - grasses of the genera Alopecurus and Setaria having dense silky or bristly brushlike
@@ -31970,6 +32938,7 @@
   - French rye
   - Arrhenatherum elatius
   partOfSpeech: n
+  wikidata: Q159815
 12129706-n:
   definition:
   - 'any of several coarse tall perennial grasses of most warm areas: reeds'
@@ -31995,6 +32964,9 @@
   - Arundo conspicua
   - Chionochloa conspicua
   partOfSpeech: n
+  wikidata:
+  - Q15512764
+  - Q39541903
 12130015-n:
   definition:
   - large rhizomatous perennial grasses found by riversides and in ditches having
@@ -32112,6 +33084,7 @@
   - awnless bromegrass
   - Bromus inermis
   partOfSpeech: n
+  wikidata: Q159066
 12131755-n:
   definition:
   - weedy annual native to Europe but widely distributed as a weed especially in wheat
@@ -32123,6 +33096,7 @@
   - cheat
   - Bromus secalinus
   partOfSpeech: n
+  wikidata: Q161800
 12131916-n:
   definition:
   - annual or winter annual grass with softly hairy leaves of the Mediterranean
@@ -32138,6 +33112,9 @@
   - drooping brome
   - Bromus tectorum
   partOfSpeech: n
+  wikidata:
+  - Q111417203
+  - Q164128
 12132144-n:
   definition:
   - annual grass of Europe and temperate Asia
@@ -32160,6 +33137,7 @@
   - Japanese chess
   - Bromus japonicus
   partOfSpeech: n
+  wikidata: Q164429
 12132399-n:
   definition:
   - forage grasses
@@ -32195,6 +33173,7 @@
   - blue grama
   - Bouteloua gracilis
   partOfSpeech: n
+  wikidata: Q2922605
 12132854-n:
   definition:
   - a pasture grass (especially of western coastal regions of North America)
@@ -32205,6 +33184,7 @@
   - black grama
   - Bouteloua eriopoda
   partOfSpeech: n
+  wikidata: Q4543400
 12133005-n:
   definition:
   - buffalo grass
@@ -32311,6 +33291,7 @@
   - field sandbur
   - Cenchrus tribuloides
   partOfSpeech: n
+  wikidata: Q15512258
 12134527-n:
   definition:
   - erect tussock-forming perennial bur grass used particularly in South Africa and
@@ -32323,6 +33304,9 @@
   - Cenchrus ciliaris
   - Pennisetum cenchroides
   partOfSpeech: n
+  wikidata:
+  - Q28936180
+  - Q2715047
 12134743-n:
   definition:
   - 'tufted or perennial or annual grasses having runners: finger grass; windmill
@@ -32356,6 +33340,7 @@
   - Rhodes grass
   - Chloris gayana
   partOfSpeech: n
+  wikidata: Q3133411
 12135287-n:
   definition:
   - perennial Australian grass having numerous long spikes arranged like the vanes
@@ -32395,6 +33380,7 @@
   - pampas grass
   - Cortaderia selloana
   partOfSpeech: n
+  wikidata: Q470109
 12135900-n:
   definition:
   - tall grass of New Zealand grown for plumelike flower heads
@@ -32408,6 +33394,9 @@
   - Cortaderia richardii
   - Arundo richardii
   partOfSpeech: n
+  wikidata:
+  - Q28819289
+  - Q39543786
 12136080-n:
   definition:
   - creeping perennial grasses of tropical and southern Africa
@@ -32439,6 +33428,7 @@
   - star grass
   - Cynodon dactylon
   partOfSpeech: n
+  wikidata: Q208705
 12136575-n:
   definition:
   - perennial grass having stems 3 to 4 feet high; used especially in Africa and India
@@ -32473,6 +33463,7 @@
   - cockspur
   - Dactylis glomerata
   partOfSpeech: n
+  wikidata: Q161735
 12137100-n:
   definition:
   - a monocotyledonous genus of the family Gramineae
@@ -32530,6 +33521,7 @@
   - smooth crabgrass
   - Digitaria ischaemum
   partOfSpeech: n
+  wikidata: Q159824
 12137843-n:
   definition:
   - a European forage grass grown for hay; a naturalized weed in United States
@@ -32612,6 +33604,7 @@
   - goose grass
   - Eleusine indica
   partOfSpeech: n
+  wikidata: Q1148930
 12139178-n:
   definition:
   - East Indian cereal grass whose seed yield a somewhat bitter flour, a staple in
@@ -32673,6 +33666,9 @@
   - Elymus condensatus
   - Leymus condensatus
   partOfSpeech: n
+  wikidata:
+  - Q6538092
+  - Q32856001
 12140056-n:
   definition:
   - a dune grass of the Pacific seacoast used as a sand binder
@@ -32685,6 +33681,9 @@
   - Elymus arenarius
   - Leymus arenaria
   partOfSpeech: n
+  wikidata:
+  - Q1426766
+  - Q21874166
 12140234-n:
   definition:
   - North American wild rye
@@ -32695,6 +33694,7 @@
   - Canada wild rye
   - Elymus canadensis
   partOfSpeech: n
+  wikidata: Q5368479
 12140339-n:
   definition:
   - weedy rye grass having long bristling awns
@@ -32705,6 +33705,9 @@
   - medusa's head
   - Elymus caput-medusae
   partOfSpeech: n
+  wikidata:
+  - Q3837887
+  - Q21874168
 12140464-n:
   definition:
   - annual or perennial grasses of tropics and subtropics
@@ -32742,6 +33745,7 @@
   - Eragrostis tef
   - Eragrostic abyssinica
   partOfSpeech: n
+  wikidata: Q843942
 12141095-n:
   definition:
   - perennial South African grass having densely clumped flimsy stems; introduced
@@ -32754,6 +33758,7 @@
   - African love grass
   - Eragrostis curvula
   partOfSpeech: n
+  wikidata: Q5384814
 12141329-n:
   definition:
   - genus of reedlike grasses having spikes crowded in a panicle covered with long
@@ -32790,6 +33795,7 @@
   - wool grass
   - Erianthus ravennae
   partOfSpeech: n
+  wikidata: Q50828970
 12141922-n:
   definition:
   - a genus of tufted perennial grasses of the family Gramineae
@@ -32818,6 +33824,7 @@
   - meadow fescue
   - Festuca elatior
   partOfSpeech: n
+  wikidata: Q3744284
 12142352-n:
   definition:
   - cultivated for sheep pasturage in upland regions or used as a lawn grass
@@ -32873,6 +33880,7 @@
   - reed meadow grass
   - Glyceria grandis
   partOfSpeech: n
+  wikidata: Q5572533
 12143098-n:
   definition:
   - a genus of Old World grasses widely cultivated in America
@@ -32896,6 +33904,9 @@
   - Yorkshire fog
   - Holcus lanatus
   partOfSpeech: n
+  wikidata:
+  - Q87628221
+  - Q158110
 12143435-n:
   definition:
   - European perennial grass with soft velvety foliage
@@ -32955,7 +33966,9 @@
   - wall barley
   - Hordeum murinum
   partOfSpeech: n
-  wikidata: Q161674
+  wikidata:
+  - Q50840504
+  - Q161674
 12144449-n:
   definition:
   - barley grown for its highly ornamental flower heads with delicate long silky awns;
@@ -32981,6 +33994,7 @@
   - little barley
   - Hordeum pusillum
   partOfSpeech: n
+  wikidata: Q4117447
 12144875-n:
   definition:
   - genus that in some classifications overlaps the genus Elymus
@@ -33026,6 +34040,9 @@
   - English ryegrass
   - Lolium perenne
   partOfSpeech: n
+  wikidata:
+  - Q32856031
+  - Q161722
 12145518-n:
   definition:
   - European grass much used for hay and in United States also for turf and green
@@ -33038,6 +34055,7 @@
   - Italian rye
   - Lolium multiflorum
   partOfSpeech: n
+  wikidata: Q157883
 12145700-n:
   definition:
   - weedy annual grass often occurs in grainfields and other cultivated land; seeds
@@ -33052,6 +34070,9 @@
   - cheat
   - Lolium temulentum
   partOfSpeech: n
+  wikidata:
+  - Q32856034
+  - Q162088
 12145915-n:
   definition:
   - a genus of grasses of the family Gramineae grown in America and Asia
@@ -33114,6 +34135,7 @@
   mero_part:
   - 07820299-n
   partOfSpeech: n
+  wikidata: Q161426
 12146755-n:
   definition:
   - rice grass
@@ -33151,6 +34173,7 @@
   - Indian millet
   - Oryzopsis hymenoides
   partOfSpeech: n
+  wikidata: Q24700467
 12147253-n:
   definition:
   - perennial mountain rice native to Mediterranean region and introduced into North
@@ -33163,6 +34186,7 @@
   - smilo grass
   - Oryzopsis miliacea
   partOfSpeech: n
+  wikidata: Q12213301
 12147428-n:
   definition:
   - panic grass
@@ -33211,6 +34235,7 @@
   - switch grass
   - Panicum virgatum
   partOfSpeech: n
+  wikidata: Q1466543
 12148092-n:
   definition:
   - extensively cultivated in Europe and Asia for its grain and in United States sometimes
@@ -33223,6 +34248,7 @@
   - hog millet
   - Panicum miliaceum
   partOfSpeech: n
+  wikidata: Q165196
 12148285-n:
   definition:
   - annual weedy grass used for hay
@@ -33314,6 +34340,7 @@
   - Pennisetum glaucum
   - Pennisetum Americanum
   partOfSpeech: n
+  wikidata: Q654332
 12149651-n:
   definition:
   - tall perennial ornamental grass with long nodding flower plumes of tropical Africa
@@ -33326,6 +34353,7 @@
   - Pennisetum ruppelii
   - Pennisetum setaceum
   partOfSpeech: n
+  wikidata: Q3899117
 12149866-n:
   definition:
   - northeastern tropical African plant having feathery panicles
@@ -33378,6 +34406,7 @@
   - birdseed grass
   - Phalaris canariensis
   partOfSpeech: n
+  wikidata: Q2086586
 12150677-n:
   definition:
   - perennial grass of Australia and South Africa; introduced in North America as
@@ -33392,6 +34421,7 @@
   - Phalaris aquatica
   - Phalaris tuberosa
   partOfSpeech: n
+  wikidata: Q28936185
 12150925-n:
   definition:
   - grasses native to temperate regions
@@ -33419,6 +34449,7 @@
   mero_part:
   - 07818128-n
   partOfSpeech: n
+  wikidata: Q256508
 12151276-n:
   definition:
   - reeds of marshes and riversides in tropical or temperate regions
@@ -33445,6 +34476,9 @@
   - carrizo
   - Phragmites communis
   partOfSpeech: n
+  wikidata:
+  - Q55934019
+  - Q65945348
 12151733-n:
   definition:
   - chiefly perennial grasses of cool temperate regions
@@ -33495,6 +34529,7 @@
   - June grass
   - Poa pratensis
   partOfSpeech: n
+  wikidata: Q147783
 12152609-n:
   definition:
   - slender European grass of shady places; grown also in northeastern America and
@@ -33536,6 +34571,7 @@
   mero_part:
   - 12153271-n
   partOfSpeech: n
+  wikidata: Q3391243
 12153271-n:
   definition:
   - juicy canes whose sap is a source of molasses and commercial sugar; fresh canes
@@ -33569,7 +34605,10 @@
   - Saccharum bengalense
   - Saccharum munja
   partOfSpeech: n
-  wikidata: Q3630865
+  wikidata:
+  - Q3630865
+  - Q93077342
+  - Q12845384
 12153849-n:
   definition:
   - overlaps the genus Andropogon
@@ -33594,7 +34633,9 @@
   - Andropogon scoparius
   - Schizachyrium scoparium
   partOfSpeech: n
-  wikidata: Q3013856
+  wikidata:
+  - Q3013856
+  - Q39582886
 12154199-n:
   definition:
   - tall grass with smooth bluish leaf sheaths grown for hay in the United States
@@ -33607,6 +34648,7 @@
   - Andropogon furcatus
   - Andropogon gerardii
   partOfSpeech: n
+  wikidata: Q50826585
 12154387-n:
   definition:
   - 'cereal grass widely cultivated for its grain: rye'
@@ -33682,6 +34724,7 @@
   - glaucous bristlegrass
   - Setaria glauca
   partOfSpeech: n
+  wikidata: Q12212708
 12155566-n:
   definition:
   - European foxtail naturalized in North America; often a troublesome weed
@@ -33696,6 +34739,7 @@
   - bottle grass
   - Setaria viridis
   partOfSpeech: n
+  wikidata: Q163052
 12155787-n:
   definition:
   - coarse drought-resistant annual grass grown for grain, hay, and forage in Europe
@@ -33966,6 +35010,7 @@
   - salt reed grass
   - Spartina cynosuroides
   partOfSpeech: n
+  wikidata: Q7573948
 12160438-n:
   definition:
   - North American cordgrass having leaves with dry membranous margins and glumes
@@ -34027,6 +35072,7 @@
   - sand dropseed
   - Sporobolus cryptandrus
   partOfSpeech: n
+  wikidata: Q7579242
 12161420-n:
   definition:
   - grass having wiry stems and sheathed panicles
@@ -34135,7 +35181,9 @@
   - Triticum turgidum
   - macaroni wheat
   partOfSpeech: n
-  wikidata: Q618324
+  wikidata:
+  - Q24878639
+  - Q618324
 12163267-n:
   definition:
   - wheat with soft starch kernels used in pastry and breakfast cereals
@@ -34158,6 +35206,7 @@
   mero_part:
   - 07819521-n
   partOfSpeech: n
+  wikidata: Q161098
 12163582-n:
   definition:
   - hardy wheat grown mostly in Europe for livestock feed
@@ -34169,6 +35218,7 @@
   - Triticum spelta
   - Triticum aestivum spelta
   partOfSpeech: n
+  wikidata: Q158767
 12163732-n:
   definition:
   - hard red wheat grown especially in Russia and Germany; in United States as stock
@@ -34182,6 +35232,9 @@
   - two-grain spelt
   - Triticum dicoccum
   partOfSpeech: n
+  wikidata:
+  - Q93448071
+  - Q167339
 12163922-n:
   definition:
   - found wild in Palestine; held to be prototype of cultivated wheat
@@ -34225,6 +35278,7 @@
   - 11698461-n
   - 13154372-n
   partOfSpeech: n
+  wikidata: Q11575
 12164634-n:
   definition:
   - (Great Britain) any of various cereal plants (especially the dominant crop of
@@ -34364,6 +35418,7 @@
   mero_part:
   - 07820747-n
   partOfSpeech: n
+  wikidata: Q15251393
 12166617-n:
   definition:
   - lawn grasses native to southeastern Asia and New Zealand; grown especially in
@@ -34411,6 +35466,7 @@
   - Japanese lawn grass
   - Zoysia japonica
   partOfSpeech: n
+  wikidata: Q15227563
 12167340-n:
   definition:
   - Asiatic creeping perennial grass; introduced in southern United States as a drought-resistant
@@ -34423,6 +35479,7 @@
   - Korean velvet grass
   - Zoysia tenuifolia
   partOfSpeech: n
+  wikidata: Q3023700
 12167548-n:
   definition:
   - bamboos
@@ -34487,6 +35544,7 @@
   mero_part:
   - 07735075-n
   partOfSpeech: n
+  wikidata: Q3219428
 12168596-n:
   definition:
   - North American bamboo
@@ -34512,6 +35570,7 @@
   - cane reed
   - Arundinaria gigantea
   partOfSpeech: n
+  wikidata: Q2866037
 12168956-n:
   definition:
   - small cane of watery or moist areas in southern United States
@@ -34523,6 +35582,7 @@
   - switch cane
   - Arundinaria tecta
   partOfSpeech: n
+  wikidata: Q30755265
 12169127-n:
   definition:
   - giant clump-forming bamboos
@@ -34548,6 +35608,7 @@
   - kyo-chiku
   - Dendrocalamus giganteus
   partOfSpeech: n
+  wikidata: Q140227
 12169479-n:
   definition:
   - medium and large bamboos
@@ -34601,6 +35662,7 @@
   - ku-chiku
   - Phyllostachys bambusoides
   partOfSpeech: n
+  wikidata: Q28933428
 12170268-n:
   definition:
   - bulrush, chufa, cotton grass, papyrus, umbrella plant
@@ -34675,6 +35737,7 @@
   - rush nut
   - Cyperus esculentus
   partOfSpeech: n
+  wikidata: Q1165724
 12171687-n:
   definition:
   - European sedge having rough-edged leaves and spikelets of reddish flowers and
@@ -34703,6 +35766,7 @@
   - paper plant
   - Cyperus papyrus
   partOfSpeech: n
+  wikidata: Q158808
 12172132-n:
   definition:
   - a widely distributed perennial sedge having small edible nutlike tubers
@@ -34755,6 +35819,7 @@
   - cypress sedge
   - Carex pseudocyperus
   partOfSpeech: n
+  wikidata: Q159021
 12172923-n:
   definition:
   - cotton grass
@@ -34788,6 +35853,7 @@
   - common cotton grass
   - Eriophorum angustifolium
   partOfSpeech: n
+  wikidata: Q161783
 12173386-n:
   definition:
   - rhizomatous perennial grasslike herbs
@@ -34813,6 +35879,9 @@
   - hardstemmed bulrush
   - Scirpus acutus
   partOfSpeech: n
+  wikidata:
+  - Q15628951
+  - Q38663645
 12173741-n:
   definition:
   - sedge of eastern North America having numerous clustered woolly spikelets
@@ -34859,6 +35928,7 @@
   mero_part:
   - 07753956-n
   partOfSpeech: n
+  wikidata: Q932664
 12174431-n:
   definition:
   - fine-leaved aquatic spike rush; popular as aerator for aquariums
@@ -34872,6 +35942,7 @@
   - hair grass
   - Eleocharis acicularis
   partOfSpeech: n
+  wikidata: Q159148
 12174631-n:
   definition:
   - cylindrical-stemmed sedge
@@ -34882,6 +35953,7 @@
   - creeping spike rush
   - Eleocharis palustris
   partOfSpeech: n
+  wikidata: Q159020
 12174745-n:
   definition:
   - families Typhaceae, Sparganiaceae, Pandanaceae
@@ -34945,6 +36017,7 @@
   - lauhala
   - Pandanus tectorius
   partOfSpeech: n
+  wikidata: Q312736
 12175643-n:
   definition:
   - fiber from leaves of the pandanus tree; used for woven articles (such as mats)
@@ -35007,6 +36080,7 @@
   - reedmace
   - Typha latifolia
   partOfSpeech: n
+  wikidata: Q147520
 12176634-n:
   definition:
   - reed maces of America, Europe, North Africa, Asia
@@ -35020,6 +36094,7 @@
   - soft flag
   - Typha angustifolia
   partOfSpeech: n
+  wikidata: Q146572
 12176825-n:
   definition:
   - coextensive with the genus Sparganium
@@ -35176,6 +36251,7 @@
   - 07751486-n
   - 07786739-n
   partOfSpeech: n
+  wikidata: Q7229863
 12179315-n:
   definition:
   - any of numerous annual trailing plants of the genus Cucurbita grown for their
@@ -35316,6 +36392,7 @@
   mero_part:
   - 07733459-n
   partOfSpeech: n
+  wikidata: Q161180
 12181802-n:
   definition:
   - squash plants bearing hard-shelled fruit shaped somewhat like a turban with a
@@ -35380,7 +36457,9 @@
   mero_part:
   - 07733940-n
   partOfSpeech: n
-  wikidata: Q311251
+  wikidata:
+  - Q311251
+  - Q87618253
 12182942-n:
   definition:
   - perennial vine of dry parts of central and southwestern United States and Mexico
@@ -35399,6 +36478,7 @@
   mero_part:
   - 12183275-n
   partOfSpeech: n
+  wikidata: Q311136
 12183275-n:
   definition:
   - small hard green-and-white inedible fruit of the prairie gourd plant
@@ -35443,6 +36523,7 @@
   - devil's turnip
   - Bryonia alba
   partOfSpeech: n
+  wikidata: Q157980
 12183973-n:
   definition:
   - bryony having fleshy roots pale green flowers and very small red berries; found
@@ -35455,6 +36536,9 @@
   - wild hop
   - Bryonia dioica
   partOfSpeech: n
+  wikidata:
+  - Q58611551
+  - Q163815
 12184166-n:
   definition:
   - a dicot genus of the family Cucurbitaceae including watermelons
@@ -35494,6 +36578,7 @@
   mero_part:
   - 07772927-n
   partOfSpeech: n
+  wikidata: Q30558042
 12184732-n:
   definition:
   - cucumbers; muskmelons
@@ -35523,6 +36608,7 @@
   mero_part:
   - 07771683-n
   partOfSpeech: n
+  wikidata: Q81602
 12185173-n:
   definition:
   - a variety of muskmelon vine having fruit with a tan rind and orange flesh
@@ -35582,6 +36668,7 @@
   mero_part:
   - 07734217-n
   partOfSpeech: n
+  wikidata: Q23425
 12186125-n:
   definition:
   - exploding cucumber; squirting cucumber
@@ -35633,6 +36720,7 @@
   - calabash
   - Lagenaria siceraria
   partOfSpeech: n
+  wikidata: Q1277255
 12186829-n:
   definition:
   - dishcloth gourds
@@ -35673,6 +36761,7 @@
   - vegetable sponge
   - Luffa cylindrica
   partOfSpeech: n
+  wikidata: Q17465532
 12187446-n:
   definition:
   - loofah of Pakistan; widely cultivated throughout tropics
@@ -35722,6 +36811,7 @@
   - balsam apple
   - Momordica balsamina
   partOfSpeech: n
+  wikidata: Q2672305
 12188119-n:
   definition:
   - tropical Old World vine with yellow-orange fruit
@@ -35732,6 +36822,7 @@
   - balsam pear
   - Momordica charantia
   partOfSpeech: n
+  wikidata: Q428750
 12188266-n:
   definition:
   - a family of sappy plants that grow in Australasia and southeast China
@@ -35815,6 +36906,7 @@
   - bladderpod
   - Lobelia inflata
   partOfSpeech: n
+  wikidata: Q1661351
 12189616-n:
   definition:
   - erect perennial aquatic herb of Europe and North America having submerged spongy
@@ -35943,6 +37035,7 @@
   - common mallow
   - Malva neglecta
   partOfSpeech: n
+  wikidata: Q153343
 12192020-n:
   definition:
   - erect or decumbent Old World perennial with axillary clusters of rosy-purple flowers;
@@ -35957,6 +37050,7 @@
   - cheeseflower
   - Malva sylvestris
   partOfSpeech: n
+  wikidata: Q156835
 12192267-n:
   definition:
   - genus of tropical coarse herbs having large lobed leaves and often yellow flowers
@@ -35990,6 +37084,7 @@
   - 07749370-n
   - 12192881-n
   partOfSpeech: n
+  wikidata: Q80531
 12192881-n:
   definition:
   - long green edible beaked pods of the okra plant
@@ -36012,6 +37107,7 @@
   - Abelmoschus moschatus
   - Hibiscus moschatus
   partOfSpeech: n
+  wikidata: Q2086536
 12193232-n:
   definition:
   - 'herbs or shrubs or small trees: flowering maple; Indian mallow'
@@ -36090,6 +37186,7 @@
   - Alcea rosea
   - Althea rosea
   partOfSpeech: n
+  wikidata: Q27682
 12194641-n:
   definition:
   - hollyhocks; in some classification systems synonymous with genus Alcea
@@ -36161,6 +37258,7 @@
   - fringed poppy mallow
   - Callirhoe digitata
   partOfSpeech: n
+  wikidata: Q15360249
 12195887-n:
   definition:
   - hairy perennial of central United States having round deeply lobed leaves and
@@ -36172,6 +37270,7 @@
   - purple poppy mallow
   - Callirhoe involucrata
   partOfSpeech: n
+  wikidata: Q5741238
 12196115-n:
   definition:
   - densely hairy perennial having mostly triangular basal leaves and rose-purple
@@ -36183,6 +37282,7 @@
   - clustered poppy mallow
   - Callirhoe triangulata
   partOfSpeech: n
+  wikidata: Q15359615
 12196314-n:
   definition:
   - 'herbs and shrubs and small trees: cotton'
@@ -36220,6 +37320,7 @@
   - tree cotton
   - Gossypium arboreum
   partOfSpeech: n
+  wikidata: Q310124
 12196970-n:
   definition:
   - small bushy tree grown on islands of the Caribbean and off the Atlantic coast
@@ -36256,6 +37357,7 @@
   - upland cotton
   - Gossypium hirsutum
   partOfSpeech: n
+  wikidata: Q133481
 12197646-n:
   definition:
   - cotton with long rough hairy fibers
@@ -36266,6 +37368,7 @@
   - Peruvian cotton
   - Gossypium peruvianum
   partOfSpeech: n
+  wikidata: Q87626490
 12197766-n:
   definition:
   - fine somewhat brownish long-staple cotton grown in Egypt; believed to be derived
@@ -36287,6 +37390,7 @@
   - Arizona wild cotton
   - Gossypium thurberi
   partOfSpeech: n
+  wikidata: Q5587520
 12198109-n:
   definition:
   - large genus of tropical and subtropical herbs and shrubs and trees often grown
@@ -36327,6 +37431,7 @@
   mero_part:
   - 12198875-n
   partOfSpeech: n
+  wikidata: Q1137540
 12198875-n:
   definition:
   - fiber from an East Indian plant Hibiscus cannabinus
@@ -36352,7 +37457,9 @@
   - mahagua
   - Hibiscus elatus
   partOfSpeech: n
-  wikidata: Q2716624
+  wikidata:
+  - Q50875360
+  - Q2716624
 12199297-n:
   definition:
   - Australian tree with acid foliage
@@ -36378,6 +37485,7 @@
   - swamp rose mallow
   - Hibiscus moscheutos
   partOfSpeech: n
+  wikidata: Q159479
 12199639-n:
   definition:
   - Chinese shrub or small tree having white or pink flowers becoming deep red at
@@ -36423,6 +37531,7 @@
   - Jamaica sorrel
   - Hibiscus sabdariffa
   partOfSpeech: n
+  wikidata: Q319390
 12200424-n:
   definition:
   - Asiatic shrub or small shrubby tree having showy bell-shaped rose or purple or
@@ -36435,6 +37544,7 @@
   - rose of Sharon
   - Hibiscus syriacus
   partOfSpeech: n
+  wikidata: Q157756
 12200685-n:
   definition:
   - shrubby tree widely distributed along tropical shores; yields a light tough wood
@@ -36451,6 +37561,9 @@
   - purau
   - Hibiscus tiliaceus
   partOfSpeech: n
+  wikidata:
+  - Q715899
+  - Q15768656
 12200973-n:
   definition:
   - annual weedy herb with ephemeral yellow purple-eyed flowers; Old World tropics;
@@ -36465,6 +37578,7 @@
   - black-eyed Susan
   - Hibiscus trionum
   partOfSpeech: n
+  wikidata: Q157854
 12201231-n:
   definition:
   - 'small genus of shrubs and small trees of New Zealand: lacebarks'
@@ -36491,6 +37605,7 @@
   - houhere
   - Hoheria populnea
   partOfSpeech: n
+  wikidata: Q1623958
 12201664-n:
   definition:
   - small genus of perennial herbs or subshrubs; some often placed in other genera
@@ -36517,6 +37632,7 @@
   - Iliamna remota
   - Sphaeralcea remota
   partOfSpeech: n
+  wikidata: Q15375635
 12202129-n:
   definition:
   - perennial of northwestern United States and western Canada resembling a hollyhock
@@ -36529,6 +37645,7 @@
   - Iliamna ruvularis
   - Iliamna acerifolia
   partOfSpeech: n
+  wikidata: Q110135881
 12202368-n:
   definition:
   - small genus of herbs of southeastern United States and tropical America and Africa
@@ -36589,6 +37706,9 @@
   - velvet-leaf
   - Lavatera arborea
   partOfSpeech: n
+  wikidata:
+  - Q12210226
+  - Q811549
 12203375-n:
   definition:
   - 'genus of shrubs or small trees: chaparral mallow'
@@ -36638,6 +37758,7 @@
   - malope
   - Malope trifida
   partOfSpeech: n
+  wikidata: Q638145
 12204153-n:
   definition:
   - genus of mallows characterized by red and yellow flowers often placed in other
@@ -36708,6 +37829,7 @@
   - glade mallow
   - Napaea dioica
   partOfSpeech: n
+  wikidata: Q21977569
 12205241-n:
   definition:
   - genus of tropical hairy shrubs or herbs of tropics and subtropics especially South
@@ -36759,6 +37881,7 @@
   mero_substance:
   - 12206043-n
   partOfSpeech: n
+  wikidata: Q16947807
 12206043-n:
   definition:
   - a fiber from the bast of New Zealand ribbon trees that resembles cotton fiber
@@ -36793,6 +37916,7 @@
   - Radyera farragei
   - Hibiscus farragei
   partOfSpeech: n
+  wikidata: Q15381586
 12206633-n:
   definition:
   - large genus of tropical subshrubs or herbs some of which yield fibers of mucilaginous
@@ -36820,6 +37944,7 @@
   - Virginia mallow
   - Sida hermaphrodita
   partOfSpeech: n
+  wikidata: Q2281662
 12207071-n:
   definition:
   - herb widely distributed in tropics and subtropics used for forage and medicinally
@@ -36833,6 +37958,7 @@
   - jellyleaf
   - Sida rhombifolia
   partOfSpeech: n
+  wikidata: Q3595921
 12207356-n:
   definition:
   - tropical American weed having pale yellow or orange flowers naturalized in southern
@@ -36844,6 +37970,7 @@
   - Indian mallow
   - Sida spinosa
   partOfSpeech: n
+  wikidata: Q5394062
 12207547-n:
   definition:
   - genus of showy plants of western North America having palmate leaves and variously
@@ -36869,6 +37996,7 @@
   - wild hollyhock
   - Sidalcea malviflora
   partOfSpeech: n
+  wikidata: Q4418705
 12207967-n:
   definition:
   - 'large genus of chiefly tropical herbs with showy flowers and mostly globose fruits:
@@ -36907,6 +38035,7 @@
   - Sphaeralcea coccinea
   - Malvastrum coccineum
   partOfSpeech: n
+  wikidata: Q3744036
 12208637-n:
   definition:
   - a small genus of tropical trees including the portia tree
@@ -36954,6 +38083,7 @@
   - seaside mahoe
   - Thespesia populnea
   partOfSpeech: n
+  wikidata: Q715739
 12209502-n:
   definition:
   - tropical trees with large dry or fleshy fruit containing usually woolly seeds
@@ -36998,6 +38128,7 @@
   - Bombax ceiba
   - Bombax malabarica
   partOfSpeech: n
+  wikidata: Q13399160
 12210137-n:
   definition:
   - baobab; cream-of-tartar tree
@@ -37145,6 +38276,7 @@
   mero_substance:
   - 12212330-n
   partOfSpeech: n
+  wikidata: Q50853353
 12212330-n:
   definition:
   - strong lightweight wood of the balsa tree used especially for floats
@@ -37229,6 +38361,7 @@
   - 12213722-n
   - 12213851-n
   partOfSpeech: n
+  wikidata: Q50828866
 12213722-n:
   definition:
   - pale easily worked timber from the quandong tree
@@ -37276,7 +38409,9 @@
   - Aristotelia serrata
   - Aristotelia racemosa
   partOfSpeech: n
-  wikidata: Q151178
+  wikidata:
+  - Q151178
+  - Q50827497
 12214481-n:
   definition:
   - 'one species: Jamaican cherry; sometimes placed in family Flacourtiaceae'
@@ -37305,6 +38440,7 @@
   - silkwood
   - Muntingia calabura
   partOfSpeech: n
+  wikidata: Q1915507
 12214983-n:
   definition:
   - genus of tropical hardwood timber trees
@@ -37330,6 +38466,7 @@
   - break-axe
   - Sloanea jamaicensis
   partOfSpeech: n
+  wikidata: Q18010233
 12215293-n:
   definition:
   - a large family of plants of order Malvales
@@ -37438,6 +38575,7 @@
   - Brachychiton acerifolius
   - Sterculia acerifolia
   partOfSpeech: n
+  wikidata: Q907118
 12217044-n:
   definition:
   - north Australian tree having white flowers and broad leaves
@@ -37449,6 +38587,7 @@
   - broad-leaved bottletree
   - Brachychiton australis
   partOfSpeech: n
+  wikidata: Q15358617
 12217211-n:
   definition:
   - widely distributed tree of eastern Australia yielding a tough durable fiber and
@@ -37631,6 +38770,7 @@
   - nut-leaved screw tree
   - Helicteres isora
   partOfSpeech: n
+  wikidata: Q5705291
 12220081-n:
   definition:
   - small genus of timber trees of eastern Asia, Australasia and tropical Africa that
@@ -37661,6 +38801,7 @@
   - Heritiera trifoliolata
   - Terrietia trifoliolata
   partOfSpeech: n
+  wikidata: Q17574079
 12220499-n:
   definition:
   - large evergreen tree of India and Burma whose leaves are silvery beneath
@@ -37671,6 +38812,7 @@
   - looking glass tree
   - Heritiera macrophylla
   partOfSpeech: n
+  wikidata: Q15373470
 12220660-n:
   definition:
   - small tree of coastal regions of Old World tropics whose leaves are silvery beneath
@@ -37681,6 +38823,7 @@
   - looking-glass plant
   - Heritiera littoralis
   partOfSpeech: n
+  wikidata: Q2574713
 12220832-n:
   definition:
   - genus of African herbs and subshrubs having honey-scented bell-shaped flowers
@@ -37707,6 +38850,7 @@
   - Hermannia verticillata
   - Mahernia verticillata
   partOfSpeech: n
+  wikidata: Q110131202
 12221264-n:
   definition:
   - genus of tropical Asian trees and shrubs
@@ -37732,6 +38876,7 @@
   - maple-leaved bayur
   - Pterospermum acerifolium
   partOfSpeech: n
+  wikidata: Q33221
 12221683-n:
   definition:
   - small genus of east Asian and Australian timber trees
@@ -37755,6 +38900,7 @@
   - silver tree
   - Tarrietia argyrodendron
   partOfSpeech: n
+  wikidata: Q110120647
 12221973-n:
   definition:
   - cacao plants
@@ -37780,6 +38926,7 @@
   - chocolate tree
   - Theobroma cacao
   partOfSpeech: n
+  wikidata: Q42385
 12222278-n:
   definition:
   - small genus of tropical African trees with maplelike leaves
@@ -37889,6 +39036,7 @@
   - American lime
   - Tilia americana
   partOfSpeech: n
+  wikidata: Q163981
 12224216-n:
   definition:
   - large spreading European linden with small dark green leaves; often cultivated
@@ -37913,7 +39061,9 @@
   - cottonwood
   - Tilia heterophylla
   partOfSpeech: n
-  wikidata: Q6579882
+  wikidata:
+  - Q29021531
+  - Q6579882
 12224549-n:
   definition:
   - medium-sized tree of Japan used as an ornamental
@@ -37997,6 +39147,7 @@
   - phalsa
   - Grewia asiatica
   partOfSpeech: n
+  wikidata: Q1998501
 12225825-n:
   definition:
   - small genus of tropical African shrubs
@@ -38198,6 +39349,7 @@
   - honey-flower
   - Protea mellifera
   partOfSpeech: n
+  wikidata: Q50847755
 12235890-n:
   definition:
   - important genus of Australian evergreen shrubs or trees with alternate leathery
@@ -38233,6 +39385,7 @@
   - coast banksia
   - Banksia integrifolia
   partOfSpeech: n
+  wikidata: Q1999614
 12236545-n:
   definition:
   - 'Australian shrubs (some trees) with flowers in dense spikes: smoke bush'
@@ -38355,7 +39508,9 @@
   - red-flowered silky oak
   - Grevillea banksii
   partOfSpeech: n
-  wikidata: Q138429
+  wikidata:
+  - Q65939934
+  - Q138429
 12238571-n:
   definition:
   - small slender tree with usually entire grey-green pendulous leaves and white or
@@ -38378,6 +39533,9 @@
   - silky oak
   - Grevillea robusta
   partOfSpeech: n
+  wikidata:
+  - Q65940436
+  - Q1989614
 12239007-n:
   definition:
   - tree yielding hard heavy reddish wood
@@ -38390,6 +39548,9 @@
   mero_substance:
   - 12246286-n
   partOfSpeech: n
+  wikidata:
+  - Q65940485
+  - Q954138
 12239138-n:
   definition:
   - Australian shrubs and small trees with evergreen usually spiny leaves and dense
@@ -38417,6 +39578,7 @@
   - pincushion hakea
   - Hakea laurina
   partOfSpeech: n
+  wikidata: Q2705988
 12239582-n:
   definition:
   - large bushy shrub with pungent pointed leaves and creamy white flowers; central
@@ -38430,6 +39592,7 @@
   - needle wood
   - Hakea leucoptera
   partOfSpeech: n
+  wikidata: Q16982618
 12239806-n:
   definition:
   - shrub with pungent rigid needle-shaped leaves and white flowers; eastern Australia
@@ -38442,6 +39605,9 @@
   - needle bush
   - Hakea lissosperma
   partOfSpeech: n
+  wikidata:
+  - Q66116230
+  - Q18079936
 12240012-n:
   definition:
   - small genus of trees or shrubs of New Zealand and New Caledonia
@@ -38573,6 +39739,7 @@
   members:
   - Macadamia integrifolia
   partOfSpeech: n
+  wikidata: Q311178
 12242039-n:
   definition:
   - small Australian tree with racemes of pink flowers; widely cultivated (especially
@@ -38589,6 +39756,7 @@
   mero_part:
   - 07790572-n
   partOfSpeech: n
+  wikidata: Q12176904
 12242318-n:
   definition:
   - bushy tree with pink to purple flowers
@@ -38688,7 +39856,7 @@
   mero_substance:
   - 12246286-n
   partOfSpeech: n
-  wikidata: Q4879779
+  wikidata: Q7607619
 12243922-n:
   definition:
   - waratahs (Telopea)
@@ -38714,6 +39882,7 @@
   - waratah
   - Telopea oreades
   partOfSpeech: n
+  wikidata: Q7697821
 12244281-n:
   definition:
   - straggling shrub with narrow leaves and conspicuous red flowers in dense globular
@@ -38750,6 +39919,7 @@
   - woody pear
   - Xylomelum pyriforme
   partOfSpeech: n
+  wikidata: Q8045461
 12244826-n:
   definition:
   - 'order of chiefly Australian trees and shrubs comprising the casuarinas; 1 family:
@@ -38951,6 +40121,7 @@
   mero_part:
   - 12248426-n
   partOfSpeech: n
+  wikidata: Q176647
 12248426-n:
   definition:
   - hard woody root of the briar Erica arborea
@@ -38998,6 +40169,7 @@
   - fine-leaved heath
   - Erica cinerea
   partOfSpeech: n
+  wikidata: Q1543735
 12249063-n:
   definition:
   - dwarf European shrub with rose-colored flowers
@@ -39046,6 +40218,7 @@
   - Prince of Wales heath
   - Erica perspicua
   partOfSpeech: n
+  wikidata: Q15382993
 12249799-n:
   definition:
   - low-growing shrubs of northern regions of Northern Hemisphere
@@ -39080,6 +40253,7 @@
   - moorwort
   - Andromeda glaucophylla
   partOfSpeech: n
+  wikidata: Q15370045
 12250404-n:
   definition:
   - erect to procumbent evergreen shrub having pendent clusters of white or pink flowers;
@@ -39092,6 +40266,7 @@
   - common bog rosemary
   - Andromeda polifolia
   partOfSpeech: n
+  wikidata: Q742866
 12250663-n:
   definition:
   - 'large evergreen shrubs and trees of southern Europe and western North America:
@@ -39127,6 +40302,7 @@
   - manzanita
   - Arbutus menziesii
   partOfSpeech: n
+  wikidata: Q469695
 12251311-n:
   definition:
   - small evergreen European shrubby tree bearing many-seeded scarlet berries that
@@ -39139,6 +40315,7 @@
   - Irish strawberry
   - Arbutus unedo
   partOfSpeech: n
+  wikidata: Q329046
 12251548-n:
   definition:
   - bearberry; manzanita
@@ -39182,6 +40359,7 @@
   - creashak
   - Arctostaphylos uva-ursi
   partOfSpeech: n
+  wikidata: Q208032
 12252226-n:
   definition:
   - deciduous creeping shrub bright red in autumn having black or blue-black berries;
@@ -39214,6 +40392,7 @@
   - heartleaf manzanita
   - Arctostaphylos andersonii
   partOfSpeech: n
+  wikidata: Q4787650
 12252797-n:
   definition:
   - erect treelike shrub forming dense thickets and having drooping panicles of white
@@ -39237,6 +40416,7 @@
   - woolly manzanita
   - Arctostaphylos tomentosa
   partOfSpeech: n
+  wikidata: Q4787702
 12253200-n:
   definition:
   - 'a genus containing only one species: spike heath'
@@ -39261,6 +40441,7 @@
   - spike heath
   - Bruckenthalia spiculifolia
   partOfSpeech: n
+  wikidata: Q593458
 12253611-n:
   definition:
   - a genus allied to and once included in genus Phyllodoce
@@ -39310,6 +40491,7 @@
   - broom
   - Calluna vulgaris
   partOfSpeech: n
+  wikidata: Q26615
 12254276-n:
   definition:
   - low tufted evergreen shrubs of colder parts of north temperate regions having
@@ -39334,6 +40516,7 @@
   - white heather
   - Cassiope mertensiana
   partOfSpeech: n
+  wikidata: Q4168143
 12254693-n:
   definition:
   - 'one species: leatherleaf'
@@ -39384,6 +40567,7 @@
   - St. Dabeoc's heath
   - Daboecia cantabrica
   partOfSpeech: n
+  wikidata: Q1156577
 12255430-n:
   definition:
   - 'small creeping evergreen shrubs: trailing arbutus'
@@ -39407,6 +40591,7 @@
   - mayflower
   - Epigaea repens
   partOfSpeech: n
+  wikidata: Q4532195
 12255780-n:
   definition:
   - widely distributed genus of creeping or upright evergreen shrubs
@@ -39508,6 +40693,7 @@
   mero_part:
   - 07759360-n
   partOfSpeech: n
+  wikidata: Q5528871
 12257494-n:
   definition:
   - huckleberry of the eastern United States with pink flowers and sweet blue fruit
@@ -39519,6 +40705,7 @@
   - dangle-berry
   - Gaylussacia frondosa
   partOfSpeech: n
+  wikidata: Q5528874
 12257669-n:
   definition:
   - creeping evergreen shrub of southeastern United States having small shiny boxlike
@@ -39530,6 +40717,7 @@
   - box huckleberry
   - Gaylussacia brachycera
   partOfSpeech: n
+  wikidata: Q5528872
 12257867-n:
   definition:
   - 'erect evergreen shrubs: mountain laurel'
@@ -39565,6 +40753,7 @@
   - calico bush
   - Kalmia latifolia
   partOfSpeech: n
+  wikidata: Q1235131
 12258372-n:
   definition:
   - laurel of bogs of northwestern United States having small purple flowers and pale
@@ -39592,6 +40781,7 @@
   - lambkill
   - Kalmia angustifolia
   partOfSpeech: n
+  wikidata: Q3192236
 12258823-n:
   definition:
   - evergreen shrubs of north temperate regions
@@ -39619,6 +40809,9 @@
   - crystal tea
   - Ledum groenlandicum
   partOfSpeech: n
+  wikidata:
+  - Q247753
+  - Q38907427
 12259273-n:
   definition:
   - a Rocky Mountain shrub similar to Ledum groenlandicum
@@ -39640,6 +40833,7 @@
   - marsh tea
   - Ledum palustre
   partOfSpeech: n
+  wikidata: Q21975996
 12259617-n:
   definition:
   - 'one species: sand myrtle'
@@ -39664,6 +40858,7 @@
   - sand myrtle
   - Leiophyllum buxifolium
   partOfSpeech: n
+  wikidata: Q32858428
 12259975-n:
   definition:
   - American and Asiatic deciduous and evergreen shrubs
@@ -39702,6 +40897,7 @@
   - Leucothoe fontanesiana
   - Leucothoe editorum
   partOfSpeech: n
+  wikidata: Q6534431
 12260667-n:
   definition:
   - bushy deciduous shrub of the eastern United States with long racemes of pinkish
@@ -39713,6 +40909,7 @@
   - sweet bells
   - Leucothoe racemosa
   partOfSpeech: n
+  wikidata: Q15386933
 12260852-n:
   definition:
   - 'one species: alpine azalea'
@@ -39766,6 +40963,7 @@
   - stagger bush
   - Lyonia mariana
   partOfSpeech: n
+  wikidata: Q17244999
 12261709-n:
   definition:
   - deciduous much-branched shrub with dense downy panicles of small bell-shaped white
@@ -39833,6 +41031,7 @@
   - minnie bush
   - Menziesia pilosa
   partOfSpeech: n
+  wikidata: Q15386778
 12262804-n:
   definition:
   - sourwood
@@ -39926,6 +41125,7 @@
   - lily-of-the-valley tree
   - Pieris japonica
   partOfSpeech: n
+  wikidata: Q2333372
 12264210-n:
   definition:
   - ornamental evergreen shrub of southeastern United States having small white bell-shaped
@@ -39975,6 +41175,9 @@
   - coast rhododendron
   - Rhododendron californicum
   partOfSpeech: n
+  wikidata:
+  - Q15387197
+  - Q38907276
 12265167-n:
   definition:
   - late-spring-blooming rhododendron of eastern North America having rosy to pink-purple
@@ -39999,6 +41202,7 @@
   - white honeysuckle
   - Rhododendron viscosum
   partOfSpeech: n
+  wikidata: Q15392729
 12265584-n:
   definition:
   - group of evergreen or deciduous shrubs formerly considered a separate genus; now
@@ -40059,6 +41263,9 @@
   mero_part:
   - 07759878-n
   partOfSpeech: n
+  wikidata:
+  - Q50852926
+  - Q149397
 12266554-n:
   definition:
   - small red-fruited trailing cranberry of Arctic and cool regions of the Northern
@@ -40071,6 +41278,7 @@
   - small cranberry
   - Vaccinium oxycoccus
   partOfSpeech: n
+  wikidata: Q113227308
 12266749-n:
   definition:
   - any of numerous shrubs of the genus Vaccinium bearing blueberries
@@ -40101,6 +41309,7 @@
   - sparkleberry
   - Vaccinium arboreum
   partOfSpeech: n
+  wikidata: Q3249733
 12267458-n:
   definition:
   - low-growing deciduous shrub of northeastern North America having flowers in compact
@@ -40114,6 +41323,7 @@
   - Vaccinium angustifolium
   - Vaccinium pennsylvanicum
   partOfSpeech: n
+  wikidata: Q41393482
 12267719-n:
   definition:
   - shrub of southeastern United States grown commercially especially for canning
@@ -40127,6 +41337,7 @@
   - rabbiteye
   - Vaccinium ashei
   partOfSpeech: n
+  wikidata: Q41778446
 12267924-n:
   definition:
   - low-growing tufted deciduous shrub of northern and alpine North America having
@@ -40156,6 +41367,7 @@
   mero_part:
   - 07759520-n
   partOfSpeech: n
+  wikidata: Q468695
 12268480-n:
   definition:
   - shrub of the eastern United States having shining evergreen leaves and bluish-black
@@ -40231,6 +41443,7 @@
   - dryland berry
   - Vaccinium pallidum
   partOfSpeech: n
+  wikidata: Q7907968
 12269639-n:
   definition:
   - shrub of northwestern North America bearing red berries
@@ -40243,6 +41456,7 @@
   - grouse whortleberry
   - Vaccinium scoparium
   partOfSpeech: n
+  wikidata: Q7907969
 12269811-n:
   definition:
   - small branching blueberry common in marshy areas of the eastern United States
@@ -40255,6 +41469,9 @@
   - squaw huckleberry
   - Vaccinium stamineum
   partOfSpeech: n
+  wikidata:
+  - Q15386677
+  - Q7907970
 12270059-n:
   definition:
   - low evergreen shrub of high north temperate regions of Europe and Asia and America
@@ -40273,6 +41490,7 @@
   mero_part:
   - 07760033-n
   partOfSpeech: n
+  wikidata: Q93235
 12270338-n:
   definition:
   - coextensive with the genus Clethra
@@ -40313,6 +41531,7 @@
   - white alder
   - Clethra alnifolia
   partOfSpeech: n
+  wikidata: Q5131966
 12270930-n:
   definition:
   - north temperate low evergreen plants; in some classifications placed in its own
@@ -40452,6 +41671,9 @@
   - oconee bells
   - Shortia galacifolia
   partOfSpeech: n
+  wikidata:
+  - Q15394339
+  - Q867748
 12273137-n:
   definition:
   - Australasian shrubs or small trees
@@ -40537,6 +41759,9 @@
   - Port Jackson heath
   - Epacris purpurascens
   partOfSpeech: n
+  wikidata:
+  - Q65942827
+  - Q15376759
 12274531-n:
   definition:
   - evergreen shrubs of Australia and Tasmania
@@ -40565,6 +41790,7 @@
   - Astroloma humifusum
   - Styphelia humifusum
   partOfSpeech: n
+  wikidata: Q4811591
 12274995-n:
   definition:
   - evergreen trees or shrubs of mountains of Australia and Tasmania
@@ -40590,6 +41816,7 @@
   - Australian grass tree
   - Richea dracophylla
   partOfSpeech: n
+  wikidata: Q7330383
 12275408-n:
   definition:
   - gaunt Tasmanian evergreen shrubby tree with slender tapering leaves 3 to 5 feet
@@ -40627,6 +41854,7 @@
   - pink fivecorner
   - Styphelia triflora
   partOfSpeech: n
+  wikidata: Q17242869
 12275969-n:
   definition:
   - family of fleshy parasitic herbs lacking green foliage and having heads of small
@@ -40689,6 +41917,7 @@
   - Pyrola americana
   - Pyrola rotundifolia americana
   partOfSpeech: n
+  wikidata: Q16988962
 12277039-n:
   definition:
   - the common wintergreen having many-flowered racemes of pink-tinged white flowers;
@@ -40700,6 +41929,7 @@
   - lesser wintergreen
   - Pyrola minor
   partOfSpeech: n
+  wikidata: Q950247
 12277225-n:
   definition:
   - North American evergreen with small pinkish bell-shaped flowers and oblong leaves
@@ -40712,6 +41942,7 @@
   - shinleaf
   - Pyrola elliptica
   partOfSpeech: n
+  wikidata: Q15387050
 12277437-n:
   definition:
   - evergreen with rounded leaves and very fragrant creamy-white flowers; widely distributed
@@ -40723,6 +41954,9 @@
   - wild lily of the valley
   - Pyrola rotundifolia
   partOfSpeech: n
+  wikidata:
+  - Q38908718
+  - Q692248
 12277657-n:
   definition:
   - a shrubby perennial rhizomatous evergreen herb; grows in damp coniferous woodlands
@@ -40771,6 +42005,7 @@
   - Chimaphila umbellata
   - Chimaphila corymbosa
   partOfSpeech: n
+  wikidata: Q158939
 12278437-n:
   definition:
   - 'one species: one-flowered wintergreen; sometimes included in genus Pyrola'
@@ -40867,6 +42102,7 @@
   - false beachdrops
   - Monotropa hypopithys
   partOfSpeech: n
+  wikidata: Q15248961
 12280132-n:
   definition:
   - snow plant; in some classifications placed in family Pyrolaceae
@@ -40891,6 +42127,7 @@
   - snow plant
   - Sarcodes sanguinea
   partOfSpeech: n
+  wikidata: Q63510
 12280538-n:
   definition:
   - an order of dicotyledonous trees of the subclass Hamamelidae
@@ -41022,6 +42259,7 @@
   - Fagus pendula
   - Fagus sylvatica pendula
   partOfSpeech: n
+  wikidata: Q111332760
 12282702-n:
   definition:
   - a beech native to Japan having soft light yellowish-brown wood
@@ -41084,6 +42322,7 @@
   - American sweet chestnut
   - Castanea dentata
   partOfSpeech: n
+  wikidata: Q468698
 12283721-n:
   definition:
   - wild or cultivated throughout southern Europe, northwestern Africa and southwestern
@@ -41108,6 +42347,7 @@
   - Chinese chestnut
   - Castanea mollissima
   partOfSpeech: n
+  wikidata: Q699584
 12284105-n:
   definition:
   - a spreading tree of Japan that has a short trunk
@@ -41118,6 +42358,7 @@
   - Japanese chestnut
   - Castanea crenata
   partOfSpeech: n
+  wikidata: Q717827
 12284255-n:
   definition:
   - shrubby chestnut tree of southeastern United States having small edible nuts
@@ -41133,6 +42374,7 @@
   mero_part:
   - 07788389-n
   partOfSpeech: n
+  wikidata: Q3662068
 12284504-n:
   definition:
   - shrubby tree closely related to the Allegheny chinkapin but with larger leaves;
@@ -41211,6 +42453,7 @@
   - dwarf golden chinkapin
   - Chrysolepis sempervirens
   partOfSpeech: n
+  wikidata: Q15328842
 12285783-n:
   definition:
   - tanbark oaks
@@ -41235,6 +42478,7 @@
   - tanbark oak
   - Lithocarpus densiflorus
   partOfSpeech: n
+  wikidata: Q147724
 12286117-n:
   definition:
   - small evergreen tree of China and Japan
@@ -41308,6 +42552,7 @@
   - coigue
   - Nothofagus dombeyi
   partOfSpeech: n
+  wikidata: Q1107183
 12287313-n:
   definition:
   - any of several tall New Zealand trees of the genus Nothofagus; some yield useful
@@ -41328,6 +42573,7 @@
   - silver beech
   - Nothofagus menziesii
   partOfSpeech: n
+  wikidata: Q1434315
 12287650-n:
   definition:
   - tall deciduous South American tree
@@ -41349,6 +42595,7 @@
   - rauli beech
   - Nothofagus procera
   partOfSpeech: n
+  wikidata: Q41778148
 12287928-n:
   definition:
   - New Zealand forest tree
@@ -41369,6 +42616,7 @@
   - hard beech
   - Nothofagus truncata
   partOfSpeech: n
+  wikidata: Q2842474
 12288194-n:
   definition:
   - 'fruit of the oak tree: a smooth thin-walled nut in a woody cup-shaped base'
@@ -41493,6 +42741,7 @@
   - American white oak
   - Quercus alba
   partOfSpeech: n
+  wikidata: Q469555
 12290795-n:
   definition:
   - semi-evergreen shrub or small tree of Arizona and New Mexico having acorns with
@@ -41518,6 +42767,7 @@
   - swamp oak
   - Quercus bicolor
   partOfSpeech: n
+  wikidata: Q142792
 12291258-n:
   definition:
   - large deciduous tree of central and southern Europe and Asia Minor having lanceolate
@@ -41571,6 +42821,7 @@
   - northern pin oak
   - Quercus ellipsoidalis
   partOfSpeech: n
+  wikidata: Q241698
 12292160-n:
   definition:
   - any of numerous American oaks having 4 stamens in each floret, acorns requiring
@@ -41596,6 +42847,7 @@
   - turkey oak
   - Quercus falcata
   partOfSpeech: n
+  wikidata: Q1066116
 12292756-n:
   definition:
   - small deciduous tree of western North America with crooked branches and pale grey
@@ -41609,6 +42861,7 @@
   - Garry oak
   - Quercus garryana
   partOfSpeech: n
+  wikidata: Q2029492
 12292949-n:
   definition:
   - evergreen oak of southern Europe having leaves somewhat resembling those of holly;
@@ -41623,6 +42876,7 @@
   - evergreen oak
   - Quercus ilex
   partOfSpeech: n
+  wikidata: Q218155
 12293167-n:
   definition:
   - hard wood of the holm oak tree
@@ -41642,6 +42896,7 @@
   - bear oak
   - Quercus ilicifolia
   partOfSpeech: n
+  wikidata: Q1017264
 12293400-n:
   definition:
   - small deciduous tree of eastern and central United States having leaves that shine
@@ -41654,6 +42909,7 @@
   - laurel oak
   - Quercus imbricaria
   partOfSpeech: n
+  wikidata: Q528713
 12293631-n:
   definition:
   - small semi-evergreen shrubby tree of southeastern United States having hairy young
@@ -41691,6 +42947,7 @@
   - turkey oak
   - Quercus laevis
   partOfSpeech: n
+  wikidata: Q2586757
 12294285-n:
   definition:
   - large nearly semi-evergreen oak of southeastern United States; thrives in damp
@@ -41745,6 +43002,7 @@
   - mossycup oak
   - Quercus macrocarpa
   partOfSpeech: n
+  wikidata: Q1082365
 12295147-n:
   definition:
   - any of various chiefly American small shrubby oaks often a dominant form on thin
@@ -41780,6 +43038,7 @@
   - swamp chestnut oak
   - Quercus michauxii
   partOfSpeech: n
+  wikidata: Q1460497
 12295834-n:
   definition:
   - oak with moderately light fine-grained wood; Japan
@@ -41791,6 +43050,7 @@
   - Quercus mongolica
   - Quercus grosseserrata
   partOfSpeech: n
+  wikidata: Q1367359
 12296006-n:
   definition:
   - an oak having leaves resembling those of chestnut trees
@@ -41813,6 +43073,7 @@
   - yellow chestnut oak
   - Quercus muehlenbergii
   partOfSpeech: n
+  wikidata: Q2611816
 12296405-n:
   definition:
   - small evergreen shrub or tree of southeastern United States; often forms almost
@@ -41861,7 +43122,9 @@
   - Quercus petraea
   - Quercus sessiliflora
   partOfSpeech: n
-  wikidata: Q158608
+  wikidata:
+  - Q158608
+  - Q50852450
 12297145-n:
   definition:
   - medium to large deciduous tree of the eastern United States; its durable wood
@@ -41875,7 +43138,9 @@
   - Quercus prinus
   - Quercus montana
   partOfSpeech: n
-  wikidata: Q1735296
+  wikidata:
+  - Q1735296
+  - Q21877190
 12297389-n:
   definition:
   - fast-growing medium to large pyramidal deciduous tree of northeastern United States
@@ -41901,6 +43166,7 @@
   - willow oak
   - Quercus phellos
   partOfSpeech: n
+  wikidata: Q783224
 12297851-n:
   definition:
   - deciduous shrubby tree of northeastern and central United States having a sweet
@@ -41928,6 +43194,7 @@
   - pedunculate oak
   - Quercus robur
   partOfSpeech: n
+  wikidata: Q165145
 12298317-n:
   definition:
   - large symmetrical deciduous tree with rounded crown widely distributed in eastern
@@ -41941,6 +43208,7 @@
   - Quercus rubra
   - Quercus borealis
   partOfSpeech: n
+  wikidata: Q147525
 12298624-n:
   definition:
   - large deciduous red oak of southern and eastern United States having large seven-lobed
@@ -41981,6 +43249,7 @@
   - cork oak
   - Quercus suber
   partOfSpeech: n
+  wikidata: Q156137
 12299382-n:
   definition:
   - small deciduous tree having the trunk branched almost from the base with spreading
@@ -41992,6 +43261,7 @@
   - Spanish oak
   - Quercus texana
   partOfSpeech: n
+  wikidata: Q7271351
 12299577-n:
   definition:
   - a low spreading or prostrate shrub of southwestern United States with small acorns
@@ -42013,6 +43283,7 @@
   - Chinese cork oak
   - Quercus variabilis
   partOfSpeech: n
+  wikidata: Q192608
 12299975-n:
   definition:
   - medium to large deciduous timber tree of the eastern United States and southeastern
@@ -42028,6 +43299,7 @@
   - quercitron oak
   - Quercus velutina
   partOfSpeech: n
+  wikidata: Q1001011
 12300289-n:
   definition:
   - medium-sized evergreen native to eastern North America to the east coast of Mexico;
@@ -42040,6 +43312,7 @@
   - southern live oak
   - Quercus virginiana
   partOfSpeech: n
+  wikidata: Q1758722
 12300577-n:
   definition:
   - a small shrubby evergreen tree of western North America similar to the coast live
@@ -42140,6 +43413,7 @@
   - Betula alleghaniensis
   - Betula leutea
   partOfSpeech: n
+  wikidata: Q1499241
 12302491-n:
   definition:
   - small American birch with peeling white bark often worked into e.g. baskets or
@@ -42155,6 +43429,9 @@
   - Betula cordifolia
   - Betula papyrifera
   partOfSpeech: n
+  wikidata:
+  - Q28807132
+  - Q2900277
 12302752-n:
   definition:
   - medium-sized birch of eastern North America having white or pale grey bark and
@@ -42182,6 +43459,7 @@
   - European white birch
   - Betula pendula
   partOfSpeech: n
+  wikidata: Q156895
 12303254-n:
   definition:
   - European birch with dull white to pale brown bark and somewhat drooping hairy
@@ -42194,6 +43472,7 @@
   - white birch
   - Betula pubescens
   partOfSpeech: n
+  wikidata: Q157624
 12303450-n:
   definition:
   - birch of swamps and river bottoms throughout the eastern United States having
@@ -42207,6 +43486,7 @@
   - red birch
   - Betula nigra
   partOfSpeech: n
+  wikidata: Q1510231
 12303664-n:
   definition:
   - common birch of the eastern United States having spicy brown bark yielding a volatile
@@ -42220,6 +43500,7 @@
   - black birch
   - Betula lenta
   partOfSpeech: n
+  wikidata: Q227763
 12303912-n:
   definition:
   - Alaskan birch with white to pale brown bark
@@ -42246,6 +43527,7 @@
   - Western birch
   - Betula fontinalis
   partOfSpeech: n
+  wikidata: Q50829138
 12304307-n:
   definition:
   - small shrub of colder parts of North America and Greenland
@@ -42257,6 +43539,7 @@
   - American dwarf birch
   - Betula glandulosa
   partOfSpeech: n
+  wikidata: Q218417
 12304498-n:
   definition:
   - alders
@@ -42315,6 +43598,7 @@
   - Alnus glutinosa
   - Alnus vulgaris
   partOfSpeech: n
+  wikidata: Q156904
 12305566-n:
   definition:
   - native to Europe but introduced in America
@@ -42326,6 +43610,7 @@
   - gray alder
   - Alnus incana
   partOfSpeech: n
+  wikidata: Q157641
 12305712-n:
   definition:
   - shrub or small tree of southeastern United States having soft light brown wood
@@ -42336,6 +43621,7 @@
   - seaside alder
   - Alnus maritima
   partOfSpeech: n
+  wikidata: Q2589489
 12305886-n:
   definition:
   - tree of western United States
@@ -42360,6 +43646,7 @@
   - Oregon alder
   - Alnus rubra
   partOfSpeech: n
+  wikidata: Q1818806
 12306222-n:
   definition:
   - common shrub of Canada and northeastern United States having shoots scattered
@@ -42371,6 +43658,7 @@
   - speckled alder
   - Alnus rugosa
   partOfSpeech: n
+  wikidata: Q87593614
 12306417-n:
   definition:
   - common shrub of the eastern United States with smooth bark
@@ -42404,6 +43692,7 @@
   - Alnus veridis crispa
   - Alnus crispa
   partOfSpeech: n
+  wikidata: Q10513908
 12306889-n:
   definition:
   - used in some classification systems for the genera Carpinus, Ostryopsis, and Ostryopsis
@@ -42452,6 +43741,7 @@
   - European hornbeam
   - Carpinus betulus
   partOfSpeech: n
+  wikidata: Q158776
 12307712-n:
   definition:
   - tree or large shrub with grey bark and blue-green leaves that turn red-orange
@@ -42463,6 +43753,7 @@
   - American hornbeam
   - Carpinus caroliniana
   partOfSpeech: n
+  wikidata: Q468664
 12307905-n:
   definition:
   - deciduous monoecious trees of Europe and Asia and America; sometimes placed in
@@ -42498,6 +43789,7 @@
   - Old World hop hornbeam
   - Ostrya carpinifolia
   partOfSpeech: n
+  wikidata: Q1367533
 12308522-n:
   definition:
   - medium-sized hop hornbeam of eastern North America
@@ -42510,6 +43802,7 @@
   - ironwood tree
   - Ostrya virginiana
   partOfSpeech: n
+  wikidata: Q1489573
 12308705-n:
   definition:
   - deciduous monoecious shrubs of China and Mongolia resembling trees of the genus
@@ -42597,6 +43890,7 @@
   - Corylus avellana
   - Corylus avellana grandis
   partOfSpeech: n
+  wikidata: Q124969
 12310102-n:
   definition:
   - hazel of western United States with conspicuous beaklike involucres on the nuts
@@ -42607,6 +43901,7 @@
   - beaked hazelnut
   - Corylus cornuta
   partOfSpeech: n
+  wikidata: Q972950
 12310261-n:
   definition:
   - an order of dicotyledonous plants having gamopetalous flowers, Gentianaceae, Apocynaceae,
@@ -42696,6 +43991,7 @@
   - lesser centaury
   - Centaurium minus
   partOfSpeech: n
+  wikidata: Q111802984
 12311809-n:
   definition:
   - tufted perennial of western Europe and Azores having bright pink to white flowers
@@ -42706,6 +44002,7 @@
   - tufted centaury
   - Centaurium scilloides
   partOfSpeech: n
+  wikidata: Q11985047
 12311976-n:
   definition:
   - a variety of centaury found at the seaside
@@ -42761,6 +44058,7 @@
   - bluebell
   - Eustoma grandiflorum
   partOfSpeech: n
+  wikidata: Q15708981
 12312802-n:
   definition:
   - 'genus of tropical Asiatic and African plants: especially Persian violets'
@@ -42828,6 +44126,7 @@
   - Frasera speciosa
   - Swertia speciosa
   partOfSpeech: n
+  wikidata: Q3025675
 12313936-n:
   definition:
   - type genus of the Gentianaceae; cosmopolitan genus of herbs nearly cosmopolitan
@@ -42865,6 +44164,7 @@
   - gentianella
   - Gentiana acaulis
   partOfSpeech: n
+  wikidata: Q163785
 12314848-n:
   definition:
   - gentian of eastern North America having tubular blue or white flowers that open
@@ -42890,6 +44190,7 @@
   - explorer's gentian
   - Gentiana calycosa
   partOfSpeech: n
+  wikidata: Q3007193
 12315240-n:
   definition:
   - similar to Gentiana andrewsii but with larger flowers
@@ -42912,6 +44213,7 @@
   - great yellow gentian
   - Gentiana lutea
   partOfSpeech: n
+  wikidata: Q158572
 12315550-n:
   definition:
   - perennial Eurasian gentian with sky-blue funnel-shaped flowers of damp open heaths
@@ -42923,6 +44225,7 @@
   - calathian violet
   - Gentiana pneumonanthe
   partOfSpeech: n
+  wikidata: Q161548
 12315754-n:
   definition:
   - erect perennial of wet woodlands of North America having leaves and flower buds
@@ -42934,6 +44237,7 @@
   - soapwort gentian
   - Gentiana saponaria
   partOfSpeech: n
+  wikidata: Q5533625
 12315946-n:
   definition:
   - a perennial marsh gentian of eastern North America
@@ -42944,6 +44248,7 @@
   - striped gentian
   - Gentiana villosa
   partOfSpeech: n
+  wikidata: Q5533630
 12316077-n:
   definition:
   - genus of herbs with flowers that resemble gentian; in some classifications included
@@ -42973,6 +44278,7 @@
   - Gentianella quinquefolia
   - Gentiana quinquefolia
   partOfSpeech: n
+  wikidata: Q5533636
 12316562-n:
   definition:
   - gentian of Europe and China having creamy white flowers with fringed corollas
@@ -43019,6 +44325,7 @@
   - Gentianopsis crinita
   - Gentiana crinita
   partOfSpeech: n
+  wikidata: Q3022946
 12317446-n:
   definition:
   - medium-tall fringed gentian with pale-blue to blue-purple flowers; circumboreal
@@ -43030,6 +44337,7 @@
   - Gentianopsis detonsa
   - Gentiana detonsa
   partOfSpeech: n
+  wikidata: Q15566628
 12317627-n:
   definition:
   - small blue-flowered fringed gentian of east central North America
@@ -43040,6 +44348,7 @@
   - Gentianopsid procera
   - Gentiana procera
   partOfSpeech: n
+  wikidata: Q110918102
 12317797-n:
   definition:
   - small blue-flowered fringed gentian of western United States (Rocky Mountains)
@@ -43051,6 +44360,7 @@
   - Gentianopsis thermalis
   - Gentiana thermalis
   partOfSpeech: n
+  wikidata: Q15566388
 12318024-n:
   definition:
   - small blue-flowered fringed gentian of Sierra Nevada mountains
@@ -43062,6 +44372,7 @@
   - Gentianopsis holopetala
   - Gentiana holopetala
   partOfSpeech: n
+  wikidata: Q5533637
 12318195-n:
   definition:
   - 'genus of herbs of Eurasia and the Americas: spurred gentians'
@@ -43198,6 +44509,7 @@
   - mustard tree
   - Salvadora persica
   partOfSpeech: n
+  wikidata: Q143525
 12320505-n:
   definition:
   - 'trees and shrubs having berries or drupes or capsules as fruits; sometimes placed
@@ -43285,6 +44597,7 @@
   - 07783320-n
   - 12321962-n
   partOfSpeech: n
+  wikidata: Q37083
 12321962-n:
   definition:
   - small ovoid fruit of the European olive tree; important food and source of oil
@@ -43306,6 +44619,7 @@
   - black maire
   - Olea cunninghamii
   partOfSpeech: n
+  wikidata: Q50846874
 12322283-n:
   definition:
   - small New Zealand tree having red pulpy one-seeded fruit
@@ -43316,6 +44630,7 @@
   - white maire
   - Olea lanceolata
   partOfSpeech: n
+  wikidata: Q111538596
 12322434-n:
   definition:
   - 'deciduous trees or shrubs: fringe tree'
@@ -43349,6 +44664,7 @@
   - fringe bush
   - Chionanthus virginicus
   partOfSpeech: n
+  wikidata: Q140341
 12322935-n:
   definition:
   - genus of often spiny American shrubs and trees
@@ -43468,6 +44784,7 @@
   - swamp ash
   - Fraxinus caroliniana
   partOfSpeech: n
+  wikidata: Q4117757
 12324937-n:
   definition:
   - shrubby ash of southwestern United States having fragrant white flowers
@@ -43478,6 +44795,7 @@
   - flowering ash
   - Fraxinus cuspidata
   partOfSpeech: n
+  wikidata: Q12242019
 12325089-n:
   definition:
   - shrubby California ash with showy off-white flowers
@@ -43488,6 +44806,7 @@
   - flowering ash
   - Fraxinus dipetala
   partOfSpeech: n
+  wikidata: Q28814749
 12325220-n:
   definition:
   - tall ash of Europe to the Caucasus having leaves shiny dark-green above and pale
@@ -43500,6 +44819,7 @@
   - common European ash
   - Fraxinus excelsior
   partOfSpeech: n
+  wikidata: Q156907
 12325416-n:
   definition:
   - timber tree of western North America yielding hard light wood; closely related
@@ -43512,6 +44832,7 @@
   - Fraxinus latifolia
   - Fraxinus oregona
   partOfSpeech: n
+  wikidata: Q50841607
 12325606-n:
   definition:
   - vigorous spreading North American tree having dark brown heavy wood; leaves turn
@@ -43526,6 +44847,7 @@
   - hoop ash
   - Fraxinus nigra
   partOfSpeech: n
+  wikidata: Q1790101
 12325810-n:
   definition:
   - southern Mediterranean ash having fragrant white flowers in dense panicles and
@@ -43538,6 +44860,7 @@
   - flowering ash
   - Fraxinus ornus
   partOfSpeech: n
+  wikidata: Q161421
 12325992-n:
   definition:
   - smallish American tree with velvety branchlets and lower leaf surfaces
@@ -43549,6 +44872,7 @@
   - downy ash
   - Fraxinus pennsylvanica
   partOfSpeech: n
+  wikidata: Q161164
 12326171-n:
   definition:
   - a variety of red ash having glossy branchlets and lower leaf surfaces
@@ -43570,6 +44894,7 @@
   - blue ash
   - Fraxinus quadrangulata
   partOfSpeech: n
+  wikidata: Q882296
 12326503-n:
   definition:
   - low-growing ash of Texas
@@ -43592,6 +44917,7 @@
   - pumpkin ash
   - Fraxinus tomentosa
   partOfSpeech: n
+  wikidata: Q12242024
 12326787-n:
   definition:
   - small shrubby ash of southwestern United States and northwestern Mexico
@@ -43602,6 +44928,7 @@
   - Arizona ash
   - Fraxinus velutina
   partOfSpeech: n
+  wikidata: Q258068
 12326936-n:
   definition:
   - winged seed of the ash tree
@@ -43644,6 +44971,7 @@
   - primrose jasmine
   - Jasminum mesnyi
   partOfSpeech: n
+  wikidata: Q1024036
 12327593-n:
   definition:
   - deciduous rambling shrub widely cultivated for its winter-blooming yellow flowers
@@ -43668,6 +44996,7 @@
   - jessamine
   - Jasminum officinale
   partOfSpeech: n
+  wikidata: Q515610
 12327972-n:
   definition:
   - East Indian evergreen vine cultivated for its profuse fragrant white flowers
@@ -43678,6 +45007,7 @@
   - Arabian jasmine
   - Jasminum sambac
   partOfSpeech: n
+  wikidata: Q1356614
 12328128-n:
   definition:
   - 'genus of Old World shrubs: privet'
@@ -43711,6 +45041,7 @@
   - Amur privet
   - Ligustrum amurense
   partOfSpeech: n
+  wikidata: Q17713043
 12328776-n:
   definition:
   - fast-growing and tightly branched hybrid of Ligustrum ovalifolium and Ligustrum
@@ -43734,6 +45065,7 @@
   - Japanese privet
   - Ligustrum japonicum
   partOfSpeech: n
+  wikidata: Q1209219
 12329181-n:
   definition:
   - erect evergreen treelike shrub of China and Korea and Japan having acuminate leaves
@@ -43746,6 +45078,7 @@
   - white wax tree
   - Ligustrum lucidum
   partOfSpeech: n
+  wikidata: Q732933
 12329424-n:
   definition:
   - small deciduous shrub having graceful arching branches and luxuriant foliage
@@ -43755,6 +45088,7 @@
   members:
   - Ligustrum obtusifolium
   partOfSpeech: n
+  wikidata: Q1069783
 12329569-n:
   definition:
   - semi-evergreen Japanese shrub having malodorous flowers; used extensively for
@@ -43766,6 +45100,7 @@
   - California privet
   - Ligustrum ovalifolium
   partOfSpeech: n
+  wikidata: Q1938923
 12329794-n:
   definition:
   - deciduous semi-evergreen shrub used for hedges
@@ -43803,6 +45138,7 @@
   - American olive
   - Osmanthus americanus
   partOfSpeech: n
+  wikidata: Q468520
 12330367-n:
   definition:
   - small genus of evergreen shrubs of the Mediterranean region
@@ -43873,6 +45209,7 @@
   - Syringa josikaea
   - Syringa josikea
   partOfSpeech: n
+  wikidata: Q159135
 12331562-n:
   definition:
   - small densely branching Asiatic shrub having lanceolate leaves and panicles of
@@ -44118,6 +45455,7 @@
   - Virginian witch hazel
   - Hamamelis virginiana
   partOfSpeech: n
+  wikidata: Q913129
 12335762-n:
   definition:
   - fragrant shrub of lower Mississippi valley having very small flowers from midwinter
@@ -44129,6 +45467,7 @@
   - vernal witch hazel
   - Hamamelis vernalis
   partOfSpeech: n
+  wikidata: Q1151064
 12335941-n:
   definition:
   - small genus of deciduous shrubs of temperate regions of Asia
@@ -44218,6 +45557,7 @@
   mero_substance:
   - 12337370-n
   partOfSpeech: n
+  wikidata: Q469652
 12337370-n:
   definition:
   - aromatic exudate from the sweet gum tree
@@ -44366,6 +45706,7 @@
   - California black walnut
   - Juglans californica
   partOfSpeech: n
+  wikidata: Q890824
 12339482-n:
   definition:
   - North American walnut tree having light-brown wood and edible nuts; source of
@@ -44469,6 +45810,7 @@
   - water bitternut
   - Carya aquatica
   partOfSpeech: n
+  wikidata: Q5047664
 12341144-n:
   definition:
   - an American hickory tree having bitter nuts
@@ -44482,6 +45824,7 @@
   - black hickory
   - Carya glabra
   partOfSpeech: n
+  wikidata: Q1406355
 12341323-n:
   definition:
   - hickory of the eastern United States having a leaves with 7 or 9 leaflets and
@@ -44497,6 +45840,7 @@
   - swamp hickory
   - Carya cordiformis
   partOfSpeech: n
+  wikidata: Q879016
 12341594-n:
   definition:
   - tree of southern United States and Mexico cultivated for its nuts
@@ -44539,6 +45883,7 @@
   mero_part:
   - 07790271-n
   partOfSpeech: n
+  wikidata: Q4215101
 12342186-n:
   definition:
   - hickory of southern United States and Mexico having hard nutmeg-shaped nuts
@@ -44550,6 +45895,7 @@
   - Carya myristicaeformis
   - Carya myristiciformis
   partOfSpeech: n
+  wikidata: Q5047669
 12342390-n:
   definition:
   - North American hickory having loose grey shaggy bark and edible nuts
@@ -44565,6 +45911,7 @@
   mero_part:
   - 07790271-n
   partOfSpeech: n
+  wikidata: Q2601238
 12342616-n:
   definition:
   - smooth-barked North American hickory with 7 to 9 leaflets bearing a hard-shelled
@@ -44616,6 +45963,7 @@
   - Caucasian walnut
   - Pterocarya fraxinifolia
   partOfSpeech: n
+  wikidata: Q121749
 12343404-n:
   definition:
   - Myrtaceae, Combretaceae, Elaeagnaceae, Haloragidaceae, Melastomaceae, Lecythidaceae,
@@ -44707,6 +46055,7 @@
   - hiccough nut
   - Combretum bracteosum
   partOfSpeech: n
+  wikidata: Q10862678
 12344905-n:
   definition:
   - small deciduous tree of the Transvaal having spikes of yellow flowers
@@ -44777,6 +46126,7 @@
   - white mangrove
   - Laguncularia racemosa
   partOfSpeech: n
+  wikidata: Q1760533
 12346014-n:
   definition:
   - shrubs or small trees often armed
@@ -44824,6 +46174,7 @@
   - wild olive
   - Elaeagnus latifolia
   partOfSpeech: n
+  wikidata: Q10801011
 12346695-n:
   definition:
   - deciduous unarmed North American shrub with silvery leaves and fruits
@@ -45008,7 +46359,9 @@
   - spiked loosestrife
   - Lythrum salicaria
   partOfSpeech: n
-  wikidata: Q157513
+  wikidata:
+  - Q10890069
+  - Q157513
 12349318-n:
   definition:
   - annual with small solitary pink flowers; originally of Europe but widely naturalized
@@ -45021,6 +46374,7 @@
   - hyssop loosestrife
   - Lythrum hyssopifolia
   partOfSpeech: n
+  wikidata: Q159617
 12349537-n:
   definition:
   - shrubs or small trees of tropical Asia and Africa usually with showy white, pink,
@@ -45136,6 +46490,7 @@
   - common myrtle
   - Myrtus communis
   partOfSpeech: n
+  wikidata: Q6122027
 12351268-n:
   definition:
   - allspice tree
@@ -45163,6 +46518,7 @@
   - wild cinnamon
   - Pimenta acris
   partOfSpeech: n
+  wikidata: Q50851106
 12351583-n:
   definition:
   - aromatic West Indian tree that produces allspice berries
@@ -45177,6 +46533,7 @@
   mero_part:
   - 07829983-n
   partOfSpeech: n
+  wikidata: Q158468
 12351780-n:
   definition:
   - tropical American tree having small white flowers and aromatic berries
@@ -45187,6 +46544,7 @@
   - allspice tree
   - Pimenta officinalis
   partOfSpeech: n
+  wikidata: Q50851095
 12351932-n:
   definition:
   - tropical trees and shrubs with aromatic leaves and often valuable hard wood
@@ -45213,6 +46571,9 @@
   - sour cherry
   - Eugenia corynantha
   partOfSpeech: n
+  wikidata:
+  - Q7663973
+  - Q39286715
 12352305-n:
   definition:
   - tree of extreme southern Florida and West Indies having thin scaly bark and aromatic
@@ -45224,6 +46585,7 @@
   - nakedwood
   - Eugenia dicrana
   partOfSpeech: n
+  wikidata: Q110514778
 12352547-n:
   definition:
   - Brazilian tree with spicy red fruit; often cultivated in California and Florida
@@ -45235,6 +46597,7 @@
   - pitanga
   - Eugenia uniflora
   partOfSpeech: n
+  wikidata: Q306504
 12352735-n:
   definition:
   - tropical tree of the East Indies cultivated for its edible fruit
@@ -45249,6 +46612,9 @@
   mero_part:
   - 07786010-n
   partOfSpeech: n
+  wikidata:
+  - Q31931
+  - Q21874222
 12352939-n:
   definition:
   - small South American shrubs or trees
@@ -45315,6 +46681,7 @@
   mero_part:
   - 07781838-n
   partOfSpeech: n
+  wikidata: Q50844164
 12353914-n:
   definition:
   - guavas
@@ -45344,6 +46711,7 @@
   mero_part:
   - 07781337-n
   partOfSpeech: n
+  wikidata: Q166843
 12354288-n:
   definition:
   - small tropical shrubby tree bearing small yellowish fruit
@@ -45379,6 +46747,7 @@
   - Brazilian guava
   - Psidium guineense
   partOfSpeech: n
+  wikidata: Q6090472
 12354810-n:
   definition:
   - any of various trees of the genera Eucalyptus or Liquidambar or Nyssa that are
@@ -45498,6 +46867,9 @@
   - marri
   - Eucalyptus calophylla
   partOfSpeech: n
+  wikidata:
+  - Q2998198
+  - Q21266867
 12356850-n:
   definition:
   - somewhat crooked red gum tree growing chiefly along rivers; has durable reddish
@@ -45514,8 +46886,8 @@
   - 12359607-n
   partOfSpeech: n
   wikidata:
-  - Q5850228
   - Q162822
+  - Q5850228
 12357103-n:
   definition:
   - medium-sized swamp gum of New South Wales and Victoria
@@ -45526,6 +46898,9 @@
   - mountain swamp gum
   - Eucalyptus camphora
   partOfSpeech: n
+  wikidata:
+  - Q66115606
+  - Q12839325
 12357244-n:
   definition:
   - small to medium-sized tree of Australia and Tasmania having smooth white to light-grey
@@ -45540,7 +46915,9 @@
   - Eucalyptus coriacea
   - Eucalyptus pauciflora
   partOfSpeech: n
-  wikidata: Q2165298
+  wikidata:
+  - Q2165298
+  - Q50835432
 12357490-n:
   definition:
   - tall timber tree with hard heavy pinkish or light brown wood
@@ -45600,6 +46977,7 @@
   - fever tree
   - Eucalyptus globulus
   partOfSpeech: n
+  wikidata: Q159528
 12358317-n:
   definition:
   - very tall tree of Queensland and New South Wales
@@ -45640,6 +47018,9 @@
   - spotted gum
   - Eucalyptus maculata
   partOfSpeech: n
+  wikidata:
+  - Q3337015
+  - Q24852937
 12358775-n:
   definition:
   - similar to but smaller than the spotted gum and having lemon-scented leaves
@@ -45651,6 +47032,9 @@
   - Eucalyptus citriodora
   - Eucalyptus maculata citriodora
   partOfSpeech: n
+  wikidata:
+  - Q2549523
+  - Q24852935
 12358971-n:
   definition:
   - a small mallee with rough dark-colored bark toward the butt; yields a red eucalyptus
@@ -45685,6 +47069,7 @@
   - mountain ash
   - Eucalyptus regnans
   partOfSpeech: n
+  wikidata: Q1542486
 12359496-n:
   definition:
   - tall tree yielding a false manna
@@ -45695,6 +47080,7 @@
   - manna gum
   - Eucalyptus viminalis
   partOfSpeech: n
+  wikidata: Q2137116
 12359607-n:
   definition:
   - reddish-brown dried gummy exudation from any of several trees of the genus Eucalyptus
@@ -45737,6 +47123,7 @@
   mero_part:
   - 12360348-n
   partOfSpeech: n
+  wikidata: Q26736
 12360348-n:
   definition:
   - aromatic flower bud of a clove tree; yields a spice
@@ -45800,6 +47187,7 @@
   - water gum
   - Nyssa aquatica
   partOfSpeech: n
+  wikidata: Q7071273
 12361272-n:
   definition:
   - columnar tree of eastern North America having horizontal limbs and small leaves
@@ -45874,6 +47262,7 @@
   - Alpine enchanter's nightshade
   - Circaea alpina
   partOfSpeech: n
+  wikidata: Q159427
 12362448-n:
   definition:
   - tall evening primrose with inconspicuous flowers
@@ -45883,6 +47272,7 @@
   members:
   - Circaea lutetiana
   partOfSpeech: n
+  wikidata: Q163955
 12362560-n:
   definition:
   - large widely distributed genus of herbs and subshrubs of especially western North
@@ -45924,6 +47314,9 @@
   - wickup
   - Epilobium angustifolium
   partOfSpeech: n
+  wikidata:
+  - Q160104
+  - Q12217056
 12363369-n:
   definition:
   - shrublet of southwestern United States to Mexico having brilliant scarlet flowers
@@ -45936,6 +47329,7 @@
   - Epilobium canum canum
   - Zauschneria californica
   partOfSpeech: n
+  wikidata: Q87592509
 12363609-n:
   definition:
   - plant of Europe and Asia having purplish-red flowers and hairy stems and leaves;
@@ -45984,6 +47378,7 @@
   - ladies'-eardrops
   - Fuchsia coccinea
   partOfSpeech: n
+  wikidata: Q15332540
 12364468-n:
   definition:
   - erect deciduous shrub or tree to 10 feet with maroon flowers; New Zealand
@@ -45996,6 +47391,7 @@
   - native fuchsia
   - Fuchsia excorticata
   partOfSpeech: n
+  wikidata: Q311743
 12364648-n:
   definition:
   - chiefly North American herbs with usually nocturnal flowers
@@ -46028,7 +47424,9 @@
   - German rampion
   - Oenothera biennis
   partOfSpeech: n
-  wikidata: Q157353
+  wikidata:
+  - Q50849869
+  - Q157353
 12365217-n:
   definition:
   - a day-flowering biennial or perennial of the genus Oenothera
@@ -46039,7 +47437,9 @@
   - sundrops
   - Oenothera fruticosa
   partOfSpeech: n
-  wikidata: Q7078662
+  wikidata:
+  - Q15345195
+  - Q7078662
 12365354-n:
   definition:
   - evening-opening primrose of south central United States
@@ -46051,6 +47451,9 @@
   - Ozark sundrops
   - Oenothera macrocarpa
   partOfSpeech: n
+  wikidata:
+  - Q15330425
+  - Q9373395
 12365513-n:
   definition:
   - 'one species: pomegranates'
@@ -46090,6 +47493,7 @@
   mero_part:
   - 07784670-n
   partOfSpeech: n
+  wikidata: Q13188
 12366012-n:
   definition:
   - trees and shrubs that usually form dense jungles along tropical seacoasts
@@ -46191,6 +47595,7 @@
   - wood laurel
   - Daphne laureola
   partOfSpeech: n
+  wikidata: Q161418
 12367675-n:
   definition:
   - small European deciduous shrub with fragrant lilac-colored flowers followed by
@@ -46205,6 +47610,7 @@
   mero_part:
   - 12367897-n
   partOfSpeech: n
+  wikidata: Q165166
 12367897-n:
   definition:
   - the dried bark of the shrub mezereon
@@ -46242,6 +47648,7 @@
   - ropebark
   - Dirca palustris
   partOfSpeech: n
+  wikidata: Q5280175
 12368409-n:
   definition:
   - family comprising solely the genus Trapa; in some classifications treated as a
@@ -46345,6 +47752,7 @@
   - Indian rhododendron
   - Melastoma malabathricum
   partOfSpeech: n
+  wikidata: Q722767
 12370008-n:
   definition:
   - tropical Old World ornamental evergreen shrubs having fleshy leaves and large
@@ -46471,7 +47879,9 @@
   - Canna indica
   - Canna edulis
   partOfSpeech: n
-  wikidata: Q163559
+  wikidata:
+  - Q163559
+  - Q15250761
 12371804-n:
   definition:
   - tropical perennial herbs with usually starchy rhizomes
@@ -46573,6 +47983,7 @@
   mero_part:
   - 07769568-n
   partOfSpeech: n
+  wikidata: Q132970
 12373361-n:
   definition:
   - Asiatic banana plant cultivated especially as a foliage plant in Japan
@@ -46583,6 +47994,7 @@
   - Japanese banana
   - Musa basjoo
   partOfSpeech: n
+  wikidata: Q33331
 12373507-n:
   definition:
   - a banana tree bearing hanging clusters of edible angular greenish starchy fruits;
@@ -46622,6 +48034,7 @@
   - Manila hemp
   - Musa textilis
   partOfSpeech: n
+  wikidata: Q161097
 12374121-n:
   definition:
   - Abyssinian bananas (Ensete)
@@ -46691,6 +48104,7 @@
   - bird of paradise
   - Strelitzia reginae
   partOfSpeech: n
+  wikidata: Q148904
 12375366-n:
   definition:
   - woody tropical plants with tall trunks; sometimes placed in family Musaceae
@@ -46774,6 +48188,7 @@
   mero_part:
   - 07830901-n
   partOfSpeech: n
+  wikidata: Q35625
 12376772-n:
   definition:
   - tropical Asiatic perennial herbs
@@ -46801,7 +48216,9 @@
   mero_part:
   - 07837895-n
   partOfSpeech: n
-  wikidata: Q42562
+  wikidata:
+  - Q42562
+  - Q50832769
 12377185-n:
   definition:
   - perennial rhizomatous herbs of Asia and Australia and Polynesia having ginger-scented
@@ -46831,6 +48248,7 @@
   - galangal
   - Alpinia galanga
   partOfSpeech: n
+  wikidata: Q402971
 12377617-n:
   definition:
   - Chinese perennial with pyramidal racemes of white flowers and pungent aromatic
@@ -46843,6 +48261,7 @@
   - Alpinia officinarum
   - Alpinia officinalis
   partOfSpeech: n
+  wikidata: Q1281083
 12377860-n:
   definition:
   - an ornamental ginger native to Pacific islands
@@ -46869,6 +48288,7 @@
   - Alpinia speciosa
   - Languas speciosa
   partOfSpeech: n
+  wikidata: Q2703227
 12378319-n:
   definition:
   - an African genus of plants of the family Zingiberaceae
@@ -46895,6 +48315,7 @@
   - melagueta pepper
   - Aframomum melegueta
   partOfSpeech: n
+  wikidata: Q1503476
 12378690-n:
   definition:
   - cardamom
@@ -46921,6 +48342,7 @@
   mero_part:
   - 07838299-n
   partOfSpeech: n
+  wikidata: Q33466
 12379002-n:
   definition:
   - a group of families of more or less advanced trees and shrubs and herbs having
@@ -47137,6 +48559,7 @@
   - wax begonia
   - Begonia semperflorens
   partOfSpeech: n
+  wikidata: Q125176497
 12383031-n:
   definition:
   - semi-tuberous begonia having peltate leaves and rose-pink flowers; Yemen
@@ -47147,6 +48570,7 @@
   - Socotra begonia
   - Begonia socotrana
   partOfSpeech: n
+  wikidata: Q4880578
 12383185-n:
   definition:
   - any of numerous hybrid begonias having tuberous roots and variously colored flowers
@@ -47293,6 +48717,7 @@
   - Santa Maria tree
   - Calophyllum calaba
   partOfSpeech: n
+  wikidata: Q15386689
 12385675-n:
   definition:
   - valuable timber tree of Panama
@@ -47303,6 +48728,7 @@
   - Maria
   - Calophyllum longifolium
   partOfSpeech: n
+  wikidata: Q15387468
 12385802-n:
   definition:
   - tropical American tree; valued for its hard durable wood
@@ -47325,6 +48751,7 @@
   - Alexandrian laurel
   - Calophyllum inophyllum
   partOfSpeech: n
+  wikidata: Q311471
 12386187-n:
   definition:
   - tropical American aromatic trees or shrubs; often epiphytic; some stranglers
@@ -47359,6 +48786,7 @@
   - wild fig
   - Clusia flava
   partOfSpeech: n
+  wikidata: Q20983176
 12386703-n:
   definition:
   - epiphytic clusia of British Guiana
@@ -47369,6 +48797,7 @@
   - waxflower
   - Clusia insignis
   partOfSpeech: n
+  wikidata: Q15353528
 12386830-n:
   definition:
   - a common tropical American clusia having solitary white or rose flowers
@@ -47381,6 +48810,7 @@
   - Clusia rosea
   - Clusia major
   partOfSpeech: n
+  wikidata: Q5136653
 12387024-n:
   definition:
   - 'evergreen trees and shrubs: mangosteens'
@@ -47408,6 +48838,7 @@
   mero_part:
   - 07779963-n
   partOfSpeech: n
+  wikidata: Q170662
 12387387-n:
   definition:
   - low spreading tree of Indonesia yielding an orange to brown gum resin (gamboge)
@@ -47422,8 +48853,9 @@
   - Garcinia gummi-gutta
   partOfSpeech: n
   wikidata:
-  - Q2089493
   - Q767747
+  - Q2089493
+  - Q18187249
 12387639-n:
   definition:
   - used in some classification systems for plants usually included among the Guttiferae
@@ -47497,6 +48929,7 @@
   - creeping St John's wort
   - Hypericum calycinum
   partOfSpeech: n
+  wikidata: Q159330
 12389154-n:
   definition:
   - annual wiry-stemmed North American weed with minute scalelike leaves and small
@@ -47511,6 +48944,7 @@
   - pine-weed
   - Hypericum gentianoides
   partOfSpeech: n
+  wikidata: Q5958086
 12389364-n:
   definition:
   - 'shrubby plant having yellow to apricot flowers with four petals arranged in a
@@ -47533,6 +48967,7 @@
   - low St Andrew's cross
   - Hypericum hypericoides
   partOfSpeech: n
+  wikidata: Q17812225
 12389826-n:
   definition:
   - yellow-flowered perennial common in fields and waste places but a weed in rangelands
@@ -47543,6 +48978,7 @@
   - klammath weed
   - Hypericum perforatum
   partOfSpeech: n
+  wikidata: Q158289
 12389993-n:
   definition:
   - stiff shrub having oblong entire leaves and dense cymes of yellow flowers
@@ -47554,6 +48990,9 @@
   - Hypericum prolificum
   - Hypericum spathulatum
   partOfSpeech: n
+  wikidata:
+  - Q15367030
+  - Q17812747
 12390182-n:
   definition:
   - European perennial St John's wort; Ireland and France to western Siberia
@@ -47604,6 +49043,7 @@
   mero_part:
   - 07782506-n
   partOfSpeech: n
+  wikidata: Q1888040
 12390901-n:
   definition:
   - genus of tropical Asiatic trees having large solitary flowers
@@ -47631,6 +49071,7 @@
   - ironwood tree
   - Mesua ferrea
   partOfSpeech: n
+  wikidata: Q2001737
 12391359-n:
   definition:
   - tropical trees or shrubs or woody vines
@@ -47671,6 +49112,7 @@
   - tara vine
   - Actinidia arguta
   partOfSpeech: n
+  wikidata: Q848074
 12391956-n:
   definition:
   - climbing vine native to China; cultivated in New Zealand for its fuzzy edible
@@ -47688,8 +49130,8 @@
   - 07779605-n
   partOfSpeech: n
   wikidata:
-  - Q163522
   - Q343300
+  - Q163522
 12392221-n:
   definition:
   - ornamental vine of eastern Asia having yellow edible fruit and leaves with silver-white
@@ -47702,6 +49144,7 @@
   - silver vine
   - Actinidia polygama
   partOfSpeech: n
+  wikidata: Q1357333
 12392428-n:
   definition:
   - 'one genus: aromatic tropical trees of eastern Africa and Florida to West Indies'
@@ -47743,7 +49186,9 @@
   mero_part:
   - 12393037-n
   partOfSpeech: n
-  wikidata: Q2706419
+  wikidata:
+  - Q2706419
+  - Q5747460
 12393037-n:
   definition:
   - highly aromatic inner bark of the Canella winterana used as a condiment and a
@@ -47801,6 +49246,7 @@
   mero_part:
   - 07778220-n
   partOfSpeech: n
+  wikidata: Q34887
 12393878-n:
   definition:
   - small genus of tropical South American trees
@@ -47961,6 +49407,7 @@
   - Helianthemum canadense
   - Crocanthemum canadense
   partOfSpeech: n
+  wikidata: Q15342368
 12396590-n:
   definition:
   - any of numerous varieties of helianthemums having small rose-like yellow or white
@@ -47982,6 +49429,9 @@
   - rush rose
   - Helianthemum scoparium
   partOfSpeech: n
+  wikidata:
+  - Q17570180
+  - Q5704829
 12396899-n:
   definition:
   - small evergreen subshrubs of North America
@@ -48007,6 +49457,7 @@
   - golden heather
   - Hudsonia ericoides
   partOfSpeech: n
+  wikidata: Q16983350
 12397257-n:
   definition:
   - small heathlike plant covered with white down growing on beaches in northeastern
@@ -48019,7 +49470,9 @@
   - poverty grass
   - Hudsonia tomentosa
   partOfSpeech: n
-  wikidata: Q3142179
+  wikidata:
+  - Q55869003
+  - Q3142179
 12397467-n:
   definition:
   - chiefly tropical Asian trees with two-winged fruits; yield valuable woods and
@@ -48070,6 +49523,7 @@
   mero_substance:
   - 12398175-n
   partOfSpeech: n
+  wikidata: Q5479075
 12398175-n:
   definition:
   - hard heavy red wood of the red lauan tree; often sold as Philippine mahogany
@@ -48126,6 +49580,7 @@
   - batoko palm
   - Flacourtia indica
   partOfSpeech: n
+  wikidata: Q621082
 12399063-n:
   definition:
   - small genus of sometimes spiny shrubs or small trees; Africa, India, Sri Lanka
@@ -48204,6 +49659,7 @@
   - Taraktagenos kurzii
   - Taraktogenos kurzii
   partOfSpeech: n
+  wikidata: Q5693433
 12400298-n:
   definition:
   - leathery-leaved tree of western India bearing round fruits with brown densely
@@ -48274,6 +49730,7 @@
   - wild peach
   - Kiggelaria africana
   partOfSpeech: n
+  wikidata: Q6405945
 12401443-n:
   definition:
   - genus of tropical American and Asiatic spiny evergreen trees and shrubs
@@ -48349,6 +49806,7 @@
   - vine cactus
   - Fouquieria splendens
   partOfSpeech: n
+  wikidata: Q138966
 12402750-n:
   definition:
   - candlewood of Mexico and southwestern California having tall columnar stems and
@@ -48402,6 +49860,7 @@
   - bird's-eye bush
   - Ochna serrulata
   partOfSpeech: n
+  wikidata: Q568648
 12403590-n:
   definition:
   - tropical woody tendril-climbing vines
@@ -48452,6 +49911,7 @@
   - purple granadillo
   - Passiflora edulis
   partOfSpeech: n
+  wikidata: Q156790
 12404411-n:
   definition:
   - considered best for fruit
@@ -48479,6 +49939,7 @@
   mero_part:
   - 07769956-n
   partOfSpeech: n
+  wikidata: Q159105
 12404744-n:
   definition:
   - of southern United States; having an insipid berry the size of a hen egg
@@ -48489,6 +49950,7 @@
   - maypop
   - Passiflora incarnata
   partOfSpeech: n
+  wikidata: Q128939
 12404892-n:
   definition:
   - West Indian passionflower; cultivated for its yellow edible fruit
@@ -48502,6 +49964,7 @@
   mero_part:
   - 07770255-n
   partOfSpeech: n
+  wikidata: Q164659
 12405086-n:
   definition:
   - cultivated for fruit
@@ -48512,6 +49975,7 @@
   - banana passion fruit
   - Passiflora mollissima
   partOfSpeech: n
+  wikidata: Q15093181
 12405197-n:
   definition:
   - West Indian passionflower with edible apple-sized fruit
@@ -48588,6 +50052,7 @@
   - sweet reseda
   - Reseda odorata
   partOfSpeech: n
+  wikidata: Q159158
 12406347-n:
   definition:
   - European mignonette cultivated as a source of yellow dye; naturalized in North
@@ -48667,6 +50132,7 @@
   - German tamarisk
   - Myricaria germanica
   partOfSpeech: n
+  wikidata: Q162609
 12407620-n:
   definition:
   - plant growing naturally in very salty soil
@@ -48736,6 +50202,7 @@
   - heartsease
   - Viola arvensis
   partOfSpeech: n
+  wikidata: Q341680
 12408810-n:
   definition:
   - violet of eastern North America having pale violet to white flowers
@@ -48746,6 +50213,7 @@
   - American dog violet
   - Viola conspersa
   partOfSpeech: n
+  wikidata: Q15387636
 12408961-n:
   definition:
   - short-stemmed violet of eastern North America having fragrant purple-veined white
@@ -48759,6 +50227,7 @@
   - woodland white violet
   - Viola blanda
   partOfSpeech: n
+  wikidata: Q1709370
 12409169-n:
   definition:
   - tall North American perennial with heart-shaped leaves and white flowers with
@@ -48772,6 +50241,7 @@
   - white violet
   - Viola canadensis
   partOfSpeech: n
+  wikidata: Q3024523
 12409375-n:
   definition:
   - Old World leafy-stemmed blue-flowered violet
@@ -48795,6 +50265,7 @@
   - tufted pansy
   - Viola cornuta
   partOfSpeech: n
+  wikidata: Q494841
 12409647-n:
   definition:
   - violet of Pacific coast of North America having white petals tinged with yellow
@@ -48820,6 +50291,7 @@
   - English violet
   - Viola odorata
   partOfSpeech: n
+  wikidata: Q108684
 12410018-n:
   definition:
   - common violet of the eastern United States with large pale blue or purple flowers
@@ -48846,6 +50318,7 @@
   - downy yellow violet
   - Viola pubescens
   partOfSpeech: n
+  wikidata: Q3283803
 12410449-n:
   definition:
   - violet of eastern North America having lilac-purple flowers with a long slender
@@ -48857,6 +50330,9 @@
   - long-spurred violet
   - Viola rostrata
   partOfSpeech: n
+  wikidata:
+  - Q15357379
+  - Q3024420
 12410616-n:
   definition:
   - leafy-stemmed violet of eastern North America having large white or creamy flowers
@@ -48870,6 +50346,9 @@
   - cream violet
   - Viola striata
   partOfSpeech: n
+  wikidata:
+  - Q15357426
+  - Q16736005
 12410831-n:
   definition:
   - common European violet that grows in woods and hedgerows
@@ -48882,7 +50361,9 @@
   - Viola sylvatica
   - Viola reichenbachiana
   partOfSpeech: n
-  wikidata: Q594058
+  wikidata:
+  - Q594058
+  - Q21301601
 12411002-n:
   definition:
   - large-flowered garden plant derived chiefly from the wild pansy of Europe and
@@ -48909,6 +50390,7 @@
   - pink of my John
   - Viola tricolor
   partOfSpeech: n
+  wikidata: Q190326
 12411431-n:
   definition:
   - a genus of herbs and small shrubs with white or purple flowers; grows in tropical
@@ -49016,6 +50498,7 @@
   - stinging nettle
   - Urtica dioica
   partOfSpeech: n
+  wikidata: Q155909
 12413282-n:
   definition:
   - annual European nettle with stinging foliage and small clusters of green flowers
@@ -49064,6 +50547,7 @@
   - China grass
   - Boehmeria nivea
   partOfSpeech: n
+  wikidata: Q750467
 12414044-n:
   definition:
   - one species; a dwarf creeping mat-forming evergreen herb
@@ -49206,6 +50690,7 @@
   - panamiga
   - Pilea involucrata
   partOfSpeech: n
+  wikidata: Q3388414
 12416234-n:
   definition:
   - an Australian genus of woody plants of the family Urticaceae
@@ -49230,6 +50715,7 @@
   - Queensland grass-cloth plant
   - Pipturus argenteus
   partOfSpeech: n
+  wikidata: Q15610979
 12416608-n:
   definition:
   - Hawaiian tree of genus Pipturus having a bark (tapa) from which tapa cloth is
@@ -49240,6 +50726,7 @@
   members:
   - Pipturus albidus
   partOfSpeech: n
+  wikidata: Q16988147
 12416772-n:
   definition:
   - two genera of erect or twining herbs that are pollinated by the wind, including
@@ -49299,6 +50786,7 @@
   mero_part:
   - 02672679-n
   partOfSpeech: n
+  wikidata: Q26726
 12417936-n:
   definition:
   - source of e.g. bhang and hashish as well as fiber
@@ -49312,6 +50800,9 @@
   - 02837352-n
   - 03502307-n
   partOfSpeech: n
+  wikidata:
+  - Q8262024
+  - Q2936421
 12418099-n:
   definition:
   - 'hops: hardy perennial vines of Europe, North America and central and eastern
@@ -49363,6 +50854,9 @@
   - American hop
   - Humulus americanus
   partOfSpeech: n
+  wikidata:
+  - Q42688584
+  - Q32856065
 12419031-n:
   definition:
   - ornamental vine native to eastern Asia; cultivated for its variegated foliage
@@ -49373,6 +50867,7 @@
   - Japanese hop
   - Humulus japonicus
   partOfSpeech: n
+  wikidata: Q162736
 12419187-n:
   definition:
   - trees or shrubs having a milky juice; in some classifications includes genus Cannabis
@@ -49427,6 +50922,7 @@
   - white mulberry
   - Morus alba
   partOfSpeech: n
+  wikidata: Q157307
 12420039-n:
   definition:
   - European mulberry having dark foliage and fruit
@@ -49437,6 +50933,7 @@
   - black mulberry
   - Morus nigra
   partOfSpeech: n
+  wikidata: Q161040
 12420161-n:
   definition:
   - North American mulberry having dark purple edible fruit
@@ -49447,6 +50944,7 @@
   - red mulberry
   - Morus rubra
   partOfSpeech: n
+  wikidata: Q1520764
 12420289-n:
   definition:
   - yellowwood trees or shrubs
@@ -49473,6 +50971,7 @@
   - mock orange
   - Maclura pomifera
   partOfSpeech: n
+  wikidata: Q1066106
 12420766-n:
   definition:
   - 'evergreen Asiatic trees now grown through the tropics: breadfruit; jackfruit'
@@ -49516,6 +51015,7 @@
   mero_part:
   - 07770660-n
   partOfSpeech: n
+  wikidata: Q45757
 12421429-n:
   definition:
   - Philippine tree similar to the breadfruit tree bearing edible fruit
@@ -49569,6 +51069,7 @@
   - 07769089-n
   - 13158002-n
   partOfSpeech: n
+  wikidata: Q36146
 12422398-n:
   definition:
   - wild variety of the common fig used to facilitate pollination of certain figs
@@ -49593,6 +51094,7 @@
   - wild fig
   - Ficus aurea
   partOfSpeech: n
+  wikidata: Q2561277
 12422853-n:
   definition:
   - East Indian tree that puts out aerial shoots that grow down into the soil forming
@@ -49625,6 +51127,7 @@
   - bo tree
   - Ficus religiosa
   partOfSpeech: n
+  wikidata: Q3071706
 12423345-n:
   definition:
   - large tropical Asian tree frequently dwarfed as a houseplant; source of Assam
@@ -49640,6 +51143,7 @@
   - Assam rubber
   - Ficus elastica
   partOfSpeech: n
+  wikidata: Q160576
 12423580-n:
   definition:
   - shrub or small tree often grown as a houseplant having foliage like mistletoe
@@ -49652,6 +51156,7 @@
   - Ficus diversifolia
   - Ficus deltoidea
   partOfSpeech: n
+  wikidata: Q406938
 12423781-n:
   definition:
   - Australian tree resembling the banyan often planted for ornament; introduced into
@@ -49681,6 +51186,7 @@
   - mulberry fig
   - Ficus sycomorus
   partOfSpeech: n
+  wikidata: Q750217
 12424367-n:
   definition:
   - paper mulberry
@@ -49706,6 +51212,7 @@
   - paper mulberry
   - Broussonetia papyrifera
   partOfSpeech: n
+  wikidata: Q389185
 12424819-n:
   definition:
   - in some classifications included in family Moraceae
@@ -49855,6 +51362,7 @@
   - European field elm
   - Ulmus carpinifolia
   partOfSpeech: n
+  wikidata: Q3547946
 12427407-n:
   definition:
   - elm of southern United States and Mexico having spreading pendulous corky branches
@@ -49865,6 +51373,7 @@
   - cedar elm
   - Ulmus crassifolia
   partOfSpeech: n
+  wikidata: Q7879431
 12427584-n:
   definition:
   - Eurasian elm often planted as a shade tree
@@ -49876,6 +51385,7 @@
   - wych elm
   - Ulmus glabra
   partOfSpeech: n
+  wikidata: Q147498
 12427727-n:
   definition:
   - any of various hybrid ornamental European shade trees ranging from dwarf to tall
@@ -49906,6 +51416,7 @@
   - water elm
   - Ulmus laevis
   partOfSpeech: n
+  wikidata: Q147492
 12428220-n:
   definition:
   - small fast-growing tree native to Asia; widely grown as shelterbelts and hedges
@@ -49916,6 +51427,7 @@
   - Chinese elm
   - Ulmus parvifolia
   partOfSpeech: n
+  wikidata: Q1074099
 12428395-n:
   definition:
   - broad spreading rough-leaved elm common throughout Europe and planted elsewhere
@@ -49927,6 +51439,7 @@
   - European elm
   - Ulmus procera
   partOfSpeech: n
+  wikidata: Q1342743
 12428582-n:
   definition:
   - fast-growing shrubby Asian tree naturalized in United States for shelter or ornament
@@ -49966,6 +51479,7 @@
   - Ulmus campestris sarniensis
   - Ulmus campestris wheatleyi
   partOfSpeech: n
+  wikidata: Q18913016
 12429222-n:
   definition:
   - autumn-flowering elm of southeastern United States
@@ -50038,6 +51552,7 @@
   - American hackberry
   - Celtis occidentalis
   partOfSpeech: n
+  wikidata: Q470006
 12430345-n:
   definition:
   - deciduous shade tree with small black berries; southern United States; yields
@@ -50222,7 +51737,9 @@
   - dwarf iris
   - Iris cristata
   partOfSpeech: n
-  wikidata: Q6070337
+  wikidata:
+  - Q42953917
+  - Q6070337
 12433806-n:
   definition:
   - bulbous Spanish iris with red-violet flowers
@@ -50233,6 +51750,7 @@
   - Dutch iris
   - Iris filifolia
   partOfSpeech: n
+  wikidata: Q15570314
 12433924-n:
   definition:
   - German iris having large white flowers with lavender-tinged falls and a fragrant
@@ -50248,6 +51766,9 @@
   mero_member:
   - 12433492-n
   partOfSpeech: n
+  wikidata:
+  - Q16120935
+  - Q104250895
 12434147-n:
   definition:
   - iris with purple flowers and foul-smelling leaves; southern and western Europe
@@ -50263,6 +51784,9 @@
   - roast beef plant
   - Iris foetidissima
   partOfSpeech: n
+  wikidata:
+  - Q93186409
+  - Q2484930
 12434385-n:
   definition:
   - a large iris with purple or white flowers, native to central and southern Europe
@@ -50273,6 +51797,7 @@
   - German iris
   - Iris germanica
   partOfSpeech: n
+  wikidata: Q161734
 12434540-n:
   definition:
   - iris native to Japan having large showy flowers
@@ -50283,6 +51808,7 @@
   - Japanese iris
   - Iris kaempferi
   partOfSpeech: n
+  wikidata: Q50842570
 12434664-n:
   definition:
   - iris of northern Italy having deep blue-purple flowers; similar to but smaller
@@ -50294,6 +51820,7 @@
   - German iris
   - Iris kochii
   partOfSpeech: n
+  wikidata: Q110971181
 12434834-n:
   definition:
   - European iris having soft lilac-blue flowers
@@ -50304,6 +51831,9 @@
   - Dalmatian iris
   - Iris pallida
   partOfSpeech: n
+  wikidata:
+  - Q93431036
+  - Q161347
 12434954-n:
   definition:
   - bulbous iris native to Asia Minor cultivated for its pale lilac-colored flowers
@@ -50314,6 +51844,7 @@
   - Persian iris
   - Iris persica
   partOfSpeech: n
+  wikidata: Q15296233
 12435107-n:
   definition:
   - common yellow-flowered iris of Europe and North Africa, naturalized in United
@@ -50327,6 +51858,7 @@
   - yellow water flag
   - Iris pseudacorus
   partOfSpeech: n
+  wikidata: Q21173
 12435323-n:
   definition:
   - bulbous Spanish iris having blue flowers
@@ -50337,6 +51869,7 @@
   - Dutch iris
   - Iris tingitana
   partOfSpeech: n
+  wikidata: Q15572483
 12435437-n:
   definition:
   - low-growing spring-flowering American iris with bright blue-lilac flowers
@@ -50348,6 +51881,9 @@
   - vernal iris
   - Iris verna
   partOfSpeech: n
+  wikidata:
+  - Q42960889
+  - Q15296151
 12435594-n:
   definition:
   - a common iris of the eastern United States having blue or blue-violet flowers;
@@ -50359,6 +51895,9 @@
   - blue flag
   - Iris versicolor
   partOfSpeech: n
+  wikidata:
+  - Q92937504
+  - Q164844
 12435777-n:
   definition:
   - similar to blue flag; the eastern United States
@@ -50369,6 +51908,9 @@
   - southern blue flag
   - Iris virginica
   partOfSpeech: n
+  wikidata:
+  - Q92937551
+  - Q7934335
 12435906-n:
   definition:
   - bulbous iris native to the Pyrenees; widely cultivated for its large delicate
@@ -50380,6 +51922,7 @@
   - English iris
   - Iris xiphioides
   partOfSpeech: n
+  wikidata: Q50842901
 12436100-n:
   definition:
   - bulbous iris of western Mediterranean region having usually violet-purple flowers
@@ -50391,6 +51934,9 @@
   - xiphium iris
   - Iris xiphium
   partOfSpeech: n
+  wikidata:
+  - Q91363501
+  - Q1505610
 12436270-n:
   definition:
   - the petals or sepals of a flower that bend downward (especially the outer perianth
@@ -50426,6 +51972,7 @@
   - leopard lily
   - Belamcanda chinensis
   partOfSpeech: n
+  wikidata: Q10957184
 12436783-n:
   definition:
   - a monocotyledonous genus of the family Iridaceae, comprising 90 species of perennials
@@ -50464,6 +52011,7 @@
   mero_part:
   - 07843260-n
   partOfSpeech: n
+  wikidata: Q15041677
 12437422-n:
   definition:
   - cormous perennial herbs; native to South Africa
@@ -50581,6 +52129,7 @@
   - wandflower
   - Sparaxis tricolor
   partOfSpeech: n
+  wikidata: Q954256
 12439185-n:
   definition:
   - snowdrop, narcissus, daffodil; in some classification systems considered a subfamily
@@ -50634,6 +52183,7 @@
   - naked lady
   - Amaryllis belladonna
   partOfSpeech: n
+  wikidata: Q159792
 12440097-n:
   definition:
   - large genus of tropical American vines having showy often spotted umbellate flowers;
@@ -50672,6 +52222,7 @@
   - salsilla
   - Bomarea salsilla
   partOfSpeech: n
+  wikidata: Q5651380
 12440840-n:
   definition:
   - 'genus of African deciduous or evergreen bulbous herbs: blood lilies'
@@ -50708,6 +52259,7 @@
   - Cape tulip
   - Haemanthus coccineus
   partOfSpeech: n
+  wikidata: Q5638197
 12441496-n:
   definition:
   - bulbous flowering plants of tropical America
@@ -50731,6 +52283,7 @@
   - hippeastrum
   - Hippeastrum puniceum
   partOfSpeech: n
+  wikidata: Q10657527
 12441839-n:
   definition:
   - Old World perennial bulbous herbs
@@ -50764,6 +52317,7 @@
   - daffodil
   - Narcissus pseudonarcissus
   partOfSpeech: n
+  wikidata: Q27498
 12442422-n:
   definition:
   - widely cultivated ornamental plant native to southern Europe but naturalized elsewhere
@@ -50775,6 +52329,7 @@
   - jonquil
   - Narcissus jonquilla
   partOfSpeech: n
+  wikidata: Q1703489
 12442634-n:
   definition:
   - often used colloquially for any yellow daffodil
@@ -50795,6 +52350,7 @@
   - paper white
   - Narcissus papyraceus
   partOfSpeech: n
+  wikidata: Q161450
 12442904-n:
   definition:
   - a monocotyledonous genus of the amaryllis family
@@ -50867,6 +52423,7 @@
   - American star grass
   - Hypoxis hirsuta
   partOfSpeech: n
+  wikidata: Q5961537
 12444070-n:
   definition:
   - 'includes species sometimes divided among the following families: Alliaceae, Aloeaceae,
@@ -50993,6 +52550,7 @@
   - mountain lily
   - Lilium auratum
   partOfSpeech: n
+  wikidata: Q134486
 12447254-n:
   definition:
   - common lily of the eastern United States having nodding yellow or reddish flowers
@@ -51007,6 +52565,7 @@
   - wild meadow lily
   - Lilium canadense
   partOfSpeech: n
+  wikidata: Q1723444
 12447483-n:
   definition:
   - lily of eastern Mediterranean and the Balkans with broad funnel-shaped white flowers
@@ -51020,6 +52579,7 @@
   - Lent lily
   - Lilium candidum
   partOfSpeech: n
+  wikidata: Q159811
 12447689-n:
   definition:
   - lily of southeastern United States having cup-shaped flowers with deep yellow
@@ -51045,6 +52605,7 @@
   - Oregon lily
   - Lilium columbianum
   partOfSpeech: n
+  wikidata: Q141828
 12448071-n:
   definition:
   - east Asian perennial having large reddish-orange black-spotted flowers with reflexed
@@ -51058,6 +52619,7 @@
   - kentan
   - Lilium lancifolium
   partOfSpeech: n
+  wikidata: Q266317
 12448262-n:
   definition:
   - tall lily have large white trumpet-shaped flowers that bloom in the spring
@@ -51104,6 +52666,7 @@
   - Michigan lily
   - Lilium michiganense
   partOfSpeech: n
+  wikidata: Q141803
 12448917-n:
   definition:
   - lily of western United States having orange-red to crimson maroon-spotted flowers
@@ -51138,6 +52701,7 @@
   - Turk's cap-lily
   - Lilium superbum
   partOfSpeech: n
+  wikidata: Q136882
 12449420-n:
   definition:
   - small genus of South African evergreen or deciduous plants; sometimes placed in
@@ -51241,6 +52805,7 @@
   - ague grass
   - Aletris farinosa
   partOfSpeech: n
+  wikidata: Q2832875
 12451180-n:
   definition:
   - colicroot with yellow-bracted racemose flowers; smaller than Aletris farinosa;
@@ -51252,6 +52817,7 @@
   - yellow colicroot
   - Aletris aurea
   partOfSpeech: n
+  wikidata: Q2832866
 12451383-n:
   definition:
   - one of many families or subfamilies into which some classification systems subdivide
@@ -51324,6 +52890,7 @@
   - kurrat
   - Allium ampeloprasum
   partOfSpeech: n
+  wikidata: Q148995
 12453079-n:
   definition:
   - North American bulbous plant
@@ -51336,6 +52903,7 @@
   - rose leek
   - Allium canadense
   partOfSpeech: n
+  wikidata: Q582461
 12453212-n:
   definition:
   - Eurasian bulbous plant
@@ -51363,6 +52931,7 @@
   mero_substance:
   - 15057934-n
   partOfSpeech: n
+  wikidata: Q23485
 12453586-n:
   definition:
   - the bulb of an onion plant
@@ -51388,6 +52957,7 @@
   - 07738922-n
   - 12453934-n
   partOfSpeech: n
+  wikidata: Q193498
 12453934-n:
   definition:
   - aggregate bulb of the multiplier onion
@@ -51422,6 +52992,7 @@
   - lady's leek
   - Allium cernuum
   partOfSpeech: n
+  wikidata: Q10641333
 12454457-n:
   definition:
   - Asiatic onion with slender bulbs; used as early green onions
@@ -51444,6 +53015,7 @@
   - red-skinned onion
   - Allium haematochiton
   partOfSpeech: n
+  wikidata: Q4732908
 12454744-n:
   definition:
   - plant having a large slender white bulb and flat overlapping dark green leaves;
@@ -51458,6 +53030,9 @@
   mero_part:
   - 07738784-n
   partOfSpeech: n
+  wikidata:
+  - Q33681353
+  - Q21870138
 12454988-n:
   definition:
   - European onion with white flowers
@@ -51494,6 +53069,7 @@
   mero_part:
   - 07834253-n
   partOfSpeech: n
+  wikidata: Q23400
 12455490-n:
   definition:
   - European leek cultivated and used like leeks
@@ -51507,6 +53083,7 @@
   - rocambole
   - Allium scorodoprasum
   partOfSpeech: n
+  wikidata: Q161099
 12455657-n:
   definition:
   - perennial having hollow cylindrical leaves used for seasoning
@@ -51522,6 +53099,7 @@
   mero_part:
   - 07833000-n
   partOfSpeech: n
+  wikidata: Q51148
 12455843-n:
   definition:
   - North American perennial having a slender bulb and whitish flowers
@@ -51548,6 +53126,7 @@
   - wild garlic
   - Allium vineale
   partOfSpeech: n
+  wikidata: Q161230
 12456154-n:
   definition:
   - pungent Old World weedy plant
@@ -51560,6 +53139,9 @@
   - ramsons
   - Allium ursinum
   partOfSpeech: n
+  wikidata:
+  - Q92558539
+  - Q130882
 12456282-n:
   definition:
   - a plant of eastern Asia; larger than Allium schoenoprasum
@@ -51574,6 +53156,7 @@
   mero_part:
   - 07834548-n
   partOfSpeech: n
+  wikidata: Q42285
 12456470-n:
   definition:
   - Old World leek with a spherical bulb
@@ -51584,6 +53167,7 @@
   - round-headed leek
   - Allium sphaerocephalum
   partOfSpeech: n
+  wikidata: Q32857774
 12456595-n:
   definition:
   - European leek naturalized in Great Britain; leaves are triangular
@@ -51595,6 +53179,9 @@
   - triquetrous leek
   - Allium triquetrum
   partOfSpeech: n
+  wikidata:
+  - Q92558489
+  - Q1532690
 12456765-n:
   definition:
   - one of many families or subfamilies into which some classification systems subdivide
@@ -51654,6 +53241,7 @@
   - burn plant
   - Aloe vera
   partOfSpeech: n
+  wikidata: Q80079
 12457816-n:
   definition:
   - genus of showy clump-forming African herbs with grasslike leaves; sometimes placed
@@ -51703,6 +53291,7 @@
   - red-hot poker
   - Kniphofia praecox
   partOfSpeech: n
+  wikidata: Q1337550
 12458551-n:
   definition:
   - one of many families or subfamilies into which some classification systems subdivide
@@ -51815,6 +53404,7 @@
   - amber lily
   - Anthericum torreyi
   partOfSpeech: n
+  wikidata: Q50826199
 12460633-n:
   definition:
   - one of many families or subfamilies into which some classification systems subdivide
@@ -51891,6 +53481,9 @@
   - Asparagus setaceous
   - Asparagus plumosus
   partOfSpeech: n
+  wikidata:
+  - Q42561493
+  - Q28934742
 12462057-n:
   definition:
   - fragile twining plant of South Africa with bright green flattened stems and glossy
@@ -51902,6 +53495,7 @@
   - smilax
   - Asparagus asparagoides
   partOfSpeech: n
+  wikidata: Q4807698
 12462275-n:
   definition:
   - one of many subfamilies into which some classification systems subdivide the Liliaceae,
@@ -51961,6 +53555,7 @@
   - yellow asphodel
   - Asphodeline lutea
   partOfSpeech: n
+  wikidata: Q1499312
 12463370-n:
   definition:
   - small genus of tall striking annuals or perennials with grasslike foliage and
@@ -52023,6 +53618,7 @@
   - coral drops
   - Bessera elegans
   partOfSpeech: n
+  wikidata: Q15502650
 12464434-n:
   definition:
   - small genus of tuberous Australian perennial herbs
@@ -52071,6 +53667,7 @@
   - golden stars
   - Bloomeria crocea
   partOfSpeech: n
+  wikidata: Q2907031
 12465171-n:
   definition:
   - small genus of tropical African perennial bulbous herbs with deciduous twining
@@ -52096,6 +53693,7 @@
   - climbing onion
   - Bowiea volubilis
   partOfSpeech: n
+  wikidata: Q140288
 12465643-n:
   definition:
   - genus of western United States bulbous plants with basal leaves and variously
@@ -52131,6 +53729,7 @@
   - elegant brodiaea
   - Brodiaea elegans
   partOfSpeech: n
+  wikidata: Q4972993
 12466353-n:
   definition:
   - large genus of western North American leafy-stemmed bulbous herbs
@@ -52197,6 +53796,7 @@
   - white fairy lantern
   - Calochortus albus
   partOfSpeech: n
+  wikidata: Q1385456
 12467626-n:
   definition:
   - globe lily having open branched clusters of clear yellow egg-shaped flowers; northern
@@ -52209,6 +53809,7 @@
   - golden fairy lantern
   - Calochortus amabilis
   partOfSpeech: n
+  wikidata: Q578667
 12467851-n:
   definition:
   - globe lily with deep rose-pink or purple egg-shaped flowers on flexuous stems;
@@ -52220,6 +53821,7 @@
   - rose globe lily
   - Calochortus amoenus
   partOfSpeech: n
+  wikidata: Q5023089
 12468086-n:
   definition:
   - small plant with slender bent stems bearing branched clusters of a few white star-shaped
@@ -52233,6 +53835,7 @@
   - elegant cat's ears
   - Calochortus elegans
   partOfSpeech: n
+  wikidata: Q5023098
 12468396-n:
   definition:
   - mariposa with clusters of bell-shaped vermilion or orange or yellow flowers atop
@@ -52244,6 +53847,7 @@
   - desert mariposa tulip
   - Calochortus kennedyi
   partOfSpeech: n
+  wikidata: Q2934341
 12468641-n:
   definition:
   - mariposa having clusters of a few large deep yellow bell-shaped flowers atop slender
@@ -52255,6 +53859,7 @@
   - yellow mariposa tulip
   - Calochortus luteus
   partOfSpeech: n
+  wikidata: Q5023108
 12468866-n:
   definition:
   - mariposa having loose clusters of one to three handsome lilac flowers resembling
@@ -52324,6 +53929,7 @@
   - common camas
   - Camassia quamash
   partOfSpeech: n
+  wikidata: Q4992158
 12470289-n:
   definition:
   - camas found to the west of Cascade Mountains
@@ -52334,6 +53940,7 @@
   - Leichtlin's camas
   - Camassia leichtlinii
   partOfSpeech: n
+  wikidata: Q6594876
 12470439-n:
   definition:
   - eastern camas; eastern and central North America
@@ -52345,6 +53952,7 @@
   - indigo squill
   - Camassia scilloides
   partOfSpeech: n
+  wikidata: Q5025007
 12470604-n:
   definition:
   - 'perennial bulbous herbs most of northern United States: dogtooth violet; adder''s
@@ -52398,6 +54006,7 @@
   - amberbell
   - Erythronium americanum
   partOfSpeech: n
+  wikidata: Q159580
 12471575-n:
   definition:
   - sturdy European dogtooth with rose to mauve flowers; cultivated in many varieties
@@ -52408,6 +54017,7 @@
   - European dogtooth
   - Erythronium dens-canis
   partOfSpeech: n
+  wikidata: Q159285
 12471745-n:
   definition:
   - California dogtooth violet with creamy white flowers sometimes yellow-tinged
@@ -52430,6 +54040,7 @@
   - snow lily
   - Erythronium grandiflorum
   partOfSpeech: n
+  wikidata: Q1423048
 12472071-n:
   definition:
   - perennial herb having large white flowers marked with orange; found near the snow
@@ -52479,6 +54090,7 @@
   - Fritillaria lanceolata
   - Fritillaria mutica
   partOfSpeech: n
+  wikidata: Q111514799
 12472985-n:
   definition:
   - herb of southwestern United States having dark purple bell-shaped flowers mottled
@@ -52491,6 +54103,7 @@
   - black fritillary
   - Fritillaria biflora
   partOfSpeech: n
+  wikidata: Q5504776
 12473178-n:
   definition:
   - a malodorous California herb with bell-shaped flowers; a common weed in grainfields
@@ -52513,6 +54126,7 @@
   - crown imperial
   - Fritillaria imperialis
   partOfSpeech: n
+  wikidata: Q161939
 12473523-n:
   definition:
   - California herb with white conic or bell-shaped flowers usually tinged with green
@@ -52538,6 +54152,7 @@
   - leper lily
   - Fritillaria meleagris
   partOfSpeech: n
+  wikidata: Q157339
 12474044-n:
   definition:
   - California herb with brownish-purple or greenish bell-shaped flowers
@@ -52561,6 +54176,7 @@
   - pink fritillary
   - Fritillaria pluriflora
   partOfSpeech: n
+  wikidata: Q1651896
 12474362-n:
   definition:
   - western United States herb with scarlet and yellow narrow bell-shaped flowers
@@ -52571,6 +54187,7 @@
   - scarlet fritillary
   - Fritillaria recurva
   partOfSpeech: n
+  wikidata: Q2231384
 12474526-n:
   definition:
   - Eurasian perennial bulbous herbs
@@ -52605,7 +54222,9 @@
   - Tulipa armena
   - Tulipa suaveolens
   partOfSpeech: n
-  wikidata: Q7852084
+  wikidata:
+  - Q7852084
+  - Q2425417
 12475061-n:
   definition:
   - Eurasian tulip with small flowers blotched at the base
@@ -52617,6 +54236,7 @@
   - candlestick tulip
   - Tulipa clusiana
   partOfSpeech: n
+  wikidata: Q1158346
 12475210-n:
   definition:
   - tall late blooming tulip
@@ -52626,6 +54246,7 @@
   members:
   - Tulipa gesneriana
   partOfSpeech: n
+  wikidata: Q163060
 12475298-n:
   definition:
   - any of several long-stemmed tulips that flower in May; have egg-shaped variously
@@ -52712,6 +54333,7 @@
   - creeping lily
   - Gloriosa superba
   partOfSpeech: n
+  wikidata: Q2175092
 12476783-n:
   definition:
   - one of many subfamilies into which some classification systems subdivide the Liliaceae
@@ -52762,6 +54384,7 @@
   - Hemerocallis lilio-asphodelus
   - Hemerocallis flava
   partOfSpeech: n
+  wikidata: Q87605304
 12477755-n:
   definition:
   - one of many families or subfamilies into which some classification systems subdivide
@@ -52869,6 +54492,9 @@
   - Hyacinthus candicans
   - Galtonia candicans
   partOfSpeech: n
+  wikidata:
+  - Q2366444
+  - Q38492612
 12479553-n:
   definition:
   - small genus of perennial bulbs of western Europe and North Africa; sometimes placed
@@ -52897,6 +54523,7 @@
   - Hyacinthoides nonscripta
   - Scilla nonscripta
   partOfSpeech: n
+  wikidata: Q113251901
 12479976-n:
   definition:
   - sometimes placed in family Hyacinthaceae, common name Star-of-Bethlehem (Ornithogalum)
@@ -52933,6 +54560,7 @@
   - summer snowflake
   - Ornithogalum umbellatum
   partOfSpeech: n
+  wikidata: Q161155
 12480651-n:
   definition:
   - Old World star of Bethlehem having edible young shoots
@@ -52944,6 +54572,7 @@
   - Prussian asparagus
   - Ornithogalum pyrenaicum
   partOfSpeech: n
+  wikidata: Q2303755
 12480813-n:
   definition:
   - South African perennial with long-lasting spikes of white blossoms that are shipped
@@ -52956,6 +54585,7 @@
   - wonder flower
   - Ornithogalum thyrsoides
   partOfSpeech: n
+  wikidata: Q1308104
 12481054-n:
   definition:
   - sometimes placed in family Hyacinthaceae, common name grape hyacinth (Muscari)
@@ -53001,6 +54631,7 @@
   - tassel hyacinth
   - Muscari comosum
   partOfSpeech: n
+  wikidata: Q163946
 12481831-n:
   definition:
   - sometimes placed in subfamily Hyacinthaceae
@@ -53035,6 +54666,9 @@
   - Scilla verna
   - sea onion
   partOfSpeech: n
+  wikidata:
+  - Q29784102
+  - Q3034404
 12482314-n:
   definition:
   - genus of perennial herbs of cool temperate regions; sometimes placed in family
@@ -53101,6 +54735,7 @@
   mero_substance:
   - 92426965-n
   partOfSpeech: n
+  wikidata: Q50872038
 12483310-n:
   definition:
   - bulb of the sea squill, which is sliced, dried, and used as an expectorant
@@ -53191,6 +54826,7 @@
   - American bog asphodel
   - Narthecium americanum
   partOfSpeech: n
+  wikidata: Q6966410
 12484783-n:
   definition:
   - a genus of coarse poisonous perennial herbs; sometimes placed in subfamily Melanthiaceae
@@ -53228,6 +54864,7 @@
   - bugbane
   - Veratrum viride
   partOfSpeech: n
+  wikidata: Q2707753
 12485408-n:
   definition:
   - a monocot subfamily of the family Asparagaceae, including beargrasses
@@ -53354,6 +54991,9 @@
   - alkali grass
   - Zigadenus elegans
   partOfSpeech: n
+  wikidata:
+  - Q2853166
+  - Q15221394
 12487702-n:
   definition:
   - plant of eastern and central North America having creamy white flowers tinged
@@ -53365,6 +55005,7 @@
   - white camas
   - Zigadenus glaucus
   partOfSpeech: n
+  wikidata: Q122654505
 12487938-n:
   definition:
   - a common perennial death camas; Tennessee to Kansas to Texas
@@ -53386,6 +55027,9 @@
   - Zigadenus venenosus
   - Zigadenus venenosus gramineus
   partOfSpeech: n
+  wikidata:
+  - Q3849177
+  - Q15547277
 12488316-n:
   definition:
   - small family of herbs having flowers with 3 petals and 3 sepals; in some classification
@@ -53436,6 +55080,7 @@
   - prairie trillium
   - Trillium recurvatum
   partOfSpeech: n
+  wikidata: Q3009702
 12489224-n:
   definition:
   - a low perennial white-flowered trillium found in the southeastern United States
@@ -53460,6 +55105,7 @@
   - birthroot
   - Trillium erectum
   partOfSpeech: n
+  wikidata: Q3539177
 12489662-n:
   definition:
   - trillium of northeastern United States with sessile leaves and red or purple flowers
@@ -53473,6 +55119,7 @@
   - sessile trillium
   - Trillium sessile
   partOfSpeech: n
+  wikidata: Q3005858
 12489877-n:
   definition:
   - sometimes placed in subfamily Trilliaceae
@@ -53576,6 +55223,7 @@
   - rough bindweed
   - Smilax aspera
   partOfSpeech: n
+  wikidata: Q161119
 12491655-n:
   definition:
   - one of many subfamilies into which some classification systems subdivide the Liliaceae
@@ -53614,6 +55262,7 @@
   - May lily
   - Convallaria majalis
   partOfSpeech: n
+  wikidata: Q101711
 12492330-n:
   definition:
   - sometimes placed in family Convallariaceae
@@ -53652,6 +55301,7 @@
   - Andrew's clintonia
   - Clintonia andrewsiana
   partOfSpeech: n
+  wikidata: Q5134293
 12493064-n:
   definition:
   - common woodland herb of temperate North America having yellow nodding flowers
@@ -53664,6 +55314,7 @@
   - heal all
   - Clintonia borealis
   partOfSpeech: n
+  wikidata: Q291670
 12493283-n:
   definition:
   - plant with 1 or 2 white starlike flowers on short leafless stalks; Alaska to California
@@ -53676,6 +55327,7 @@
   - bride's bonnet
   - Clintonia uniflora
   partOfSpeech: n
+  wikidata: Q309753
 12493516-n:
   definition:
   - 'sometimes placed in family Convallariaceae: lilyturf'
@@ -53701,6 +55353,7 @@
   - lily turf
   - Liriope muscari
   partOfSpeech: n
+  wikidata: Q141540
 12493910-n:
   definition:
   - 'sometimes placed in family Convallariaceae: false lily of the valley'
@@ -53726,6 +55379,7 @@
   - false lily of the valley
   - Maianthemum canadense
   partOfSpeech: n
+  wikidata: Q3303394
 12494345-n:
   definition:
   - small white-flowered plant of western Europe to Japan
@@ -53773,8 +55427,8 @@
   - Polygonatum commutatum
   partOfSpeech: n
   wikidata:
-  - Q4117736
   - Q7226448
+  - Q4117736
 12495125-n:
   definition:
   - one of many subfamilies into which some classification systems subdivide the Liliaceae,
@@ -53827,6 +55481,7 @@
   - cornflower
   - Uvularia grandiflora
   partOfSpeech: n
+  wikidata: Q635060
 12495955-n:
   definition:
   - small family of tropical herbs
@@ -53866,6 +55521,7 @@
   - Tacca leontopetaloides
   - Tacca pinnatifida
   partOfSpeech: n
+  wikidata: Q66604178
 12496541-n:
   definition:
   - 'chiefly tropical and xerophytic plants: includes Dracenaceae (Dracaenaceae);
@@ -53954,6 +55610,7 @@
   - cantala
   - Agave cantala
   partOfSpeech: n
+  wikidata: Q293281
 12498252-n:
   definition:
   - Mexican plant used especially for making pulque which is the source of the colorless
@@ -53980,7 +55637,9 @@
   mero_substance:
   - 07922219-n
   partOfSpeech: n
-  wikidata: Q311065
+  wikidata:
+  - Q93242898
+  - Q311065
 12498636-n:
   definition:
   - hard fiber used in making coarse twine; from Philippine agave plants
@@ -54019,6 +55678,7 @@
   - ti
   - Cordyline terminalis
   partOfSpeech: n
+  wikidata: Q50828645
 12499273-n:
   definition:
   - elegant tree having either a single trunk or a branching trunk each with terminal
@@ -54079,6 +55739,7 @@
   - dragon tree
   - Dracaena draco
   partOfSpeech: n
+  wikidata: Q157952
 12500326-n:
   definition:
   - perennial plants resembling yucca; found in southern United States and Mexico
@@ -54129,6 +55790,9 @@
   - tuberose
   - Polianthes tuberosa
   partOfSpeech: n
+  wikidata:
+  - Q64402156
+  - Q17270998
 12501182-n:
   definition:
   - Old World tropical herbaceous perennial of the agave family; in some classifications
@@ -54166,6 +55830,7 @@
   - African hemp
   - Sansevieria guineensis
   partOfSpeech: n
+  wikidata: Q50862089
 12501794-n:
   definition:
   - plant having thick fibrous leaves transversely banded in light and dark green
@@ -54188,7 +55853,9 @@
   - snake plant
   - Sansevieria trifasciata
   partOfSpeech: n
-  wikidata: Q5859273
+  wikidata:
+  - Q65936984
+  - Q5859273
 12502146-n:
   definition:
   - strong fiber that resembles hemp; obtained from sansevieria and used for e.g.
@@ -54269,6 +55936,7 @@
   - Spanish dagger
   - Yucca carnerosana
   partOfSpeech: n
+  wikidata: Q1466312
 12503787-n:
   definition:
   - tall arborescent yucca of southwestern United States
@@ -54281,6 +55949,7 @@
   - soap tree
   - Yucca elata
   partOfSpeech: n
+  wikidata: Q200844
 12503932-n:
   definition:
   - yucca with long stiff leaves having filamentlike appendages
@@ -54294,6 +55963,7 @@
   - needle palm
   - Yucca filamentosa
   partOfSpeech: n
+  wikidata: Q1194599
 12504130-n:
   definition:
   - yucca of west central United States having a clump of basal grasslike leaves and
@@ -54305,6 +55975,7 @@
   - bear grass
   - Yucca glauca
   partOfSpeech: n
+  wikidata: Q882878
 12504346-n:
   definition:
   - yucca of southeastern United States similar to the Spanish bayonets but with shorter
@@ -54316,6 +55987,7 @@
   - Spanish dagger
   - Yucca gloriosa
   partOfSpeech: n
+  wikidata: Q164135
 12504534-n:
   definition:
   - yucca of southern United States having a clump of basal grasslike leaves and a
@@ -54327,6 +55999,7 @@
   - bear grass
   - Yucca smalliana
   partOfSpeech: n
+  wikidata: Q10871260
 12504749-n:
   definition:
   - yucca of southwestern United States and Mexico with a tall spike of creamy white
@@ -54338,7 +56011,9 @@
   - Our Lord's candle
   - Yucca whipplei
   partOfSpeech: n
-  wikidata: Q290767
+  wikidata:
+  - Q19848612
+  - Q290767
 12504918-n:
   definition:
   - a dicotyledonous family of marsh plants of order Gentianales
@@ -54460,6 +56135,7 @@
   - evening trumpet flower
   - Gelsemium sempervirens
   partOfSpeech: n
+  wikidata: Q978130
 12506759-n:
   definition:
   - a widely distributed family of plants
@@ -54617,6 +56293,7 @@
   mero_part:
   - 11709666-n
   partOfSpeech: n
+  wikidata: Q87613669
 12509214-n:
   definition:
   - small thornless tree or shrub of tropical America whose seed pods are a source
@@ -54630,6 +56307,7 @@
   mero_part:
   - 12509419-n
   partOfSpeech: n
+  wikidata: Q1230627
 12509419-n:
   definition:
   - twisted seed pods of the divi-divi tree; source of tannin
@@ -54651,6 +56329,7 @@
   - Caesalpinia decapetala
   - Caesalpinia sepiaria
   partOfSpeech: n
+  wikidata: Q2720939
 12509773-n:
   definition:
   - tropical tree with prickly trunk; its heavy red wood yields a red dye and is used
@@ -54667,6 +56346,7 @@
   mero_substance:
   - 12510029-n
   partOfSpeech: n
+  wikidata: Q216469
 12510029-n:
   definition:
   - heavy wood of various brazilwood trees; used for violin bows and as dyewoods
@@ -54686,6 +56366,9 @@
   - brazilian ironwood
   - Caesalpinia ferrea
   partOfSpeech: n
+  wikidata:
+  - Q29549903
+  - Q4116530
 12510320-n:
   definition:
   - a tropical flowering shrub having bright orange or red flowers; sometimes placed
@@ -54714,6 +56397,7 @@
   - Caesalpinia pulcherrima
   - Poinciana pulcherrima
   partOfSpeech: n
+  wikidata: Q1428973
 12510835-n:
   definition:
   - small genus of trees of Indonesia and Malaysia
@@ -54763,6 +56447,7 @@
   - butterfly flower
   - Bauhinia monandra
   partOfSpeech: n
+  wikidata: Q2859792
 12511522-n:
   definition:
   - small East Indian tree having orchid-like flowers and hard dark wood
@@ -54774,6 +56459,7 @@
   - orchid tree
   - Bauhinia variegata
   partOfSpeech: n
+  wikidata: Q840341
 12511705-n:
   definition:
   - 'small genus of tropical African timber trees having pale golden heartwood uniformly
@@ -54854,6 +56540,7 @@
   - horse cassia
   - Cassia grandis
   partOfSpeech: n
+  wikidata: Q164094
 12513187-n:
   definition:
   - deciduous ornamental hybrid of southeastern Asia and Hawaii having racemes of
@@ -54877,6 +56564,7 @@
   - Cassia roxburghii
   - Cassia marginata
   partOfSpeech: n
+  wikidata: Q15475041
 12513595-n:
   definition:
   - carobs
@@ -54905,6 +56593,7 @@
   mero_part:
   - 12513931-n
   partOfSpeech: n
+  wikidata: Q68763
 12513931-n:
   definition:
   - long pod containing small beans and sweetish edible pulp; used as animal feed
@@ -55048,6 +56737,7 @@
   - swamp locust
   - Gleditsia aquatica
   partOfSpeech: n
+  wikidata: Q603036
 12516400-n:
   definition:
   - tall usually spiny North American tree having small greenish-white flowers in
@@ -55060,6 +56750,7 @@
   - honey locust
   - Gleditsia triacanthos
   partOfSpeech: n
+  wikidata: Q157650
 12516712-n:
   definition:
   - small genus of deciduous trees of China and United States having paniculate flowers
@@ -55088,6 +56779,7 @@
   - chicot
   - Gymnocladus dioica
   partOfSpeech: n
+  wikidata: Q105034954
 12517240-n:
   definition:
   - small genus of tropical American spiny bushy shrubs or trees
@@ -55159,6 +56851,7 @@
   - horsebean
   - Parkinsonia aculeata
   partOfSpeech: n
+  wikidata: Q279482
 12518560-n:
   definition:
   - densely branched spiny tree of southwestern United States having showy yellow
@@ -55197,6 +56890,7 @@
   - Petteria ramentacea
   - Cytisus ramentaceus
   partOfSpeech: n
+  wikidata: Q1786791
 12519244-n:
   definition:
   - small subgenus of ornamental tropical shrubs or trees; not recognized in some
@@ -55250,6 +56944,7 @@
   - Senna alata
   - Cassia alata
   partOfSpeech: n
+  wikidata: Q41504
 12520262-n:
   definition:
   - evergreen Indian shrub with vivid yellow flowers whose bark is used in tanning;
@@ -55281,6 +56976,7 @@
   - Cassia acutifolia
   - Cassia augustifolia
   partOfSpeech: n
+  wikidata: Q132675
 12520814-n:
   definition:
   - North American perennial herb; leaves are used medicinally; sometimes placed in
@@ -55307,8 +57003,8 @@
   - Cassia tora
   partOfSpeech: n
   wikidata:
-  - Q1378803
   - Q21872227
+  - Q1378803
 12521256-n:
   definition:
   - very leafy malodorous tropical weedy shrub whose seeds have been used as an adulterant
@@ -55324,6 +57020,7 @@
   - Senna occidentalis
   - Cassia occidentalis
   partOfSpeech: n
+  wikidata: Q2720961
 12521540-n:
   definition:
   - widely cultivated tropical trees originally of Africa
@@ -55516,6 +57213,7 @@
   - lead plant
   - Amorpha canescens
   partOfSpeech: n
+  wikidata: Q2074094
 12525075-n:
   definition:
   - an erect to spreading hairy shrub of the Pacific coast of the United States having
@@ -55571,6 +57269,7 @@
   - Amphicarpaea bracteata
   - Amphicarpa bracteata
   partOfSpeech: n
+  wikidata: Q4748227
 12526068-n:
   definition:
   - very small genus of shrubs of southern Europe having backward curving seed pods
@@ -55596,6 +57295,7 @@
   - stinking bean trefoil
   - Anagyris foetida
   partOfSpeech: n
+  wikidata: Q2630262
 12526492-n:
   definition:
   - small genus of evergreen trees of tropical America and western Africa
@@ -55633,6 +57333,7 @@
   - cabbage tree
   - Andira inermis
   partOfSpeech: n
+  wikidata: Q4754500
 12527119-n:
   definition:
   - genus of Mediterranean herbs and shrubs
@@ -55659,6 +57360,7 @@
   - silver-bush
   - Anthyllis barba-jovis
   partOfSpeech: n
+  wikidata: Q1874595
 12527496-n:
   definition:
   - perennial Eurasian herb having heads of red or yellow flowers and common in meadows
@@ -55670,6 +57372,9 @@
   - kidney vetch
   - Anthyllis vulneraria
   partOfSpeech: n
+  wikidata:
+  - Q92988397
+  - Q126256
 12527741-n:
   definition:
   - twining perennial North American plants
@@ -55701,6 +57406,7 @@
   mero_part:
   - 07790008-n
   partOfSpeech: n
+  wikidata: Q568933
 12528175-n:
   definition:
   - genus of South African heathlike shrubs
@@ -55726,6 +57432,7 @@
   - Aspalathus linearis
   - Aspalathus cedcarbergensis
   partOfSpeech: n
+  wikidata: Q272181
 12528582-n:
   definition:
   - large genus of annual or perennial herbs or shrubs of north temperate regions;
@@ -55761,6 +57468,7 @@
   - wild liquorice
   - Astragalus glycyphyllos
   partOfSpeech: n
+  wikidata: Q158127
 12529123-n:
   definition:
   - perennial of mountainous areas of Eurasia and North America
@@ -55808,6 +57516,7 @@
   - African sandalwood
   - Baphia nitida
   partOfSpeech: n
+  wikidata: Q5028820
 12529802-n:
   definition:
   - genus of North American plants with showy flowers and an inflated pod
@@ -55841,6 +57550,7 @@
   - blue false indigo
   - Baptisia australis
   partOfSpeech: n
+  wikidata: Q916179
 12530326-n:
   definition:
   - erect or spreading herb having racemes of creamy white flowers; the eastern United
@@ -55852,6 +57562,7 @@
   - white false indigo
   - Baptisia lactea
   partOfSpeech: n
+  wikidata: Q17444972
 12530498-n:
   definition:
   - much-branched erect herb with bright yellow flowers; distributed from Massachusetts
@@ -55865,6 +57576,7 @@
   - rattle weed
   - Baptisia tinctoria
   partOfSpeech: n
+  wikidata: Q783093
 12530702-n:
   definition:
   - 'genus of East Indian trees or shrubs: dhak'
@@ -55892,6 +57604,7 @@
   - Butea frondosa
   - Butea monosperma
   partOfSpeech: n
+  wikidata: Q87613622
 12531074-n:
   definition:
   - erect densely branched shrubby perennials of Old World tropics; naturalized in
@@ -55965,6 +57678,7 @@
   - sword bean
   - Canavalia gladiata
   partOfSpeech: n
+  wikidata: Q1937714
 12532208-n:
   definition:
   - large genus of Asiatic deciduous shrubs or small trees
@@ -55999,6 +57713,9 @@
   - Siberian pea tree
   - Caragana arborescens
   partOfSpeech: n
+  wikidata:
+  - Q15502974
+  - Q162124
 12532799-n:
   definition:
   - shrub with dark-green glossy foliage and solitary pale yellow flowers; northern
@@ -56010,6 +57727,7 @@
   - Chinese pea tree
   - Caragana sinica
   partOfSpeech: n
+  wikidata: Q1074164
 12532965-n:
   definition:
   - 'a rosid dicot genus of the subfamily Papilionoideae having one species: Moreton
@@ -56061,6 +57779,7 @@
   - butterfly pea
   - Centrosema virginianum
   partOfSpeech: n
+  wikidata: Q5063036
 12533931-n:
   definition:
   - deciduous shrubs and trees of eastern Asia, southern Europe and the United States
@@ -56098,6 +57817,7 @@
   - redbud
   - Cercis canadensis
   partOfSpeech: n
+  wikidata: Q2452407
 12534643-n:
   definition:
   - shrub of western United States having pink or crimson flowers; often forms thickets
@@ -56109,6 +57829,9 @@
   - California redbud
   - Cercis occidentalis
   partOfSpeech: n
+  wikidata:
+  - Q15538466
+  - Q5063945
 12534829-n:
   definition:
   - small late-flowering trees or subshrubs having yellow to red flowers and leathery
@@ -56136,8 +57859,8 @@
   - Cytesis proliferus
   partOfSpeech: n
   wikidata:
-  - Q7675170
   - Q15531292
+  - Q7675170
 12535307-n:
   definition:
   - '2 species of small New Zealand trees: weeping tree broom; endangered'
@@ -56210,6 +57933,7 @@
   - 07742071-n
   - 12536430-n
   partOfSpeech: n
+  wikidata: Q81375
 12536430-n:
   definition:
   - the seed of the chickpea plant
@@ -56246,6 +57970,7 @@
   - Cladrastis lutea
   - Cladrastis kentukea
   partOfSpeech: n
+  wikidata: Q87599757
 12536937-n:
   definition:
   - genus of semi-prostrate Australasian shrubs or vines
@@ -56284,6 +58009,7 @@
   - Clianthus formosus
   - Clianthus speciosus
   partOfSpeech: n
+  wikidata: Q87616518
 12537582-n:
   definition:
   - evergreen shrub with scarlet to white clawlike or beaklike flowers; New Zealand
@@ -56320,6 +58046,7 @@
   - butterfly pea
   - Clitoria mariana
   partOfSpeech: n
+  wikidata: Q10865523
 12538147-n:
   definition:
   - vine of tropical Asia having pinnate leaves and bright blue flowers with yellow
@@ -56420,6 +58147,9 @@
   - crown vetch
   - Coronilla varia
   partOfSpeech: n
+  wikidata:
+  - Q158908
+  - Q15248508
 12539833-n:
   definition:
   - large genus of herbs with simple leaves and racemes of yellow flowers; mainly
@@ -56456,6 +58186,7 @@
   - American rattlebox
   - Crotalaria sagitallis
   partOfSpeech: n
+  wikidata: Q65935304
 12540520-n:
   definition:
   - erect subshrub having purple-tinted flowers and an inflated pod in which the ripe
@@ -56494,6 +58225,7 @@
   - Cyamopsis tetragonolobus
   - Cyamopsis psoraloides
   partOfSpeech: n
+  wikidata: Q12233863
 12541166-n:
   definition:
   - 'large genus of stiff or spiny evergreen or deciduous Old World shrubs: broom'
@@ -56544,6 +58276,7 @@
   - green broom
   - Cytisus scoparius
   partOfSpeech: n
+  wikidata: Q145781
 12542129-n:
   definition:
   - an abnormal tufted growth of small branches on a tree or shrub caused by fungi
@@ -56611,6 +58344,7 @@
   - Indian rosewood
   - Dalbergia latifolia
   partOfSpeech: n
+  wikidata: Q726420
 12543399-n:
   definition:
   - East Indian tree whose leaves are used for fodder; yields a compact dark brown
@@ -56638,6 +58372,7 @@
   mero_substance:
   - 12543824-n
   partOfSpeech: n
+  wikidata: Q2705553
 12543824-n:
   definition:
   - handsome violet-streaked wood of the kingwood tree; used especially in cabinetwork
@@ -56671,6 +58406,7 @@
   - Honduras rosewood
   - Dalbergia stevensonii
   partOfSpeech: n
+  wikidata: Q15532192
 12544355-n:
   definition:
   - a valuable timber tree of tropical South America
@@ -56740,6 +58476,9 @@
   - smoke tree
   - Dalea spinosa
   partOfSpeech: n
+  wikidata:
+  - Q7256142
+  - Q39169915
 12545449-n:
   definition:
   - genus of Australasian shrubs and subshrubs having small yellow or purple flowers
@@ -56800,6 +58539,7 @@
   - tuba root
   - Derris elliptica
   partOfSpeech: n
+  wikidata: Q11128689
 12546480-n:
   definition:
   - genus of American herbs or shrubs with sensitive pinnate leaves and small whitish
@@ -56862,6 +58602,7 @@
   - Desmodium tortuosum
   - Desmodium purpureum
   partOfSpeech: n
+  wikidata: Q10908837
 12547451-n:
   definition:
   - 'one species: Australian pea'
@@ -56888,6 +58629,7 @@
   - Dipogon lignosus
   - Dolichos lignosus
   partOfSpeech: n
+  wikidata: Q15533996
 12547896-n:
   definition:
   - genus of chiefly tropical vines often placed in genera Dipogon or Lablab or Macrotyloma
@@ -56936,6 +58678,9 @@
   - Cape kafferboom
   - Erythrina caffra
   partOfSpeech: n
+  wikidata:
+  - Q15530188
+  - Q1955238
 12548887-n:
   definition:
   - deciduous shrub having racemes of deep red flowers and black-spotted red seeds
@@ -56946,6 +58691,7 @@
   - coral bean tree
   - Erythrina corallodendrum
   partOfSpeech: n
+  wikidata: Q21874216
 12549054-n:
   definition:
   - small South American spiny tree with dark crimson and scarlet flowers solitary
@@ -56960,6 +58706,9 @@
   - common coral tree
   - Erythrina crista-galli
   partOfSpeech: n
+  wikidata:
+  - Q65934939
+  - Q162849
 12549273-n:
   definition:
   - small semi-evergreen tree of South Africa having dense clusters of clear scarlet
@@ -56985,6 +58734,7 @@
   - Erythrina variegata
   - Erythrina indica
   partOfSpeech: n
+  wikidata: Q87623652
 12549725-n:
   definition:
   - prickly Australian coral tree having soft spongy wood
@@ -56995,7 +58745,9 @@
   - cork tree
   - Erythrina vespertilio
   partOfSpeech: n
-  wikidata: Q5396436
+  wikidata:
+  - Q65934946
+  - Q5396436
 12549858-n:
   definition:
   - 'small genus of Eurasian herbs: goat''s rue'
@@ -57021,6 +58773,7 @@
   - goat rue
   - Galega officinalis
   partOfSpeech: n
+  wikidata: Q157287
 12550235-n:
   definition:
   - 'genus of Australian evergreen shrubs poisonous to livestock: poison bush'
@@ -57075,6 +58828,7 @@
   - petty whin
   - Genista anglica
   partOfSpeech: n
+  wikidata: Q161720
 12551134-n:
   definition:
   - erect shrub of southwestern Europe having racemes of golden yellow flowers
@@ -57188,6 +58942,7 @@
   - 07745461-n
   - 12553069-n
   partOfSpeech: n
+  wikidata: Q11006
 12553069-n:
   definition:
   - a source of oil; used for forage and soil improvement and as food
@@ -57228,6 +58983,7 @@
   mero_part:
   - 12553942-n
   partOfSpeech: n
+  wikidata: Q257106
 12553695-n:
   definition:
   - North American plant similar to true licorice and having a root with similar properties
@@ -57241,7 +58997,7 @@
   - American liquorice
   - Glycyrrhiza lepidota
   partOfSpeech: n
-  wikidata: Q8000935
+  wikidata: Q164138
 12553942-n:
   definition:
   - root of licorice used in flavoring e.g. candy and liqueurs and medicines
@@ -57276,6 +59032,7 @@
   - Halimodendron halodendron
   - Halimodendron argenteum
   partOfSpeech: n
+  wikidata: Q10660730
 12554497-n:
   definition:
   - small genus of Australian woody vines with small violet flowers; closely related
@@ -57412,6 +59169,7 @@
   - indigo plant
   - Indigofera tinctoria
   partOfSpeech: n
+  wikidata: Q165213
 12556796-n:
   definition:
   - shrub of West Indies and South America that is a source of indigo dye
@@ -57484,6 +59242,9 @@
   - running postman
   - Kennedia prostrata
   partOfSpeech: n
+  wikidata:
+  - Q15553798
+  - Q3195154
 12557942-n:
   definition:
   - 'one species: hyacinth bean'
@@ -57514,7 +59275,9 @@
   - Lablab purpureus
   - Dolichos lablab
   partOfSpeech: n
-  wikidata: Q3712638
+  wikidata:
+  - Q3712638
+  - Q1077410
 12558493-n:
   definition:
   - flowering shrubs or trees having bright yellow flowers; all parts of the plant
@@ -57541,6 +59304,7 @@
   - Alpine golden chain
   - Laburnum alpinum
   partOfSpeech: n
+  wikidata: Q3497019
 12558885-n:
   definition:
   - an ornamental shrub or tree of the genus Laburnum; often cultivated for Easter
@@ -57615,6 +59379,9 @@
   - wild winterpea
   - Lathyrus hirsutus
   partOfSpeech: n
+  wikidata:
+  - Q15540205
+  - Q159773
 12560337-n:
   definition:
   - any of several perennial vines of the genus Lathyrus
@@ -57636,6 +59403,7 @@
   - perennial pea
   - Lathyrus latifolius
   partOfSpeech: n
+  wikidata: Q158325
 12560755-n:
   definition:
   - wild pea of seashores of north temperate zone having tough roots and purple flowers
@@ -57649,6 +59417,7 @@
   - Lathyrus maritimus
   - Lathyrus japonicus
   partOfSpeech: n
+  wikidata: Q21125
 12560993-n:
   definition:
   - perennial of Europe and North Africa; foliage turns black in drying
@@ -57659,6 +59428,7 @@
   - black pea
   - Lathyrus niger
   partOfSpeech: n
+  wikidata: Q158520
 12561152-n:
   definition:
   - annual European vetch with red flowers
@@ -57670,6 +59440,7 @@
   - grass vetchling
   - Lathyrus nissolia
   partOfSpeech: n
+  wikidata: Q159362
 12561305-n:
   definition:
   - climbing garden plant having fragrant pastel-colored flowers
@@ -57681,6 +59452,7 @@
   - sweetpea
   - Lathyrus odoratus
   partOfSpeech: n
+  wikidata: Q163944
 12561471-n:
   definition:
   - scrambling perennial of damp or marshy areas of Eurasia and North America with
@@ -57692,6 +59464,9 @@
   - marsh pea
   - Lathyrus palustris
   partOfSpeech: n
+  wikidata:
+  - Q15539021
+  - Q159365
 12561662-n:
   definition:
   - scrambling perennial Eurasian wild pea having yellowish flowers and compressed
@@ -57705,7 +59480,9 @@
   - yellow vetchling
   - Lathyrus pratensis
   partOfSpeech: n
-  wikidata: Q158592
+  wikidata:
+  - Q158592
+  - Q161639
 12561908-n:
   definition:
   - European annual grown for forage; seeds used for food in India and for stock elsewhere
@@ -57718,6 +59495,7 @@
   - khesari
   - Lathyrus sativus
   partOfSpeech: n
+  wikidata: Q162093
 12562111-n:
   definition:
   - shrubby California perennial having large pink or violet flowers; cultivated as
@@ -57729,6 +59507,7 @@
   - pride of California
   - Lathyrus splendens
   partOfSpeech: n
+  wikidata: Q13642792
 12562310-n:
   definition:
   - European perennial with mottled flowers of purple and pink; sometimes cultivated
@@ -57766,6 +59545,7 @@
   - tuberous vetch
   - Lathyrus tuberosus
   partOfSpeech: n
+  wikidata: Q162914
 12562971-n:
   definition:
   - bushy European perennial having nodding racemose violet-blue flowers
@@ -57777,6 +59557,7 @@
   - spring vetch
   - Lathyrus vernus
   partOfSpeech: n
+  wikidata: Q157490
 12563154-n:
   definition:
   - genus of shrubs or herbs of tropical Asia and Australia and the eastern United
@@ -57830,6 +59611,7 @@
   - jap clover
   - Lespedeza striata
   partOfSpeech: n
+  wikidata: Q50844423
 12564144-n:
   definition:
   - annual native to Korea but widely cultivated for forage and hay in hot dry regions
@@ -57840,6 +59622,9 @@
   - Korean lespedeza
   - Lespedeza stipulacea
   partOfSpeech: n
+  wikidata:
+  - Q3336452
+  - Q39151992
 12564331-n:
   definition:
   - perennial widely planted as for forage and as hay crop especially on poor land
@@ -57851,7 +59636,9 @@
   - Lespedeza sericea
   - Lespedeza cuneata
   partOfSpeech: n
-  wikidata: Q5364126
+  wikidata:
+  - Q5364126
+  - Q87631206
 12564532-n:
   definition:
   - 'genus of small erect or climbing herbs with pinnate leaves and small inconspicuous
@@ -57880,6 +59667,7 @@
   - 07741231-n
   - 12565044-n
   partOfSpeech: n
+  wikidata: Q131226
 12565044-n:
   definition:
   - the fruit or seed of a lentil plant
@@ -57939,6 +59727,7 @@
   - prairie trefoil
   - Lotus americanus
   partOfSpeech: n
+  wikidata: Q87632238
 12565934-n:
   definition:
   - low-growing much-branched perennial of Canary Islands having orange-red to scarlet
@@ -57950,6 +59739,9 @@
   - coral gem
   - Lotus berthelotii
   partOfSpeech: n
+  wikidata:
+  - Q15537502
+  - Q5492395
 12566140-n:
   definition:
   - European forage plant having claw-shaped pods introduced in America
@@ -57975,6 +59767,7 @@
   - asparagus pea
   - Lotus tetragonolobus
   partOfSpeech: n
+  wikidata: Q160889
 12566520-n:
   definition:
   - 'herbs or shrubs: lupin'
@@ -58014,6 +59807,7 @@
   - Egyptian lupine
   - Lupinus albus
   partOfSpeech: n
+  wikidata: Q161372
 12567122-n:
   definition:
   - evergreen shrub of the Pacific coast of the United States having showy yellow
@@ -58025,6 +59819,7 @@
   - tree lupine
   - Lupinus arboreus
   partOfSpeech: n
+  wikidata: Q4117740
 12567337-n:
   definition:
   - yellow-flowered European lupine cultivated for forage
@@ -58035,6 +59830,7 @@
   - yellow lupine
   - Lupinus luteus
   partOfSpeech: n
+  wikidata: Q159751
 12567467-n:
   definition:
   - stout perennial of eastern and central North America having palmate leaves and
@@ -58064,6 +59860,7 @@
   - Texas bluebonnet
   - Lupinus subcarnosus
   partOfSpeech: n
+  wikidata: Q12841445
 12568008-n:
   definition:
   - closely resembles Lupinus subcarnosus; southwestern United States (Texas)
@@ -58103,6 +59900,7 @@
   - Macrotyloma uniflorum
   - Dolichos biflorus
   partOfSpeech: n
+  wikidata: Q1899077
 12568639-n:
   definition:
   - a genus of herbs that resemble clover
@@ -58140,6 +59938,7 @@
   - moon trefoil
   - Medicago arborea
   partOfSpeech: n
+  wikidata: Q1668432
 12569309-n:
   definition:
   - European medic naturalized in North America having yellow flowers and sickle-shaped
@@ -58153,6 +59952,9 @@
   - sickle medick
   - Medicago falcata
   partOfSpeech: n
+  wikidata:
+  - Q158531
+  - Q21976301
 12569510-n:
   definition:
   - an annual of the Mediterranean area having spiny seed pods and leaves with dark
@@ -58165,6 +59967,7 @@
   - Medicago intertexta
   - Medicago echinus
   partOfSpeech: n
+  wikidata: Q50844926
 12569697-n:
   definition:
   - prostrate European herb with small yellow flowers and curved black pods; naturalized
@@ -58194,6 +59997,7 @@
   mero_part:
   - 07817755-n
   partOfSpeech: n
+  wikidata: Q156106
 12570154-n:
   definition:
   - genus of trees and shrubs of the Old World tropics
@@ -58262,6 +60066,7 @@
   mero_part:
   - 12571293-n
   partOfSpeech: n
+  wikidata: Q87634449
 12571293-n:
   definition:
   - pods of the cowage plant or the stinging hairs covering them; used as a vermifuge
@@ -58301,6 +60106,7 @@
   mero_substance:
   - 12572174-n
   partOfSpeech: n
+  wikidata: Q15290525
 12571962-n:
   definition:
   - tree of South and Central America yielding an aromatic balsam
@@ -58314,6 +60120,7 @@
   mero_substance:
   - 12572382-n
   partOfSpeech: n
+  wikidata: Q2412565
 12572174-n:
   definition:
   - aromatic yellowish brown balsam from the tolu balsam tree used especially in cough
@@ -58394,6 +60201,7 @@
   - rest-harrow
   - Ononis repens
   partOfSpeech: n
+  wikidata: Q161749
 12573619-n:
   definition:
   - Eurasian plant having loose racemes of pink or purple flowers and spiny stems
@@ -58446,6 +60254,7 @@
   - jumby tree
   - Ormosia monosperma
   partOfSpeech: n
+  wikidata: Q15481216
 12574534-n:
   definition:
   - West Indian tree similar to Ormosia monosperma but larger and having smaller leaflets
@@ -58458,6 +60267,7 @@
   - jumbie bead
   - Ormosia coarctata
   partOfSpeech: n
+  wikidata: Q15486044
 12574747-n:
   definition:
   - large widely-distributed genus of evergreen shrubs or subshrubs having odd-pinnate
@@ -58532,6 +60342,7 @@
   - yam bean
   - Pachyrhizus erosus
   partOfSpeech: n
+  wikidata: Q517283
 12576058-n:
   definition:
   - twining plant of Amazon basin having large edible roots
@@ -58685,6 +60496,7 @@
   - Phaseolus coccineus
   - Phaseolus multiflorus
   partOfSpeech: n
+  wikidata: Q159753
 12578500-n:
   definition:
   - a bean plant grown primarily for its edible seed rather than its pod
@@ -58763,6 +60575,7 @@
   - stingaree-bush
   - Pickeringia montana
   partOfSpeech: n
+  wikidata: Q7190834
 12579807-n:
   definition:
   - genus of shrubs or small trees having indehiscent pods with black seeds; roots
@@ -58791,6 +60604,7 @@
   - Piscidia piscipula
   - Piscidia erythrina
   partOfSpeech: n
+  wikidata: Q50851235
 12580347-n:
   definition:
   - 'small genus of variable annual Eurasian vines: peas'
@@ -58843,6 +60657,7 @@
   mero_part:
   - 12581126-n
   partOfSpeech: n
+  wikidata: Q25237
 12581126-n:
   definition:
   - the flattened to cylindric inflated multi-seeded fruit of the common pea plant
@@ -58901,6 +60716,9 @@
   - 07742362-n
   - 12582099-n
   partOfSpeech: n
+  wikidata:
+  - Q149758
+  - Q21876275
 12582099-n:
   definition:
   - seed of the field pea plant
@@ -58935,6 +60753,7 @@
   - flat pea
   - Platylobium formosum
   partOfSpeech: n
+  wikidata: Q7202647
 12582646-n:
   definition:
   - low spreading evergreen shrub of southern Australia having triangular to somewhat
@@ -58983,6 +60802,7 @@
   - roble
   - Platymiscium trinitatis
   partOfSpeech: n
+  wikidata: Q15542195
 12583550-n:
   definition:
   - large erect shrub of Colombia having large odd-pinnate leaves with large leaflets
@@ -58995,6 +60815,7 @@
   - Panama redwood
   - Platymiscium pinnatum
   partOfSpeech: n
+  wikidata: Q15541090
 12583786-n:
   definition:
   - hard heavy red wood of a quira tree
@@ -59040,6 +60861,7 @@
   - Indian beech
   - Pongamia glabra
   partOfSpeech: n
+  wikidata: Q50851433
 12584418-n:
   definition:
   - species of tropical Asian and African climbing herbs
@@ -59070,6 +60892,7 @@
   mero_part:
   - 07740921-n
   partOfSpeech: n
+  wikidata: Q1468260
 12584886-n:
   definition:
   - widely distributed genus of herbs or shrubs with glandular compound leaves and
@@ -59097,7 +60920,9 @@
   - pomme de prairie
   - Psoralea esculenta
   partOfSpeech: n
-  wikidata: Q1283624
+  wikidata:
+  - Q21314347
+  - Q1283624
 12585345-n:
   definition:
   - genus of tropical trees or climbers having usually broadly winged pods
@@ -59143,6 +60968,7 @@
   mero_substance:
   - 12586095-n
   partOfSpeech: n
+  wikidata: Q979014
 12586095-n:
   definition:
   - mottled curly-grained wood of Pterocarpus indicus
@@ -59164,6 +60990,7 @@
   - Burmese rosewood
   - Pterocarpus macrocarpus
   partOfSpeech: n
+  wikidata: Q310157
 12586417-n:
   definition:
   - East Indian tree yielding a resin or extract often used medicinally and in e.g.
@@ -59177,6 +61004,7 @@
   mero_substance:
   - 12586617-n
   partOfSpeech: n
+  wikidata: Q2385259
 12586617-n:
   definition:
   - reddish or black juice or resin from certain trees of the genus Pterocarpus and
@@ -59244,6 +61072,7 @@
   - kudzu vine
   - Pueraria lobata
   partOfSpeech: n
+  wikidata: Q65946511
 12587821-n:
   definition:
   - small genus of Mediterranean shrubs; often included in genus Genista
@@ -59272,7 +61101,9 @@
   - Retama raetam
   - Genista raetam
   partOfSpeech: n
-  wikidata: Q2910823
+  wikidata:
+  - Q15531393
+  - Q2910823
 12588273-n:
   definition:
   - deciduous flowering trees and shrubs
@@ -59317,6 +61148,7 @@
   mero_substance:
   - 12589011-n
   partOfSpeech: n
+  wikidata: Q157417
 12589011-n:
   definition:
   - strong stiff wood of a black-locust tree; very resistant to decay
@@ -59361,6 +61193,9 @@
   - carib wood
   - Sabinea carinalis
   partOfSpeech: n
+  wikidata:
+  - Q15542654
+  - Q87585867
 12589738-n:
   definition:
   - small genus of tropical and subtropical leguminous herbs or shrubs or trees
@@ -59395,6 +61230,7 @@
   - Colorado River hemp
   - Sesbania exaltata
   partOfSpeech: n
+  wikidata: Q21297263
 12590356-n:
   definition:
   - a softwood tree with lax racemes of usually red or pink flowers; tropical Australia
@@ -59407,6 +61243,7 @@
   - vegetable hummingbird
   - Sesbania grandiflora
   partOfSpeech: n
+  wikidata: Q947251
 12590631-n:
   definition:
   - cosmopolitan genus of trees and shrubs having odd-pinnate leaves and showy flowers;
@@ -59437,6 +61274,9 @@
   - Sophora japonica
   - Sophora sinensis
   partOfSpeech: n
+  wikidata:
+  - Q288558
+  - Q10881597
 12591208-n:
   definition:
   - shrub or small tree having pinnate leaves poisonous to livestock and dense racemes
@@ -59451,6 +61291,7 @@
   - frijolillo
   - Sophora secundiflora
   partOfSpeech: n
+  wikidata: Q59282651
 12591477-n:
   definition:
   - shrub or small tree of New Zealand and Chile having pendulous racemes of tubular
@@ -59462,6 +61303,7 @@
   - kowhai
   - Sophora tetraptera
   partOfSpeech: n
+  wikidata: Q7563134
 12591699-n:
   definition:
   - 'one species: Spanish broom'
@@ -59487,6 +61329,7 @@
   - weaver's broom
   - Spartium junceum
   partOfSpeech: n
+  wikidata: Q910358
 12592111-n:
   definition:
   - genus of Polynesian or southeastern Asian shrubs or vines
@@ -59537,6 +61380,7 @@
   - flame bush
   - Templetonia retusa
   partOfSpeech: n
+  wikidata: Q15543573
 12592878-n:
   definition:
   - 'genus of tropical and subtropical herbs or shrubs: hoary peas'
@@ -59584,6 +61428,7 @@
   - wild sweet pea
   - Tephrosia virginiana
   partOfSpeech: n
+  wikidata: Q13956906
 12593583-n:
   definition:
   - 'genus of American and Asiatic showy rhizomatous herbs: bush peas'
@@ -59630,6 +61475,7 @@
   - Carolina lupine
   - Thermopsis villosa
   partOfSpeech: n
+  wikidata: Q12070907
 12594265-n:
   definition:
   - 'one species: South American tree: tipu tree'
@@ -59680,6 +61526,7 @@
   - bird's foot trefoil
   - Trigonella ornithopodioides
   partOfSpeech: n
+  wikidata: Q15552843
 12594975-n:
   definition:
   - annual herb or southern Europe and eastern Asia having off-white flowers and aromatic
@@ -59771,6 +61618,7 @@
   - Calnada pea
   - Vicia cracca
   partOfSpeech: n
+  wikidata: Q147159
 12596534-n:
   definition:
   - Old World upright plant grown especially for its large flat edible seeds but also
@@ -59790,6 +61638,7 @@
   - 07817868-n
   - 12596828-n
   partOfSpeech: n
+  wikidata: Q131342
 12596828-n:
   definition:
   - seed of the broad-bean plant
@@ -59811,6 +61660,7 @@
   - bitter betch
   - Vicia orobus
   partOfSpeech: n
+  wikidata: Q159825
 12597060-n:
   definition:
   - herbaceous climbing plant valuable as fodder and for soil-building
@@ -59832,6 +61682,9 @@
   - bush vetch
   - Vicia sepium
   partOfSpeech: n
+  wikidata:
+  - Q15525238
+  - Q148570
 12597343-n:
   definition:
   - European vetch much cultivated as forage and cover crops
@@ -59876,6 +61729,7 @@
   - Vigna aconitifolia
   - Phaseolus aconitifolius
   partOfSpeech: n
+  wikidata: Q511249
 12598191-n:
   definition:
   - bushy annual widely grown in China and Japan for the flour made from its seeds
@@ -59888,6 +61742,7 @@
   - Vigna angularis
   - Phaseolus angularis
   partOfSpeech: n
+  wikidata: Q380279
 12598400-n:
   definition:
   - perennial tropical American vine cultivated for its racemes of showy yellow and
@@ -59905,6 +61760,7 @@
   - Vigna caracalla
   - Phaseolus caracalla
   partOfSpeech: n
+  wikidata: Q1313429
 12598760-n:
   definition:
   - erect bushy annual widely cultivated in warm regions of India and Indonesia and
@@ -59923,6 +61779,7 @@
   - 07741018-n
   - 12599160-n
   partOfSpeech: n
+  wikidata: Q484447
 12599160-n:
   definition:
   - seed of the mung bean plant; used for food
@@ -59957,6 +61814,7 @@
   - 07742648-n
   - 12599664-n
   partOfSpeech: n
+  wikidata: Q498940
 12599664-n:
   definition:
   - fruit or seed of the cowpea plant
@@ -60003,6 +61861,7 @@
   - Viminaria juncea
   - Viminaria denudata
   partOfSpeech: n
+  wikidata: Q50878244
 12600341-n:
   definition:
   - genus of South African trees having pinnate leaves and rose-purple flowers followed
@@ -60029,6 +61888,7 @@
   - Virgilia capensis
   - Virgilia oroboides
   partOfSpeech: n
+  wikidata: Q13035160
 12600760-n:
   definition:
   - fast-growing roundheaded tree with fragrant white to deep rose flowers; planted
@@ -60040,6 +61900,7 @@
   - keurboom
   - Virgilia divaricata
   partOfSpeech: n
+  wikidata: Q15529056
 12600952-n:
   definition:
   - Asiatic deciduous woody vine having large drooping racemes of white or bluish
@@ -60073,6 +61934,7 @@
   - Japanese wistaria
   - Wisteria floribunda
   partOfSpeech: n
+  wikidata: Q1329209
 12601534-n:
   definition:
   - having deep purple flowers
@@ -60083,6 +61945,9 @@
   - Chinese wistaria
   - Wisteria chinensis
   partOfSpeech: n
+  wikidata:
+  - Q15527909
+  - Q39151976
 12601644-n:
   definition:
   - an eastern United States native resembling the cultivated Japanese wisteria having
@@ -60095,6 +61960,7 @@
   - American wisteria
   - Wisteria frutescens
   partOfSpeech: n
+  wikidata: Q8027753
 12601858-n:
   definition:
   - a wisteria of China having white flowers
@@ -60105,6 +61971,9 @@
   - silky wisteria
   - Wisteria venusta
   partOfSpeech: n
+  wikidata:
+  - Q15532945
+  - Q15235903
 12601978-n:
   definition:
   - 'coextensive with the family Palmae: palms'
@@ -60235,6 +62104,7 @@
   - coyol palm
   - Acrocomia vinifera
   partOfSpeech: n
+  wikidata: Q22110820
 12604603-n:
   definition:
   - tropical American feather palm having a swollen spiny trunk and edible nuts
@@ -60287,6 +62157,7 @@
   mero_part:
   - 07786845-n
   partOfSpeech: n
+  wikidata: Q156969
 12605320-n:
   definition:
   - a genus of tropical Asian and Malaysian palm trees
@@ -60344,6 +62215,7 @@
   mero_part:
   - 12606134-n
   partOfSpeech: n
+  wikidata: Q379397
 12606134-n:
   definition:
   - nut having a hard hazel-brown shell used like vegetable ivory
@@ -60384,6 +62256,7 @@
   mero_substance:
   - 12606728-n
   partOfSpeech: n
+  wikidata: Q500857
 12606728-n:
   definition:
   - coarse leaf fiber from palmyra palms used in making brushes and brooms
@@ -60430,6 +62303,7 @@
   mero_part:
   - 12157098-n
   partOfSpeech: n
+  wikidata: Q416369
 12607486-n:
   definition:
   - tall scrambling spiny palm of northeastern Queensland, Australia
@@ -60440,6 +62314,7 @@
   - lawyer cane
   - Calamus australis
   partOfSpeech: n
+  wikidata: Q5018495
 12607628-n:
   definition:
   - fishtail palms
@@ -60478,6 +62353,7 @@
   - toddy palm
   - Caryota urens
   partOfSpeech: n
+  wikidata: Q766995
 12608127-n:
   definition:
   - wax palms
@@ -60502,6 +62378,7 @@
   - Ceroxylon andicola
   - Ceroxylon alpinum
   partOfSpeech: n
+  wikidata: Q87614666
 12608447-n:
   definition:
   - coconut palms
@@ -60532,6 +62409,7 @@
   mero_part:
   - 07788911-n
   partOfSpeech: n
+  wikidata: Q13187
 12608815-n:
   definition:
   - stiff coarse fiber from the outer husk of a coconut
@@ -60597,6 +62475,7 @@
   - Copernicia australis
   - Copernicia alba
   partOfSpeech: n
+  wikidata: Q50831532
 12609750-n:
   definition:
   - a monocotyledonous genus of tropical American palm trees
@@ -60645,6 +62524,7 @@
   - Corypha utan
   - Corypha gebanga
   partOfSpeech: n
+  wikidata: Q50831918
 12610448-n:
   definition:
   - fan palms of the southern United States and the Caribbean region
@@ -60670,6 +62550,7 @@
   - 14891841-n
   - 15000729-n
   partOfSpeech: n
+  wikidata: Q856001
 12610878-n:
   definition:
   - oil palms
@@ -60752,6 +62633,7 @@
   - cabbage palm
   - Euterpe oleracea
   partOfSpeech: n
+  wikidata: Q33943
 12611956-n:
   definition:
   - fan palms of Asia and Australia and Malaysia
@@ -60776,6 +62658,7 @@
   - cabbage tree
   - Livistona australis
   partOfSpeech: n
+  wikidata: Q690845
 12612284-n:
   definition:
   - a genus of Malayan pinnate-leaved palm trees that flower and fruit once and then
@@ -60829,6 +62712,7 @@
   mero_substance:
   - 07907588-n
   partOfSpeech: n
+  wikidata: Q85192860
 12613112-n:
   definition:
   - 'palms of southern Mexico to northern South America: babassu palm'
@@ -60860,6 +62744,7 @@
   mero_part:
   - 12613600-n
   partOfSpeech: n
+  wikidata: Q50846904
 12613600-n:
   definition:
   - hard-shelled nut of the babassu palm
@@ -60895,6 +62780,7 @@
   mero_part:
   - 12614102-n
   partOfSpeech: n
+  wikidata: Q67193150
 12614102-n:
   definition:
   - nut of the cohune palm having hard white shells like those of ivory nuts
@@ -60952,6 +62838,7 @@
   mero_part:
   - 07781049-n
   partOfSpeech: n
+  wikidata: Q25292
 12614926-n:
   definition:
   - small genus of South American feather palms
@@ -61139,6 +63026,7 @@
   - cabbage palm
   - Roystonea oleracea
   partOfSpeech: n
+  wikidata: Q141233
 12617767-n:
   definition:
   - American dwarf fan palms
@@ -61164,6 +63052,7 @@
   - cabbage palm
   - Sabal palmetto
   partOfSpeech: n
+  wikidata: Q1088471
 12618094-n:
   definition:
   - 'one species: saw palmetto'
@@ -61188,6 +63077,7 @@
   - scrub palmetto
   - Serenoa repens
   partOfSpeech: n
+  wikidata: Q927607
 12618401-n:
   definition:
   - small to medium-sized fan palms
@@ -61231,6 +63121,7 @@
   - Thrinax morrisii
   - Thrinax keyensis
   partOfSpeech: n
+  wikidata: Q55965298
 12619008-n:
   definition:
   - coextensive with the family Plantaginaceae
@@ -61299,6 +63190,7 @@
   - buckthorn
   - Plantago lanceolata
   partOfSpeech: n
+  wikidata: Q157408
 12620196-n:
   definition:
   - common European perennial naturalized worldwide; a troublesome weed
@@ -61313,6 +63205,7 @@
   - cart-track plant
   - Plantago major
   partOfSpeech: n
+  wikidata: Q157154
 12620422-n:
   definition:
   - widely distributed Old World perennial naturalized in North America having finely
@@ -61324,6 +63217,7 @@
   - hoary plantain
   - Plantago media
   partOfSpeech: n
+  wikidata: Q157272
 12620635-n:
   definition:
   - plantain of Mediterranean regions whose seeds swell and become gelatinous when
@@ -61337,6 +63231,7 @@
   - Spanish psyllium
   - Plantago psyllium
   partOfSpeech: n
+  wikidata: Q21876280
 12620856-n:
   definition:
   - North American plantain having reddish leafstalks and broad leaves
@@ -61348,6 +63243,7 @@
   - broad-leaved plantain
   - Plantago rugelii
   partOfSpeech: n
+  wikidata: Q7201575
 12621028-n:
   definition:
   - North American annual or biennial with long soft hairs on the leaves
@@ -61419,6 +63315,9 @@
   - Russian vine
   - Polygonum aubertii
   partOfSpeech: n
+  wikidata:
+  - Q11093157
+  - Q10350936
 12622096-n:
   definition:
   - buckwheat; in some classifications included in the genus Polygonum
@@ -61445,6 +63344,7 @@
   mero_part:
   - 07819286-n
   partOfSpeech: n
+  wikidata: Q21876809
 12622566-n:
   definition:
   - annual with broadly ovate leaves and slender drooping spikes of crimson flowers;
@@ -61459,6 +63359,9 @@
   - prince's-plume
   - Polygonum orientale
   partOfSpeech: n
+  wikidata:
+  - Q164344
+  - Q80352483
 12622879-n:
   definition:
   - North American herbs of the buckwheat family
@@ -61492,6 +63395,7 @@
   - umbrella plant
   - Eriogonum allenii
   partOfSpeech: n
+  wikidata: Q15592785
 12623373-n:
   definition:
   - low-growing shrub with spreading branches and flowers in loose heads; desert regions
@@ -61542,6 +63446,7 @@
   - Rheum australe
   - Rheum emodi
   partOfSpeech: n
+  wikidata: Q15247758
 12624210-n:
   definition:
   - long cultivated hybrid of Rheum palmatum; stems often cooked in pies or as sauce
@@ -61607,6 +63512,7 @@
   mero_part:
   - 07752347-n
   partOfSpeech: n
+  wikidata: Q26297
 12625221-n:
   definition:
   - small plant having pleasantly acid-tasting arrow-shaped leaves; common in dry
@@ -61633,6 +63539,7 @@
   - yellow dock
   - Rumex obtusifolius
   partOfSpeech: n
+  wikidata: Q162800
 12625606-n:
   definition:
   - low perennial with small silvery-green ovate to hastate leaves
@@ -61646,6 +63553,7 @@
   mero_part:
   - 07752503-n
   partOfSpeech: n
+  wikidata: Q1735396
 12625780-n:
   definition:
   - an order of monocotyledonous herbs
@@ -61714,6 +63622,7 @@
   - tall yellow-eye
   - Xyris operculata
   partOfSpeech: n
+  wikidata: Q15478297
 12626726-n:
   definition:
   - 'large widely distributed family of chiefly perennial herbs or climbers: spiderworts'
@@ -61773,6 +63682,7 @@
   - St.-Bruno's-lily
   - Paradisea liliastrum
   partOfSpeech: n
+  wikidata: Q660341
 12627558-n:
   definition:
   - spiderworts
@@ -61829,6 +63739,7 @@
   mero_part:
   - 07769251-n
   partOfSpeech: n
+  wikidata: Q1493
 12628478-n:
   definition:
   - the type genus of the family Bromeliaceae which includes tropical American plants
@@ -61868,6 +63779,7 @@
   - long moss
   - Tillandsia usneoides
   partOfSpeech: n
+  wikidata: Q311524
 12629208-n:
   definition:
   - a monocotyledonous family of bog plants of order Xyridales
@@ -61985,6 +63897,7 @@
   - wampee
   - Pontederia cordata
   partOfSpeech: n
+  wikidata: Q621050
 12630947-n:
   definition:
   - water hyacinth; water orchid
@@ -62011,6 +63924,7 @@
   - Eichhornia crassipes
   - Eichhornia spesiosa
   partOfSpeech: n
+  wikidata: Q690645
 12631370-n:
   definition:
   - mud plantains
@@ -62035,6 +63949,7 @@
   - mud plantain
   - Heteranthera dubia
   partOfSpeech: n
+  wikidata: Q15296490
 12631694-n:
   definition:
   - an order of aquatic monocotyledonous herbaceous plants
@@ -62247,7 +64162,7 @@
   - hydrilla
   - Hydrilla verticillata
   partOfSpeech: n
-  wikidata: Q2720105
+  wikidata: Q164181
 12634729-n:
   definition:
   - American frogbit
@@ -62306,7 +64221,9 @@
   - Canadian pondweed
   - Elodea canadensis
   partOfSpeech: n
-  wikidata: Q159760
+  wikidata:
+  - Q49606627
+  - Q159760
 12635524-n:
   definition:
   - aquatic plant with deep green foliage useful to oxygenate an aquarium; sometimes
@@ -62319,6 +64236,7 @@
   - Elodea densa
   - Egeria densa
   partOfSpeech: n
+  wikidata: Q50839363
 12635723-n:
   definition:
   - small genus of dioecious tropical aquatic plants
@@ -62410,6 +64328,7 @@
   - curly pondweed
   - Potamogeton crispus
   partOfSpeech: n
+  wikidata: Q157863
 12637203-n:
   definition:
   - of Europe (except the Mediterranean area) and the northern United States
@@ -62431,6 +64350,7 @@
   - Potamogeton nodosus
   - Potamogeton americanus
   partOfSpeech: n
+  wikidata: Q3337247
 12637586-n:
   definition:
   - a monocotyledonous genus of the family Potamogetonaceae
@@ -62492,6 +64412,7 @@
   - arrow grass
   - Triglochin maritima
   partOfSpeech: n
+  wikidata: Q157862
 12638500-n:
   definition:
   - alternative classification for some genera included in Potamogetonaceae; one species
@@ -62568,6 +64489,7 @@
   - sea wrack
   - Zostera marina
   partOfSpeech: n
+  wikidata: Q21128
 12639703-n:
   definition:
   - in some classifications this category does not include Leguminosae
@@ -62709,6 +64631,7 @@
   - dog rose
   - Rosa canina
   partOfSpeech: n
+  wikidata: Q146066
 12642021-n:
   definition:
   - shrubby Chinese rose; ancestor of many cultivated garden roses
@@ -62733,6 +64656,7 @@
   - summer damask rose
   - Rosa damascena
   partOfSpeech: n
+  wikidata: Q578904
 12642380-n:
   definition:
   - Eurasian rose with prickly stems and fragrant leaves and bright pink flowers followed
@@ -62748,6 +64672,7 @@
   - eglantine
   - Rosa eglanteria
   partOfSpeech: n
+  wikidata: Q161146
 12642597-n:
   definition:
   - tangled mass of prickly plants
@@ -62769,6 +64694,7 @@
   - Cherokee rose
   - Rosa laevigata
   partOfSpeech: n
+  wikidata: Q1070309
 12642833-n:
   definition:
   - vigorously growing rose having clusters of numerous small flowers; used for hedges
@@ -62795,6 +64721,7 @@
   - musk rose
   - Rosa moschata
   partOfSpeech: n
+  wikidata: Q141182
 12643244-n:
   definition:
   - any of several hybrid bush roses derived from a tea-scented Chinese rose with
@@ -62839,6 +64766,7 @@
   - harvest-lice
   - Agrimonia eupatoria
   partOfSpeech: n
+  wikidata: Q156865
 12643972-n:
   definition:
   - fragrant European perennial herb found at woodland margins on moist soils
@@ -62849,6 +64777,7 @@
   - fragrant agrimony
   - Agrimonia procera
   partOfSpeech: n
+  wikidata: Q953646
 12644129-n:
   definition:
   - North American deciduous trees or shrubs
@@ -62890,6 +64819,7 @@
   - alder-leaved serviceberry
   - Amelanchier alnifolia
   partOfSpeech: n
+  wikidata: Q164158
 12644816-n:
   definition:
   - open-growing shrub of eastern North America having pure white flowers and small
@@ -62901,6 +64831,7 @@
   - Bartram juneberry
   - Amelanchier bartramiana
   partOfSpeech: n
+  wikidata: Q693732
 12645010-n:
   definition:
   - flowering quince
@@ -62934,6 +64865,7 @@
   - maule's quince
   - Chaenomeles japonica
   partOfSpeech: n
+  wikidata: Q158037
 12645482-n:
   definition:
   - deciduous thorny shrub native to China having red or white blossoms
@@ -62973,6 +64905,7 @@
   mero_part:
   - 07774383-n
   partOfSpeech: n
+  wikidata: Q577669
 12645976-n:
   definition:
   - genus of deciduous or evergreen Old World shrubs widely cultivated
@@ -63006,6 +64939,9 @@
   members:
   - Cotoneaster dammeri
   partOfSpeech: n
+  wikidata:
+  - Q65946889
+  - Q159655
 12646584-n:
   definition:
   - deciduous flat-growing shrub with a fanned herringbone pattern and having reddish
@@ -63016,6 +64952,9 @@
   members:
   - Cotoneaster horizontalis
   partOfSpeech: n
+  wikidata:
+  - Q65946893
+  - Q159650
 12646791-n:
   definition:
   - 'thorny shrubs and small trees: hawthorn; thorn; thorn apple'
@@ -63059,6 +64998,7 @@
   - Crataegus apiifolia
   - Crataegus marshallii
   partOfSpeech: n
+  wikidata: Q5182573
 12647639-n:
   definition:
   - common shrub or small tree of the eastern United States having few thorns and
@@ -63070,6 +65010,9 @@
   - scarlet haw
   - Crataegus biltmoreana
   partOfSpeech: n
+  wikidata:
+  - Q92527415
+  - Q5182549
 12647880-n:
   definition:
   - erect and almost thornless American hawthorn with somewhat pear-shaped berries
@@ -63083,6 +65026,7 @@
   - Crataegus calpodendron
   - Crataegus tomentosa
   partOfSpeech: n
+  wikidata: Q21872902
 12648108-n:
   definition:
   - eastern United States hawthorn with long straight thorns
@@ -63094,6 +65038,7 @@
   - cockspur hawthorn
   - Crataegus crus-galli
   partOfSpeech: n
+  wikidata: Q916961
 12648287-n:
   definition:
   - hawthorn of southern United States bearing a juicy, acidic, scarlet fruit that
@@ -63135,7 +65080,9 @@
   - English hawthorn
   - Crataegus monogyna
   partOfSpeech: n
-  wikidata: Q161511
+  wikidata:
+  - Q15543909
+  - Q161511
 12649117-n:
   definition:
   - American red-fruited hawthorn with stems and leaves densely covered with short
@@ -63149,6 +65096,7 @@
   - Crataegus mollis
   - Crataegus coccinea mollis
   partOfSpeech: n
+  wikidata: Q2671022
 12649340-n:
   definition:
   - evergreen hawthorn of southeastern Europe
@@ -63159,6 +65107,7 @@
   - evergreen thorn
   - Crataegus oxyacantha
   partOfSpeech: n
+  wikidata: Q3780432
 12649466-n:
   definition:
   - American red-fruited hawthorn with dense corymbs of pink-red flowers
@@ -63170,7 +65119,9 @@
   - Crataegus pedicellata
   - Crataegus coccinea
   partOfSpeech: n
-  wikidata: Q3002196
+  wikidata:
+  - Q15543298
+  - Q3002196
 12649633-n:
   definition:
   - quince
@@ -63197,6 +65148,7 @@
   mero_part:
   - 07785560-n
   partOfSpeech: n
+  wikidata: Q43300
 12649948-n:
   definition:
   - mountain avens
@@ -63304,6 +65256,9 @@
   - wood strawberry
   - Fragaria vesca
   partOfSpeech: n
+  wikidata:
+  - Q50857565
+  - Q146684
 12651524-n:
   definition:
   - wild strawberry of western United States and South America; source of many varieties
@@ -63329,6 +65284,9 @@
   - scarlet strawberry
   - Fragaria virginiana
   partOfSpeech: n
+  wikidata:
+  - Q15545616
+  - Q978247
 12651985-n:
   definition:
   - avens
@@ -63385,6 +65343,7 @@
   - yellow avens
   - Geum macrophyllum
   partOfSpeech: n
+  wikidata: Q2917893
 12652833-n:
   definition:
   - erect perennial of north temperate zone having pinnate leaves and a few nodding
@@ -63412,6 +65371,7 @@
   - purple avens
   - Geum triflorum
   partOfSpeech: n
+  wikidata: Q2709956
 12653287-n:
   definition:
   - hairy Eurasian plant with small yellow flowers and an astringent root formerly
@@ -63426,6 +65386,7 @@
   - wood avens
   - Geum urbanum
   partOfSpeech: n
+  wikidata: Q157407
 12653494-n:
   definition:
   - avens of Virginia having pale or greenish yellow flowers
@@ -63466,6 +65427,7 @@
   - Heteromeles arbutifolia
   - Photinia arbutifolia
   partOfSpeech: n
+  wikidata: Q21546397
 12654147-n:
   definition:
   - apple trees; found throughout temperate zones of the Northern Hemisphere
@@ -63557,6 +65519,7 @@
   - cherry crab
   - Malus baccata
   partOfSpeech: n
+  wikidata: Q1743596
 12655747-n:
   definition:
   - wild crab apple native to Europe; a chief ancestor of cultivated apples
@@ -63567,6 +65530,7 @@
   - wild crab
   - Malus sylvestris
   partOfSpeech: n
+  wikidata: Q47161
 12655912-n:
   definition:
   - medium-sized tree of the eastern United States having pink blossoms and small
@@ -63655,7 +65619,9 @@
   mero_part:
   - 07782867-n
   partOfSpeech: n
-  wikidata: Q146186
+  wikidata:
+  - Q37995935
+  - Q146186
 12657191-n:
   definition:
   - genus of deciduous and evergreen east Asian trees and shrubs widely cultivated
@@ -63706,6 +65672,9 @@
   - goose grass
   - Potentilla anserina
   partOfSpeech: n
+  wikidata:
+  - Q64061702
+  - Q157815
 12658080-n:
   definition:
   - a genus of thorny herbs or shrubs of the family Rosaceae
@@ -63734,6 +65703,7 @@
   mero_part:
   - 07836012-n
   partOfSpeech: n
+  wikidata: Q21877146
 12658490-n:
   definition:
   - a genus of shrubs and trees of the family Rosaceae that is widely distributed
@@ -63801,6 +65771,7 @@
   mero_part:
   - 07768085-n
   partOfSpeech: n
+  wikidata: Q2892789
 12659725-n:
   definition:
   - wild plum trees of eastern and central North America having red-orange fruit with
@@ -63814,6 +65785,7 @@
   - goose plum
   - Prunus americana
   partOfSpeech: n
+  wikidata: Q469524
 12659929-n:
   definition:
   - small native American shrubby tree bearing small edible yellow to reddish fruit
@@ -63828,6 +65800,7 @@
   mero_part:
   - 07781704-n
   partOfSpeech: n
+  wikidata: Q3010229
 12660137-n:
   definition:
   - seacoast shrub of northeastern North America having showy white blossoms and edible
@@ -63853,6 +65826,7 @@
   - common plum
   - Prunus domestica
   partOfSpeech: n
+  wikidata: Q44120
 12660497-n:
   definition:
   - small wild or half-domesticated Eurasian plum bearing small ovoid fruit in clusters
@@ -63863,6 +65837,9 @@
   - bullace
   - Prunus insititia
   partOfSpeech: n
+  wikidata:
+  - Q149195
+  - Q10878191
 12660671-n:
   definition:
   - plum tree long cultivated for its edible fruit
@@ -63898,6 +65875,7 @@
   - Canada plum
   - Prunus nigra
   partOfSpeech: n
+  wikidata: Q2724971
 12661196-n:
   definition:
   - hybrid produced by crossing Prunus domestica and Prunus armeniaca
@@ -63933,6 +65911,7 @@
   - mei
   - Prunus mume
   partOfSpeech: n
+  wikidata: Q157763
 12661768-n:
   definition:
   - temperate zone tree bearing downy yellow to rosy fruits
@@ -63958,6 +65937,9 @@
   - black apricot
   - Prunus dasycarpa
   partOfSpeech: n
+  wikidata:
+  - Q15533117
+  - Q16988612
 12662174-n:
   definition:
   - any of numerous trees and shrubs producing a small fleshy round fruit with a single
@@ -64016,6 +65998,7 @@
   mero_part:
   - 07773288-n
   partOfSpeech: n
+  wikidata: Q165137
 12663196-n:
   definition:
   - any of several cultivated sweet cherries having sweet juicy heart-shaped fruits
@@ -64050,6 +66033,9 @@
   - Rocky Mountains cherry
   - Prunus besseyi
   partOfSpeech: n
+  wikidata:
+  - Q3408648
+  - Q15624054
 12663725-n:
   definition:
   - Mexican black cherry tree having edible fruit
@@ -64063,6 +66049,9 @@
   mero_part:
   - 07773850-n
   partOfSpeech: n
+  wikidata:
+  - Q50913540
+  - Q39779922
 12663874-n:
   definition:
   - small flowering evergreen tree of southern United States
@@ -64089,6 +66078,7 @@
   - myrobalan plum
   - Prunus cerasifera
   partOfSpeech: n
+  wikidata: Q146951
 12664234-n:
   definition:
   - rather small Eurasian tree producing red to black acid edible fruit
@@ -64204,9 +66194,7 @@
   mero_part:
   - 07766562-n
   partOfSpeech: n
-  wikidata:
-  - Q39918
-  - Q15545507
+  wikidata: Q15545507
 12666291-n:
   definition:
   - almond trees having white blossoms and poisonous nuts yielding an oil used for
@@ -64260,6 +66248,9 @@
   - dwarf flowering almond
   - Prunus glandulosa
   partOfSpeech: n
+  wikidata:
+  - Q11175489
+  - Q149743
 12667158-n:
   definition:
   - California evergreen wild plum with spiny leathery leaves and white flowers
@@ -64273,6 +66264,7 @@
   - islay
   - Prunus ilicifolia
   partOfSpeech: n
+  wikidata: Q2114443
 12667366-n:
   definition:
   - shrubby Japanese cherry tree having pale pink blossoms
@@ -64284,6 +66276,7 @@
   - fuji cherry
   - Prunus incisa
   partOfSpeech: n
+  wikidata: Q3269605
 12667501-n:
   definition:
   - woody oriental plant with smooth unfurrowed red fruit grown especially for its
@@ -64296,6 +66289,7 @@
   - oriental bush cherry
   - Prunus japonica
   partOfSpeech: n
+  wikidata: Q1771825
 12667711-n:
   definition:
   - frequently cultivated Eurasian evergreen shrub or small tree having showy clusters
@@ -64309,6 +66303,9 @@
   - laurel cherry
   - Prunus laurocerasus
   partOfSpeech: n
+  wikidata:
+  - Q15534675
+  - Q157508
 12667992-n:
   definition:
   - evergreen shrub or small tree found on Catalina Island (California)
@@ -64319,6 +66316,7 @@
   - Catalina cherry
   - Prunus lyonii
   partOfSpeech: n
+  wikidata: Q17235505
 12668137-n:
   definition:
   - any of several small-fruited cherry trees frequented or fed on by birds
@@ -64363,7 +66361,9 @@
   - pin cherry
   - Prunus pensylvanica
   partOfSpeech: n
-  wikidata: Q2707920
+  wikidata:
+  - Q50839473
+  - Q2707920
 12668806-n:
   definition:
   - cultivated in temperate regions
@@ -64406,6 +66406,9 @@
   - Prunus susquehanae
   - Prunus cuneata
   partOfSpeech: n
+  wikidata:
+  - Q24694478
+  - Q17235424
 12669454-n:
   definition:
   - small tree of China and Japan bearing large yellow to red plums usually somewhat
@@ -64417,6 +66420,7 @@
   - Japanese plum
   - Prunus salicina
   partOfSpeech: n
+  wikidata: Q1250033
 12669649-n:
   definition:
   - large North American wild cherry with round black sour edible fruit
@@ -64429,6 +66433,7 @@
   - rum cherry
   - Prunus serotina
   partOfSpeech: n
+  wikidata: Q158987
 12669826-n:
   definition:
   - any of several shrubs or trees of the genus Prunus cultivated for their showy
@@ -64452,6 +66457,7 @@
   - Japanese flowering cherry
   - Prunus serrulata
   partOfSpeech: n
+  wikidata: Q165321
 12670300-n:
   definition:
   - ornamental tree with inedible fruit widely cultivated in many varieties for its
@@ -64463,6 +66469,7 @@
   - Japanese flowering cherry
   - Prunus sieboldii
   partOfSpeech: n
+  wikidata: Q21297628
 12670484-n:
   definition:
   - a thorny Eurasian bush with plumlike fruits
@@ -64486,6 +66493,7 @@
   - Pacific plum
   - Prunus subcordata
   partOfSpeech: n
+  wikidata: Q2725382
 12670799-n:
   definition:
   - shrub or tree native to Japan cultivated as an ornamental for its rose-pink flowers
@@ -64508,6 +66516,7 @@
   - dwarf Russian almond
   - Prunus tenella
   partOfSpeech: n
+  wikidata: Q160019
 12671140-n:
   definition:
   - deciduous Chinese shrub or small tree with often trilobed leaves grown for its
@@ -64519,7 +66528,9 @@
   - flowering almond
   - Prunus triloba
   partOfSpeech: n
-  wikidata: Q2727171
+  wikidata:
+  - Q15532819
+  - Q2727171
 12671317-n:
   definition:
   - a common wild cherry of eastern North America having small bitter black berries
@@ -64534,7 +66545,9 @@
   mero_part:
   - 12671566-n
   partOfSpeech: n
-  wikidata: Q162829
+  wikidata:
+  - Q15542944
+  - Q162829
 12671566-n:
   definition:
   - the fruit of the chokecherry tree
@@ -64555,6 +66568,7 @@
   - Prunus virginiana demissa
   - Prunus demissa
   partOfSpeech: n
+  wikidata: Q85199002
 12671823-n:
   definition:
   - Eurasian evergreen thorny shrubs bearing red or orange-red berries
@@ -64608,7 +66622,9 @@
   mero_part:
   - 07783823-n
   partOfSpeech: n
-  wikidata: Q146281
+  wikidata:
+  - Q94442924
+  - Q146281
 12672582-n:
   definition:
   - tree bearing edible fruit
@@ -64666,8 +66682,8 @@
   - Rubus australis
   partOfSpeech: n
   wikidata:
-  - Q7376205
   - Q7376203
+  - Q7376205
 12674394-n:
   definition:
   - European trailing bramble with red berrylike fruits
@@ -64678,7 +66694,9 @@
   - stone bramble
   - Rubus saxatilis
   partOfSpeech: n
-  wikidata: Q158569
+  wikidata:
+  - Q42684002
+  - Q158569
 12674523-n:
   definition:
   - bramble with sweet edible black or dark purple berries that usually do not separate
@@ -64703,6 +66721,7 @@
   mero_part:
   - 07760787-n
   partOfSpeech: n
+  wikidata: Q13541716
 12674988-n:
   definition:
   - stiff shrubby blackberry of the eastern United States (Connecticut to Florida)
@@ -64713,6 +66732,7 @@
   - sand blackberry
   - Rubus cuneifolius
   partOfSpeech: n
+  wikidata: Q15547003
 12675148-n:
   definition:
   - any of several trailing blackberry brambles especially of North America
@@ -64774,6 +66794,7 @@
   - American dewberry
   - Rubus canadensis
   partOfSpeech: n
+  wikidata: Q3446528
 12676112-n:
   definition:
   - the common dewberry of eastern North America (Rubus flagellaris)
@@ -64798,6 +66819,7 @@
   - Southern dewberry
   - Rubus trivialis
   partOfSpeech: n
+  wikidata: Q15526136
 12676366-n:
   definition:
   - the bristly dewberry of eastern North America (Rubus hispidus)
@@ -64809,6 +66831,7 @@
   - swamp blackberry
   - Rubus hispidus
   partOfSpeech: n
+  wikidata: Q744227
 12676487-n:
   definition:
   - creeping European bramble bearing dewberries
@@ -64854,6 +66877,7 @@
   - framboise
   - Rubus idaeus
   partOfSpeech: n
+  wikidata: Q12252383
 12677289-n:
   definition:
   - red raspberry of North America
@@ -64867,7 +66891,9 @@
   mero_part:
   - 07761442-n
   partOfSpeech: n
-  wikidata: Q210156
+  wikidata:
+  - Q24689114
+  - Q210156
 12677446-n:
   definition:
   - raspberry native to eastern North America having black thimble-shaped fruit
@@ -64909,6 +66935,7 @@
   - thimbleberry
   - Rubus parviflorus
   partOfSpeech: n
+  wikidata: Q2614003
 12678055-n:
   definition:
   - creeping raspberry of north temperate regions with yellow or orange berries
@@ -64937,6 +66964,7 @@
   - Rubus odoratus
   - thimbleberry
   partOfSpeech: n
+  wikidata: Q158365
 12678516-n:
   definition:
   - raspberry of China and Japan having pale pink flowers grown for ornament and for
@@ -64985,6 +67013,9 @@
   mero_part:
   - 12679242-n
   partOfSpeech: n
+  wikidata:
+  - Q87645461
+  - Q146198
 12679242-n:
   definition:
   - decorative red berrylike fruit of a rowan tree
@@ -65004,6 +67035,9 @@
   - American mountain ash
   - Sorbus americana
   partOfSpeech: n
+  wikidata:
+  - Q87645487
+  - Q285587
 12679476-n:
   definition:
   - an ash of the western coast of North America
@@ -65029,6 +67063,9 @@
   mero_part:
   - 07786156-n
   partOfSpeech: n
+  wikidata:
+  - Q18593737
+  - Q159558
 12679825-n:
   definition:
   - European tree bearing edible small speckled brown fruit
@@ -65039,6 +67076,7 @@
   - wild service tree
   - Sorbus torminalis
   partOfSpeech: n
+  wikidata: Q147459
 12679964-n:
   definition:
   - a dicotyledonous genus of the family Rosaceae
@@ -65075,6 +67113,7 @@
   - St. Peter's wreath
   - Spiraea prunifolia
   partOfSpeech: n
+  wikidata: Q1055383
 12680491-n:
   definition:
   - an order of dicotyledonous plants of the subclass Asteridae; have opposite leaves
@@ -65158,6 +67197,7 @@
   - munjeet
   - Rubia cordifolia
   partOfSpeech: n
+  wikidata: Q3237818
 12681988-n:
   definition:
   - Eurasian herb having small yellow flowers and red roots formerly an important
@@ -65169,6 +67209,7 @@
   - madder
   - Rubia tinctorum
   partOfSpeech: n
+  wikidata: Q163641
 12682181-n:
   definition:
   - woodruff
@@ -65227,6 +67268,7 @@
   - lemonwood tree
   - Calycophyllum candidissimum
   partOfSpeech: n
+  wikidata: Q5741578
 12682984-n:
   definition:
   - shrubs of tropical and subtropical New World
@@ -65252,6 +67294,7 @@
   - West Indian snowberry
   - Chiococca alba
   partOfSpeech: n
+  wikidata: Q5101397
 12683415-n:
   definition:
   - coffee trees
@@ -65289,6 +67332,7 @@
   - Arabian coffee
   - Coffea arabica
   partOfSpeech: n
+  wikidata: Q47685
 12684015-n:
   definition:
   - small tree of West Africa
@@ -65299,6 +67343,7 @@
   - Liberian coffee
   - Coffea liberica
   partOfSpeech: n
+  wikidata: Q47718
 12684120-n:
   definition:
   - native to West Africa but grown in Java and elsewhere; resistant to coffee rust
@@ -65311,6 +67356,7 @@
   - Coffea robusta
   - Coffea canephora
   partOfSpeech: n
+  wikidata: Q47532
 12684315-n:
   definition:
   - large genus of trees of Andean region of South America having medicinal bark
@@ -65350,6 +67396,7 @@
   - Cinchona cordifolia
   - Cinchona lancifolia
   partOfSpeech: n
+  wikidata: Q8346201
 12684948-n:
   definition:
   - Peruvian shrub or small tree having large glossy leaves and cymes of fragrant
@@ -65364,8 +67411,9 @@
   - Cinchona calisaya
   partOfSpeech: n
   wikidata:
-  - Q5120189
   - Q3091779
+  - Q5120189
+  - Q15399753
 12685230-n:
   definition:
   - small tree of Ecuador and Peru having very large glossy leaves and large panicles
@@ -65377,6 +67425,7 @@
   - cinchona tree
   - Cinchona pubescens
   partOfSpeech: n
+  wikidata: Q164574
 12685471-n:
   definition:
   - medicinal bark of cinchona trees; source of quinine and quinidine
@@ -65466,6 +67515,7 @@
   - wild licorice
   - Galium lanceolatum
   partOfSpeech: n
+  wikidata: Q15450805
 12686920-n:
   definition:
   - annual having the stem beset with curved prickles; North America and Europe and
@@ -65497,6 +67547,7 @@
   - false baby's breath
   - Galium mollugo
   partOfSpeech: n
+  wikidata: Q159744
 12687363-n:
   definition:
   - large genus of attractive Old World tropical shrubs and small trees
@@ -65532,6 +67583,7 @@
   - Gardenia jasminoides
   - Gardenia augusta
   partOfSpeech: n
+  wikidata: Q50841247
 12687940-n:
   definition:
   - tropical American evergreen trees or shrubs bearing yellow flowers and succulent
@@ -65606,7 +67658,9 @@
   - Hamelia patens
   - Hamelia erecta
   partOfSpeech: n
-  wikidata: Q4919655
+  wikidata:
+  - Q4919655
+  - Q50842199
 12689125-n:
   definition:
   - creeping evergreen herbs of North America
@@ -65659,6 +67713,7 @@
   - Nauclea diderrichii
   - Sarcocephalus diderrichii
   partOfSpeech: n
+  wikidata: Q1331299
 12689918-n:
   definition:
   - small genus of shrubs or small trees of southeastern United States and northern
@@ -65686,6 +67741,7 @@
   - bitter-bark
   - Pinckneya pubens
   partOfSpeech: n
+  wikidata: Q50851113
 12690402-n:
   definition:
   - tropical chiefly South American shrubs and trees
@@ -65714,6 +67770,7 @@
   mero_part:
   - 12690774-n
   partOfSpeech: n
+  wikidata: Q13034769
 12690774-n:
   definition:
   - hard tough elastic wood of the lemonwood tree; used for making bows and fishing
@@ -65749,6 +67806,7 @@
   - Sarcocephalus latifolius
   - Sarcocephalus esculentus
   partOfSpeech: n
+  wikidata: Q15446164
 12691319-n:
   definition:
   - tropical African and Asiatic trees and shrubs having one-seeded fruit
@@ -65777,6 +67835,7 @@
   mero_part:
   - 07782978-n
   partOfSpeech: n
+  wikidata: Q7914865
 12691723-n:
   definition:
   - shrubby tree of Madagascar occasionally cultivated for its edible apple-shaped
@@ -65788,6 +67847,7 @@
   - Spanish tamarind
   - Vangueria madagascariensis
   partOfSpeech: n
+  wikidata: Q2710367
 12691918-n:
   definition:
   - shrubs and small trees and woody vines
@@ -65897,7 +67957,9 @@
   - beauty bush
   - Kolkwitzia amabilis
   partOfSpeech: n
-  wikidata: Q1779255
+  wikidata:
+  - Q17437033
+  - Q1779255
 12693604-n:
   definition:
   - small species of shrubs of western Himalayas to China
@@ -65921,6 +67983,7 @@
   - Himalaya honeysuckle
   - Leycesteria formosa
   partOfSpeech: n
+  wikidata: Q252391
 12693939-n:
   definition:
   - 'one species: twinflower'
@@ -66003,6 +68066,7 @@
   - white honeysuckle
   - Lonicera albiflora
   partOfSpeech: n
+  wikidata: Q15399529
 12695446-n:
   definition:
   - erect deciduous North American shrub with yellow-white flowers
@@ -66014,6 +68078,7 @@
   - fly honeysuckle
   - Lonicera canadensis
   partOfSpeech: n
+  wikidata: Q2078064
 12695656-n:
   definition:
   - deciduous climbing shrub with fragrant yellow-white flowers in axillary whorls
@@ -66025,6 +68090,7 @@
   - Italian woodbine
   - Lonicera caprifolium
   partOfSpeech: n
+  wikidata: Q158538
 12695861-n:
   definition:
   - twining deciduous shrub with clusters of purple-tinged yellow-green flowers; northeastern
@@ -66036,6 +68102,7 @@
   - yellow honeysuckle
   - Lonicera dioica
   partOfSpeech: n
+  wikidata: Q17435084
 12696060-n:
   definition:
   - climbing deciduous shrub with fragrant yellow (later orange) flowers in terminal
@@ -66047,6 +68114,7 @@
   - yellow honeysuckle
   - Lonicera flava
   partOfSpeech: n
+  wikidata: Q15395421
 12696276-n:
   definition:
   - twining deciduous shrub with hairy leaves and spikes of yellow-orange flowers;
@@ -66058,6 +68126,7 @@
   - hairy honeysuckle
   - Lonicera hirsuta
   partOfSpeech: n
+  wikidata: Q16121253
 12696477-n:
   definition:
   - shrubby honeysuckle with purple flowers; western North America
@@ -66068,6 +68137,7 @@
   - twinberry
   - Lonicera involucrata
   partOfSpeech: n
+  wikidata: Q785106
 12696637-n:
   definition:
   - an Asiatic trailing evergreen honeysuckle with half-evergreen leaves and fragrant
@@ -66101,6 +68171,9 @@
   - Morrow's honeysuckle
   - Lonicera morrowii
   partOfSpeech: n
+  wikidata:
+  - Q25117628
+  - Q2701825
 12697295-n:
   definition:
   - European twining honeysuckle with fragrant red and yellow-white flowers
@@ -66111,6 +68184,7 @@
   - woodbine
   - Lonicera periclymenum
   partOfSpeech: n
+  wikidata: Q161584
 12697464-n:
   definition:
   - evergreen North American honeysuckle vine having coral-red or orange flowers
@@ -66124,6 +68198,7 @@
   - trumpet vine
   - Lonicera sempervirens
   partOfSpeech: n
+  wikidata: Q161352
 12697701-n:
   definition:
   - a honeysuckle shrub of southern Russia to central Asia
@@ -66135,6 +68210,7 @@
   - Tartarian honeysuckle
   - Lonicera tatarica
   partOfSpeech: n
+  wikidata: Q158546
 12697881-n:
   definition:
   - cultivated Eurasian shrub with twin yellowish-white flowers and scarlet fruit
@@ -66146,6 +68222,7 @@
   - European honeysuckle
   - Lonicera xylosteum
   partOfSpeech: n
+  wikidata: Q162760
 12698092-n:
   definition:
   - a variety of fly honeysuckle
@@ -66235,6 +68312,9 @@
   mero_part:
   - 07781184-n
   partOfSpeech: n
+  wikidata:
+  - Q1640817
+  - Q21877280
 12699555-n:
   definition:
   - shrub or small tree of western United States having white flowers and blue berries;
@@ -66247,6 +68327,7 @@
   - blue elderberry
   - Sambucus caerulea
   partOfSpeech: n
+  wikidata: Q12210846
 12699784-n:
   definition:
   - dwarf herbaceous elder of Europe having pink flowers and a nauseous odor
@@ -66274,6 +68355,7 @@
   - European elder
   - Sambucus nigra
   partOfSpeech: n
+  wikidata: Q22701
 12700193-n:
   definition:
   - common North American shrub or small tree
@@ -66286,6 +68368,9 @@
   - stinking elder
   - Sambucus pubens
   partOfSpeech: n
+  wikidata:
+  - Q3470723
+  - Q12210848
 12700354-n:
   definition:
   - Eurasian shrub
@@ -66297,6 +68382,7 @@
   - red-berried elder
   - Sambucus racemosa
   partOfSpeech: n
+  wikidata: Q157276
 12700473-n:
   definition:
   - 'genus of Asiatic and North American herbs: feverroot'
@@ -66356,6 +68442,7 @@
   - highbush cranberry
   - Viburnum trilobum
   partOfSpeech: n
+  wikidata: Q50877103
 12701413-n:
   definition:
   - vigorous deciduous European treelike shrub common along waysides; red berries
@@ -66398,6 +68485,7 @@
   - southern arrow wood
   - Viburnum dentatum
   partOfSpeech: n
+  wikidata: Q4115036
 12702137-n:
   definition:
   - closely related to southern arrow wood; grows in the eastern United States from
@@ -66409,6 +68497,7 @@
   - arrow wood
   - Viburnum recognitum
   partOfSpeech: n
+  wikidata: Q17434696
 12702340-n:
   definition:
   - upright deciduous shrub having frosted dark-blue fruit; east and east central
@@ -66420,6 +68509,7 @@
   - black haw
   - Viburnum prunifolium
   partOfSpeech: n
+  wikidata: Q678294
 12702529-n:
   definition:
   - east Asian flowering shrubs
@@ -66442,6 +68532,7 @@
   - weigela
   - Weigela florida
   partOfSpeech: n
+  wikidata: Q164323
 12702815-n:
   definition:
   - chiefly southern European herbs with flowers usually in dense cymose heads
@@ -66515,6 +68606,7 @@
   - wild teasel
   - Dipsacus sylvestris
   partOfSpeech: n
+  wikidata: Q17465474
 12704009-n:
   definition:
   - annual or perennial herbs or subshrubs; mainly Mediterranean
@@ -66550,6 +68642,9 @@
   - mournful widow
   - Scabiosa atropurpurea
   partOfSpeech: n
+  wikidata:
+  - Q17436334
+  - Q159446
 12704552-n:
   definition:
   - perennial having bluish-lilac flowers; introduced in the eastern United States
@@ -66560,6 +68655,7 @@
   - field scabious
   - Scabiosa arvensis
   partOfSpeech: n
+  wikidata: Q21877308
 12704711-n:
   definition:
   - distinguished from the family Geraniaceae by the irregular flowers
@@ -66602,6 +68698,7 @@
   - touch-me-not
   - Impatiens capensis
   partOfSpeech: n
+  wikidata: Q2462343
 12705401-n:
   definition:
   - an order of plants of subclass Rosidae including geraniums and many other plants;
@@ -66691,6 +68788,7 @@
   - spotted cranesbill
   - Geranium maculatum
   partOfSpeech: n
+  wikidata: Q5549871
 12707035-n:
   definition:
   - tall perennial cranesbill with paired violet-blue axillary flowers; native to
@@ -66702,6 +68800,7 @@
   - meadow cranesbill
   - Geranium pratense
   partOfSpeech: n
+  wikidata: Q157585
 12707257-n:
   definition:
   - geranium of western North America having branched clusters of white or pale pink
@@ -66727,6 +68826,7 @@
   - herb roberts
   - Geranium robertianum
   partOfSpeech: n
+  wikidata: Q160096
 12707638-n:
   definition:
   - geranium of western North America having pinkish-purple flowers in open clusters
@@ -66737,6 +68837,7 @@
   - sticky geranium
   - Geranium viscosissimum
   partOfSpeech: n
+  wikidata: Q5549882
 12707805-n:
   definition:
   - western geranium with small pink flowers; a common weed on lawns and in vacant
@@ -66778,6 +68879,7 @@
   - sweet-scented geranium
   - Pelargonium graveolens
   partOfSpeech: n
+  wikidata: Q164306
 12708459-n:
   definition:
   - an upright geranium having scalloped leaves with a broad color zone inside the
@@ -66804,6 +68906,7 @@
   - hanging geranium
   - Pelargonium peltatum
   partOfSpeech: n
+  wikidata: Q160925
 12708948-n:
   definition:
   - geranium with round fragrant leaves and small white flowers
@@ -66815,6 +68918,7 @@
   - nutmeg geranium
   - Pelargonium odoratissimum
   partOfSpeech: n
+  wikidata: Q149880
 12709133-n:
   definition:
   - a common garden geranium with lemon-scented foliage
@@ -66867,6 +68971,7 @@
   - pin clover
   - Erodium cicutarium
   partOfSpeech: n
+  wikidata: Q157726
 12710066-n:
   definition:
   - low annual European herb naturalized in America; similar to alfilaria
@@ -66879,6 +68984,7 @@
   - white-stemmed filaree
   - Erodium moschatum
   partOfSpeech: n
+  wikidata: Q159800
 12710252-n:
   definition:
   - of prairies and desert areas of southwestern United States and Mexico
@@ -66889,6 +68995,7 @@
   - Texas storksbill
   - Erodium texanum
   partOfSpeech: n
+  wikidata: Q425661
 12710402-n:
   definition:
   - a family of plants of order Geraniales; have drupaceous fruit
@@ -67004,6 +69111,7 @@
   - elephant tree
   - Bursera microphylla
   partOfSpeech: n
+  wikidata: Q2367282
 12712422-n:
   definition:
   - tropical American tree yielding a reddish resin used in cements and varnishes
@@ -67038,6 +69146,7 @@
   members:
   - Boswellia carteri
   partOfSpeech: n
+  wikidata: Q50829154
 12712921-n:
   definition:
   - East Indian tree yielding a resin used medicinally and burned as incense
@@ -67048,6 +69157,7 @@
   - salai
   - Boswellia serrata
   partOfSpeech: n
+  wikidata: Q2367334
 12713084-n:
   definition:
   - genus of East Indian and African trees yielding balsamic products
@@ -67085,6 +69195,7 @@
   mero_substance:
   - 12713636-n
   partOfSpeech: n
+  wikidata: Q164609
 12713636-n:
   definition:
   - aromatic resin that is burned as incense and used in perfume
@@ -67121,6 +69232,7 @@
   members:
   - Protium heptaphyllum
   partOfSpeech: n
+  wikidata: Q9063301
 12714113-n:
   definition:
   - tropical American tree with a girth often exceeding ten feet
@@ -67130,6 +69242,7 @@
   members:
   - Protium guianense
   partOfSpeech: n
+  wikidata: Q15544906
 12714218-n:
   definition:
   - fragrant wood of two incense trees of the genus Protium
@@ -67226,6 +69339,7 @@
   mero_part:
   - 07762310-n
   partOfSpeech: n
+  wikidata: Q273742
 12715468-n:
   definition:
   - tropical trees and shrubs including many important timber and ornamental trees
@@ -67307,6 +69421,7 @@
   - Melia azederach
   - Melia azedarach
   partOfSpeech: n
+  wikidata: Q15546527
 12717083-n:
   definition:
   - 'genus of large important East Indian trees: neem trees'
@@ -67338,6 +69453,7 @@
   mero_part:
   - 12717591-n
   partOfSpeech: n
+  wikidata: Q170461
 12717591-n:
   definition:
   - seed of neem trees; source of pesticides and fertilizer and medicinal products
@@ -67376,6 +69492,7 @@
   mero_substance:
   - 12721471-n
   partOfSpeech: n
+  wikidata: Q163004
 12718121-n:
   definition:
   - deciduous trees of India and Sri Lanka
@@ -67402,6 +69519,7 @@
   mero_substance:
   - 12718469-n
   partOfSpeech: n
+  wikidata: Q2229595
 12718469-n:
   definition:
   - hard yellowish wood of a satinwood tree having a satiny luster; used for fine
@@ -67438,6 +69556,7 @@
   - sapele mahogany
   - Entandrophragma cylindricum
   partOfSpeech: n
+  wikidata: Q286236
 12719043-n:
   definition:
   - small genus of Australian timber trees
@@ -67472,6 +69591,7 @@
   - flindosy
   - Flindersia australis
   partOfSpeech: n
+  wikidata: Q1605767
 12719534-n:
   definition:
   - Australian timber tree whose bark yields a poison
@@ -67482,6 +69602,7 @@
   - bunji-bunji
   - Flindersia schottiana
   partOfSpeech: n
+  wikidata: Q5433092
 12719665-n:
   definition:
   - African mahogany trees
@@ -67554,6 +69675,7 @@
   - African walnut
   - Lovoa klaineana
   partOfSpeech: n
+  wikidata: Q49437079
 12720538-n:
   definition:
   - tropical American mahogany trees
@@ -67721,6 +69843,7 @@
   - caracolito
   - Ruptiliocarpon caracolito
   partOfSpeech: n
+  wikidata: Q17250335
 12723203-n:
   definition:
   - a family of widely distributed herbs of the order Geraniales; have compound leaves
@@ -67773,6 +69896,7 @@
   - shamrock
   - Oxalis acetosella
   partOfSpeech: n
+  wikidata: Q158576
 12724143-n:
   definition:
   - South African bulbous wood sorrel with showy yellow flowers
@@ -67797,6 +69921,7 @@
   - creeping wood sorrel
   - Oxalis corniculata
   partOfSpeech: n
+  wikidata: Q162795
 12724476-n:
   definition:
   - short-stemmed South African plant with bluish flowers
@@ -67808,6 +69933,7 @@
   - goat's foot
   - Oxalis caprina
   partOfSpeech: n
+  wikidata: Q18010135
 12724616-n:
   definition:
   - perennial herb of eastern North America with palmately compound leaves and usually
@@ -67819,6 +69945,9 @@
   - violet wood sorrel
   - Oxalis violacea
   partOfSpeech: n
+  wikidata:
+  - Q15346873
+  - Q1067933
 12724801-n:
   definition:
   - South American wood sorrel cultivated for its edible tubers
@@ -67831,7 +69960,9 @@
   - Oxalis tuberosa
   - Oxalis crenata
   partOfSpeech: n
-  wikidata: Q1355893
+  wikidata:
+  - Q1355893
+  - Q50846934
 12724951-n:
   definition:
   - 'trees native to East Indies having pinnate leaves: carambolas'
@@ -67856,6 +69987,7 @@
   mero_part:
   - 07762527-n
   partOfSpeech: n
+  wikidata: Q159447
 12725273-n:
   definition:
   - East Indian evergreen tree bearing very acid fruit
@@ -67866,6 +69998,7 @@
   - bilimbi
   - Averrhoa bilimbi
   partOfSpeech: n
+  wikidata: Q237465
 12725396-n:
   definition:
   - trees, shrubs, and herbs widely distributed throughout both hemispheres
@@ -67915,6 +70048,7 @@
   mero_part:
   - 12727000-n
   partOfSpeech: n
+  wikidata: Q15577754
 12726218-n:
   definition:
   - bog plant of pine barrens of southeastern United States having spikes of irregular
@@ -67929,6 +70063,7 @@
   - yellow bachelor's button
   - Polygala lutea
   partOfSpeech: n
+  wikidata: Q17468845
 12726458-n:
   definition:
   - common trailing perennial milkwort of eastern North America having leaves like
@@ -67943,7 +70078,9 @@
   - fringed polygala
   - Polygala paucifolia
   partOfSpeech: n
-  wikidata: Q4296863
+  wikidata:
+  - Q17468666
+  - Q4296863
 12726738-n:
   definition:
   - eastern North American plant having a terminal cluster of small white flowers
@@ -67961,6 +70098,7 @@
   mero_part:
   - 12727000-n
   partOfSpeech: n
+  wikidata: Q3395566
 12727000-n:
   definition:
   - dried root of two plants of the genus Polygala containing an irritating saponin
@@ -67982,6 +70120,7 @@
   - gand flower
   - Polygala vulgaris
   partOfSpeech: n
+  wikidata: Q162905
 12727404-n:
   definition:
   - a family of dicotyledonous plants of order Geraniales; have flowers that are divide
@@ -68139,6 +70278,7 @@
   mero_part:
   - 07766122-n
   partOfSpeech: n
+  wikidata: Q21004587
 12730109-n:
   definition:
   - thorny evergreen small tree or shrub of India widely cultivated for its large
@@ -68178,6 +70318,7 @@
   mero_part:
   - 07765945-n
   partOfSpeech: n
+  wikidata: Q41350
 12730661-n:
   definition:
   - shrub or small tree having flattened globose fruit with very sweet aromatic pulp
@@ -68262,6 +70403,7 @@
   mero_part:
   - 07763787-n
   partOfSpeech: n
+  wikidata: Q67192697
 12731942-n:
   definition:
   - hybrid between grapefruit and mandarin orange; cultivated especially in Florida
@@ -68456,6 +70598,7 @@
   - cork tree
   - Phellodendron amurense
   partOfSpeech: n
+  wikidata: Q481711
 12734874-n:
   definition:
   - 'one species: trifoliate orange'
@@ -68521,7 +70664,9 @@
   - Zanthoxylum americanum
   - Zanthoxylum fraxineum
   partOfSpeech: n
-  wikidata: Q3079244
+  wikidata:
+  - Q3079244
+  - Q50881685
 12735955-n:
   definition:
   - densely spiny ornamental of southeastern United States and West Indies
@@ -68617,6 +70762,7 @@
   - bitterwood
   - Simarouba glauca
   partOfSpeech: n
+  wikidata: Q19690498
 12737621-n:
   definition:
   - small genus of east Asian and Chinese trees with odd-pinnate leaves and long twisted
@@ -68653,6 +70799,7 @@
   - tree of the gods
   - Ailanthus altissima
   partOfSpeech: n
+  wikidata: Q159570
 12738284-n:
   definition:
   - wild mango
@@ -68706,6 +70853,7 @@
   - pepper tree
   - Kirkia wilmsii
   partOfSpeech: n
+  wikidata: Q18076323
 12739074-n:
   definition:
   - small genus of deciduous trees of tropical America and Asia
@@ -68733,6 +70881,7 @@
   mero_substance:
   - 12739445-n
   partOfSpeech: n
+  wikidata: Q5462032
 12739445-n:
   definition:
   - similar to the extract from Quassia amara
@@ -68768,6 +70917,7 @@
   - bitterwood
   - Quassia amara
   partOfSpeech: n
+  wikidata: Q135389
 12740037-n:
   definition:
   - coextensive with the genus Tropaeolum
@@ -68831,6 +70981,7 @@
   - bush nasturtium
   - Tropaeolum minus
   partOfSpeech: n
+  wikidata: Q161283
 12741114-n:
   definition:
   - a climber having flowers that are the color of canaries
@@ -68843,6 +70994,9 @@
   - canary creeper
   - Tropaeolum peregrinum
   partOfSpeech: n
+  wikidata:
+  - Q15603773
+  - Q5477895
 12741292-n:
   definition:
   - 'small trees, shrubs, and herbs of warm arid and saline regions; often resinous;
@@ -68954,6 +71108,7 @@
   - 12743142-n
   - 12743528-n
   partOfSpeech: n
+  wikidata: Q2051175
 12743142-n:
   definition:
   - hard greenish-brown wood of the lignum vitae tree and other trees of the genus
@@ -68977,6 +71132,7 @@
   - bastard lignum vitae
   - Guaiacum sanctum
   partOfSpeech: n
+  wikidata: Q2248958
 12743528-n:
   definition:
   - medicinal resin from the lignum vitae tree
@@ -69014,6 +71170,7 @@
   mero_part:
   - 12744090-n
   partOfSpeech: n
+  wikidata: Q965954
 12744090-n:
   definition:
   - acidulous gum resin of the creosote bush
@@ -69176,7 +71333,10 @@
   - Salix alba vitellina
   - Salix vitellina
   partOfSpeech: n
-  wikidata: Q5649436
+  wikidata:
+  - Q5649436
+  - Q20061120
+  - Q21877272
 12747117-n:
   definition:
   - Eurasian willow tree having greyish leaves and ascending branches
@@ -69197,6 +71357,7 @@
   - arctic willow
   - Salix arctica
   partOfSpeech: n
+  wikidata: Q674096
 12747430-n:
   definition:
   - willow with long drooping branches and slender leaves native to China; widely
@@ -69209,6 +71370,9 @@
   - Babylonian weeping willow
   - Salix babylonica
   partOfSpeech: n
+  wikidata:
+  - Q89245133
+  - Q156307
 12747662-n:
   definition:
   - hybrid willow usually not strongly weeping in habit
@@ -69221,6 +71385,7 @@
   - Salix blanda
   - Salix pendulina blanda
   partOfSpeech: n
+  wikidata: Q17561914
 12747861-n:
   definition:
   - small willow of eastern North America having greyish leaves and silky catkins
@@ -69232,6 +71397,7 @@
   - pussy willow
   - Salix discolor
   partOfSpeech: n
+  wikidata: Q3124760
 12748061-n:
   definition:
   - any of several Old World shrubby broad-leaved willows having large catkins; some
@@ -69294,6 +71460,7 @@
   - sage willow
   - Salix candida
   partOfSpeech: n
+  wikidata: Q7404892
 12749082-n:
   definition:
   - large willow tree with stiff branches that are easily broken
@@ -69317,6 +71484,7 @@
   - prairie willow
   - Salix humilis
   partOfSpeech: n
+  wikidata: Q3469829
 12749416-n:
   definition:
   - widely distributed boreal shrubby willow with partially underground creeping stems
@@ -69340,6 +71508,7 @@
   - gray willow
   - Salix cinerea
   partOfSpeech: n
+  wikidata: Q157540
 12749783-n:
   definition:
   - shrubby willow of the western United States
@@ -69350,6 +71519,7 @@
   - arroyo willow
   - Salix lasiolepis
   partOfSpeech: n
+  wikidata: Q5240848
 12749924-n:
   definition:
   - common North American shrub with shiny lanceolate leaves
@@ -69360,6 +71530,7 @@
   - shining willow
   - Salix lucida
   partOfSpeech: n
+  wikidata: Q159412
 12750075-n:
   definition:
   - North American shrubby willow having dark bark and linear leaves growing close
@@ -69372,6 +71543,7 @@
   - black willow
   - Salix nigra
   partOfSpeech: n
+  wikidata: Q469220
 12750281-n:
   definition:
   - European willow tree with shining leathery leaves; widely naturalized in the eastern
@@ -69384,6 +71556,7 @@
   - laurel willow
   - Salix pentandra
   partOfSpeech: n
+  wikidata: Q158912
 12750489-n:
   definition:
   - Eurasian osier having reddish or purple twigs and bark rich in tannin
@@ -69398,6 +71571,7 @@
   - purple osier
   - Salix purpurea
   partOfSpeech: n
+  wikidata: Q39708
 12750710-n:
   definition:
   - small shrubby tree of eastern North America having leaves exuding an odor of balsam
@@ -69409,6 +71583,7 @@
   - balsam willow
   - Salix pyrifolia
   partOfSpeech: n
+  wikidata: Q805516
 12750903-n:
   definition:
   - small trailing bush of Europe and Asia having straggling branches with silky green
@@ -69446,6 +71621,9 @@
   - sage willow
   - Salix tristis
   partOfSpeech: n
+  wikidata:
+  - Q24694533
+  - Q39908047
 12751536-n:
   definition:
   - dwarf prostrate mat-forming shrub of Arctic and alpine regions of North America
@@ -69457,6 +71635,7 @@
   - bearberry willow
   - Salix uva-ursi
   partOfSpeech: n
+  wikidata: Q17562974
 12751789-n:
   definition:
   - willow with long flexible twigs used in basketry
@@ -69518,6 +71697,9 @@
   - tacamahac
   - Populus balsamifera
   partOfSpeech: n
+  wikidata:
+  - Q15384833
+  - Q149471
 12752769-n:
   definition:
   - a poplar that is widely cultivated in the United States; has white bark and leaves
@@ -69533,6 +71715,7 @@
   - silver-leaved poplar
   - Populus alba
   partOfSpeech: n
+  wikidata: Q146269
 12753012-n:
   definition:
   - large rapidly growing poplar with faintly lobed dentate leaves grey on the lower
@@ -69545,6 +71728,7 @@
   - gray poplar
   - Populus canescens
   partOfSpeech: n
+  wikidata: Q149553
 12753251-n:
   definition:
   - large European poplar
@@ -69555,6 +71739,7 @@
   - black poplar
   - Populus nigra
   partOfSpeech: n
+  wikidata: Q147064
 12753365-n:
   definition:
   - distinguished by its columnar fastigiate shape and erect branches
@@ -69587,6 +71772,7 @@
   - necklace poplar
   - Populus deltoides
   partOfSpeech: n
+  wikidata: Q149319
 12753978-n:
   definition:
   - cottonwood of western North America with dark green leaves shining above and rusty
@@ -69599,6 +71785,7 @@
   - Western balsam poplar
   - Populus trichocarpa
   partOfSpeech: n
+  wikidata: Q149382
 12754188-n:
   definition:
   - North American poplar with large rounded scalloped leaves and brownish bark and
@@ -69648,6 +71835,7 @@
   - American aspen
   - Populus tremuloides
   partOfSpeech: n
+  wikidata: Q469576
 12754975-n:
   definition:
   - aspen with a narrow crown; eastern North America
@@ -69663,6 +71851,7 @@
   - large tooth aspen
   - Populus grandidentata
   partOfSpeech: n
+  wikidata: Q1536353
 12755206-n:
   definition:
   - order of plants distinguished by having a one-celled inferior ovary; many are
@@ -69724,6 +71913,7 @@
   mero_substance:
   - 12756212-n
   partOfSpeech: n
+  wikidata: Q210858
 12756212-n:
   definition:
   - close-grained fragrant yellowish heartwood of the true sandalwood; has insect
@@ -69782,6 +71972,9 @@
   - bastard toadflax
   - Comandra pallida
   partOfSpeech: n
+  wikidata:
+  - Q32795129
+  - Q32794876
 12757215-n:
   definition:
   - quandong trees
@@ -69813,6 +72006,7 @@
   - 07785282-n
   - 07785441-n
   partOfSpeech: n
+  wikidata: Q87643137
 12757600-n:
   definition:
   - small genus of chiefly Asiatic parasitic shrubs
@@ -69840,6 +72034,7 @@
   mero_part:
   - 12758011-n
   partOfSpeech: n
+  wikidata: Q18076760
 12758011-n:
   definition:
   - oily drupaceous fruit of rabbitwood
@@ -69894,6 +72089,7 @@
   - mistletoe
   - Loranthus europaeus
   partOfSpeech: n
+  wikidata: Q164391
 12758847-n:
   definition:
   - genus of chiefly American plants parasitic on conifers
@@ -69918,6 +72114,7 @@
   - American mistletoe
   - Arceuthobium pusillum
   partOfSpeech: n
+  wikidata: Q15379241
 12759240-n:
   definition:
   - a genus containing the species Nuytsia floribunda, also known as the Western Australian
@@ -69987,6 +72184,7 @@
   - Viscum album
   - Old World mistletoe
   partOfSpeech: n
+  wikidata: Q144940
 12760355-n:
   definition:
   - 'any of various American parasitic plants similar to Old World mistletoe: false
@@ -70023,6 +72221,7 @@
   - Phoradendron serotinum
   - Phoradendron flavescens
   partOfSpeech: n
+  wikidata: Q15392705
 12760956-n:
   definition:
   - an order of dicotyledonous plants, containing the families Anacardiaceae, Biebersteiniaceae,
@@ -70128,6 +72327,7 @@
   - Sapindus drumondii
   - Sapindus marginatus
   partOfSpeech: n
+  wikidata: Q22112311
 12762552-n:
   definition:
   - evergreen of tropical America having pulpy fruit containing saponin which was
@@ -70204,6 +72404,7 @@
   - heartseed
   - Cardiospermum grandiflorum
   partOfSpeech: n
+  wikidata: Q15547168
 12763769-n:
   definition:
   - woody perennial climbing plant with large ornamental seed pods that resemble balloons;
@@ -70216,6 +72417,7 @@
   - heart pea
   - Cardiospermum halicacabum
   partOfSpeech: n
+  wikidata: Q1377406
 12763992-n:
   definition:
   - longan
@@ -70246,7 +72448,9 @@
   mero_part:
   - 07782385-n
   partOfSpeech: n
-  wikidata: Q193449
+  wikidata:
+  - Q87620602
+  - Q193449
 12764440-n:
   definition:
   - genus of tropical Asiatic and African trees
@@ -70279,6 +72483,7 @@
   - harpulla
   - Harpullia cupanioides
   partOfSpeech: n
+  wikidata: Q10888557
 12764902-n:
   definition:
   - Australian tree yielding a variegated tulipwood
@@ -70318,7 +72523,9 @@
   mero_part:
   - 07782149-n
   partOfSpeech: n
-  wikidata: Q13182
+  wikidata:
+  - Q13182
+  - Q87631717
 12765416-n:
   definition:
   - tropical American trees and shrubs bearing berries
@@ -70382,6 +72589,7 @@
   mero_part:
   - 07785707-n
   partOfSpeech: n
+  wikidata: Q476864
 12766324-n:
   definition:
   - East Indian fruit tree bearing fruit similar to but sweeter than that of the rambutan
@@ -70396,6 +72604,7 @@
   mero_part:
   - 07785862-n
   partOfSpeech: n
+  wikidata: Q50849806
 12766548-n:
   definition:
   - widely distributed evergreen shrubs and trees
@@ -70448,6 +72657,7 @@
   - European box
   - Buxus sempervirens
   partOfSpeech: n
+  wikidata: Q27344
 12767234-n:
   definition:
   - 'very hard tough close-grained light yellow wood of the box (particularly the
@@ -70494,6 +72704,7 @@
   - Allegheny mountain spurge
   - Pachysandra procumbens
   partOfSpeech: n
+  wikidata: Q160280
 12768131-n:
   definition:
   - slow-growing Japanese evergreen subshrub having terminal spikes of white flowers;
@@ -70505,6 +72716,7 @@
   - Japanese spurge
   - Pachysandra terminalis
   partOfSpeech: n
+  wikidata: Q159315
 12768323-n:
   definition:
   - trees and shrubs and woody vines usually having bright-colored fruits
@@ -70563,6 +72775,7 @@
   - shrubby bittersweet
   - Celastrus scandens
   partOfSpeech: n
+  wikidata: Q469628
 12769294-n:
   definition:
   - ornamental Asiatic vine with showy orange-yellow fruit with a scarlet aril; naturalized
@@ -70616,6 +72829,7 @@
   - common spindle tree
   - Euonymus europaeus
   partOfSpeech: n
+  wikidata: Q161379
 12770216-n:
   definition:
   - bushy deciduous shrub with branches having thin wide corky longitudinal wings;
@@ -70638,6 +72852,7 @@
   - burning bush
   - Euonymus atropurpureus
   partOfSpeech: n
+  wikidata: Q4117752
 12770612-n:
   definition:
   - upright deciduous plant with crimson pods and seeds; the eastern United States
@@ -70650,6 +72865,7 @@
   - wahoo
   - Euonymus americanus
   partOfSpeech: n
+  wikidata: Q4117758
 12770836-n:
   definition:
   - broad and bushy Asiatic twining shrub with pinkish fruit; many subspecies or varieties
@@ -70704,6 +72920,7 @@
   - white titi
   - Cyrilla racemiflora
   partOfSpeech: n
+  wikidata: Q140549
 12771803-n:
   definition:
   - 'one species: titi'
@@ -70836,6 +73053,7 @@
   - silver maple
   - Acer saccharinum
   partOfSpeech: n
+  wikidata: Q158301
 12774005-n:
   definition:
   - maple of eastern and central North America having three-lobed to five-lobed leaves
@@ -70890,6 +73108,7 @@
   - big-leaf maple
   - Acer macrophyllum
   partOfSpeech: n
+  wikidata: Q599523
 12774934-n:
   definition:
   - small maple of northwestern North America
@@ -70901,6 +73120,7 @@
   - Rocky-mountain maple
   - Acer glabrum
   partOfSpeech: n
+  wikidata: Q540650
 12775071-n:
   definition:
   - small shrubby maple of eastern North America; scarlet in autumn
@@ -70936,6 +73156,7 @@
   - field maple
   - Acer campestre
   partOfSpeech: n
+  wikidata: Q158785
 12775541-n:
   definition:
   - a large Eurasian maple tree naturalized in North America; five-lobed leaves yellow
@@ -70947,6 +73168,7 @@
   - Norway maple
   - Acer platanoides
   partOfSpeech: n
+  wikidata: Q26745
 12775741-n:
   definition:
   - Eurasian maple tree with pale grey bark that peels in flakes like that of a sycamore
@@ -70972,6 +73194,7 @@
   - ash-leaved maple
   - Acer negundo
   partOfSpeech: n
+  wikidata: Q161166
 12776147-n:
   definition:
   - maple of the Pacific coast of the United States; fruits are white when mature
@@ -70993,6 +73216,7 @@
   - pointed-leaf maple
   - Acer argutum
   partOfSpeech: n
+  wikidata: Q357629
 12776487-n:
   definition:
   - leaves deeply incised and bright red in autumn; Japan
@@ -71004,6 +73228,7 @@
   - full moon maple
   - Acer japonicum
   partOfSpeech: n
+  wikidata: Q149269
 12776636-n:
   definition:
   - ornamental shrub or small tree of Japan and Korea with deeply incised leaves;
@@ -71078,6 +73303,7 @@
   - Chinese holly
   - Ilex cornuta
   partOfSpeech: n
+  wikidata: Q1074050
 12778063-n:
   definition:
   - deciduous shrub of southeastern and central United States
@@ -71090,7 +73316,9 @@
   - winterberry
   - Ilex decidua
   partOfSpeech: n
-  wikidata: Q5997670
+  wikidata:
+  - Q15383155
+  - Q5997670
 12778218-n:
   definition:
   - evergreen holly of eastern North America with oblong leathery leaves and small
@@ -71105,6 +73333,7 @@
   - evergreen winterberry
   - Ilex glabra
   partOfSpeech: n
+  wikidata: Q5997676
 12778428-n:
   definition:
   - South American holly; leaves used in making a drink like tea
@@ -71116,6 +73345,7 @@
   - Paraguay tea
   - Ilex paraguariensis
   partOfSpeech: n
+  wikidata: Q117068
 12778576-n:
   definition:
   - an evergreen tree (Ilex opaca)
@@ -71262,6 +73492,7 @@
   mero_part:
   - 07788123-n
   partOfSpeech: n
+  wikidata: Q34007
 12780256-n:
   definition:
   - a genus of dicotyledonous plants of the family Anacardiaceae
@@ -71363,6 +73594,7 @@
   - Malosma laurina
   - Rhus laurina
   partOfSpeech: n
+  wikidata: Q15544644
 12781883-n:
   definition:
   - tropical tree native to Asia bearing fleshy fruit
@@ -71389,6 +73621,7 @@
   mero_part:
   - 07780131-n
   partOfSpeech: n
+  wikidata: Q3919027
 12782231-n:
   definition:
   - a dicotyledonous genus of trees of the family Anacardiaceae having drupaceous
@@ -71429,6 +73662,7 @@
   - terebinth
   - Pistacia terebinthus
   partOfSpeech: n
+  wikidata: Q63045
 12782809-n:
   definition:
   - an evergreen shrub of the Mediterranean region that is cultivated for its resin
@@ -71441,6 +73675,7 @@
   - lentisk
   - Pistacia lentiscus
   partOfSpeech: n
+  wikidata: Q159812
 12783005-n:
   definition:
   - one species; an Australian evergreen sumac
@@ -71465,6 +73700,7 @@
   - Rhodosphaera rhodanthema
   - Rhus rhodanthema
   partOfSpeech: n
+  wikidata: Q7321221
 12783343-n:
   definition:
   - deciduous or evergreen shrubs and shrubby trees of temperate and subtropical North
@@ -71515,6 +73751,7 @@
   - lemon sumac
   - Rhus aromatica
   partOfSpeech: n
+  wikidata: Q62864
 12784289-n:
   definition:
   - common nonpoisonous shrub of eastern North America with waxy compound leaves and
@@ -71528,7 +73765,9 @@
   - vinegar tree
   - Rhus glabra
   partOfSpeech: n
-  wikidata: Q3177997
+  wikidata:
+  - Q15525206
+  - Q3177997
 12784522-n:
   definition:
   - common nonpoisonous shrub of eastern North America with compound leaves and green
@@ -71555,7 +73794,9 @@
   - sugar sumac
   - Rhus ovata
   partOfSpeech: n
-  wikidata: Q7321569
+  wikidata:
+  - Q15525262
+  - Q7321569
 12784962-n:
   definition:
   - deciduous shrubby tree or eastern North America with compound leaves that turn
@@ -71571,6 +73812,7 @@
   - vinegar tree
   - Rhus typhina
   partOfSpeech: n
+  wikidata: Q148986
 12785267-n:
   definition:
   - deciduous shrub of California with unpleasantly scented usually trifoliate leaves
@@ -71584,7 +73826,9 @@
   - skunkbush
   - Rhus trilobata
   partOfSpeech: n
-  wikidata: Q7155056
+  wikidata:
+  - Q50908404
+  - Q7155056
 12785463-n:
   definition:
   - genus of evergreen shrubs and trees of tropical and subtropical regions of South
@@ -71612,6 +73856,7 @@
   - Brazilian pepper tree
   - Schinus terebinthifolia
   partOfSpeech: n
+  wikidata: Q899313
 12785875-n:
   definition:
   - small Peruvian evergreen with broad rounded head and slender pendant branches
@@ -71626,6 +73871,7 @@
   - Peruvian mastic tree
   - Schinus molle
   partOfSpeech: n
+  wikidata: Q855896
 12786439-n:
   definition:
   - tropical trees having one-seeded fruit
@@ -71654,6 +73900,7 @@
   mero_part:
   - 07781588-n
   partOfSpeech: n
+  wikidata: Q794969
 12786803-n:
   definition:
   - common tropical American shrub or small tree with purplish fruit
@@ -71668,6 +73915,7 @@
   mero_part:
   - 07781493-n
   partOfSpeech: n
+  wikidata: Q1424396
 12787001-n:
   definition:
   - 'in some classifications: comprising those members of the genus Rhus having foliage
@@ -71700,6 +73948,7 @@
   - Toxicodendron vernix
   - Rhus vernix
   partOfSpeech: n
+  wikidata: Q7002291
 12787629-n:
   definition:
   - climbing plant common in eastern and central United States with ternate leaves
@@ -71715,6 +73964,7 @@
   - Toxicodendron radicans
   - Rhus radicans
   partOfSpeech: n
+  wikidata: Q7218532
 12787968-n:
   definition:
   - poisonous shrub of the Pacific coast of North America that causes a rash on contact
@@ -71739,6 +73989,7 @@
   - Rhus quercifolia
   - Rhus toxicodenedron
   partOfSpeech: n
+  wikidata: Q15525575
 12788408-n:
   definition:
   - small Asiatic tree yielding a toxic exudate from which lacquer is obtained
@@ -71755,6 +74006,7 @@
   - Toxicodendron vernicifluum
   - Rhus verniciflua
   partOfSpeech: n
+  wikidata: Q28933284
 12788711-n:
   definition:
   - trees having showy flowers and inedible nutlike seeds in a leathery capsule
@@ -71795,6 +74047,7 @@
   - buckeye
   - Aesculus hippocastanum
   partOfSpeech: n
+  wikidata: Q26899
 12789442-n:
   definition:
   - the inedible nutlike seed of the horse chestnut
@@ -71938,6 +74191,7 @@
   mero_substance:
   - 12791496-n
   partOfSpeech: n
+  wikidata: Q5279626
 12791496-n:
   definition:
   - hard dark-colored heartwood of the ebony tree; used in cabinetwork and for piano
@@ -71962,6 +74216,7 @@
   mero_substance:
   - 12791845-n
   partOfSpeech: n
+  wikidata: Q15340072
 12791845-n:
   definition:
   - hard marbled wood
@@ -72010,6 +74265,7 @@
   mero_part:
   - 07762162-n
   partOfSpeech: n
+  wikidata: Q158356
 12792650-n:
   definition:
   - an Asiatic persimmon tree cultivated for its small yellow or purplish-black edible
@@ -72021,6 +74277,7 @@
   - date plum
   - Diospyros lotus
   partOfSpeech: n
+  wikidata: Q771101
 12792841-n:
   definition:
   - tropical trees or shrubs with milky juice and often edible fleshy fruit
@@ -72090,6 +74347,7 @@
   - mock orange
   - Bumelia lycioides
   partOfSpeech: n
+  wikidata: Q59922235
 12793902-n:
   definition:
   - deciduous tree of southeastern United States and Mexico
@@ -72104,6 +74362,7 @@
   - black haw
   - Bumelia lanuginosa
   partOfSpeech: n
+  wikidata: Q85194128
 12794094-n:
   definition:
   - a genus of tropical American trees of the family Sapotaceae
@@ -72155,6 +74414,7 @@
   - damson plum
   - Chrysophyllum oliviforme
   partOfSpeech: n
+  wikidata: Q5114905
 12794887-n:
   definition:
   - genus of large evergreen trees with milky latex; pantropical
@@ -72234,6 +74494,7 @@
   - gutta-percha tree
   - Palaquium gutta
   partOfSpeech: n
+  wikidata: Q160029
 12795985-n:
   definition:
   - genus of medium to large Malaysian trees yielding gutta-percha
@@ -72405,6 +74666,7 @@
   - snowbell
   - Styrax obassia
   partOfSpeech: n
+  wikidata: Q845222
 12798538-n:
   definition:
   - shrubby tree of China and Japan
@@ -72462,6 +74724,7 @@
   - Halesia carolina
   - Halesia tetraptera
   partOfSpeech: n
+  wikidata: Q3125935
 12799365-n:
   definition:
   - plants adapted to attract and capture and digest primarily insects but also other
@@ -72544,6 +74807,7 @@
   - huntsman's cups
   - Sarracenia purpurea
   partOfSpeech: n
+  wikidata: Q1927560
 12800928-n:
   definition:
   - (botany) a leaf that is modified in such a way as to resemble a pitcher or ewer
@@ -72582,6 +74846,7 @@
   - trumpets
   - Sarracenia flava
   partOfSpeech: n
+  wikidata: Q1499289
 12801612-n:
   definition:
   - 'one species: California pitcher plant'
@@ -72606,6 +74871,7 @@
   - California pitcher plant
   - Darlingtonia californica
   partOfSpeech: n
+  wikidata: Q1138945
 12802001-n:
   definition:
   - genus of pitcher plants of the Guiana Highlands in South America
@@ -72733,6 +74999,7 @@
   - Venus's flytraps
   - Dionaea muscipula
   partOfSpeech: n
+  wikidata: Q155825
 12803933-n:
   definition:
   - 'one species: waterwheel plant'
@@ -72784,6 +75051,7 @@
   members:
   - Drosophyllum lusitanicum
   partOfSpeech: n
+  wikidata: Q736307
 12804756-n:
   definition:
   - in some classifications included in the family Droseraceae
@@ -72857,6 +75125,7 @@
   - Australian pitcher plant
   - Cephalotus follicularis
   partOfSpeech: n
+  wikidata: Q140898
 12805870-n:
   definition:
   - succulent shrubs and herbs
@@ -72945,6 +75214,7 @@
   - midsummer-men
   - Sedum rosea
   partOfSpeech: n
+  wikidata: Q50862450
 12807224-n:
   definition:
   - perennial northern temperate plant with toothed leaves and heads of small purplish-white
@@ -72959,6 +75229,9 @@
   - live-forever
   - Sedum telephium
   partOfSpeech: n
+  wikidata:
+  - Q1327535
+  - Q13390371
 12807444-n:
   definition:
   - a genus of plants of the family Crassulaceae
@@ -72982,6 +75255,7 @@
   - pinwheel
   - Aeonium haworthii
   partOfSpeech: n
+  wikidata: Q511569
 12807767-n:
   definition:
   - trees or shrubs or climbers; mostly Southern Hemisphere
@@ -73020,6 +75294,7 @@
   - Christmas tree
   - Ceratopetalum gummiferum
   partOfSpeech: n
+  wikidata: Q2946376
 12808325-n:
   definition:
   - sometimes included in the family Saxifragaceae
@@ -73077,6 +75352,7 @@
   - climbing hydrangea
   - Hydrangea anomala
   partOfSpeech: n
+  wikidata: Q148137
 12809438-n:
   definition:
   - deciduous shrub with creamy white flower clusters; eastern United States
@@ -73087,6 +75363,7 @@
   - wild hydrangea
   - Hydrangea arborescens
   partOfSpeech: n
+  wikidata: Q278173
 12809614-n:
   definition:
   - deciduous shrub bearing roundheaded flower clusters opening green and aging to
@@ -73108,6 +75385,7 @@
   - fall-blooming hydrangea
   - Hydrangea paniculata
   partOfSpeech: n
+  wikidata: Q158443
 12809986-n:
   definition:
   - deciduous climber with aerial roots having large flat flower heads
@@ -73118,6 +75396,7 @@
   - climbing hydrangea
   - Hydrangea petiolaris
   partOfSpeech: n
+  wikidata: Q159332
 12810159-n:
   definition:
   - one species; sometimes placed in family Saxifragaceae
@@ -73141,6 +75420,7 @@
   - carpenteria
   - Carpenteria californica
   partOfSpeech: n
+  wikidata: Q15324410
 12810527-n:
   definition:
   - small genus of woody climbers with adhesive aerial roots; sometimes placed in
@@ -73167,6 +75447,9 @@
   - Decumaria barbata
   - Decumaria barbara
   partOfSpeech: n
+  wikidata:
+  - Q58763080
+  - Q15337547
 12810945-n:
   definition:
   - genus of ornamental mostly deciduous shrubs native to Asia and Central America;
@@ -73265,6 +75548,9 @@
   - climbing hydrangea
   - Schizophragma hydrangeoides
   partOfSpeech: n
+  wikidata:
+  - Q92191445
+  - Q11287263
 12812801-n:
   definition:
   - a large and diverse family of evergreen or deciduous herbs; widely distributed
@@ -73339,6 +75625,7 @@
   - yellow mountain saxifrage
   - Saxifraga aizoides
   partOfSpeech: n
+  wikidata: Q133893
 12814254-n:
   definition:
   - rosette-forming perennial having compact panicles of white flowers; Europe
@@ -73350,6 +75637,7 @@
   - fair-maids-of-France
   - Saxifraga granulata
   partOfSpeech: n
+  wikidata: Q133867
 12814455-n:
   definition:
   - tufted or mat-forming perennial of mountains of Europe; cultivated for its white
@@ -73361,6 +75649,7 @@
   - mossy saxifrage
   - Saxifraga hypnoides
   partOfSpeech: n
+  wikidata: Q5397333
 12814646-n:
   definition:
   - saxifrage having loose clusters of white flowers on hairy stems growing from a
@@ -73372,6 +75661,7 @@
   - western saxifrage
   - Saxifraga occidentalis
   partOfSpeech: n
+  wikidata: Q39924421
 12814895-n:
   definition:
   - plants forming dense cushions with bright reddish-lavender flowers; rocky areas
@@ -73395,7 +75685,9 @@
   - starry saxifrage
   - Saxifraga stellaris
   partOfSpeech: n
-  wikidata: Q162521
+  wikidata:
+  - Q18121653
+  - Q162521
 12815328-n:
   definition:
   - eastern Asiatic saxifrage with racemes of small red-and-white flowers; spreads
@@ -73410,6 +75702,7 @@
   - Saxifraga stolonifera
   - Saxifraga sarmentosam
   partOfSpeech: n
+  wikidata: Q159002
 12815613-n:
   definition:
   - 'chiefly Asiatic perennials: spirea'
@@ -73442,6 +75735,7 @@
   - false goatsbeard
   - Astilbe biternata
   partOfSpeech: n
+  wikidata: Q15605463
 12816112-n:
   definition:
   - mat-forming evergreen Asiatic plant with finely cut leaves and small pink to burgundy
@@ -73517,6 +75811,7 @@
   - Boykinia elata
   - Boykinia occidentalis
   partOfSpeech: n
+  wikidata: Q1756050
 12817377-n:
   definition:
   - genus of widely distributed semiaquatic herbs with minute greenish-yellow apetalous
@@ -73553,6 +75848,7 @@
   - water mat
   - Chrysosplenium americanum
   partOfSpeech: n
+  wikidata: Q15604950
 12817973-n:
   definition:
   - a genus containing Darmera peltata, or Indian rhubarb (Darmera, Peltiphyllum)
@@ -73582,6 +75878,7 @@
   - Darmera peltata
   - Peltiphyllum peltatum
   partOfSpeech: n
+  wikidata: Q1537045
 12818453-n:
   definition:
   - perennial evergreen herbs with white or pink flowers; Chile
@@ -73643,6 +75940,7 @@
   - rock geranium
   - Heuchera americana
   partOfSpeech: n
+  wikidata: Q3134929
 12819392-n:
   definition:
   - plant with leathery heart-shaped leaf blades clustered at base of long stalks
@@ -73655,6 +75953,7 @@
   - poker heuchera
   - Heuchera cylindrica
   partOfSpeech: n
+  wikidata: Q17780590
 12819670-n:
   definition:
   - perennial plant of the western United States having bright red flowers in feathery
@@ -73666,6 +75965,7 @@
   - coralbells
   - Heuchera sanguinea
   partOfSpeech: n
+  wikidata: Q12332586
 12819879-n:
   definition:
   - 'one species: leatherleaf saxifrage'
@@ -73719,6 +76019,7 @@
   - Lithophragma affinis
   - Tellima affinis
   partOfSpeech: n
+  wikidata: Q6648091
 12820809-n:
   definition:
   - plant with mostly basal leaves and slender open racemes of white or pale pink
@@ -73771,6 +76072,7 @@
   - fairy cup
   - Mitella diphylla
   partOfSpeech: n
+  wikidata: Q16755693
 12821832-n:
   definition:
   - small plant with leaves in a basal cluster and tiny greenish flowers in slender
@@ -73782,6 +76084,9 @@
   - five-point bishop's cap
   - Mitella pentandra
   partOfSpeech: n
+  wikidata:
+  - Q15606119
+  - Q12901065
 12822083-n:
   definition:
   - genus of bog herbs of Arctic and northern temperate regions
@@ -73819,6 +76124,7 @@
   - bog star
   - Parnassia palustris
   partOfSpeech: n
+  wikidata: Q161633
 12822726-n:
   definition:
   - bog plant with broadly heart-shaped basal leaves and cream-colored or white saucer-shaped
@@ -73830,6 +76136,7 @@
   - fringed grass of Parnassus
   - Parnassia fimbriata
   partOfSpeech: n
+  wikidata: Q7139267
 12823008-n:
   definition:
   - small genus of rhizomatous herbs of northwestern America and South America
@@ -73892,6 +76199,7 @@
   - fringe cups
   - Tellima grandiflora
   partOfSpeech: n
+  wikidata: Q847750
 12824277-n:
   definition:
   - small genus of North American herbs having mostly basal leaves and slender racemes
@@ -73920,6 +76228,7 @@
   - false mitrewort
   - Tiarella cordifolia
   partOfSpeech: n
+  wikidata: Q11891603
 12824718-n:
   definition:
   - plant with tiny white flowers hanging in loose clusters on leafy stems; moist
@@ -73932,6 +76241,7 @@
   - false mitrewort
   - Tiarella unifoliata
   partOfSpeech: n
+  wikidata: Q110570693
 12824976-n:
   definition:
   - 'one species: pickaback plant'
@@ -73958,6 +76268,7 @@
   - youth-on-age
   - Tolmiea menziesii
   partOfSpeech: n
+  wikidata: Q1422351
 12825381-n:
   definition:
   - 'in some classifications considered a part of the family Saxifragaceae: plants
@@ -74014,6 +76325,7 @@
   mero_part:
   - 07760658-n
   partOfSpeech: n
+  wikidata: Q146661
 12826321-n:
   definition:
   - widely cultivated currant bearing edible black aromatic berries
@@ -74027,6 +76339,7 @@
   mero_part:
   - 07760535-n
   partOfSpeech: n
+  wikidata: Q146604
 12826522-n:
   definition:
   - garden currant bearing small white berries
@@ -74037,6 +76350,7 @@
   - white currant
   - Ribes sativum
   partOfSpeech: n
+  wikidata: Q15441838
 12826659-n:
   definition:
   - a flowering shrub also known as flowering currant or red-flowering currant (Ribes
@@ -74064,7 +76378,9 @@
   mero_part:
   - 07760406-n
   partOfSpeech: n
-  wikidata: Q41503
+  wikidata:
+  - Q41503
+  - Q21877236
 12827030-n:
   definition:
   - 'coextensive with the genus Platanus: plane trees'
@@ -74144,6 +76460,7 @@
   - buttonwood
   - Platanus occidentalis
   partOfSpeech: n
+  wikidata: Q157739
 12828384-n:
   definition:
   - large tree of southeastern Europe to Asia Minor
@@ -74154,6 +76471,7 @@
   - oriental plane
   - Platanus orientalis
   partOfSpeech: n
+  wikidata: Q161105
 12828533-n:
   definition:
   - tall tree of Baja California having deciduous bark and large alternate palmately
@@ -74165,6 +76483,7 @@
   - California sycamore
   - Platanus racemosa
   partOfSpeech: n
+  wikidata: Q164301
 12828767-n:
   definition:
   - medium-sized tree of Arizona and adjacent regions having deeply lobed leaves and
@@ -74176,6 +76495,7 @@
   - Arizona sycamore
   - Platanus wrightii
   partOfSpeech: n
+  wikidata: Q4115345
 12828987-n:
   definition:
   - Polemoniaceae, Solanaceae, Boraginaceae, Labiatae, Lentibulariaceae, Pedaliaceae;
@@ -74290,6 +76610,7 @@
   - northern Jacob's ladder
   - Polemonium boreale
   partOfSpeech: n
+  wikidata: Q1796649
 12830911-n:
   definition:
   - tall herb of the Rocky Mountains having sticky leaves and an offensive smell
@@ -74338,6 +76659,9 @@
   - Phlox bifida
   - Phlox stellaria
   partOfSpeech: n
+  wikidata:
+  - Q49459738
+  - Q39594870
 12831787-n:
   definition:
   - low tufted perennial phlox with needlelike evergreen leaves and pink or white
@@ -74390,7 +76714,9 @@
   - evening-snow
   - Linanthus dichotomus
   partOfSpeech: n
-  wikidata: Q6550250
+  wikidata:
+  - Q15400423
+  - Q6550250
 12832616-n:
   definition:
   - widely distributed herbs and shrubs and trees; sometimes placed in the order Scrophulariales
@@ -74441,6 +76767,7 @@
   - sea holly
   - Acanthus mollis
   partOfSpeech: n
+  wikidata: Q136648
 12833425-n:
   definition:
   - caricature plant
@@ -74465,6 +76792,7 @@
   - caricature plant
   - Graptophyllum pictum
   partOfSpeech: n
+  wikidata: Q2649413
 12833784-n:
   definition:
   - a genus of herbs or vines of the family Acanthaceae
@@ -74489,6 +76817,7 @@
   - black-eyed Susan vine
   - Thunbergia alata
   partOfSpeech: n
+  wikidata: Q161248
 12834153-n:
   definition:
   - trees or shrubs or woody vines or herbs having fruit resembling gourds or capsules;
@@ -74543,6 +76872,7 @@
   - quarter-vine
   - Bignonia capreolata
   partOfSpeech: n
+  wikidata: Q149466
 12834995-n:
   definition:
   - a North American woody vine having pinnate leaves and large red trumpet-shaped
@@ -74649,6 +76979,7 @@
   - calabash tree
   - Crescentia cujete
   partOfSpeech: n
+  wikidata: Q214542
 12836598-n:
   definition:
   - round gourd of the calabash tree
@@ -74711,6 +77042,7 @@
   mero_part:
   - 07832374-n
   partOfSpeech: n
+  wikidata: Q147075
 12837513-n:
   definition:
   - 'rough annual herbs of Europe and the Americas: fiddlenecks'
@@ -74735,6 +77067,7 @@
   - common amsinckia
   - Amsinckia intermedia
   partOfSpeech: n
+  wikidata: Q21083612
 12837889-n:
   definition:
   - annual of the western United States having large coiled flower spikes; a threatened
@@ -74746,7 +77079,9 @@
   - large-flowered fiddleneck
   - Amsinckia grandiflora
   partOfSpeech: n
-  wikidata: Q4748790
+  wikidata:
+  - Q15493011
+  - Q4748790
 12838095-n:
   definition:
   - rough and hairy Old World herbs
@@ -74780,6 +77115,7 @@
   - alkanet
   - Anchusa officinalis
   partOfSpeech: n
+  wikidata: Q157577
 12838615-n:
   definition:
   - anchusa of southern Africa having blue flowers with white throats
@@ -74790,6 +77126,7 @@
   - cape forget-me-not
   - Anchusa capensis
   partOfSpeech: n
+  wikidata: Q15574107
 12838764-n:
   definition:
   - anchusa of southern Africa having blue to red-purple flowers
@@ -74800,6 +77137,7 @@
   - cape forget-me-not
   - Anchusa riparia
   partOfSpeech: n
+  wikidata: Q21244137
 12838907-n:
   definition:
   - tropical deciduous or evergreen trees or shrubs of the family Boraginaceae
@@ -74829,6 +77167,7 @@
   - princewood
   - Cordia alliodora
   partOfSpeech: n
+  wikidata: Q3303753
 12839361-n:
   definition:
   - tropical American timber tree
@@ -74840,6 +77179,7 @@
   - Spanish elm
   - Cordia gerascanthus
   partOfSpeech: n
+  wikidata: Q15290191
 12839502-n:
   definition:
   - a large genus of tall rough herbs belonging to the family Boraginaceae
@@ -74877,6 +77217,7 @@
   - hound's-tongue
   - Cynoglossum officinale
   partOfSpeech: n
+  wikidata: Q381584
 12840114-n:
   definition:
   - perennial shrub of North America having coarse tongue-shaped leaves and pale-blue
@@ -74915,6 +77256,7 @@
   - viper's bugloss
   - Echium vulgare
   partOfSpeech: n
+  wikidata: Q157722
 12840713-n:
   definition:
   - stickweed; beggar's lice
@@ -74974,6 +77316,7 @@
   - gromwell
   - Lithospermum officinale
   partOfSpeech: n
+  wikidata: Q515267
 12841613-n:
   definition:
   - perennial plant of eastern North America having hairy foliage yielding a red or
@@ -74998,6 +77341,7 @@
   - Indian paint
   - Lithospermum canescens
   partOfSpeech: n
+  wikidata: Q6648182
 12842017-n:
   definition:
   - a genus of herbs belonging to the family Boraginaceae that grow in temperate regions
@@ -75024,6 +77368,7 @@
   - Virginia cowslip
   - Mertensia virginica
   partOfSpeech: n
+  wikidata: Q12901028
 12842496-n:
   definition:
   - forget-me-nots; scorpion grass
@@ -75049,6 +77394,7 @@
   - garden forget-me-not
   - Myosotis sylvatica
   partOfSpeech: n
+  wikidata: Q149464
 12842875-n:
   definition:
   - small perennial herb having bright blue or white flowers
@@ -75187,6 +77533,9 @@
   - wild morning-glory
   - Convolvulus arvensis
   partOfSpeech: n
+  wikidata:
+  - Q15517213
+  - Q111346
 12845049-n:
   definition:
   - twining plant of Asia Minor having cream-colored to purple flowers and long thick
@@ -75198,6 +77547,7 @@
   - scammony
   - Convolvulus scammonia
   partOfSpeech: n
+  wikidata: Q310388
 12845242-n:
   definition:
   - resin from the root of Convolvulus scammonia
@@ -75292,6 +77642,7 @@
   - love vine
   - Cuscuta gronovii
   partOfSpeech: n
+  wikidata: Q1547364
 12846709-n:
   definition:
   - genus of chiefly tropical prostrate perennial herbs with creeping stems that root
@@ -75316,6 +77667,7 @@
   - dichondra
   - Dichondra micrantha
   partOfSpeech: n
+  wikidata: Q17464870
 12847155-n:
   definition:
   - morning glory
@@ -75362,6 +77714,7 @@
   - common morning glory
   - Ipomoea tricolor
   partOfSpeech: n
+  wikidata: Q159698
 12848030-n:
   definition:
   - tropical American annual climber having red (sometimes white) flowers and finely
@@ -75388,6 +77741,7 @@
   - belle de nuit
   - Ipomoea alba
   partOfSpeech: n
+  wikidata: Q133294
 12848444-n:
   definition:
   - pantropical vine widely cultivated in several varieties for its large sweet tuberous
@@ -75402,6 +77756,7 @@
   mero_part:
   - 07727808-n
   partOfSpeech: n
+  wikidata: Q37937
 12848667-n:
   definition:
   - tropical American prostrate or climbing herbaceous perennial having an enormous
@@ -75451,6 +77806,7 @@
   - scammony
   - Ipomoea orizabensis
   partOfSpeech: n
+  wikidata: Q15484739
 12849388-n:
   definition:
   - a prostrate perennial of coastal sand dunes Florida to Texas
@@ -75485,6 +77841,7 @@
   - imperial Japanese morning glory
   - Ipomoea imperialis
   partOfSpeech: n
+  wikidata: Q110703232
 12849859-n:
   definition:
   - large family of tropical herbs or shrubs or lianas; in some classification systems
@@ -75599,6 +77956,7 @@
   - lipstick plant
   - Aeschynanthus radicans
   partOfSpeech: n
+  wikidata: Q4688539
 12851734-n:
   definition:
   - tropical American herbs sometimes included in genus Episcia
@@ -75624,6 +77982,7 @@
   - Alsobia dianthiflora
   - Episcia dianthiflora
   partOfSpeech: n
+  wikidata: Q17683027
 12852149-n:
   definition:
   - genus of tropical American subshrubs and lianas
@@ -75700,6 +78059,7 @@
   - Canterbury bell
   - Gloxinia perennis
   partOfSpeech: n
+  wikidata: Q5572270
 12853450-n:
   definition:
   - genus of tropical American shrubs
@@ -75745,7 +78105,9 @@
   - African violet
   - Saintpaulia ionantha
   partOfSpeech: n
-  wikidata: Q165406
+  wikidata:
+  - Q50870323
+  - Q165406
 12854101-n:
   definition:
   - genus of perennial tuberous herbs and shrubs of Central and South America
@@ -75771,6 +78133,7 @@
   - Sinningia speciosa
   - Gloxinia spesiosa
   partOfSpeech: n
+  wikidata: Q163267
 12854553-n:
   definition:
   - 'large genus of usually stemless African or Asian herbs: Cape primrose'
@@ -75860,6 +78223,7 @@
   - John's cabbage
   - Hydrophyllum virginianum
   partOfSpeech: n
+  wikidata: Q5955321
 12855956-n:
   definition:
   - 'one species: yellow bells'
@@ -75910,6 +78274,7 @@
   - yerba santa
   - Eriodictyon californicum
   partOfSpeech: n
+  wikidata: Q3056647
 12856793-n:
   definition:
   - 'genus of ornamental chiefly California herbs: baby blue-eyes'
@@ -75942,6 +78307,7 @@
   - baby blue-eyes
   - Nemophila menziesii
   partOfSpeech: n
+  wikidata: Q4838435
 12857268-n:
   definition:
   - California annual having white flowers with a deep purple blotch on each petal
@@ -75952,6 +78318,7 @@
   - five-spot
   - Nemophila maculata
   partOfSpeech: n
+  wikidata: Q10860459
 12857423-n:
   definition:
   - American herbs with usually pinnatifid leaves and blue or purple or white flowers
@@ -76002,6 +78369,7 @@
   - Phacelia minor
   - Phacelia whitlavia
   partOfSpeech: n
+  wikidata: Q428718
 12858226-n:
   definition:
   - hairy annual of California to Mexico with crowded cymes of small blue to lilac
@@ -76039,6 +78407,7 @@
   - Pholistoma auritum
   - Nemophila aurita
   partOfSpeech: n
+  wikidata: Q7187098
 12858787-n:
   definition:
   - a large family of aromatic herbs and shrubs having flowers resembling the lips
@@ -76142,6 +78511,7 @@
   - Acinos arvensis
   - Satureja acinos
   partOfSpeech: n
+  wikidata: Q157947
 12860599-n:
   definition:
   - giant hyssop; Mexican hyssop
@@ -76175,6 +78545,7 @@
   - yellow giant hyssop
   - Agastache nepetoides
   partOfSpeech: n
+  wikidata: Q15339634
 12861122-n:
   definition:
   - much-branched North American herb with an odor like fennel
@@ -76196,6 +78567,7 @@
   - Mexican hyssop
   - Agastache mexicana
   partOfSpeech: n
+  wikidata: Q1897366
 12861400-n:
   definition:
   - bugle
@@ -76231,6 +78603,7 @@
   - creeping bugle
   - Ajuga reptans
   partOfSpeech: n
+  wikidata: Q157249
 12861953-n:
   definition:
   - upright rhizomatous perennial with bright blue flowers; southern Europe
@@ -76253,6 +78626,7 @@
   - pyramid bugle
   - Ajuga pyramidalis
   partOfSpeech: n
+  wikidata: Q159714
 12862232-n:
   definition:
   - low-growing annual with yellow flowers dotted red; faintly aromatic of pine resin;
@@ -76292,6 +78666,7 @@
   - stinking horehound
   - Ballota nigra
   partOfSpeech: n
+  wikidata: Q157878
 12862865-n:
   definition:
   - 'small genus of North American herbs: wood mints'
@@ -76328,6 +78703,7 @@
   - hairy wood mint
   - Blephilia hirsuta
   partOfSpeech: n
+  wikidata: Q4926162
 12863402-n:
   definition:
   - a variety of wood mint with pink-purple flowers stacked to resemble a pagoda (Blephilia
@@ -76373,6 +78749,9 @@
   - Calamintha sylvatica
   - Satureja calamintha officinalis
   partOfSpeech: n
+  wikidata:
+  - Q92346932
+  - Q32979672
 12864076-n:
   definition:
   - aromatic herb with large pink flowers; native to southern and southeastern Europe,
@@ -76386,6 +78765,7 @@
   - Clinopodium grandiflorum
   - Satureja grandiflora
   partOfSpeech: n
+  wikidata: Q2629469
 12864317-n:
   definition:
   - low-growing strongly aromatic perennial herb of southern Europe to Great Britain;
@@ -76401,6 +78781,7 @@
   - Satureja nepeta
   - Satureja calamintha glandulosa
   partOfSpeech: n
+  wikidata: Q164271
 12864604-n:
   definition:
   - wild basil
@@ -76427,6 +78808,7 @@
   - Clinopodium vulgare
   - Satureja vulgaris
   partOfSpeech: n
+  wikidata: Q163952
 12864980-n:
   definition:
   - small genus of perennial erect or spreading aromatic herbs; United States
@@ -76456,6 +78838,7 @@
   - stone root
   - Collinsonia canadensis
   partOfSpeech: n
+  wikidata: Q5147449
 12865457-n:
   definition:
   - genus of Old World tropical plants cultivated for their variegated leaves; various
@@ -76493,6 +78876,9 @@
   - Coleus amboinicus
   - Plectranthus amboinicus
   partOfSpeech: n
+  wikidata:
+  - Q2359202
+  - Q39087854
 12866173-n:
   definition:
   - perennial aromatic herb of southeastern Asia having large usually bright-colored
@@ -76508,6 +78894,7 @@
   - Solenostemon blumei
   - Solenostemon scutellarioides
   partOfSpeech: n
+  wikidata: Q50838949
 12866492-n:
   definition:
   - small genus of low aromatic shrubs of southeastern United States
@@ -76532,6 +78919,7 @@
   - Apalachicola rosemary
   - Conradina glabra
   partOfSpeech: n
+  wikidata: Q5162656
 12866903-n:
   definition:
   - 'genus of American herbs and dwarf shrubs of the mint family: dragonheads'
@@ -76557,6 +78945,7 @@
   - dragon's head
   - Dracocephalum parviflorum
   partOfSpeech: n
+  wikidata: Q5304642
 12867306-n:
   definition:
   - genus of Asiatic and African aromatic herbs
@@ -76605,6 +78994,7 @@
   - dead nettle
   - Galeopsis tetrahit
   partOfSpeech: n
+  wikidata: Q157684
 12868014-n:
   definition:
   - ground ivy
@@ -76701,6 +79091,7 @@
   mero_part:
   - 07832551-n
   partOfSpeech: n
+  wikidata: Q137931
 12869530-n:
   definition:
   - used chiefly in liqueurs
@@ -76745,6 +79136,7 @@
   - white dead nettle
   - Lamium album
   partOfSpeech: n
+  wikidata: Q157626
 12870176-n:
   definition:
   - Eurasian plant having toothed leaves and small two-lipped white or purplish-red
@@ -76756,6 +79148,7 @@
   - henbit
   - Lamium amplexicaule
   partOfSpeech: n
+  wikidata: Q159008
 12870357-n:
   definition:
   - lavender
@@ -76791,7 +79184,9 @@
   - Lavandula angustifolia
   - Lavandula officinalis
   partOfSpeech: n
-  wikidata: Q42081
+  wikidata:
+  - Q42081
+  - Q50844455
 12870928-n:
   definition:
   - shrubby greyish lavender of southwestern Europe having usually reddish-purple
@@ -76803,6 +79198,7 @@
   - French lavender
   - Lavandula stoechas
   partOfSpeech: n
+  wikidata: Q1342976
 12871096-n:
   definition:
   - Mediterranean plant with pale purple flowers that yields spike lavender oil
@@ -76868,6 +79264,7 @@
   - Leonotis nepetaefolia
   - Leonotis nepetifolia
   partOfSpeech: n
+  wikidata: Q104996230
 12872064-n:
   definition:
   - genus of stout Old World herbs having flowers in whorls
@@ -76919,6 +79316,7 @@
   - Lepechinia calycina
   - Sphacele calycina
   partOfSpeech: n
+  wikidata: Q6527334
 12872809-n:
   definition:
   - small genus of herbs of the mint family
@@ -77021,6 +79419,7 @@
   mero_part:
   - 07834971-n
   partOfSpeech: n
+  wikidata: Q134283
 12874242-n:
   definition:
   - aromatic European plant native to Mediterranean and Turkey; not widespread in
@@ -77034,6 +79433,7 @@
   - Origanum majorana
   - Majorana hortensis
   partOfSpeech: n
+  wikidata: Q22694
 12874466-n:
   definition:
   - dwarf aromatic shrub of Crete
@@ -77048,6 +79448,7 @@
   - winter sweet
   - Origanum dictamnus
   partOfSpeech: n
+  wikidata: Q1227336
 12874661-n:
   definition:
   - horehound (Marrubium)
@@ -77082,6 +79483,7 @@
   - white horehound
   - Marrubium vulgare
   partOfSpeech: n
+  wikidata: Q157631
 12875203-n:
   definition:
   - a genus of Old World mints of the family Labiatae
@@ -77149,6 +79551,7 @@
   - field mint
   - Mentha arvensis
   partOfSpeech: n
+  wikidata: Q160585
 12876254-n:
   definition:
   - a European mint that thrives in wet places; has a perfume like that of the bergamot
@@ -77161,6 +79564,7 @@
   - water mint
   - Mentha aquatica
   partOfSpeech: n
+  wikidata: Q161232
 12876470-n:
   definition:
   - mint with leaves having perfume like that of the bergamot orange
@@ -77173,7 +79577,9 @@
   - eau de cologne mint
   - Mentha citrata
   partOfSpeech: n
-  wikidata: Q2607185
+  wikidata:
+  - Q65556563
+  - Q2607185
 12876646-n:
   definition:
   - a coarse Old World wild water mint having long leaves and spikelike clusters of
@@ -77199,6 +79605,7 @@
   mero_substance:
   - 07828473-n
   partOfSpeech: n
+  wikidata: Q102165594
 12877047-n:
   definition:
   - common garden herb having clusters of small purplish flowers and yielding an oil
@@ -77212,6 +79619,7 @@
   mero_substance:
   - 07828638-n
   partOfSpeech: n
+  wikidata: Q160114
 12877239-n:
   definition:
   - mint with apple-scented stems of southern and western Europe; naturalized in United
@@ -77239,6 +79647,7 @@
   mero_substance:
   - 12877628-n
   partOfSpeech: n
+  wikidata: Q161235
 12877628-n:
   definition:
   - oil from European pennyroyal having an odor like mint; used chiefly in soaps
@@ -77275,6 +79684,7 @@
   - Micromeria douglasii
   - Satureja douglasii
   partOfSpeech: n
+  wikidata: Q110069657
 12878216-n:
   definition:
   - dwarf aromatic shrub of Mediterranean regions
@@ -77285,6 +79695,7 @@
   - savory
   - Micromeria juliana
   partOfSpeech: n
+  wikidata: Q15342450
 12878354-n:
   definition:
   - small genus of aromatic herbs of Mediterranean regions; widely cultivated
@@ -77346,6 +79757,7 @@
   - oswego tea
   - Monarda didyma
   partOfSpeech: n
+  wikidata: Q164010
 12879378-n:
   definition:
   - tall erect perennial or annual having lanceolate leaves and heads of purple-spotted
@@ -77358,6 +79770,7 @@
   - horsemint
   - Monarda punctata
   partOfSpeech: n
+  wikidata: Q1760733
 12879631-n:
   definition:
   - perennial herb of North America
@@ -77369,6 +79782,7 @@
   - beebalm
   - Monarda fistulosa
   partOfSpeech: n
+  wikidata: Q1521039
 12879747-n:
   definition:
   - an annual horsemint of central and western United States and northern Mexico
@@ -77380,6 +79794,7 @@
   - horsemint
   - Monarda citriodora
   partOfSpeech: n
+  wikidata: Q159776
 12879913-n:
   definition:
   - annual of southern United States
@@ -77390,6 +79805,9 @@
   - plains lemon monarda
   - Monarda pectinata
   partOfSpeech: n
+  wikidata:
+  - Q89028606
+  - Q15343760
 12880032-n:
   definition:
   - perennial herb of North America (New York to Illinois and mountains of Alaska)
@@ -77401,6 +79819,7 @@
   - basil balm
   - Monarda clinopodia
   partOfSpeech: n
+  wikidata: Q15342522
 12880248-n:
   definition:
   - a genus of fragrant herbs of the family Labiatae in the western United States
@@ -77425,6 +79844,9 @@
   - mustang mint
   - Monardella lanceolata
   partOfSpeech: n
+  wikidata:
+  - Q32852632
+  - Q12842241
 12880633-n:
   definition:
   - catmint
@@ -77451,6 +79873,7 @@
   - catnip
   - Nepeta cataria
   partOfSpeech: n
+  wikidata: Q161139
 12881014-n:
   definition:
   - basil
@@ -77489,6 +79912,7 @@
   mero_part:
   - 07832140-n
   partOfSpeech: n
+  wikidata: Q38859
 12881602-n:
   definition:
   - small genus of Asiatic herbs
@@ -77547,6 +79971,7 @@
   - Jerusalem sage
   - Phlomis fruticosa
   partOfSpeech: n
+  wikidata: Q1322796
 12882511-n:
   definition:
   - genus of North American perennial herbs
@@ -77693,6 +80118,7 @@
   - basil mint
   - Pycnanthemum virginianum
   partOfSpeech: n
+  wikidata: Q7262902
 12884798-n:
   definition:
   - rosemary
@@ -77718,6 +80144,7 @@
   mero_part:
   - 07836121-n
   partOfSpeech: n
+  wikidata: Q122679
 12885123-n:
   definition:
   - 'large genus of shrubs and subshrubs of the mint family varying greatly in habit:
@@ -77751,6 +80178,7 @@
   - blue sage
   - Salvia azurea
   partOfSpeech: n
+  wikidata: Q768344
 12885797-n:
   definition:
   - stout Mediterranean sage with white or pink or violet flowers; yields oil used
@@ -77775,6 +80203,7 @@
   - mealy sage
   - Salvia farinacea
   partOfSpeech: n
+  wikidata: Q796716
 12886127-n:
   definition:
   - sage of western North America to Central America having violet-blue flowers; widespread
@@ -77787,6 +80216,7 @@
   - Salvia reflexa
   - Salvia lancifolia
   partOfSpeech: n
+  wikidata: Q7155221
 12886322-n:
   definition:
   - silvery-leaved California herb with purple flowers
@@ -77824,6 +80254,7 @@
   mero_part:
   - 07836473-n
   partOfSpeech: n
+  wikidata: Q1111359
 12886762-n:
   definition:
   - tall perennial Old World salvia with violet-blue flowers; found in open grasslands
@@ -77846,6 +80277,7 @@
   - clary
   - Salvia sclarea
   partOfSpeech: n
+  wikidata: Q157872
 12887093-n:
   definition:
   - California erect and sparsely branched perennial
@@ -77856,6 +80288,7 @@
   - pitcher sage
   - Salvia spathacea
   partOfSpeech: n
+  wikidata: Q7406901
 12887219-n:
   definition:
   - an herb from Oaxaca that has a powerful hallucinogenic effect; the active ingredient
@@ -77867,6 +80300,7 @@
   - Mexican mint
   - Salvia divinorum
   partOfSpeech: n
+  wikidata: Q320584
 12887395-n:
   definition:
   - Eurasian sage with blue flowers and foliage like verbena; naturalized in United
@@ -77880,6 +80314,7 @@
   - vervain sage
   - Salvia verbenaca
   partOfSpeech: n
+  wikidata: Q1313052
 12887584-n:
   definition:
   - savory
@@ -77919,6 +80354,7 @@
   mero_part:
   - 07836936-n
   partOfSpeech: n
+  wikidata: Q157283
 12888209-n:
   definition:
   - erect perennial subshrub having pink or white flowers and leathery leaves with
@@ -77933,6 +80369,7 @@
   mero_part:
   - 07837083-n
   partOfSpeech: n
+  wikidata: Q160186
 12888439-n:
   definition:
   - an asterid dicot genus that includes the skullcaps
@@ -78067,6 +80504,7 @@
   - wood sage
   - Teucrium canadense
   partOfSpeech: n
+  wikidata: Q15370692
 12890634-n:
   definition:
   - European perennial subshrub with red-purple or bright rose flowers with red and
@@ -78091,6 +80529,7 @@
   - marum
   - Teucrium marum
   partOfSpeech: n
+  wikidata: Q2701046
 12890985-n:
   definition:
   - European germander with one-sided racemes of yellow flowers; naturalized in North
@@ -78138,6 +80577,7 @@
   mero_part:
   - 07837734-n
   partOfSpeech: n
+  wikidata: Q148668
 12891651-n:
   definition:
   - aromatic dwarf shrub common on banks and hillsides in Europe; naturalized in United
@@ -78150,6 +80590,7 @@
   - creeping thyme
   - Thymus serpyllum
   partOfSpeech: n
+  wikidata: Q147251
 12891834-n:
   definition:
   - 'genus of North American aromatic herbs or subshrubs: blue curls'
@@ -78185,6 +80626,7 @@
   - California romero
   - Trichostema lanatum
   partOfSpeech: n
+  wikidata: Q7841025
 12892456-n:
   definition:
   - aromatic plant of western United States
@@ -78197,6 +80639,7 @@
   - vinegarweed
   - Trichostema lanceolatum
   partOfSpeech: n
+  wikidata: Q7841022
 12892619-n:
   definition:
   - aromatic plant of the eastern United States
@@ -78207,6 +80650,7 @@
   - bastard pennyroyal
   - Trichostema dichotomum
   partOfSpeech: n
+  wikidata: Q7841020
 12892752-n:
   definition:
   - 'carnivorous aquatic or bog plants: genera Utricularia, Pinguicula, and Genlisea'
@@ -78385,6 +80829,7 @@
   mero_part:
   - 07843386-n
   partOfSpeech: n
+  wikidata: Q2763698
 12895756-n:
   definition:
   - in some classifications included in the genus Martynia and hence the two taxonomic
@@ -78417,6 +80862,7 @@
   - ram's horn
   - Proboscidea louisianica
   partOfSpeech: n
+  wikidata: Q2111569
 12896354-n:
   definition:
   - a beaklike, tapering tip on certain plant structures
@@ -78437,6 +80883,7 @@
   - Proboscidea arenaria
   - Martynia arenaria
   partOfSpeech: n
+  wikidata: Q112115808
 12896621-n:
   definition:
   - a herbaceous plant of the genus Proboscidea
@@ -78448,6 +80895,7 @@
   - Proboscidea fragrans
   - Martynia fragrans
   partOfSpeech: n
+  wikidata: Q65946234
 12896792-n:
   definition:
   - a family of dicotyledonous plants of the order Polemoniales; includes figwort
@@ -78537,6 +80985,9 @@
   - white snapdragon
   - Antirrhinum coulterianum
   partOfSpeech: n
+  wikidata:
+  - Q15358127
+  - Q10955022
 12898397-n:
   definition:
   - southwestern United States plant with yellow flowers on stems that twist and twine
@@ -78548,6 +80999,9 @@
   - yellow twining snapdragon
   - Antirrhinum filipes
   partOfSpeech: n
+  wikidata:
+  - Q3338172
+  - Q4775223
 12898598-n:
   definition:
   - perennial native to the Mediterranean but widely cultivated for its purple or
@@ -78593,6 +81047,7 @@
   - Alpine besseya
   - Besseya alpina
   partOfSpeech: n
+  wikidata: Q15349558
 12899285-n:
   definition:
   - small genus of North American herbs often root-parasitic and bearing golden-yellow
@@ -78620,6 +81075,7 @@
   - Aureolaria pedicularia
   - Gerardia pedicularia
   partOfSpeech: n
+  wikidata: Q15347219
 12899828-n:
   definition:
   - sparsely branched North American perennial with terminal racemes of bright yellow
@@ -78632,6 +81088,7 @@
   - Aureolaria virginica
   - Gerardia virginica
   partOfSpeech: n
+  wikidata: Q15344264
 12900110-n:
   definition:
   - large genus of tropical American herbs and shrubs with showy cymose flowers
@@ -78716,6 +81173,7 @@
   - great plains paintbrush
   - Castilleja sessiliflora
   partOfSpeech: n
+  wikidata: Q5049928
 12901559-n:
   definition:
   - plant of moist highland meadows having ragged clusters of pale yellow flowers
@@ -78726,6 +81184,7 @@
   - sulfur paintbrush
   - Castilleja sulphurea
   partOfSpeech: n
+  wikidata: Q15348639
 12901723-n:
   definition:
   - 'herbaceous perennials: shellflower'
@@ -78784,6 +81243,7 @@
   - Collinsia bicolor
   - Collinsia heterophylla
   partOfSpeech: n
+  wikidata: Q5147432
 12902673-n:
   definition:
   - small widely branching western plant with tiny blue-and-white flowers; British
@@ -78806,6 +81266,7 @@
   - blue-eyed Mary
   - Collinsia verna
   partOfSpeech: n
+  wikidata: Q5147442
 12903081-n:
   definition:
   - a tall perennial herb having spikes of small white or purple flowers; common in
@@ -78821,6 +81282,7 @@
   - whorlywort
   - Veronicastrum virginicum
   partOfSpeech: n
+  wikidata: Q4108065
 12903351-n:
   definition:
   - genus of Eurasian herbs having alternate leaves and racemes of showy bell-shaped
@@ -78861,6 +81323,7 @@
   - finger-root
   - Digitalis purpurea
   partOfSpeech: n
+  wikidata: Q157555
 12904025-n:
   definition:
   - European yellow-flowered foxglove
@@ -78872,6 +81335,7 @@
   - straw foxglove
   - Digitalis lutea
   partOfSpeech: n
+  wikidata: Q157914
 12904155-n:
   definition:
   - genus of annual or perennial herbs with showy pink or purple or yellow flowers;
@@ -78930,6 +81394,7 @@
   - old-field toadflax
   - Linaria canadensis
   partOfSpeech: n
+  wikidata: Q50844254
 12905020-n:
   definition:
   - common European perennial having showy yellow and orange flowers; a naturalized
@@ -78944,6 +81409,7 @@
   - devil's flax
   - Linaria vulgaris
   partOfSpeech: n
+  wikidata: Q157078
 12905283-n:
   definition:
   - large genus of subshrubs or herbs having showy blue or purple or red or yellow
@@ -78984,6 +81450,7 @@
   - golden-beard penstemon
   - Penstemon barbatus
   partOfSpeech: n
+  wikidata: Q7154496
 12906025-n:
   definition:
   - plant with bright red tubular flowers in long narrow clusters near tips of erect
@@ -78995,6 +81462,7 @@
   - scarlet bugler
   - Penstemon centranthifolius
   partOfSpeech: n
+  wikidata: Q7164841
 12906270-n:
   definition:
   - low branching dark green shrub with bunches of brick-red flowers at ends of branches;
@@ -79017,6 +81485,7 @@
   - Platte River penstemon
   - Penstemon cyananthus
   partOfSpeech: n
+  wikidata: Q17739470
 12906716-n:
   definition:
   - mat-forming plant with blue and lavender flowers clustered on short erect stems;
@@ -79028,6 +81497,7 @@
   - Davidson's penstemon
   - Penstemon davidsonii
   partOfSpeech: n
+  wikidata: Q17514283
 12906945-n:
   definition:
   - stems in clumps with cream-colored flowers; found from Washington to Wyoming and
@@ -79039,6 +81509,7 @@
   - hot-rock penstemon
   - Penstemon deustus
   partOfSpeech: n
+  wikidata: Q7164848
 12907162-n:
   definition:
   - low plant with light blue and violet flowers in short clusters near tips of stems;
@@ -79050,6 +81521,7 @@
   - Jones' penstemon
   - Penstemon dolius
   partOfSpeech: n
+  wikidata: Q3374845
 12907360-n:
   definition:
   - low bushy plant with large showy pale lavender or blue-violet flowers in narrow
@@ -79062,6 +81534,7 @@
   - lowbush penstemon
   - Penstemon fruticosus
   partOfSpeech: n
+  wikidata: Q15352492
 12907591-n:
   definition:
   - plant having small narrow leaves and blue-violet flowers in long open clusters;
@@ -79073,6 +81546,7 @@
   - narrow-leaf penstemon
   - Penstemon linarioides
   partOfSpeech: n
+  wikidata: Q15352545
 12907825-n:
   definition:
   - mat-forming plant with deep pink flowers on short erect leafy stems; rocky places
@@ -79084,6 +81558,7 @@
   - mountain pride
   - Penstemon newberryi
   partOfSpeech: n
+  wikidata: Q7164872
 12908053-n:
   definition:
   - fragrant puffed-up white to reddish-pink flowers in long narrow clusters on erect
@@ -79096,6 +81571,7 @@
   - scented penstemon
   - Penstemon palmeri
   partOfSpeech: n
+  wikidata: Q2716749
 12908292-n:
   definition:
   - erect stems with pinkish-lavender flowers in long interrupted clusters; Arizona
@@ -79106,6 +81582,7 @@
   - Parry's penstemon
   - Penstemon parryi
   partOfSpeech: n
+  wikidata: Q7164874
 12908473-n:
   definition:
   - one of the West's most beautiful wildflowers; large brilliant pink or rose flowers
@@ -79131,6 +81608,7 @@
   - Rydberg's penstemon
   - Penstemon rydbergii
   partOfSpeech: n
+  wikidata: Q17739134
 12908994-n:
   definition:
   - whorls of deep blue to dark purple flowers at tips of erect leafy stems; moist
@@ -79142,6 +81620,7 @@
   - cascade penstemon
   - Penstemon serrulatus
   partOfSpeech: n
+  wikidata: Q17514290
 12909217-n:
   definition:
   - wine and lavender to purple and black flowers in several clusters on the upper
@@ -79154,6 +81633,7 @@
   - Whipple's penstemon
   - Penstemon whippleanus
   partOfSpeech: n
+  wikidata: Q17741157
 12909493-n:
   definition:
   - genus of coarse herbs and subshrubs mostly with woolly leaves
@@ -79190,6 +81670,7 @@
   - moth mullein
   - Verbascum blattaria
   partOfSpeech: n
+  wikidata: Q159450
 12910172-n:
   definition:
   - densely hairy Eurasian herb with racemose white flowers; naturalized in North
@@ -79201,6 +81682,7 @@
   - white mullein
   - Verbascum lychnitis
   partOfSpeech: n
+  wikidata: Q158889
 12910339-n:
   definition:
   - Eurasian mullein with showy purple or pink flowers
@@ -79211,6 +81693,7 @@
   - purple mullein
   - Verbascum phoeniceum
   partOfSpeech: n
+  wikidata: Q159104
 12910473-n:
   definition:
   - tall-stalked very woolly mullein with densely packed yellow flowers; ancient Greeks
@@ -79227,6 +81710,7 @@
   - torch
   - Verbascum thapsus
   partOfSpeech: n
+  wikidata: Q160095
 12910769-n:
   definition:
   - 'widespread genus of herbs with pink or white or blue or purple flowers: speedwell'
@@ -79264,6 +81748,7 @@
   - field speedwell
   - Veronica agrestis
   partOfSpeech: n
+  wikidata: Q159120
 12911445-n:
   definition:
   - plant of western North America and northeastern Asia having prostrate stems with
@@ -79287,6 +81772,7 @@
   - corn speedwell
   - Veronica arvensis
   partOfSpeech: n
+  wikidata: Q157903
 12911853-n:
   definition:
   - European plant having low-lying stems with blue flowers; sparsely naturalized
@@ -79311,6 +81797,7 @@
   - bird's eye
   - Veronica chamaedrys
   partOfSpeech: n
+  wikidata: Q157343
 12912229-n:
   definition:
   - plant of wet places in Eurasia and America
@@ -79322,6 +81809,7 @@
   - Veronica michauxii
   - Veronica anagallis-aquatica
   partOfSpeech: n
+  wikidata: Q15373683
 12912403-n:
   definition:
   - common hairy European perennial with pale blue or lilac flowers in axillary racemes
@@ -79357,6 +81845,7 @@
   - thyme-leaved speedwell
   - Veronica serpyllifolia
   partOfSpeech: n
+  wikidata: Q159724
 12912986-n:
   definition:
   - large and economically important family of herbs or shrubs or trees often strongly
@@ -79458,6 +81947,7 @@
   - ball nightshade
   - Solanum carolinense
   partOfSpeech: n
+  wikidata: Q1044376
 12915007-n:
   definition:
   - hardy climbing shrub of Chile grown as an ornamental for its fragrant flowers;
@@ -79469,6 +81959,7 @@
   - potato tree
   - Solanum crispum
   partOfSpeech: n
+  wikidata: Q145597
 12915198-n:
   definition:
   - South American potato vine
@@ -79482,6 +81973,7 @@
   mero_part:
   - 07727544-n
   partOfSpeech: n
+  wikidata: Q3489179
 12915367-n:
   definition:
   - poisonous perennial Old World vine having violet flowers and oval coral-red berries;
@@ -79498,6 +81990,7 @@
   - woody nightshade
   - Solanum dulcamara
   partOfSpeech: n
+  wikidata: Q147707
 12915690-n:
   definition:
   - weedy nightshade with silvery foliage and violet or blue or white flowers; roundish
@@ -79515,6 +82008,7 @@
   - silver-leaved nettle
   - Solanum elaeagnifolium
   partOfSpeech: n
+  wikidata: Q2716800
 12916058-n:
   definition:
   - woolly-stemmed biennial arborescent shrub of tropical Africa and southern Asia
@@ -79527,6 +82021,7 @@
   - African holly
   - Solanum giganteum
   partOfSpeech: n
+  wikidata: Q15535391
 12916338-n:
   definition:
   - erect or spreading perennial of southwestern United States and Mexico bearing
@@ -79568,6 +82063,7 @@
   mero_part:
   - 07728819-n
   partOfSpeech: n
+  wikidata: Q7540
 12917067-n:
   definition:
   - Eurasian herb naturalized in America having white flowers and poisonous hairy
@@ -79611,6 +82107,7 @@
   - Madeira winter cherry
   - Solanum pseudocapsicum
   partOfSpeech: n
+  wikidata: Q1475749
 12917878-n:
   definition:
   - small perennial shrub cultivated in uplands of South America for its edible bright
@@ -79622,6 +82119,7 @@
   - naranjilla
   - Solanum quitoense
   partOfSpeech: n
+  wikidata: Q795069
 12918101-n:
   definition:
   - North American nightshade with prickly foliage and racemose yellow flowers
@@ -79632,7 +82130,9 @@
   - buffalo bur
   - Solanum rostratum
   partOfSpeech: n
-  wikidata: Q1788430
+  wikidata:
+  - Q65944342
+  - Q1788430
 12918253-n:
   definition:
   - annual native to South America having underground stolons bearing edible starchy
@@ -79648,6 +82148,9 @@
   mero_part:
   - 07726361-n
   partOfSpeech: n
+  wikidata:
+  - Q50921950
+  - Q10998
 12918548-n:
   definition:
   - vine of Costa Rica sparsely armed with hooklike spines and having large lilac-blue
@@ -79660,6 +82163,7 @@
   - giant potato creeper
   - Solanum wendlandii
   partOfSpeech: n
+  wikidata: Q1764686
 12918759-n:
   definition:
   - South American shrub or small tree widely cultivated in the tropics; not a true
@@ -79673,6 +82177,7 @@
   - Solanum wrightii
   - Solanum macranthum
   partOfSpeech: n
+  wikidata: Q3489192
 12918986-n:
   definition:
   - belladonna
@@ -79748,6 +82253,7 @@
   - lady-of-the-night
   - Brunfelsia americana
   partOfSpeech: n
+  wikidata: Q992604
 12920093-n:
   definition:
   - 'includes some plants often placed in the genus Datura: angel''s trumpets'
@@ -79775,6 +82281,7 @@
   - Brugmansia arborea
   - Datura arborea
   partOfSpeech: n
+  wikidata: Q134360
 12920512-n:
   definition:
   - South American plant cultivated for its very large nocturnally fragrant trumpet-shaped
@@ -79787,6 +82294,7 @@
   - Brugmansia suaveolens
   - Datura suaveolens
   partOfSpeech: n
+  wikidata: Q3314772
 12920731-n:
   definition:
   - arborescent South American shrub having very large orange-red flowers
@@ -79798,6 +82306,9 @@
   - Brugmansia sanguinea
   - Datura sanguinea
   partOfSpeech: n
+  wikidata:
+  - Q2926516
+  - Q39929581
 12920908-n:
   definition:
   - 'chiefly tropical perennial shrubby plants having many-seeded fruits: sweet and
@@ -79906,6 +82417,7 @@
   - Capsicum frutescens baccatum
   - Capsicum baccatum
   partOfSpeech: n
+  wikidata: Q132263
 12922781-n:
   definition:
   - plant bearing very hot medium-sized oblong red peppers; grown principally in the
@@ -79921,6 +82433,7 @@
   mero_part:
   - 07737797-n
   partOfSpeech: n
+  wikidata: Q311426
 12923057-n:
   definition:
   - genus of fragrant tropical American shrubs
@@ -79946,6 +82459,7 @@
   - day jessamine
   - Cestrum diurnum
   partOfSpeech: n
+  wikidata: Q1057574
 12923422-n:
   definition:
   - West Indian evergreen shrub having clusters of funnel-shaped yellow-white flowers
@@ -79958,6 +82472,7 @@
   - night jessamine
   - Cestrum nocturnum
   partOfSpeech: n
+  wikidata: Q36125
 12923647-n:
   definition:
   - tree tomato
@@ -80019,6 +82534,7 @@
   - apple of Peru
   - Datura stramonium
   partOfSpeech: n
+  wikidata: Q30959
 12924554-n:
   definition:
   - genus of South and Central American heathlike evergreen shrubs
@@ -80082,6 +82598,7 @@
   - Egyptian henbane
   - Hyoscyamus muticus
   partOfSpeech: n
+  wikidata: Q254080
 12925480-n:
   definition:
   - deciduous and evergreen shrubs often spiny; cosmopolitan in temperate and subtropical
@@ -80121,6 +82638,7 @@
   - Lycium barbarum
   - Lycium halimifolium
   partOfSpeech: n
+  wikidata: Q50844764
 12926172-n:
   definition:
   - spiny evergreen shrub of southeastern United States having spreading branches
@@ -80133,6 +82651,7 @@
   - Christmas berry
   - Lycium carolinianum
   partOfSpeech: n
+  wikidata: Q1878512
 12926415-n:
   definition:
   - tomatoes
@@ -80162,6 +82681,7 @@
   mero_part:
   - 07749993-n
   partOfSpeech: n
+  wikidata: Q15530945
 12926781-n:
   definition:
   - plant bearing small red to yellow fruit
@@ -80210,6 +82730,7 @@
   mero_part:
   - 12927531-n
   partOfSpeech: n
+  wikidata: Q545550
 12927531-n:
   definition:
   - the root of the mandrake plant; used medicinally or as a narcotic
@@ -80317,6 +82838,7 @@
   - mustard tree
   - Nicotiana glauca
   partOfSpeech: n
+  wikidata: Q882908
 12929192-n:
   definition:
   - genus of tropical American erect or creeping herbs with solitary flowers
@@ -80364,6 +82886,7 @@
   - tall cupflower
   - Nierembergia frutescens
   partOfSpeech: n
+  wikidata: Q17400389
 12930012-n:
   definition:
   - annual or perennial herbs or shrubs of tropical South America
@@ -80470,6 +82993,7 @@
   - bladder cherry
   - Physalis alkekengi
   partOfSpeech: n
+  wikidata: Q161780
 12931839-n:
   definition:
   - annual of tropical South America having edible purple fruits
@@ -80481,6 +83005,7 @@
   - purple ground cherry
   - Physalis peruviana
   partOfSpeech: n
+  wikidata: Q165227
 12932024-n:
   definition:
   - stout hairy annual of eastern North America with sweet yellow fruits
@@ -80508,6 +83033,9 @@
   mero_part:
   - 07750531-n
   partOfSpeech: n
+  wikidata:
+  - Q92954215
+  - Q15532679
 12932433-n:
   definition:
   - Mexican annual naturalized in eastern North America having yellow to purple edible
@@ -80522,6 +83050,7 @@
   - jamberry
   - Physalis philadelphica
   partOfSpeech: n
+  wikidata: Q622525
 12932674-n:
   definition:
   - found on sea beaches from Virginia to South America having greenish-yellow flowers
@@ -80559,6 +83088,7 @@
   - Salpichroa organifolia
   - Salpichroa rhomboidea
   partOfSpeech: n
+  wikidata: Q50864821
 12933258-n:
   definition:
   - small genus of herbs of the southern Andes having large showy flowers
@@ -80591,6 +83121,7 @@
   - painted tongue
   - Salpiglossis sinuata
   partOfSpeech: n
+  wikidata: Q2624440
 12933764-n:
   definition:
   - Chilean herbs with orchid-like flowers
@@ -80638,6 +83169,7 @@
   members:
   - Scopolia carniolica
   partOfSpeech: n
+  wikidata: Q1786332
 12934405-n:
   definition:
   - shrubby climbers of tropical America
@@ -80664,6 +83196,7 @@
   - cupflower
   - Solandra guttata
   partOfSpeech: n
+  wikidata: Q15539874
 12934808-n:
   definition:
   - 'one species: marmalade bush'
@@ -80780,6 +83313,7 @@
   - black mangrove
   - Avicennia marina
   partOfSpeech: n
+  wikidata: Q312094
 12936571-n:
   definition:
   - a small to medium-sized tree growing in brackish water especially along the shores
@@ -80791,6 +83325,7 @@
   - white mangrove
   - Avicennia officinalis
   partOfSpeech: n
+  wikidata: Q150558
 12936785-n:
   definition:
   - a genus of herbs of the family Verbenaceae
@@ -80814,6 +83349,7 @@
   - black mangrove
   - Aegiceras majus
   partOfSpeech: n
+  wikidata: Q65930392
 12937116-n:
   definition:
   - 'small genus of southeastern Asian tropics: teak'
@@ -80840,6 +83376,7 @@
   mero_substance:
   - 12937483-n
   partOfSpeech: n
+  wikidata: Q156938
 12937483-n:
   definition:
   - hard strong durable yellowish-brown wood of teak trees; resistant to insects and
@@ -80931,7 +83468,9 @@
   - mole plant
   - Euphorbia lathyris
   partOfSpeech: n
-  wikidata: Q164223
+  wikidata:
+  - Q110382330
+  - Q164223
 12939369-n:
   definition:
   - not unattractive European weed whose flowers turn toward the sun
@@ -80945,6 +83484,7 @@
   - devil's milk
   - Euphorbia helioscopia
   partOfSpeech: n
+  wikidata: Q148889
 12939570-n:
   definition:
   - an Old World spurge introduced as a weed in the eastern United States
@@ -80956,6 +83496,7 @@
   - devil's milk
   - Euphorbia peplus
   partOfSpeech: n
+  wikidata: Q148924
 12939751-n:
   definition:
   - African dwarf succulent perennial shrub with numerous slender drooping branches
@@ -80967,6 +83508,7 @@
   - Euphorbia medusae
   - Euphorbia caput-medusae
   partOfSpeech: n
+  wikidata: Q8846349
 12939955-n:
   definition:
   - common perennial United States spurge having showy white petallike bracts
@@ -80979,7 +83521,9 @@
   - tramp's spurge
   - Euphorbia corollata
   partOfSpeech: n
-  wikidata: Q5410423
+  wikidata:
+  - Q117838085
+  - Q5410423
 12940163-n:
   definition:
   - annual spurge of western United States having showy white-bracted flower clusters
@@ -80993,6 +83537,9 @@
   - ghost weed
   - Euphorbia marginata
   partOfSpeech: n
+  wikidata:
+  - Q117845990
+  - Q1152788
 12940406-n:
   definition:
   - Old World perennial having foliage resembling cypress; naturalized as a weed in
@@ -81004,6 +83551,7 @@
   - cypress spurge
   - Euphorbia cyparissias
   partOfSpeech: n
+  wikidata: Q148552
 12940607-n:
   definition:
   - tall European perennial naturalized and troublesome as a weed in eastern North
@@ -81016,7 +83564,9 @@
   - wolf's milk
   - Euphorbia esula
   partOfSpeech: n
-  wikidata: Q148882
+  wikidata:
+  - Q15388851
+  - Q148882
 12940964-n:
   definition:
   - tropical American plant having poisonous milk and showy tapering usually scarlet
@@ -81033,6 +83583,9 @@
   - painted leaf
   - Euphorbia pulcherrima
   partOfSpeech: n
+  wikidata:
+  - Q87624187
+  - Q208253
 12941281-n:
   definition:
   - showy poinsettia found from the southern United States to Peru
@@ -81045,6 +83598,9 @@
   - paint leaf
   - Euphorbia heterophylla
   partOfSpeech: n
+  wikidata:
+  - Q117845540
+  - Q3060418
 12941479-n:
   definition:
   - poinsettia of United States and eastern Mexico; often confused with Euphorbia
@@ -81082,6 +83638,7 @@
   mero_substance:
   - 14815462-n
   partOfSpeech: n
+  wikidata: Q143244
 12942075-n:
   definition:
   - European erect or depressed annual weedy spurge adventive in northeastern United
@@ -81093,6 +83650,7 @@
   - dwarf spurge
   - Euphorbia exigua
   partOfSpeech: n
+  wikidata: Q149723
 12942259-n:
   definition:
   - Mexican shrub often cultivated for its scarlet-bracted flowers
@@ -81103,6 +83661,9 @@
   - scarlet plume
   - Euphorbia fulgens
   partOfSpeech: n
+  wikidata:
+  - Q117953175
+  - Q4301001
 12942420-n:
   definition:
   - small tree of dry open parts of southern Africa having erect angled branches suggesting
@@ -81140,6 +83701,7 @@
   - toothed spurge
   - Euphorbia dentata
   partOfSpeech: n
+  wikidata: Q978763
 12943043-n:
   definition:
   - a genus of herbs and shrubs belonging to the family Euphorbiaceae
@@ -81163,6 +83725,7 @@
   - three-seeded mercury
   - Acalypha virginica
   partOfSpeech: n
+  wikidata: Q2822480
 12943360-n:
   definition:
   - tropical shrubs and herbs; source of croton oil
@@ -81188,6 +83751,7 @@
   mero_substance:
   - 12943693-n
   partOfSpeech: n
+  wikidata: Q2089847
 12943693-n:
   definition:
   - viscid acrid brownish-yellow oil from the seeds of Croton tiglium having a violent
@@ -81210,6 +83774,7 @@
   mero_part:
   - 12944017-n
   partOfSpeech: n
+  wikidata: Q135671
 12944017-n:
   definition:
   - aromatic bark of cascarilla; used as a tonic and for making incense
@@ -81274,6 +83839,7 @@
   - boys-and-girls
   - Mercurialis annua
   partOfSpeech: n
+  wikidata: Q163949
 12945044-n:
   definition:
   - European perennial weedy plant with greenish flowers
@@ -81285,6 +83851,7 @@
   - dog mercury
   - Mercurialis perennis
   partOfSpeech: n
+  wikidata: Q158132
 12945212-n:
   definition:
   - 'a genus of herb having only one known species: castor-oil plant'
@@ -81315,6 +83882,7 @@
   mero_part:
   - 11710147-n
   partOfSpeech: n
+  wikidata: Q155867
 12945744-n:
   definition:
   - a genus of perennial plant with bristles; belonging to the family Euphorbiaceae
@@ -81441,6 +84009,7 @@
   mero_substance:
   - 07948563-n
   partOfSpeech: n
+  wikidata: Q83124
 12947773-n:
   definition:
   - cassava root eaten as a staple food after drying and leaching; source of tapioca
@@ -81464,6 +84033,7 @@
   - sweet cassava
   - Manihot dulcis
   partOfSpeech: n
+  wikidata: Q87632945
 12948114-n:
   definition:
   - candlenut
@@ -81504,6 +84074,9 @@
   - tung-oil tree
   - Aleurites fordii
   partOfSpeech: n
+  wikidata:
+  - Q1422363
+  - Q38926734
 12948681-n:
   definition:
   - tropical American succulent shrubs
@@ -81541,6 +84114,7 @@
   mero_substance:
   - 14815462-n
   partOfSpeech: n
+  wikidata: Q50859233
 12949251-n:
   definition:
   - low tropical American shrub having powerful emetic properties
@@ -81555,6 +84129,7 @@
   - redbird flower
   - Pedilanthus tithymaloides
   partOfSpeech: n
+  wikidata: Q24852279
 12949450-n:
   definition:
   - Mexican spurges
@@ -81629,6 +84204,7 @@
   - japonica
   - Camellia japonica
   partOfSpeech: n
+  wikidata: Q160121
 12950543-n:
   definition:
   - a tropical evergreen shrub or small tree extensively cultivated in e.g. China
@@ -81755,6 +84331,7 @@
   - 07843872-n
   - 07844017-n
   partOfSpeech: n
+  wikidata: Q26686
 12952498-n:
   definition:
   - biennial or perennial herbs of the Northern Hemisphere; have a taproot
@@ -81803,6 +84380,7 @@
   - wild angelica
   - Angelica sylvestris
   partOfSpeech: n
+  wikidata: Q958823
 12953292-n:
   definition:
   - 'chervil: of Europe, North Africa and Asia'
@@ -81842,6 +84420,7 @@
   - wild chervil
   - Anthriscus sylvestris
   partOfSpeech: n
+  wikidata: Q683490
 12953924-n:
   definition:
   - celery
@@ -81865,6 +84444,7 @@
   - wild celery
   - Apium graveolens
   partOfSpeech: n
+  wikidata: Q28298
 12954163-n:
   definition:
   - widely cultivated herb with aromatic leaf stalks that are eaten raw or cooked
@@ -81930,6 +84510,7 @@
   - greater masterwort
   - Astrantia major
   partOfSpeech: n
+  wikidata: Q158066
 12955128-n:
   definition:
   - caraway
@@ -81956,6 +84537,9 @@
   - 07832702-n
   - 07843530-n
   partOfSpeech: n
+  wikidata:
+  - Q17134090
+  - Q26811
 12955445-n:
   definition:
   - a caraway with whorled leaves
@@ -82058,6 +84642,7 @@
   - earthnut
   - Conopodium denudatum
   partOfSpeech: n
+  wikidata: Q17136675
 12957093-n:
   definition:
   - small genus of annual Mediterranean herbs
@@ -82087,6 +84672,7 @@
   - 07833291-n
   - 07833441-n
   partOfSpeech: n
+  wikidata: Q41611
 12957473-n:
   definition:
   - cumin
@@ -82204,6 +84790,7 @@
   - sea eryngium
   - Eryngium maritimum
   partOfSpeech: n
+  wikidata: Q21110
 12959205-n:
   definition:
   - coarse prickly perennial eryngo with aromatic roots; southeastern United States;
@@ -82215,6 +84802,7 @@
   - button snakeroot
   - Eryngium aquaticum
   partOfSpeech: n
+  wikidata: Q5396287
 12959427-n:
   definition:
   - coarse prickly perennial eryngo of United States thought to cure rattlesnake bite
@@ -82278,6 +84866,7 @@
   mero_part:
   - 07833847-n
   partOfSpeech: n
+  wikidata: Q17132698
 12960424-n:
   definition:
   - widely distributed genus of plants with usually thick rootstocks and large umbels
@@ -82303,6 +84892,7 @@
   - hogweed
   - Heracleum sphondylium
   partOfSpeech: n
+  wikidata: Q752675
 12960820-n:
   definition:
   - genus of aromatic European herbs with yellow flowers
@@ -82329,6 +84919,7 @@
   mero_part:
   - 07834801-n
   partOfSpeech: n
+  wikidata: Q27615
 12961187-n:
   definition:
   - European perennial herbs having pinnate leaves and umbels of white flowers
@@ -82381,6 +84972,7 @@
   - hemlock water dropwort
   - Oenanthe crocata
   partOfSpeech: n
+  wikidata: Q1818309
 12961980-n:
   definition:
   - European poisonous herb with fibrous roots
@@ -82391,6 +84983,7 @@
   - water fennel
   - Oenanthe aquatica
   partOfSpeech: n
+  wikidata: Q1549096
 12962120-n:
   definition:
   - a rosid dicot genus of the family Umbelliferae; includes parsnips
@@ -82415,6 +85008,7 @@
   - parsnip
   - Pastinaca sativa
   partOfSpeech: n
+  wikidata: Q188614
 12962477-n:
   definition:
   - European biennial having a long fusiform root that has been made palatable through
@@ -82472,6 +85066,7 @@
   - parsley
   - Petroselinum crispum
   partOfSpeech: n
+  wikidata: Q25284
 12963332-n:
   definition:
   - a variety of parsley having flat leaves
@@ -82521,6 +85116,7 @@
   mero_part:
   - 07842629-n
   partOfSpeech: n
+  wikidata: Q28692
 12964062-n:
   definition:
   - 'chiefly American herbs: sanicle'
@@ -82676,6 +85272,7 @@
   - skirret
   - Sium sisarum
   partOfSpeech: n
+  wikidata: Q228122
 12966468-n:
   definition:
   - Alexanders
@@ -82783,6 +85380,7 @@
   - eastern flowering dogwood
   - Cornus florida
   partOfSpeech: n
+  wikidata: Q887221
 12968304-n:
   definition:
   - common North American shrub with reddish purple twigs and white flowers
@@ -82797,6 +85395,9 @@
   - redbrush
   - Cornus stolonifera
   partOfSpeech: n
+  wikidata:
+  - Q93392546
+  - Q50831688
 12968516-n:
   definition:
   - shrub of eastern North America closely resembling silky cornel
@@ -82807,6 +85408,9 @@
   - silky dogwood
   - Cornus obliqua
   partOfSpeech: n
+  wikidata:
+  - Q28808166
+  - Q17244868
 12968655-n:
   definition:
   - shrub of eastern North America having purplish stems and blue fruit
@@ -82818,6 +85422,7 @@
   - silky dogwood
   - Cornus amomum
   partOfSpeech: n
+  wikidata: Q2266551
 12968813-n:
   definition:
   - European deciduous shrub turning red in autumn having dull white flowers
@@ -82831,6 +85436,7 @@
   - pedwood
   - Cornus sanguinea
   partOfSpeech: n
+  wikidata: Q161416
 12969011-n:
   definition:
   - creeping perennial herb distinguished by red berries and clustered leaf whorls
@@ -82856,6 +85462,7 @@
   - cornelian cherry
   - Cornus mas
   partOfSpeech: n
+  wikidata: Q158642
 12969393-n:
   definition:
   - evergreen shrubs with intricately twisted wiry stems that in summer are smothered
@@ -82904,6 +85511,7 @@
   - puka
   - Griselinia lucida
   partOfSpeech: n
+  wikidata: Q15536178
 12970121-n:
   definition:
   - small New Zealand broadleaf evergreen tree often cultivated in warm regions as
@@ -82915,6 +85523,7 @@
   - kapuka
   - Griselinia littoralis
   partOfSpeech: n
+  wikidata: Q5609634
 12970309-n:
   definition:
   - deciduous dioecious shrubs native to woodland thickets in low mountains in Japan
@@ -83011,6 +85620,7 @@
   - Valerianella olitoria
   - Valerianella locusta
   partOfSpeech: n
+  wikidata: Q22111834
 12971744-n:
   definition:
   - genus of southern European herbs and subshrubs
@@ -83118,6 +85728,9 @@
   - hare's-foot bristle fern
   - Trichomanes boschianum
   partOfSpeech: n
+  wikidata:
+  - Q17042905
+  - Q17262693
 12973350-n:
   definition:
   - large stout fern of extreme western Europe
@@ -83128,7 +85741,9 @@
   - Killarney fern
   - Trichomanes speciosum
   partOfSpeech: n
-  wikidata: Q2000383
+  wikidata:
+  - Q3554491
+  - Q2000383
 12973477-n:
   definition:
   - large fern of New Zealand having kidney-shaped fronds
@@ -83139,6 +85754,9 @@
   - kidney fern
   - Trichomanes reniforme
   partOfSpeech: n
+  wikidata:
+  - Q15606693
+  - Q27837164
 12973612-n:
   definition:
   - large family of ferns widely distributed in temperate and tropical areas
@@ -83192,6 +85810,7 @@
   - French bracken
   - Osmunda regalis
   partOfSpeech: n
+  wikidata: Q733398
 12974472-n:
   definition:
   - North American fern having tall erect pinnate fronds and a few sporogenous pinnae
@@ -83245,6 +85864,7 @@
   - Leptopteris superba
   - Todea superba
   partOfSpeech: n
+  wikidata: Q16984393
 12975394-n:
   definition:
   - a genus of delicate ferns belonging to the family Osmundaceae
@@ -83269,6 +85889,7 @@
   - king fern
   - Todea barbara
   partOfSpeech: n
+  wikidata: Q2206381
 12975738-n:
   definition:
   - small family of mainly tropical ferns
@@ -83311,6 +85932,7 @@
   - curly grass fern
   - Schizaea pusilla
   partOfSpeech: n
+  wikidata: Q16749685
 12976399-n:
   definition:
   - genus of terrestrial or lithophytic ferns having pinnatifid fronds; chiefly of
@@ -83336,6 +85958,7 @@
   - pine fern
   - Anemia adiantifolia
   partOfSpeech: n
+  wikidata: Q17043127
 12976789-n:
   definition:
   - chiefly tropical climbing ferns
@@ -83371,6 +85994,7 @@
   - Hartford fern
   - Lygodium palmatum
   partOfSpeech: n
+  wikidata: Q6707803
 12977348-n:
   definition:
   - tropical fern widespread in Old World; naturalized in Jamaica and Florida
@@ -83407,6 +86031,7 @@
   - scented fern
   - Mohria caffrorum
   partOfSpeech: n
+  wikidata: Q17256610
 12977836-n:
   definition:
   - ferns that grow in water
@@ -83481,6 +86106,7 @@
   - water clover
   - Marsilea quadrifolia
   partOfSpeech: n
+  wikidata: Q1332525
 12978900-n:
   definition:
   - pillworts
@@ -83505,6 +86131,7 @@
   - pillwort
   - Pilularia globulifera
   partOfSpeech: n
+  wikidata: Q299246
 12979230-n:
   definition:
   - one species of aquatic or semiaquatic fern
@@ -83667,6 +86294,7 @@
   - ribbon fern
   - Ophioglossum pendulum
   partOfSpeech: n
+  wikidata: Q17120363
 12981489-n:
   definition:
   - grape fern; moonwort
@@ -83701,6 +86329,7 @@
   - common moonwort
   - Botrychium lunaria
   partOfSpeech: n
+  wikidata: Q579784
 12982002-n:
   definition:
   - of North America and Eurasia
@@ -83712,6 +86341,7 @@
   - daisy-leaved grape fern
   - Botrychium matricariifolium
   partOfSpeech: n
+  wikidata: Q2247460
 12982153-n:
   definition:
   - European fern with leathery and sparsely hairy fronds
@@ -83722,6 +86352,7 @@
   - leathery grape fern
   - Botrychium multifidum
   partOfSpeech: n
+  wikidata: Q2220785
 12982296-n:
   definition:
   - American fern whose clustered sporangia resemble a snake's rattle
@@ -83732,6 +86363,7 @@
   - rattlesnake fern
   - Botrychium virginianum
   partOfSpeech: n
+  wikidata: Q17258002
 12982449-n:
   definition:
   - 'one species: terrestrial fern of southeastern Asia and Australia'
@@ -83755,6 +86387,7 @@
   - flowering fern
   - Helminthostachys zeylanica
   partOfSpeech: n
+  wikidata: Q3235483
 12982819-n:
   definition:
   - a variety of grainy club
@@ -83958,6 +86591,9 @@
   - Dutch elm fungus
   - Ceratostomella ulmi
   partOfSpeech: n
+  wikidata:
+  - Q2324137
+  - Q59546811
 12985816-n:
   definition:
   - used in some classifications for the family Hypocreaceae
@@ -84262,6 +86898,7 @@
   - Scleroderma citrinum
   - Scleroderma aurantium
   partOfSpeech: n
+  wikidata: Q104096695
 12990430-n:
   definition:
   - an earthball with a smooth upper surface that is at first buried in sand; the
@@ -84402,6 +87039,7 @@
   members:
   - Rhizopogon idahoensis
   partOfSpeech: n
+  wikidata: Q108322658
 12992716-n:
   definition:
   - a genus of fungi belonging to the family Rhizopogonaceae
@@ -84426,6 +87064,7 @@
   members:
   - Truncocolumella citrina
   partOfSpeech: n
+  wikidata: Q10705333
 12993174-n:
   definition:
   - division of fungi having sexually produced zygospores
@@ -84539,6 +87178,7 @@
   - bread mold
   - Rhizopus nigricans
   partOfSpeech: n
+  wikidata: Q7320783
 12994822-n:
   definition:
   - fungus causing soft watery rot in fruits and vegetables and rings of dry rot around
@@ -84551,6 +87191,7 @@
   - ring rot fungus
   - Rhizopus stolonifer
   partOfSpeech: n
+  wikidata: Q1500736
 12995046-n:
   definition:
   - coextensive with the family Entomophthoraceae
@@ -84905,7 +87546,7 @@
   - white fungus
   - Saprolegnia ferax
   partOfSpeech: n
-  wikidata: Q7994710
+  wikidata: Q49439977
 13000840-n:
   definition:
   - parasitic or saprobic organisms living chiefly in fresh water or moist soil
@@ -84993,6 +87634,7 @@
   - onion mildew
   - Peronospora destructor
   partOfSpeech: n
+  wikidata: Q3900048
 13002203-n:
   definition:
   - fungus causing a downy mildew on growing tobacco
@@ -85003,6 +87645,7 @@
   - tobacco mildew
   - Peronospora hyoscyami
   partOfSpeech: n
+  wikidata: Q107460144
 13002355-n:
   definition:
   - fungi that produce white sori resembling blisters on certain flowering plants
@@ -85084,6 +87727,7 @@
   - damping off fungus
   - Pythium debaryanum
   partOfSpeech: n
+  wikidata: Q3926085
 13003483-n:
   definition:
   - destructive parasitic fungi causing brown rot in plants
@@ -85107,6 +87751,7 @@
   members:
   - Phytophthora citrophthora
   partOfSpeech: n
+  wikidata: Q3901761
 13003808-n:
   definition:
   - fungus causing late blight in solanaceous plants especially tomatoes and potatoes
@@ -85578,6 +88223,7 @@
   - beard moss
   - Usnea barbata
   partOfSpeech: n
+  wikidata: Q3552691
 13010852-n:
   definition:
   - lichens of the family Usneaceae having a pendulous or shrubby thallus
@@ -85731,6 +88377,7 @@
   - Iceland lichen
   - Cetraria islandica
   partOfSpeech: n
+  wikidata: Q582664
 13013224-n:
   definition:
   - the taxonomic kingdom including yeast, molds, smuts, mushrooms, and toadstools;
@@ -86077,6 +88724,9 @@
   - horse mushroom
   - Agaricus arvensis
   partOfSpeech: n
+  wikidata:
+  - Q108691770
+  - Q690801
 13022289-n:
   definition:
   - common edible mushroom found naturally in moist open soil; the cultivated mushroom
@@ -86089,6 +88739,9 @@
   - field mushroom
   - Agaricus campestris
   partOfSpeech: n
+  wikidata:
+  - Q108691775
+  - Q234529
 13022503-n:
   definition:
   - a genus of fungus belonging to the family Tricholomataceae
@@ -86118,6 +88771,7 @@
   - Oriental black mushroom
   - Lentinus edodes
   partOfSpeech: n
+  wikidata: Q105057495
 13022969-n:
   definition:
   - a fungus with a scaly cap and white flesh and a ring on the stalk (with scales
@@ -86129,6 +88783,7 @@
   - scaly lentinus
   - Lentinus lepideus
   partOfSpeech: n
+  wikidata: Q105057518
 13023193-n:
   definition:
   - genus of widely distributed agarics that have white spores and are poisonous with
@@ -86170,6 +88825,7 @@
   - false deathcap
   - Amanita mappa
   partOfSpeech: n
+  wikidata: Q105049199
 13023821-n:
   definition:
   - poisonous (but rarely fatal) woodland fungus having a scarlet cap with white warts
@@ -86208,6 +88864,9 @@
   - blusher
   - Amanita rubescens
   partOfSpeech: n
+  wikidata:
+  - Q108559035
+  - Q623485
 13024472-n:
   definition:
   - fungus similar to Amanita phalloides
@@ -86218,7 +88877,9 @@
   - destroying angel
   - Amanita verna
   partOfSpeech: n
-  wikidata: Q571885
+  wikidata:
+  - Q108561516
+  - Q571885
 13024606-n:
   definition:
   - a mushroom of the genus Amanita
@@ -86276,7 +88937,9 @@
   - chantarelle
   - Cantharellus cibarius
   partOfSpeech: n
-  wikidata: Q188749
+  wikidata:
+  - Q107600474
+  - Q188749
 13025400-n:
   definition:
   - a mildly poisonous fungus with a fruiting body shaped like a hollow trumpet
@@ -86287,6 +88950,9 @@
   - floccose chanterelle
   - Cantharellus floccosus
   partOfSpeech: n
+  wikidata:
+  - Q2031545
+  - Q59511989
 13025586-n:
   definition:
   - an edible agaric with a brown fruiting body that is often compound
@@ -86297,6 +88963,7 @@
   - pig's ears
   - Cantharellus clavatus
   partOfSpeech: n
+  wikidata: Q107546750
 13025752-n:
   definition:
   - mushroom with a distinctive pink to vermillion fruiting body
@@ -86334,6 +89001,7 @@
   - jack-a-lantern
   - Omphalotus illudens
   partOfSpeech: n
+  wikidata: Q7090729
 13026328-n:
   definition:
   - genus of black-spotted agarics in which the cap breaks down at maturity into an
@@ -86371,6 +89039,7 @@
   - inky-cap mushroom
   - Coprinus atramentarius
   partOfSpeech: n
+  wikidata: Q62921457
 13026931-n:
   definition:
   - common edible mushroom having an elongated shaggy white cap and black spores
@@ -86383,6 +89052,7 @@
   - shaggymane mushroom
   - Coprinus comatus
   partOfSpeech: n
+  wikidata: Q275125
 13027137-n:
   definition:
   - large genus of agarics that have white spore and contain a white or milky juice
@@ -86429,6 +89099,7 @@
   - fairy-ring mushroom
   - Marasmius oreades
   partOfSpeech: n
+  wikidata: Q752492
 13027794-n:
   definition:
   - a ring of fungi marking the periphery of the perennial underground growth of the
@@ -86468,6 +89139,7 @@
   - oyster agaric
   - Pleurotus ostreatus
   partOfSpeech: n
+  wikidata: Q186451
 13028389-n:
   definition:
   - red luminescent mushroom of Europe
@@ -86509,6 +89181,7 @@
   members:
   - Pholiota astragalina
   partOfSpeech: n
+  wikidata: Q10658810
 13029075-n:
   definition:
   - a beautiful yellow gilled fungus found from Alaska south along the coast
@@ -86519,6 +89192,7 @@
   - Pholiota aurea
   - golden pholiota
   partOfSpeech: n
+  wikidata: Q108181442
 13029245-n:
   definition:
   - a large fungus with whitish scales on the cap and remnants of the veil hanging
@@ -86529,6 +89203,7 @@
   members:
   - Pholiota destruens
   partOfSpeech: n
+  wikidata: Q108182176
 13029449-n:
   definition:
   - a fungus with a yellow cap covered with fine scales as is the stalk
@@ -86549,6 +89224,7 @@
   members:
   - Pholiota flavida
   partOfSpeech: n
+  wikidata: Q10628047
 13029845-n:
   definition:
   - one of the most important fungi cultivated in Japan
@@ -86592,6 +89268,7 @@
   members:
   - Pholiota squarrosoides
   partOfSpeech: n
+  wikidata: Q10549618
 13030540-n:
   definition:
   - large genus of fungi with stout stems and white spores and neither annulus nor
@@ -86670,6 +89347,7 @@
   members:
   - Stropharia hornemannii
   partOfSpeech: n
+  wikidata: Q334957
 13031981-n:
   definition:
   - a large gilled fungus with a broad cap and a long stalk; the cap is dark brown;
@@ -86680,6 +89358,7 @@
   members:
   - Stropharia rugoso-annulata
   partOfSpeech: n
+  wikidata: Q84822961
 13032221-n:
   definition:
   - an organ shaped like a helmet; usually a vaulted and enlarged petal as in Aconitum
@@ -86749,6 +89428,7 @@
   - Entoloma lividum
   - Entoloma sinuatum
   partOfSpeech: n
+  wikidata: Q1424216
 13033229-n:
   definition:
   - an agaric with a dark brown conical cap; fruits in early spring
@@ -86758,6 +89438,7 @@
   members:
   - Entoloma aprile
   partOfSpeech: n
+  wikidata: Q10575514
 13033373-n:
   definition:
   - a family of fungi having free gills and a cap that is cleanly separable from the
@@ -86835,6 +89516,7 @@
   - parasol mushroom
   - Lepiota procera
   partOfSpeech: n
+  wikidata: Q100459857
 13034725-n:
   definition:
   - an agaric regarded as poisonous
@@ -86855,6 +89537,7 @@
   members:
   - Lepiota naucina
   partOfSpeech: n
+  wikidata: Q105057768
 13035025-n:
   definition:
   - an agaric with a large cap with brown scales and a thick stalk
@@ -86864,6 +89547,7 @@
   members:
   - Lepiota rhacodes
   partOfSpeech: n
+  wikidata: Q105057780
 13035169-n:
   definition:
   - an agaric with a pallid cap and a stalk that is enlarged near the base
@@ -86874,6 +89558,7 @@
   - American parasol
   - Lepiota americana
   partOfSpeech: n
+  wikidata: Q107975442
 13035341-n:
   definition:
   - an agaric with a relatively small pink to red cap and white gills and stalk
@@ -86883,6 +89568,9 @@
   members:
   - Lepiota rubrotincta
   partOfSpeech: n
+  wikidata:
+  - Q19059353
+  - Q59537348
 13035501-n:
   definition:
   - an agaric with a ragged stalk and a soft floccose cap
@@ -86892,6 +89580,7 @@
   members:
   - Lepiota clypeolaria
   partOfSpeech: n
+  wikidata: Q300967
 13035639-n:
   definition:
   - a white agaric that tends to cluster and has a club-shaped base
@@ -86902,6 +89591,7 @@
   - onion stem
   - Lepiota cepaestipes
   partOfSpeech: n
+  wikidata: Q105057662
 13035800-n:
   definition:
   - fungi having leathery or membranous sporophores
@@ -86941,6 +89631,9 @@
   - pink disease fungus
   - Corticium salmonicolor
   partOfSpeech: n
+  wikidata:
+  - Q7982506
+  - Q59548727
 13036448-n:
   definition:
   - fungus causing bottom rot in lettuce
@@ -86951,6 +89644,7 @@
   - bottom rot fungus
   - Corticium solani
   partOfSpeech: n
+  wikidata: Q107596533
 13036586-n:
   definition:
   - genus of fungi having the hymenium in the form of a crust; some species formerly
@@ -86978,6 +89672,7 @@
   - Pellicularia filamentosa
   - Rhizoctinia solani
   partOfSpeech: n
+  wikidata: Q105060226
 13037049-n:
   definition:
   - fungus causing a disease in coffee and some other tropical plants
@@ -86988,6 +89683,9 @@
   - coffee fungus
   - Pellicularia koleroga
   partOfSpeech: n
+  wikidata:
+  - Q107527889
+  - Q108145682
 13037217-n:
   definition:
   - a family of fungi belonging to the order Agaricales, inclusive of any white-,
@@ -87041,6 +89739,7 @@
   - blewits
   - Clitocybe nuda
   partOfSpeech: n
+  wikidata: Q105050987
 13038000-n:
   definition:
   - an edible agaric that fruits in great clusters (especially in sandy soil under
@@ -87052,6 +89751,7 @@
   - sandy mushroom
   - Tricholoma populinum
   partOfSpeech: n
+  wikidata: Q9284015
 13038199-n:
   definition:
   - a mildly poisonous agaric with a viscid reddish brown cap and white gills and
@@ -87085,6 +89785,7 @@
   - man-on-a-horse
   - Tricholoma flavovirens
   partOfSpeech: n
+  wikidata: Q54357581
 13038739-n:
   definition:
   - a poisonous white agaric
@@ -87103,6 +89804,7 @@
   members:
   - Tricholoma pardinum
   partOfSpeech: n
+  wikidata: Q1928462
 13038992-n:
   definition:
   - an agaric with a cap that is densely covered with reddish fibrils and pale gills
@@ -87113,6 +89815,7 @@
   members:
   - Tricholoma vaccinum
   partOfSpeech: n
+  wikidata: Q3506262
 13039167-n:
   definition:
   - an orange tan agaric whose gills become brown by maturity; has a strong odor and
@@ -87158,6 +89861,7 @@
   members:
   - Volvaria bombycina
   partOfSpeech: n
+  wikidata: Q105068900
 13039777-n:
   definition:
   - a family of fungi belonging to the order Agaricales, with free gill attachment
@@ -87199,6 +89903,7 @@
   members:
   - Pluteus aurantiorugosus
   partOfSpeech: n
+  wikidata: Q4365937
 13040403-n:
   definition:
   - an edible agaric found in piles of hardwood sawdust; the caps are black and coarsely
@@ -87210,6 +89915,7 @@
   - Pluteus magnus
   - sawdust mushroom
   partOfSpeech: n
+  wikidata: Q96358654
 13040595-n:
   definition:
   - a small edible agaric with a slender stalk; usually found on rotting hardwoods
@@ -87220,6 +89926,7 @@
   - deer mushroom
   - Pluteus cervinus
   partOfSpeech: n
+  wikidata: Q790598
 13040771-n:
   definition:
   - an important genus of mushrooms in the Orient
@@ -87246,6 +89953,7 @@
   - Chinese mushroom
   - Volvariella volvacea
   partOfSpeech: n
+  wikidata: Q641656
 13041241-n:
   definition:
   - a mushroom with a dry yellowish to white fibrillose cap
@@ -87255,6 +89963,7 @@
   members:
   - Volvariella bombycina
   partOfSpeech: n
+  wikidata: Q1654979
 13041383-n:
   definition:
   - a genus of agarics with white to pale yellow spore deposits and fleshy stalks
@@ -87305,6 +90014,7 @@
   members:
   - Clitocybe inornata
   partOfSpeech: n
+  wikidata: Q10659009
 13042303-n:
   definition:
   - a large white agaric; edible but not palatable
@@ -87315,6 +90025,9 @@
   - Clitocybe robusta
   - Clytocybe alba
   partOfSpeech: n
+  wikidata:
+  - Q107977878
+  - Q10455220
 13042449-n:
   definition:
   - an edible agaric with large silky white caps and thick stalks
@@ -87326,6 +90039,7 @@
   - Tricholoma irinum
   - Lepista irina
   partOfSpeech: n
+  wikidata: Q107573793
 13042627-n:
   definition:
   - an edible white agaric that fruits in dense clusters; the gills are narrow and
@@ -87336,6 +90050,9 @@
   members:
   - Clitocybe subconnexa
   partOfSpeech: n
+  wikidata:
+  - Q10557728
+  - Q59534250
 13042838-n:
   definition:
   - a genus of agarics
@@ -87361,6 +90078,7 @@
   - winter mushroom
   - Flammulina velutipes
   partOfSpeech: n
+  wikidata: Q372893
 13043298-n:
   definition:
   - any of the threadlike filaments forming the mycelium of a fungus
@@ -87671,6 +90389,7 @@
   members:
   - Aspergillus fumigatus
   partOfSpeech: n
+  wikidata: Q134359
 13048430-n:
   definition:
   - genus of fungi having spherical brown perithecia and some conidia borne in chains;
@@ -87695,6 +90414,7 @@
   - brown root rot fungus
   - Thielavia basicola
   partOfSpeech: n
+  wikidata: Q10696724
 13048830-n:
   definition:
   - class of fungi in which the fruiting body is a perithecium; includes powdery mildews
@@ -87757,6 +90477,7 @@
   members:
   - Mitrula elegans
   partOfSpeech: n
+  wikidata: Q49550443
 13050086-n:
   definition:
   - a discomycete that is a harbinger of spring; the fruiting body is thin and tough
@@ -87769,6 +90490,7 @@
   - Sarcoscypha coccinea
   - scarlet cup
   partOfSpeech: n
+  wikidata: Q937345
 13050370-n:
   definition:
   - an early spring variety of discomycete with yellow to orange yellow lining of
@@ -87779,6 +90501,7 @@
   members:
   - Caloscypha fulgens
   partOfSpeech: n
+  wikidata: Q3915690
 13050520-n:
   definition:
   - a discomycete with bright orange cup-shaped or saucer-shaped fruiting bodies and
@@ -87790,6 +90513,7 @@
   - Aleuria aurantia
   - orange peel fungus
   partOfSpeech: n
+  wikidata: Q1251715
 13050706-n:
   definition:
   - order of mostly saprophytic fungi having cup-shaped ascocarps
@@ -87863,6 +90587,7 @@
   - fairy cup
   - Peziza coccinea
   partOfSpeech: n
+  wikidata: Q115669659
 13051767-n:
   definition:
   - genus of fungi in the family Pezizaceae closely related to and often included
@@ -87907,6 +90632,7 @@
   members:
   - Jafnea semitosta
   partOfSpeech: n
+  wikidata: Q107823751
 13052450-n:
   definition:
   - a family of edible fungi including the true morels
@@ -87962,6 +90688,7 @@
   - sponge mushroom
   - sponge morel
   partOfSpeech: n
+  wikidata: Q1129282
 13053378-n:
   definition:
   - an edible morel with a cup-shaped or saucer-shaped fruiting body can be up to
@@ -88010,6 +90737,7 @@
   - Verpa conica
   - conic Verpa
   partOfSpeech: n
+  wikidata: Q1417061
 13054337-n:
   definition:
   - a morel whose pitted fertile body is attached to the stalk with little free skirt
@@ -88024,6 +90752,9 @@
   - Morchella angusticeps
   - narrowhead morel
   partOfSpeech: n
+  wikidata:
+  - Q108657321
+  - Q1327882
 13054639-n:
   definition:
   - a delicious morel with a conic fertile portion having deep and irregular pits
@@ -88034,6 +90765,7 @@
   - Morchella crassipes
   - thick-footed morel
   partOfSpeech: n
+  wikidata: Q3323803
 13054822-n:
   definition:
   - a morel with the ridged and pitted fertile portion attached to the stipe for about
@@ -88046,7 +90778,9 @@
   - half-free morel
   - cow's head
   partOfSpeech: n
-  wikidata: Q1795398
+  wikidata:
+  - Q3324089
+  - Q1795398
 13055037-n:
   definition:
   - family of fungi belonging to the order Pezizales
@@ -88080,6 +90814,7 @@
   members:
   - Wynnea americana
   partOfSpeech: n
+  wikidata: Q8040214
 13055548-n:
   definition:
   - a fungus with a long solid stalk embedded in soil and a yellow-brown head shaped
@@ -88090,6 +90825,7 @@
   members:
   - Wynnea sparassoides
   partOfSpeech: n
+  wikidata: Q108478445
 13055713-n:
   definition:
   - family of false morels or lorchels; some are edible and some are poisonous
@@ -88174,6 +90910,7 @@
   members:
   - Helvella acetabulum
   partOfSpeech: n
+  wikidata: Q3388167
 13057072-n:
   definition:
   - a helvella with an irregularly convoluted cap that is dark brown when young and
@@ -88185,6 +90922,9 @@
   members:
   - Helvella sulcata
   partOfSpeech: n
+  wikidata:
+  - Q108607218
+  - Q80915422
 13057352-n:
   definition:
   - a genus of fungi of the family Helvellaceae with a cup-shaped or saucer-shaped
@@ -88217,6 +90957,9 @@
   members:
   - Discina macrospora
   partOfSpeech: n
+  wikidata:
+  - Q107718019
+  - Q80914340
 13057884-n:
   definition:
   - a genus of fungi of the family Helvellaceae with a fertile portion that is tan
@@ -88255,6 +90998,7 @@
   - Gyromitra californica
   - California false morel
   partOfSpeech: n
+  wikidata: Q65048944
 13058565-n:
   definition:
   - a gyromitra with a brown puffed up fertile part and a rosy pink fluted stalk and
@@ -88266,6 +91010,7 @@
   - Gyromitra sphaerospora
   - round-spored gyromitra
   partOfSpeech: n
+  wikidata: Q10546447
 13058828-n:
   definition:
   - a poisonous gyromitra; the surface of the fertile body is smooth at first and
@@ -88279,6 +91024,7 @@
   - brain mushroom
   - beefsteak morel
   partOfSpeech: n
+  wikidata: Q900804
 13059136-n:
   definition:
   - a poisonous fungus; saddle-shaped and dull yellow to brown fertile part is relatively
@@ -88290,6 +91036,7 @@
   - Gyromitra infula
   - saddled-shaped false morel
   partOfSpeech: n
+  wikidata: Q3495445
 13059337-n:
   definition:
   - a lorchel with deep brownish red fertile part and white stalk
@@ -88300,6 +91047,9 @@
   - Gyromitra fastigiata
   - Gyromitra brunnea
   partOfSpeech: n
+  wikidata:
+  - Q107643708
+  - Q107717878
 13059504-n:
   definition:
   - a gyromitra with a large irregular stalk and fertile part that is yellow to brown
@@ -88424,6 +91174,7 @@
   members:
   - Phallus ravenelii
   partOfSpeech: n
+  wikidata: Q7180345
 13061731-n:
   definition:
   - closely related to genus Phallus distinguished by an indusium hanging like a skirt
@@ -88458,6 +91209,7 @@
   - dog stinkhorn
   - Mutinus caninus
   partOfSpeech: n
+  wikidata: Q1500672
 13062485-n:
   definition:
   - a family of fungi belonging to the order Gasteromycetes
@@ -88483,6 +91235,7 @@
   members:
   - Calostoma lutescens
   partOfSpeech: n
+  wikidata: Q4239132
 13062894-n:
   definition:
   - a gasteromycete with a leathery stalk and a fruiting body this globose and has
@@ -88503,6 +91256,7 @@
   members:
   - Calostoma ravenelii
   partOfSpeech: n
+  wikidata: Q4239130
 13063274-n:
   definition:
   - family of fleshy fungi resembling stinkhorns
@@ -88630,6 +91384,7 @@
   - giant puffball
   - Calvatia gigantea
   partOfSpeech: n
+  wikidata: Q222449
 13065301-n:
   definition:
   - a family of earthstar fungi belonging to the order Lycoperdales
@@ -88678,6 +91433,7 @@
   members:
   - Geastrum coronatum
   partOfSpeech: n
+  wikidata: Q5223629
 13066189-n:
   definition:
   - a genus of fungus belonging to the family Geastraceae
@@ -88701,6 +91457,7 @@
   members:
   - Radiigera fuscogleba
   partOfSpeech: n
+  wikidata: Q10648361
 13066594-n:
   definition:
   - a genus of fungi belonging to the family Geastraceae
@@ -88834,6 +91591,7 @@
   members:
   - Gastrocybe lateritia
   partOfSpeech: n
+  wikidata: Q62749601
 13068972-n:
   definition:
   - a stout-stemmed genus of fungus belonging to the family Secotiaceae having fruiting
@@ -88883,6 +91641,9 @@
   members:
   - Gastroboletus scabrosus
   partOfSpeech: n
+  wikidata:
+  - Q10503330
+  - Q59518784
 13069865-n:
   definition:
   - a fungus with a cap that can vary from red to dark brown; superficially resembles
@@ -88893,6 +91654,7 @@
   members:
   - Gastroboletus turbinatus
   partOfSpeech: n
+  wikidata: Q10503311
 13070045-n:
   definition:
   - includes chiefly saprophytic fungi typically with shelflike bodies; sometimes
@@ -88977,6 +91739,7 @@
   members:
   - Albatrellus dispansus
   partOfSpeech: n
+  wikidata: Q103817214
 13071700-n:
   definition:
   - a fungus with a whitish often circular cap and a white pore surface and small
@@ -88988,6 +91751,7 @@
   - Albatrellus ovinus
   - sheep polypore
   partOfSpeech: n
+  wikidata: Q331465
 13071956-n:
   definition:
   - a genus of fungi belonging to the family Polyporaceae, containing the wood-decaying
@@ -89011,6 +91775,7 @@
   members:
   - Neolentinus ponderosus
   partOfSpeech: n
+  wikidata: Q10597380
 13072306-n:
   definition:
   - a genus of fungi belonging to the family Polyporaceae
@@ -89032,6 +91797,7 @@
   members:
   - Nigroporus vinosus
   partOfSpeech: n
+  wikidata: Q10600684
 13072626-n:
   definition:
   - a genus of fungi belonging to the family Polyporaceae, containing 10 species (Oligoporus)
@@ -89053,6 +91819,7 @@
   members:
   - Oligoporus leucospongia
   partOfSpeech: n
+  wikidata: Q108117910
 13073008-n:
   definition:
   - a fungus with a whitish kidney-shaped cap and elongated pores; causes white rot
@@ -89063,6 +91830,7 @@
   members:
   - Polyporus tenuiculus
   partOfSpeech: n
+  wikidata: Q15224043
 13073191-n:
   definition:
   - type genus of the Polyporaceae; includes important pathogens of e.g. birches and
@@ -89092,6 +91860,7 @@
   - Polyporus frondosus
   - Grifola frondosa
   partOfSpeech: n
+  wikidata: Q105065411
 13073691-n:
   definition:
   - a fungus with a lateral stalk (when there is a stalk) and a scaly cap that becomes
@@ -89167,6 +91936,7 @@
   - agaric
   - Fomes igniarius
   partOfSpeech: n
+  wikidata: Q24956240
 13074971-n:
   definition:
   - family of fleshy fungi having the germ pores easily separating from the cup and
@@ -89231,6 +92001,9 @@
   members:
   - Boletus chrysenteron
   partOfSpeech: n
+  wikidata:
+  - Q254161
+  - Q41475394
 13076337-n:
   definition:
   - an edible and choice fungus; has a convex cap that is slightly viscid when fresh
@@ -89241,7 +92014,9 @@
   members:
   - Boletus edulis
   partOfSpeech: n
-  wikidata: Q19740
+  wikidata:
+  - Q108595981
+  - Q19740
 13076552-n:
   definition:
   - a fungus with a red cap and a red coarsely reticulate stalk
@@ -89252,6 +92027,9 @@
   - Frost's bolete
   - Boletus frostii
   partOfSpeech: n
+  wikidata:
+  - Q41712963
+  - Q1933457
 13076709-n:
   definition:
   - a poisonous fungus with a dingy yellow cap and orange red undersurface and a cylindrical
@@ -89262,6 +92040,9 @@
   members:
   - Boletus luridus
   partOfSpeech: n
+  wikidata:
+  - Q752494
+  - Q41597775
 13076895-n:
   definition:
   - a fungus that is edible when young and fresh; has a dark brown convex cap with
@@ -89272,6 +92053,7 @@
   members:
   - Boletus mirabilis
   partOfSpeech: n
+  wikidata: Q107526353
 13077109-n:
   definition:
   - a fungus that has an off-white cap when it is young but later becomes dingy brown
@@ -89283,6 +92065,9 @@
   members:
   - Boletus pallidus
   partOfSpeech: n
+  wikidata:
+  - Q107799045
+  - Q12200203
 13077367-n:
   definition:
   - a beautiful but poisonous bolete; has a brown cap with a scarlet pore surface
@@ -89293,7 +92078,9 @@
   members:
   - Boletus pulcherrimus
   partOfSpeech: n
-  wikidata: Q4094251
+  wikidata:
+  - Q96776498
+  - Q4094251
 13077559-n:
   definition:
   - an edible fungus with a broadly convex blackish brown cap and a pore surface that
@@ -89305,6 +92092,9 @@
   members:
   - Boletus pulverulentus
   partOfSpeech: n
+  wikidata:
+  - Q41596453
+  - Q976933
 13077814-n:
   definition:
   - a fungus with a rusty red cap and a white pore surface that becomes yellow with
@@ -89315,6 +92105,9 @@
   members:
   - Boletus roxanae
   partOfSpeech: n
+  wikidata:
+  - Q108479890
+  - Q107526679
 13078002-n:
   definition:
   - a fungus with a velvety stalk and usually a dingy brown cap; injured areas turn
@@ -89325,6 +92118,9 @@
   members:
   - Boletus subvelutipes
   partOfSpeech: n
+  wikidata:
+  - Q108416519
+  - Q4035289
 13078182-n:
   definition:
   - an edible (but not choice) fungus found on soil under hardwoods; has a dry convex
@@ -89346,6 +92142,7 @@
   members:
   - Boletus zelleri
   partOfSpeech: n
+  wikidata: Q107527263
 13078605-n:
   definition:
   - a genus of fungi belonging to the family Boletaceae, with distinguishing feature
@@ -89372,6 +92169,7 @@
   members:
   - Fuscoboletinus paluster
   partOfSpeech: n
+  wikidata: Q107687272
 13079032-n:
   definition:
   - an edible fungus with a broadly convex brown cap and a whitish pore surface and
@@ -89382,6 +92180,7 @@
   members:
   - Fuscoboletinus serotinus
   partOfSpeech: n
+  wikidata: Q107687273
 13079207-n:
   definition:
   - a genus of fungi belonging to the family Boletaceae, known for their small, rigid
@@ -89431,6 +92230,9 @@
   members:
   - Phylloporus boletinoides
   partOfSpeech: n
+  wikidata:
+  - Q108199695
+  - Q49632525
 13079899-n:
   definition:
   - a genus of fungi belonging to the family Boletaceae with species in the genus
@@ -89456,6 +92258,7 @@
   members:
   - Suillus albivelatus
   partOfSpeech: n
+  wikidata: Q108416552
 13080245-n:
   definition:
   - fungi similar to Boletus but with a shaggy scaly cap
@@ -89479,6 +92282,7 @@
   - old-man-of-the-woods
   - Strobilomyces floccopus
   partOfSpeech: n
+  wikidata: Q105067577
 13080612-n:
   definition:
   - a genus of fungi belonging to the family Boletaceae, with an annual fruit body
@@ -89503,6 +92307,7 @@
   members:
   - Boletellus russellii
   partOfSpeech: n
+  wikidata: Q4939325
 13080950-n:
   definition:
   - any fungus of the order Tremellales or Auriculariales whose fruiting body is jellylike
@@ -89569,6 +92374,7 @@
   - snow mushroom
   - Tremella fuciformis
   partOfSpeech: n
+  wikidata: Q1309195
 13082108-n:
   definition:
   - a yellow jelly fungus
@@ -89579,6 +92385,7 @@
   - witches' butter
   - Tremella lutescens
   partOfSpeech: n
+  wikidata: Q11122055
 13082231-n:
   definition:
   - a jelly fungus with a fruiting body 5-15 cm broad and gelatinous in consistency;
@@ -89589,6 +92396,9 @@
   members:
   - Tremella foliacea
   partOfSpeech: n
+  wikidata:
+  - Q73413492
+  - Q882168
 13082464-n:
   definition:
   - a jelly fungus with an erect whitish fruiting body and a highly variable shape
@@ -89601,6 +92411,7 @@
   members:
   - Tremella reticulata
   partOfSpeech: n
+  wikidata: Q49415723
 13082681-n:
   definition:
   - coextensive with the family Auriculariaceae; sometimes included in the order Tremellales
@@ -89651,6 +92462,7 @@
   - ear fungus
   - Auricularia auricula
   partOfSpeech: n
+  wikidata: Q81165435
 13083390-n:
   definition:
   - a family of basidiomycetous fungi belonging to the order Tremellales having a
@@ -89761,6 +92573,7 @@
   - flax rust fungus
   - Melampsora lini
   partOfSpeech: n
+  wikidata: Q3813701
 13085007-n:
   definition:
   - rust fungi having aecia produced in raised or swollen sori and teliospores borne
@@ -89786,6 +92599,7 @@
   - blister rust
   - Cronartium ribicola
   partOfSpeech: n
+  wikidata: Q2301438
 13085438-n:
   definition:
   - large important family of rust fungi
@@ -89824,6 +92638,7 @@
   - wheat rust
   - Puccinia graminis
   partOfSpeech: n
+  wikidata: Q1342327
 13085975-n:
   definition:
   - genus of fungi that produce galls on cedars and other conifers of genera Juniperus
@@ -89850,6 +92665,7 @@
   - cedar-apple rust
   - Gymnosporangium juniperi-virginianae
   partOfSpeech: n
+  wikidata: Q5625087
 13086462-n:
   definition:
   - category used in some systems to comprise the two orders Ustilaginales (smuts)
@@ -89957,6 +92773,7 @@
   - boil smut
   - Ustilago maydis
   partOfSpeech: n
+  wikidata: Q1430040
 13088292-n:
   definition:
   - genus of smut fungus
@@ -90021,6 +92838,7 @@
   - bunt
   - Tilletia caries
   partOfSpeech: n
+  wikidata: Q1634854
 13089194-n:
   definition:
   - similar to Tilletia caries
@@ -90032,6 +92850,7 @@
   - stinking smut
   - Tilletia foetida
   partOfSpeech: n
+  wikidata: Q108430036
 13089325-n:
   definition:
   - a genus of smut fungi belonging to the family Tilletiaceae
@@ -90056,6 +92875,7 @@
   - onion smut
   - Urocystis cepulae
   partOfSpeech: n
+  wikidata: Q14950172
 13089677-n:
   definition:
   - a smut fungus causing a smut in cereals and other grasses that chiefly affects
@@ -90077,6 +92897,7 @@
   - wheat flag smut
   - Urocystis tritici
   partOfSpeech: n
+  wikidata: Q15643666
 13090108-n:
   definition:
   - a family of fungi belonging to the subdivision Basidiomycota
@@ -90168,6 +92989,7 @@
   - Hygrocybe acutoconica
   - conic waxycap
   partOfSpeech: n
+  wikidata: Q2255842
 13091789-n:
   definition:
   - a genus of fungi belonging to the family Hygrophoraceae, containing agarics commonly
@@ -90201,6 +93023,9 @@
   members:
   - Hygrophorus borealis
   partOfSpeech: n
+  wikidata:
+  - Q21159506
+  - Q59489281
 13092313-n:
   definition:
   - a fungus with a broadly convex cap that is cream color with a tint of blue over
@@ -90212,6 +93037,7 @@
   members:
   - Hygrophorus caeruleus
   partOfSpeech: n
+  wikidata: Q15637409
 13092575-n:
   definition:
   - a fungus with a drab squamulose cap and grey-brown squamules over the white background
@@ -90222,6 +93048,7 @@
   members:
   - Hygrophorus inocybiformis
   partOfSpeech: n
+  wikidata: Q10670895
 13092791-n:
   definition:
   - a fungus with a slightly viscid cap; cap and gills are reddish brown and the stalk
@@ -90232,6 +93059,7 @@
   members:
   - Hygrophorus kauffmanii
   partOfSpeech: n
+  wikidata: Q107750823
 13092969-n:
   definition:
   - a grey fungus frequently found near melting snow banks
@@ -90252,6 +93080,7 @@
   members:
   - Hygrophorus purpurascens
   partOfSpeech: n
+  wikidata: Q76836
 13093288-n:
   definition:
   - an edible fungus with a reddish cap and close pale gills and dry stalk; found
@@ -90272,6 +93101,7 @@
   members:
   - Hygrophorus sordidus
   partOfSpeech: n
+  wikidata: Q127326824
 13093623-n:
   definition:
   - a fungus having a brownish sticky cap with a white margin and white gills and
@@ -90282,6 +93112,7 @@
   members:
   - Hygrophorus tennesseensis
   partOfSpeech: n
+  wikidata: Q107751568
 13093815-n:
   definition:
   - a small fungus with orange cap and yellow gills found in sphagnum bogs
@@ -90291,6 +93122,7 @@
   members:
   - Hygrophorus turundus
   partOfSpeech: n
+  wikidata: Q107751585
 13093971-n:
   definition:
   - a genus of fungi belonging to the family Hygrophoraceae
@@ -90313,6 +93145,7 @@
   members:
   - Hygrotrama foetens
   partOfSpeech: n
+  wikidata: Q107751646
 13094286-n:
   definition:
   - a genus of fungi belonging to the family Hygrophoraceae,with type species being
@@ -90338,6 +93171,7 @@
   members:
   - Neohygrophorus angelesianus
   partOfSpeech: n
+  wikidata: Q10597324
 13094739-n:
   definition:
   - a cobwebby partial veil consisting of silky fibrils
@@ -90392,6 +93226,7 @@
   members:
   - Cortinarius armillatus
   partOfSpeech: n
+  wikidata: Q1517961
 13095574-n:
   definition:
   - an edible fungus with a slimy viscid cap that is initially yellow but turns olive
@@ -90402,6 +93237,7 @@
   members:
   - Cortinarius atkinsonianus
   partOfSpeech: n
+  wikidata: Q107596835
 13095780-n:
   definition:
   - a fungus with a viscid wrinkled tawny cap; the stalk has a basal bulb that diminishes
@@ -90412,6 +93248,7 @@
   members:
   - Cortinarius corrugatus
   partOfSpeech: n
+  wikidata: Q49414038
 13096032-n:
   definition:
   - a poisonous fungus with a bright yellow brown cap and a long cinnamon-colored
@@ -90434,6 +93271,7 @@
   - Cortinarius mutabilis
   - purple-staining Cortinarius
   partOfSpeech: n
+  wikidata: Q49425514
 13096444-n:
   definition:
   - a fungus with a dry brown cap and rusty red gills and a yellowish stalk
@@ -90490,6 +93328,7 @@
   members:
   - Gymnopilus spectabilis
   partOfSpeech: n
+  wikidata: Q103817247
 13097403-n:
   definition:
   - a poisonous fungus with a dry cap and a cortina that does not leave much of a
@@ -90511,6 +93350,7 @@
   members:
   - Gymnopilus ventricosus
   partOfSpeech: n
+  wikidata: Q5625037
 13097793-n:
   definition:
   - a fungus that produces a superficial growth on various kinds of damp or decaying
@@ -90669,6 +93509,7 @@
   - Candida albicans
   - Monilia albicans
   partOfSpeech: n
+  wikidata: Q310443
 13100535-n:
   definition:
   - form genus of imperfect fungi lacking pigment in the spores and conidiophores
@@ -90775,6 +93616,7 @@
   - green smut fungus
   - Ustilaginoidea virens
   partOfSpeech: n
+  wikidata: Q3278240
 13102129-n:
   definition:
   - large family of mainly saprophytic imperfect fungi
@@ -93409,6 +96251,7 @@
   - alder dogwood
   - Rhamnus frangula
   partOfSpeech: n
+  wikidata: Q11122869
 13163281-n:
   definition:
   - small spiny evergreen shrub of western United States and Mexico with minute flowers
@@ -93474,6 +96317,7 @@
   mero_part:
   - 07781975-n
   partOfSpeech: n
+  wikidata: Q11181633
 13164260-n:
   definition:
   - shrubby deciduous tree of the Mediterranean region
@@ -93509,6 +96353,7 @@
   - Jerusalem thorn
   - Paliurus spina-christi
   partOfSpeech: n
+  wikidata: Q660414
 13164707-n:
   definition:
   - a genus of Australasian shrubs and trees
@@ -93596,6 +96441,7 @@
   mero_part:
   - 07774926-n
   partOfSpeech: n
+  wikidata: Q311720
 13166027-n:
   definition:
   - native grape of southeastern United States; origin of many cultivated varieties
@@ -93624,6 +96470,7 @@
   mero_part:
   - 07775792-n
   partOfSpeech: n
+  wikidata: Q30046
 13166701-n:
   definition:
   - white wine grape
@@ -93791,6 +96638,7 @@
   - Japanese ivy
   - Parthenocissus tricuspidata
   partOfSpeech: n
+  wikidata: Q157979
 13169167-n:
   definition:
   - common North American vine with compound leaves and bluish-black berrylike fruit
@@ -93803,6 +96651,7 @@
   - woodbine
   - Parthenocissus quinquefolia
   partOfSpeech: n
+  wikidata: Q157968
 13169385-n:
   definition:
   - Piperaceae, Saururaceae, Chloranthaceae
@@ -93880,6 +96729,7 @@
   mero_substance:
   - 15057756-n
   partOfSpeech: n
+  wikidata: Q43084
 13170612-n:
   definition:
   - slender tropical climber of the eastern Himalayas
@@ -93890,6 +96740,7 @@
   - long pepper
   - Piper longum
   partOfSpeech: n
+  wikidata: Q685336
 13170753-n:
   definition:
   - Asian pepper plant whose leaves are chewed with betel nut (seed of the betel palm)
@@ -93902,6 +96753,7 @@
   - betel pepper
   - Piper betel
   partOfSpeech: n
+  wikidata: Q67193257
 13170955-n:
   definition:
   - tropical southeast Asian shrubby vine bearing spicy berrylike fruits
@@ -93971,6 +96823,7 @@
   - Peperomia argyreia
   - Peperomia sandersii
   partOfSpeech: n
+  wikidata: Q15248654
 13172042-n:
   definition:
   - small family of tropical herbs and shrubs and trees
@@ -94037,6 +96890,7 @@
   - water dragon
   - Saururus cernuus
   partOfSpeech: n
+  wikidata: Q162365
 13172980-n:
   definition:
   - 'one species: yerba mansa'
@@ -94061,6 +96915,7 @@
   - yerba mansa
   - Anemopsis californica
   partOfSpeech: n
+  wikidata: Q4761678
 13173369-n:
   definition:
   - one species; east Asian low-growing plant of wet places
@@ -95149,6 +98004,7 @@
   - giant scrambling fern
   - Diplopterygium longissimum
   partOfSpeech: n
+  wikidata: Q17041888
 13191939-n:
   definition:
   - umbrella ferns; warm regions of Australia and New Zealand
@@ -95175,6 +98031,7 @@
   - Sticherus flabellatus
   - Gleichenia flabellata
   partOfSpeech: n
+  wikidata: Q7616161
 13192345-n:
   definition:
   - coextensive with the genus Ceratopteris; sometimes included in family Polypodiaceae
@@ -95213,6 +98070,7 @@
   - water sprite
   - Ceratopteris pteridioides
   partOfSpeech: n
+  wikidata: Q17197299
 13192873-n:
   definition:
   - pantropical aquatic fern
@@ -95286,6 +98144,7 @@
   - licorice fern
   - Polypodium glycyrrhiza
   partOfSpeech: n
+  wikidata: Q3395763
 13194157-n:
   definition:
   - fern growing on rocks or tree trunks and having fronds greyish and scurfy below;
@@ -95299,6 +98158,7 @@
   - resurrection fern
   - Polypodium polypodioides
   partOfSpeech: n
+  wikidata: Q17169503
 13194386-n:
   definition:
   - stiff leathery-leaved fern of western North America having ovate fronds parted
@@ -95312,6 +98172,7 @@
   - coast polypody
   - Polypodium scouleri
   partOfSpeech: n
+  wikidata: Q7226780
 13194595-n:
   definition:
   - chiefly lithophytic or epiphytic fern of North America and east Asia
@@ -95341,7 +98202,9 @@
   - sweet fern
   - Polypodium vulgare
   partOfSpeech: n
-  wikidata: Q743883
+  wikidata:
+  - Q15337906
+  - Q743883
 13195104-n:
   definition:
   - epiphytic ferns of tropical Asia
@@ -95365,6 +98228,9 @@
   - bear's-paw fern
   - Aglaomorpha meyeniana
   partOfSpeech: n
+  wikidata:
+  - Q42741482
+  - Q3335252
 13195413-n:
   definition:
   - epiphytic ferns of tropical America
@@ -95446,6 +98312,7 @@
   - basket fern
   - Drynaria rigidula
   partOfSpeech: n
+  wikidata: Q15251254
 13196745-n:
   definition:
   - epiphytic ferns of southeastern Asia to New Guinea
@@ -95491,6 +98358,7 @@
   - snake polypody
   - Microgramma piloselloides
   partOfSpeech: n
+  wikidata: Q15334451
 13197421-n:
   definition:
   - tropical usually epiphytic ferns; Africa to Asia and Polynesia to Australia
@@ -95541,6 +98409,7 @@
   - Phlebodium aureum
   - Polypodium aureum
   partOfSpeech: n
+  wikidata: Q1231082
 13198252-n:
   definition:
   - often epiphytic tropical Old World ferns
@@ -95588,9 +98457,7 @@
   - Platycerium bifurcatum
   - Platycerium alcicorne
   partOfSpeech: n
-  wikidata:
-  - Q4364577
-  - Q2170121
+  wikidata: Q2170121
 13199005-n:
   definition:
   - epiphytic or lithophytic or terrestrial ferns of tropical Old World
@@ -95616,6 +98483,7 @@
   - Pyrrosia lingua
   - Cyclophorus lingua
   partOfSpeech: n
+  wikidata: Q3281617
 13199398-n:
   definition:
   - tropical American epiphytic ferns having rhizomes with tubers and roots as well
@@ -95640,6 +98508,7 @@
   - potato fern
   - Solanopteris bifrons
   partOfSpeech: n
+  wikidata: Q15347014
 13199781-n:
   definition:
   - tropical Old World ferns having closely crowded circular sori and no indusia
@@ -95711,6 +98580,7 @@
   - ribbon fern
   - Vittaria lineata
   partOfSpeech: n
+  wikidata: Q17117515
 13200870-n:
   definition:
   - one of a number of families into which Polypodiaceae has been subdivided in some
@@ -95766,6 +98636,7 @@
   - black spleenwort
   - Asplenium adiantum-nigrum
   partOfSpeech: n
+  wikidata: Q923786
 13201953-n:
   definition:
   - tropical Old World or Australian epiphytic fern frequently forming tufts in tree
@@ -95777,7 +98648,9 @@
   - bird's nest fern
   - Asplenium nidus
   partOfSpeech: n
-  wikidata: Q1736890
+  wikidata:
+  - Q15283521
+  - Q1736890
 13202142-n:
   definition:
   - common North American fern with polished black stripes
@@ -95789,6 +98662,7 @@
   - Scott's spleenwort
   - Asplenium platyneuron
   partOfSpeech: n
+  wikidata: Q4808139
 13202304-n:
   definition:
   - 'fern of tropical America: from southern United States to West Indies and Mexico
@@ -95825,6 +98699,9 @@
   - Asplenium rhizophyllum
   - Camptosorus rhizophyllus
   partOfSpeech: n
+  wikidata:
+  - Q17172165
+  - Q4808143
 13202886-n:
   definition:
   - small rock-inhabiting fern of northern temperate zone and Hawaii with pinnate
@@ -95836,6 +98713,9 @@
   - maidenhair spleenwort
   - Asplenium trichomanes
   partOfSpeech: n
+  wikidata:
+  - Q2205624
+  - Q902211
 13203062-n:
   definition:
   - a small fern with slim green fronds; widely distributed in cool parts of Northern
@@ -95847,6 +98727,7 @@
   - green spleenwort
   - Asplenium viride
   partOfSpeech: n
+  wikidata: Q1552374
 13203236-n:
   definition:
   - a spleenwort of eastern North America
@@ -95857,6 +98738,9 @@
   - mountain spleenwort
   - Asplenium montanum
   partOfSpeech: n
+  wikidata:
+  - Q55834740
+  - Q4808134
 13203360-n:
   definition:
   - small delicate spleenwort found on a steep slope (as a wall or cliff) of Eurasia
@@ -95869,6 +98753,9 @@
   - wall rue spleenwort
   - Asplenium ruta-muraria
   partOfSpeech: n
+  wikidata:
+  - Q24955230
+  - Q1125768
 13203560-n:
   definition:
   - a spleenwort of eastern to southern United States
@@ -95879,6 +98766,7 @@
   - Bradley's spleenwort
   - Asplenium bradleyi
   partOfSpeech: n
+  wikidata: Q4808119
 13203697-n:
   definition:
   - a spleenwort of eastern and southern United States
@@ -95889,6 +98777,9 @@
   - lobed spleenwort
   - Asplenium pinnatifidum
   partOfSpeech: n
+  wikidata:
+  - Q17181419
+  - Q4808138
 13203835-n:
   definition:
   - a spleenwort of western Europe
@@ -95899,6 +98790,7 @@
   - lanceolate spleenwort
   - Asplenium billotii
   partOfSpeech: n
+  wikidata: Q862916
 13203954-n:
   definition:
   - Eurasian fern with simple lanceolate fronds
@@ -95911,7 +98803,9 @@
   - Asplenium scolopendrium
   - Phyllitis scolopendrium
   partOfSpeech: n
-  wikidata: Q1130272
+  wikidata:
+  - Q10956573
+  - Q1130272
 13204149-n:
   definition:
   - small genus of Old World ferns; superseded in some classification systems which
@@ -95936,6 +98830,7 @@
   - Asplenium ceterach
   - Ceterach officinarum
   partOfSpeech: n
+  wikidata: Q1754958
 13204567-n:
   definition:
   - small genus comprising terrestrial ferns; found in Chile and Spain and Morocco
@@ -95972,6 +98867,7 @@
   - Asplenium nigripes
   - Scolopendrium nigripes
   partOfSpeech: n
+  wikidata: Q15609645
 13205062-n:
   definition:
   - a genus of ferns belonging to the family Polypodiaceae (in some classification
@@ -96047,6 +98943,7 @@
   - deer fern
   - Blechnum spicant
   partOfSpeech: n
+  wikidata: Q925696
 13206334-n:
   definition:
   - in some classification systems placed in family Polypodiaceae; small terrestrial
@@ -96128,6 +99025,7 @@
   - Virginia chain fern
   - Woodwardia virginica
   partOfSpeech: n
+  wikidata: Q8033594
 13207552-n:
   definition:
   - any of numerous usually tropical ferns having a thick woody stem or caudex and
@@ -96179,6 +99077,7 @@
   - black tree fern
   - Cyathea medullaris
   partOfSpeech: n
+  wikidata: Q5197621
 13208502-n:
   definition:
   - one of a number of families into which Polypodiaceae has been subdivided in some
@@ -96250,6 +99149,9 @@
   - Australian hare's foot
   - Davallia pyxidata
   partOfSpeech: n
+  wikidata:
+  - Q17167445
+  - Q38230025
 13209665-n:
   definition:
   - feathery fern of tropical Asia and Malaysia
@@ -96305,6 +99207,7 @@
   - boulder fern
   - Dennstaedtia punctilobula
   partOfSpeech: n
+  wikidata: Q2863582
 13210554-n:
   definition:
   - a genus of ferns belonging to the family Dennstaedtiaceae
@@ -96331,6 +99234,7 @@
   - brake
   - Pteridium aquilinum
   partOfSpeech: n
+  wikidata: Q213548
 13210958-n:
   definition:
   - fern of southeastern Asia; not hardy in cold temperate regions
@@ -96382,7 +99286,9 @@
   - soft tree fern
   - Dicksonia antarctica
   partOfSpeech: n
-  wikidata: Q630002
+  wikidata:
+  - Q17188267
+  - Q630002
 13211815-n:
   definition:
   - 'in some classification systems placed in family Cyatheaceae: ornamental tree
@@ -96433,6 +99339,7 @@
   - false bracken
   - Culcita dubia
   partOfSpeech: n
+  wikidata: Q65935500
 13212668-n:
   definition:
   - a tree fern genus containing Thyrsopteris elegans (Thyrsopteris)
@@ -96574,6 +99481,7 @@
   - male fern
   - Dryopteris filix-mas
   partOfSpeech: n
+  wikidata: Q322994
 13214934-n:
   definition:
   - North American fern with evergreen fronds
@@ -96586,6 +99494,7 @@
   - leatherleaf wood fern
   - Dryopteris marginalis
   partOfSpeech: n
+  wikidata: Q3459756
 13215110-n:
   definition:
   - a fern of the genus Dryopteris
@@ -96596,6 +99505,7 @@
   - mountain male fern
   - Dryopteris oreades
   partOfSpeech: n
+  wikidata: Q15547977
 13215226-n:
   definition:
   - temperate and tropical lady ferns; in some classifications placed in family Polypodiaceae
@@ -96621,6 +99531,7 @@
   - lady fern
   - Athyrium filix-femina
   partOfSpeech: n
+  wikidata: Q1345500
 13215656-n:
   definition:
   - a lady fern with deeply cut leaf segments; found in the Rocky Mountains
@@ -96631,6 +99542,7 @@
   - Alpine lady fern
   - Athyrium distentifolium
   partOfSpeech: n
+  wikidata: Q674547
 13215816-n:
   definition:
   - North American fern with narrow fronds on yellowish leafstalks
@@ -96644,6 +99556,7 @@
   - Athyrium pycnocarpon
   - Diplazium pycnocarpon
   partOfSpeech: n
+  wikidata: Q16034617
 13216049-n:
   definition:
   - small genus of tropical Asiatic greenhouse ferns; in some classifications placed
@@ -96793,6 +99706,7 @@
   - Gymnocarpium dryopteris
   - Thelypteris dryopteris
   partOfSpeech: n
+  wikidata: Q1301661
 13218405-n:
   definition:
   - yellow-green fern of rocky areas of Northern Hemisphere
@@ -96804,6 +99718,7 @@
   - northern oak fern
   - Gymnocarpium robertianum
   partOfSpeech: n
+  wikidata: Q2092520
 13218568-n:
   definition:
   - tropical terrestrial shield ferns
@@ -96846,6 +99761,7 @@
   - Pteretis struthiopteris
   - Onoclea struthiopteris
   partOfSpeech: n
+  wikidata: Q1130386
 13219252-n:
   definition:
   - genus of fern having only one species
@@ -96871,6 +99787,7 @@
   - Polybotrya cervina
   - Polybotria cervina
   partOfSpeech: n
+  wikidata: Q15602670
 13219626-n:
   definition:
   - 'one species: sensitive fern; in some classifications included in Polypodiaceae'
@@ -96897,6 +99814,7 @@
   - bead fern
   - Onoclea sensibilis
   partOfSpeech: n
+  wikidata: Q718312
 13220142-n:
   definition:
   - tropical American ferns; usually terrestrial when young but scandent later
@@ -96940,6 +99858,7 @@
   - evergreen wood fern
   - Polystichum acrostichoides
   partOfSpeech: n
+  wikidata: Q7226975
 13220868-n:
   definition:
   - any of various ferns of the genus Polystichum having fronds with texture and gloss
@@ -96962,6 +99881,7 @@
   - prickly shield fern
   - Polystichum braunii
   partOfSpeech: n
+  wikidata: Q2654918
 13221309-n:
   definition:
   - evergreen European fern widely cultivated
@@ -96972,6 +99892,7 @@
   - northern holly fern
   - Polystichum lonchitis
   partOfSpeech: n
+  wikidata: Q542735
 13221440-n:
   definition:
   - North American fern, also known by the names mountain holly fern and rock sword
@@ -96983,6 +99904,7 @@
   - western holly fern
   - Polystichum scopulinum
   partOfSpeech: n
+  wikidata: Q7226986
 13221549-n:
   definition:
   - European shield fern cultivated in many varieties
@@ -96993,6 +99915,7 @@
   - soft shield fern
   - Polystichum setiferum
   partOfSpeech: n
+  wikidata: Q2018810
 13221704-n:
   definition:
   - 'leatherleaf ferns: in some classifications included in genus Polystichum'
@@ -97020,6 +99943,7 @@
   - Rumohra adiantiformis
   - Polystichum adiantiformis
   partOfSpeech: n
+  wikidata: Q7379334
 13222137-n:
   definition:
   - terrestrial or epilithic ferns of tropical rain forests
@@ -97044,6 +99968,7 @@
   - button fern
   - Tectaria cicutaria
   partOfSpeech: n
+  wikidata: Q7692800
 13222464-n:
   definition:
   - fern of tropical Asia having round buttonlike bulbils
@@ -97054,6 +99979,7 @@
   - Indian button fern
   - Tectaria macrodonta
   partOfSpeech: n
+  wikidata: Q17169090
 13222623-n:
   definition:
   - genus of small to medium-sized usually rock-inhabiting ferns of temperate and
@@ -97089,6 +100015,7 @@
   - oblong woodsia
   - Woodsia ilvensis
   partOfSpeech: n
+  wikidata: Q2233063
 13223253-n:
   definition:
   - slender fern of northern North America with shining chestnut-colored stipes and
@@ -97102,6 +100029,7 @@
   - flower-cup fern
   - Woodsia alpina
   partOfSpeech: n
+  wikidata: Q661822
 13223500-n:
   definition:
   - rock-inhabiting fern of Arctic and subarctic Europe to eastern Asia
@@ -97239,6 +100167,7 @@
   - Oleandra neriiformis
   - Oleandra mollis
   partOfSpeech: n
+  wikidata: Q17264116
 13225380-n:
   definition:
   - tropical and subtropical Old World epiphytic or lithophytic ferns
@@ -97297,6 +100226,7 @@
   - toothed sword fern
   - Nephrolepis pectinata
   partOfSpeech: n
+  wikidata: Q17048243
 13226380-n:
   definition:
   - one of a number of families into which the family Polypodiaceae has been subdivided
@@ -97352,6 +100282,7 @@
   - leather fern
   - Acrostichum aureum
   partOfSpeech: n
+  wikidata: Q4676527
 13227336-n:
   definition:
   - terrestrial ferns of tropical Asia and Africa
@@ -97402,6 +100333,7 @@
   - Venus maidenhair
   - Adiantum capillus-veneris
   partOfSpeech: n
+  wikidata: Q4678994
 13228233-n:
   definition:
   - hardy palmately branched North American fern with divergent recurved branches
@@ -97476,6 +100408,7 @@
   - Jersey fern
   - Anogramma leptophylla
   partOfSpeech: n
+  wikidata: Q946400
 13229366-n:
   definition:
   - 'small evergreen ferns: lipferns; in some classifications placed in family Polypodiaceae
@@ -97513,6 +100446,7 @@
   - Alabama lip fern
   - Cheilanthes alabamensis
   partOfSpeech: n
+  wikidata: Q15607240
 13230027-n:
   definition:
   - small tufted fern of northwestern America
@@ -97523,6 +100457,9 @@
   - lace fern
   - Cheilanthes gracillima
   partOfSpeech: n
+  wikidata:
+  - Q15610965
+  - Q5089650
 13230168-n:
   definition:
   - small North American evergreen fern whose stipes and lower frond surfaces are
@@ -97535,6 +100472,7 @@
   - hairy lip fern
   - Cheilanthes lanosa
   partOfSpeech: n
+  wikidata: Q15611266
 13230358-n:
   definition:
   - lip fern of Texas to Oklahoma and Colorado and Arizona and Mexico having tall
@@ -97546,6 +100484,9 @@
   - southwestern lip fern
   - Cheilanthes eatonii
   partOfSpeech: n
+  wikidata:
+  - Q89139268
+  - Q15610746
 13230545-n:
   definition:
   - terrestrial ferns of Pacific islands and Asia
@@ -97570,6 +100511,7 @@
   - bamboo fern
   - Coniogramme japonica
   partOfSpeech: n
+  wikidata: Q10896043
 13230904-n:
   definition:
   - sometimes placed in family Polypodiaceae or Cryptogrammataceae
@@ -97605,6 +100547,7 @@
   - American parsley fern
   - Cryptogramma acrostichoides
   partOfSpeech: n
+  wikidata: Q5190926
 13231495-n:
   definition:
   - fern of Europe and Asia Minor having short slender rhizome and densely tufted
@@ -97641,6 +100584,7 @@
   - hand fern
   - Doryopteris pedata
   partOfSpeech: n
+  wikidata: Q15612866
 13232077-n:
   definition:
   - xerophytic ferns of South America
@@ -97725,6 +100669,7 @@
   - Pellaea mucronata
   - Pellaea ornithopus
   partOfSpeech: n
+  wikidata: Q7161518
 13233457-n:
   definition:
   - fern of New Zealand and Australia having trailing fronds with dark green buttonlike
@@ -97736,6 +100681,7 @@
   - button fern
   - Pellaea rotundifolia
   partOfSpeech: n
+  wikidata: Q7161522
 13233649-n:
   definition:
   - terrestrial tropical ferns having fronds with powdery yellowish or white undersides;
@@ -97763,6 +100709,7 @@
   - silver fern
   - Pityrogramma argentea
   partOfSpeech: n
+  wikidata: Q15613078
 13234133-n:
   definition:
   - tropical American fern having fronds with white undersides
@@ -97773,6 +100720,7 @@
   - silver fern
   - Pityrogramma calomelanos
   partOfSpeech: n
+  wikidata: Q15246986
 13234295-n:
   definition:
   - tropical American fern having fronds with light golden undersides
@@ -97794,6 +100742,7 @@
   - gold fern
   - Pityrogramma chrysophylla
   partOfSpeech: n
+  wikidata: Q15605233
 13234666-n:
   definition:
   - large genus of terrestrial ferns of tropics and subtropics; sometimes placed in
@@ -97830,6 +100779,7 @@
   members:
   - Pteris cretica
   partOfSpeech: n
+  wikidata: Q2050113
 13235238-n:
   definition:
   - Asiatic fern introduced in America
@@ -97841,6 +100791,7 @@
   - spider fern
   - Pteris multifida
   partOfSpeech: n
+  wikidata: Q5872213
 13235383-n:
   definition:
   - fern of North Africa and Azores and Canary Islands
@@ -97852,6 +100803,7 @@
   - spider fern
   - Pteris serrulata
   partOfSpeech: n
+  wikidata: Q11799266
 13235543-n:
   definition:
   - lower ferns coextensive with the family Marattiaceae
@@ -97906,6 +100858,9 @@
   - potato fern
   - Marattia salicina
   partOfSpeech: n
+  wikidata:
+  - Q7257082
+  - Q27828610
 13236360-n:
   definition:
   - 'one species: tree fern'
@@ -98019,6 +100974,7 @@
   - skeleton fork fern
   - Psilotum nudum
   partOfSpeech: n
+  wikidata: Q1197925
 13238111-n:
   definition:
   - Paleozoic simple dichotomously branched plants of Europe and eastern Canada including
@@ -98198,6 +101154,9 @@
   - field horsetail
   - Equisetum arvense
   partOfSpeech: n
+  wikidata:
+  - Q17257054
+  - Q107592
 13240874-n:
   definition:
   - Eurasia; northern North America to Virginia
@@ -98209,6 +101168,7 @@
   - water horsetail
   - Equisetum fluviatile
   partOfSpeech: n
+  wikidata: Q948839
 13241020-n:
   definition:
   - evergreen erect horsetail with rough-edged stems; formerly used for scouring utensils
@@ -98222,6 +101182,7 @@
   - Equisetum hyemale robustum
   - Equisetum robustum
   partOfSpeech: n
+  wikidata: Q17259785
 13241253-n:
   definition:
   - scouring-rush horsetail widely distributed in wet or boggy areas of Northern Hemisphere
@@ -98232,6 +101193,7 @@
   - marsh horsetail
   - Equisetum palustre
   partOfSpeech: n
+  wikidata: Q21122
 13241423-n:
   definition:
   - Eurasia except southern Russia; northern North America
@@ -98384,6 +101346,9 @@
   - shining clubmoss
   - Lycopodium lucidulum
   partOfSpeech: n
+  wikidata:
+  - Q4567960
+  - Q38233964
 13243883-n:
   definition:
   - a variety of club moss which occurs throughout northern latitudes in the Northern
@@ -98395,6 +101360,9 @@
   - alpine clubmoss
   - Lycopodium alpinum
   partOfSpeech: n
+  wikidata:
+  - Q2715589
+  - Q21976234
 13243988-n:
   definition:
   - of northern Europe and America; resembling a miniature fir
@@ -98407,6 +101375,9 @@
   - little clubmoss
   - Lycopodium selago
   partOfSpeech: n
+  wikidata:
+  - Q1142154
+  - Q21976256
 13244163-n:
   definition:
   - any of several club mosses having long creeping stems and erect branches
@@ -98440,6 +101411,9 @@
   - staghorn moss
   - Lycopodium complanatum
   partOfSpeech: n
+  wikidata:
+  - Q787930
+  - Q21976241
 13244608-n:
   definition:
   - a variety of club moss, commonly called ground pine, prince's pine, or princess
@@ -98453,7 +101427,9 @@
   - tree clubmoss
   - Lycopodium obscurum
   partOfSpeech: n
-  wikidata: Q3281399
+  wikidata:
+  - Q15338742
+  - Q3281399
 13244741-n:
   definition:
   - ground pine thickly covered with bristly leaves; widely distributed in barren
@@ -98465,6 +101441,9 @@
   - foxtail grass
   - Lycopodium alopecuroides
   partOfSpeech: n
+  wikidata:
+  - Q15321697
+  - Q21976231
 13244984-n:
   definition:
   - in some classifications included in Lycopodiales
@@ -98527,6 +101506,7 @@
   - basket spikemoss
   - Selaginella apoda
   partOfSpeech: n
+  wikidata: Q3545396
 13245973-n:
   definition:
   - tufted spikemoss forming loose spreading mats; eastern North America
@@ -98549,6 +101529,7 @@
   - desert selaginella
   - Selaginella eremophila
   partOfSpeech: n
+  wikidata: Q7447413
 13246263-n:
   definition:
   - densely tufted fern ally of southwestern United States to Peru; curls up in a
@@ -98572,6 +101553,9 @@
   - florida selaginella
   - Selaginella eatonii
   partOfSpeech: n
+  wikidata:
+  - Q17263537
+  - Q17024548
 13246627-n:
   definition:
   - aquatic or marsh-growing fern allies; known to have existed since the Cenozoic;
@@ -98717,6 +101701,7 @@
   - Thelypteris palustris
   - Dryopteris thelypteris
   partOfSpeech: n
+  wikidata: Q958103
 13248915-n:
   definition:
   - fern of northeastern North America
@@ -98858,6 +101843,7 @@
   - Parathelypteris novae-boracensis
   - Dryopteris noveboracensis
   partOfSpeech: n
+  wikidata: Q17180450
 13251088-n:
   definition:
   - delicate feathery shield fern of the eastern United States; sometimes placed in
@@ -98870,6 +101856,7 @@
   - Parathelypteris simulata
   - Thelypteris simulata
   partOfSpeech: n
+  wikidata: Q17196458
 13251319-n:
   definition:
   - 'beech ferns: genus is variously classified: considered alternative name for genus
@@ -98966,6 +101953,7 @@
   - Armillaria caligata
   - booted armillaria
   partOfSpeech: n
+  wikidata: Q105049465
 13253004-n:
   definition:
   - a large white mushroom that develops brown stains as it ages; gills are white;
@@ -98988,6 +101976,9 @@
   members:
   - Armillaria zelleri
   partOfSpeech: n
+  wikidata:
+  - Q108443971
+  - Q49600720
 13253413-n:
   definition:
   - a honey-colored diminutive form of genus Armillaria; grows in clusters; edible
@@ -99014,6 +102005,7 @@
   - honey fungus
   - Armillariella mellea
   partOfSpeech: n
+  wikidata: Q105049488
 13253910-n:
   definition:
   - widely distributed family of herbs and shrubs of the order Gentianales; most with
@@ -99082,6 +102074,7 @@
   - white milkweed
   - Asclepias albicans
   partOfSpeech: n
+  wikidata: Q2866401
 13255191-n:
   definition:
   - tropical herb having orange-red flowers followed by pods suggesting a swallow
@@ -99094,6 +102087,7 @@
   - swallowwort
   - Asclepias curassavica
   partOfSpeech: n
+  wikidata: Q939991
 13255417-n:
   definition:
   - milkweed of the eastern United States with leaves resembling those of pokeweed
@@ -99116,6 +102110,7 @@
   - swamp milkweed
   - Asclepias incarnata
   partOfSpeech: n
+  wikidata: Q1057909
 13255755-n:
   definition:
   - milkweed of central North America; a threatened species
@@ -99127,6 +102122,7 @@
   - Asclepias meadii
   - Asclepia meadii
   partOfSpeech: n
+  wikidata: Q723084
 13255909-n:
   definition:
   - perennial of eastern North America having pink-purple flowers
@@ -99137,6 +102133,7 @@
   - purple silkweed
   - Asclepias purpurascens
   partOfSpeech: n
+  wikidata: Q310133
 13256057-n:
   definition:
   - milkweed of southern North America having large starry purple and pink flowers
@@ -99147,6 +102144,7 @@
   - showy milkweed
   - Asclepias speciosa
   partOfSpeech: n
+  wikidata: Q311150
 13256217-n:
   definition:
   - milkweed of southwestern United States and Mexico; poisonous to livestock
@@ -99158,6 +102156,7 @@
   - horsetail milkweed
   - Asclepias subverticillata
   partOfSpeech: n
+  wikidata: Q2866403
 13256401-n:
   definition:
   - erect perennial of eastern and southern United States having showy orange flowers
@@ -99273,6 +102272,7 @@
   - wax plant
   - Hoya carnosa
   partOfSpeech: n
+  wikidata: Q134347
 13258241-n:
   definition:
   - genus of woody vines of warm regions of the Old World
@@ -99298,6 +102298,7 @@
   - silk vine
   - Periploca graeca
   partOfSpeech: n
+  wikidata: Q632142
 13258686-n:
   definition:
   - succulent subshrubs or vines; tropical and subtropical India and Africa and Malaysia
@@ -99323,6 +102324,7 @@
   - haoma
   - Sarcostemma acidum
   partOfSpeech: n
+  wikidata: Q3950495
 13259076-n:
   definition:
   - genus of foul-smelling plants resembling cacti; found from Africa to East India
@@ -99395,6 +102397,9 @@
   - waxflower
   - Stephanotis floribunda
   partOfSpeech: n
+  wikidata:
+  - Q10475339
+  - Q1786657
 13260369-n:
   definition:
   - genus of chiefly tropical American vines having cordate leaves and large purple
@@ -99420,6 +102425,7 @@
   - Vincetoxicum hirsutum
   - Vincetoxicum negrum
   partOfSpeech: n
+  wikidata: Q124757631
 13260819-n:
   definition:
   - a plant spore formed by two similar sexual cells
@@ -99501,6 +102507,7 @@
   mero_substance:
   - 80820791-n
   partOfSpeech: n
+  wikidata: Q759873
 83153902-n:
   definition:
   - wood of a common cypress of southeastern United States having trunk expanded at
@@ -99565,6 +102572,7 @@
   members:
   - Euphorbia villosa
   partOfSpeech: n
+  wikidata: Q160026
 86491841-n:
   definition:
   - wood of any of several evergreen trees or shrubs of Australia and northern New
@@ -99610,6 +102618,9 @@
   members:
   - Euphorbia hirta
   partOfSpeech: n
+  wikidata:
+  - Q14549482
+  - Q36177
 89071275-n:
   definition:
   - common cypress of southeastern United States having trunk expanded at base; found
@@ -99625,6 +102636,7 @@
   mero_substance:
   - 83153902-n
   partOfSpeech: n
+  wikidata: Q148950
 89665091-n:
   definition:
   - either of two huge coniferous California trees that reach a height of 300 feet;


### PR DESCRIPTION
This is linking is mostly based on the taxonomic names, which was then further reviewed. Of these mappings I confirmed 4335 automatically by using the existing genus links (i.e., 'Panthera leo' was accepted as the parent 'Panthera' was already linked and the parent was the same). A further 766 could not be confirmed automatically and were manually confirmed. A second evaluation showed that 143 were not compatible with the existing links, and this was evaluated and in nearly all cases this was due to a secondary scientific name in the OEWN synset, with a small number of errors in OEWN also corrected.