### PR TITLE
Avoid PWN 3.0 mention in LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,9 +3,43 @@ and further developed under the Creative Commons Attribution 4.0 International L
 You may share and adapt this resource providing attribution is given to both
 Princeton WordNet and the Open English Wordnet team.
 
-Creative Commons Attribution 4.0 International
 
 =======================================================================
+
+WordNet License Attribution
+
+============================
+
+This work is based on or incorporates elements of the Princeton
+University WordNet database. 
+
+The original Princeton WordNet license terms apply to the underlying
+data and can be found in the file: /WNDB_License.txt (located in the
+root directory of this distribution).
+
+
+=======================================================================
+
+Open English WordNet License
+
+=============================
+
+Copyright (c) 2019-present, The Open English WordNet Team.
+
+This work is licensed under a Creative Commons Attribution 4.0
+International License. To view a copy of this license, visit
+
+http://creativecommons.org/licenses/by/4.0/
+
+or send a letter to Creative Commons, PO Box 1866,
+Mountain View, CA 94042, USA.
+
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International
+
+===============================================
 
 Creative Commons Corporation ("Creative Commons") is not a law firm and
 does not provide legal services or legal advice. Distribution of
@@ -399,9 +433,3 @@ public licenses.
 
 Creative Commons may be contacted at creativecommons.org.
 
-
-
-WordNet 3.0 license
--------------------
-
-WordNet Release 3.0 This software and database is being provided to you, the LICENSEE, by Princeton University under the following license. By obtaining, using and/or copying this software and database, you agree that you have read, understood, and will comply with these terms and conditions.: Permission to use, copy, modify and distribute this software and database and its documentation for any purpose and without fee or royalty is hereby granted, provided that you agree to comply with the following copyright notice and statements, including the disclaimer, and that the same appear on ALL copies of the software, database and documentation, including modifications that you make for internal use or for distribution. WordNet 3.0 Copyright 2006 by Princeton University. All rights reserved. THIS SOFTWARE AND DATABASE IS PROVIDED "AS IS" AND PRINCETON UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, PRINCETON UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES OF MERCHANT- ABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE LICENSED SOFTWARE, DATABASE OR DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS. The name of Princeton University or Princeton may not be used in advertising or publicity pertaining to distribution of the software and/or database. Title to copyright in this software, database and any associated documentation shall at all times remain with Princeton University and LICENSEE agrees to preserve same.


### PR DESCRIPTION
Currently, LICENSE.md includes an ill-formatted copy of the PWN 3.0 license at the end, with all linebreaks removed.
Since OEWN is based on PWN 3.1,  the appropriate license mention is 3.1, and it seems practical to just point to the WNDB_License.txt already included in the root directory of this distribution.
