### PR TITLE
migrate adverbs to new supersense taxonomy

### DIFF
--- a/ADVERBS.md
+++ b/ADVERBS.md
@@ -1,0 +1,114 @@
+## Description
+Wordnet originally proposed a single category for adverbs "all," with OEWN, the
+community expanded this category to more descriptive sets.
+
+## Manner (adverb.manner)
+
+Describes how the event or action is performed.
+
+Paraphrase Test: Can it be rephrased as "in a [X] manner"?
+
+Example:
+Sentence: "He danced stupidly."
+Paraphrase: "He danced in a stupid manner."
+
+## Subject-Oriented (adverb.subject_oriented)
+
+Attributes a property or attitude to the subject of the sentence in relation to the event.
+
+Paraphrase Test: Can it be rephrased as "It was [X] of [SUBJECT] to [VERB]"?
+
+Example:
+Sentence: "Stupidly, he walked into traffic."
+Paraphrase: "It was stupid of him to walk into traffic."
+
+## Speaker-Oriented (adverb.speaker_oriented)
+
+Expresses the speaker's stance, evaluation, or attitude toward the proposition or the act of speaking.
+he believed her story hook, line, and sinker
+Paraphrase Test: Can it be paraphrased as "I [believe / say / judge] that…" or "It is [unfortunate / fortunate / evident] that…"?
+
+Examples:
+	•	"Presumably, he missed the deadline." → "I presume that he missed the deadline."
+	•	"Unfortunately, the project failed." → "It is unfortunate that the project failed."
+	•	"Frankly, I disagree." → "I say this frankly."
+
+
+## Frequency (adverb.frequency)
+
+Describes how often the event occurs.
+
+Question Test: "How often?"
+
+Example:
+Sentence: "She frequently visits her grandmother."
+Answer: "Frequently." → Frequency adverb
+
+## Temporal (adverb.temporal)
+
+Specifies when the event happens or its duration.
+
+Question Test: "When?" or "For how long?"
+
+Examples:
+	•	Sentence: "She arrived yesterday." → When? → Yesterday
+	•	Sentence: "He stayed briefly." → For how long? → Briefly
+
+## Spatial (Locative) (adverb.spatial)
+
+Specifies where the event takes place or subject relative position.
+
+Question Test: "Where?"
+
+Example:
+Sentence: "He stood outside."
+Answer: "Outside." → Spatial adverb
+
+## Degree (adverb.degree)
+
+Describes the intensity, extent, or scalar position of another element (adjective, adverb, verb).
+
+Question Test: "To what extent?" or "How much?"
+
+Example:
+Sentence: "She is very happy."
+Question: "To what extent is she happy?"
+Answer: "Very." → Degree adverb
+
+## Domain (adverb.domain)
+
+Limits the proposition to a particular semantic or disciplinary domain.
+
+Paraphrase Test: "In a [X] sense" or "From a [X] perspective"
+
+Example:
+Sentence: "Politically, the policy is controversial."
+Paraphrase: "In a political sense, the policy is controversial."
+
+## Focus (adverb.focus)
+
+Highlights or restricts the scope of the proposition to a particular constituent — emphasizing inclusion, exclusion, or limitation. Focus adverbs mark what part of the sentence is informationally prominent.
+
+Diagnostic Questions:
+“What part of the clause is being emphasized or limited?”
+“Does it indicate exclusivity, inclusion, or emphasis?”
+
+Examples:
+Only John passed the exam. → Focus on John (exclusivity).
+Even Mary noticed the mistake. → Focus on Mary (unexpected inclusion).
+She also attended the meeting. → Focus on the act of attending (addition).
+He mainly spoke about politics. → Focus on the topic (restriction).
+
+## Contrast (adverb.contrast)
+
+Signals opposition, correction, or contrast between propositions or discourse segments. These adverbs relate the current clause to an alternative, expectation, or prior context.
+
+Paraphrase Test:
+Can it be rephrased as “in contrast,” “on the other hand,” or “however”?
+Does it mark discourse-level contrast or corrective focus?
+
+Examples:
+However, she decided to stay. → Contrast with a preceding expectation or statement.
+Conversely, rural areas saw a decline. → Opposite relation between propositions.
+Instead, he chose to wait. → Correction or substitution.
+Nevertheless, they continued the project. → Concession against expectation.

--- a/LEXNAMES.md
+++ b/LEXNAMES.md
@@ -1,0 +1,80 @@
+## Description
+
+During WordNet development synsets are organized into forty-five lexicographer files based on syntactic category and logical groupings.
+The format of the lexicographer files is described in wninput(5WN) .
+
+A file number corresponds to each lexicographer file.
+File numbers are encoded in several parts of the WordNet system as an efficient way to indicate a lexicographer file name.
+The file lexnames lists the mapping between file names and numbers, and can be used by programs or end users to correlate the two.
+
+## File Format
+
+Each line in lexnames contains 3 tab separated fields, and is terminated with a newline character. The first field is the two digit decimal integer file number. (The first file in the list is numbered 00 .) The second field is the name of the lexicographer file that is represented by that number, and the third field is an integer that indicates the syntactic category of the synsets contained in the file. This is simply a shortcut for programs and scripts, since the syntactic category is also part of the lexicographer file's name.
+Syntactic Category
+
+The syntactic category field is encoded as follows:
+
+1    NOUN
+2    VERB
+3    ADJECTIVE
+4    ADVERB
+
+ ## Lexicographer Files
+
+The names of the lexicographer files and their corresponding file numbers are listed below along with a brief description each file's contents.
+
+00 	adj.all 	all adjective clusters
+01 	adj.pert 	relational adjectives (pertainyms)
+02 	adv.all 	all adverbs (_legacy_)
+03 	noun.Tops 	unique beginner for nouns
+04 	noun.act 	nouns denoting acts or actions
+05 	noun.animal 	nouns denoting animals
+06 	noun.artifact 	nouns denoting man-made objects
+07 	noun.attribute 	nouns denoting attributes of people and objects
+08 	noun.body 	nouns denoting body parts
+09 	noun.cognition 	nouns denoting cognitive processes and contents
+10 	noun.communication 	nouns denoting communicative processes and contents
+11 	noun.event 	nouns denoting natural events
+12 	noun.feeling 	nouns denoting feelings and emotions
+13 	noun.food 	nouns denoting foods and drinks
+14 	noun.group 	nouns denoting groupings of people or objects
+15 	noun.location 	nouns denoting spatial position
+16 	noun.motive 	nouns denoting goals
+17 	noun.object 	nouns denoting natural objects (not man-made)
+18 	noun.person 	nouns denoting people
+19 	noun.phenomenon 	nouns denoting natural phenomena
+20 	noun.plant 	nouns denoting plants
+21 	noun.possession 	nouns denoting possession and transfer of possession
+22 	noun.process 	nouns denoting natural processes
+23 	noun.quantity 	nouns denoting quantities and units of measure
+24 	noun.relation 	nouns denoting relations between people or things or ideas
+25 	noun.shape 	nouns denoting two and three dimensional shapes
+26 	noun.state 	nouns denoting stable states of affairs
+27 	noun.substance 	nouns denoting substances
+28 	noun.time 	nouns denoting time and temporal relations
+29 	verb.body 	verbs of grooming, dressing and bodily care
+30 	verb.change 	verbs of size, temperature change, intensifying, etc.
+31 	verb.cognition 	verbs of thinking, judging, analyzing, doubting
+32 	verb.communication 	verbs of telling, asking, ordering, singing
+33 	verb.competition 	verbs of fighting, athletic activities
+34 	verb.consumption 	verbs of eating and drinking
+35 	verb.contact 	verbs of touching, hitting, tying, digging
+36 	verb.creation 	verbs of sewing, baking, painting, performing
+37 	verb.emotion 	verbs of feeling
+38 	verb.motion 	verbs of walking, flying, swimming
+39 	verb.perception 	verbs of seeing, hearing, feeling
+40 	verb.possession 	verbs of buying, selling, owning
+41 	verb.social 	verbs of political and social activities and events
+42 	verb.stative 	verbs of being, having, spatial relations
+43 	verb.weather 	verbs of raining, snowing, thawing, thundering
+44 	adj.ppl 	participial adjectives
+45  adv.manner   manner adverbs
+46  adv.subject_oriented     subject oriented adverbs
+47  adv.speaker_oriented     speaker oriented adverbs
+48  adv.frequency        frequency adverbs
+49  adv.temporal     time, date adverbs
+50  adv.spatial      spatial, location adverbs
+51  adv.degree       degree, intensity adverbs
+52  adv.domain       domain, scope, context adverbs
+53  adv.focus        focus adverbs
+54  adv.contrast     contrastive adverbs

--- a/src/yaml/adv.contrast.yaml
+++ b/src/yaml/adv.contrast.yaml
@@ -1,0 +1,323 @@
+00018343-r:
+  definition:
+  - at the same time as
+  example:
+  - even as he lay dying they argued over his estate
+  - the building collapsed just as he arrived
+  ili: i18244
+  members:
+  - even as
+  - just as
+  partOfSpeech: r
+00027470-r:
+  definition:
+  - in the actual state of affairs and often contrary to expectations
+  example:
+  - he might have been killed; as it is, he was severely injured
+  ili: i18296
+  members:
+  - as it is
+  partOfSpeech: r
+00027761-r:
+  definition:
+  - despite anything to the contrary (usually preceding a concession)
+  example:
+  - although I'm a little afraid, however I'd like to try it
+  - while we disliked each other, nevertheless we agreed
+  - he was a stern yet fair master
+  - granted that it is dangerous, all the same I still want to go
+  ili: i18298
+  members:
+  - however
+  - nevertheless
+  - withal
+  - still
+  - yet
+  - all the same
+  - even so
+  - nonetheless
+  - notwithstanding
+  - at the same time
+  partOfSpeech: r
+00028715-r:
+  definition:
+  - except that
+  example:
+  - It was the same story; only this time she came out better
+  ili: i18302
+  members:
+  - only
+  partOfSpeech: r
+00029193-r:
+  definition:
+  - by contrast; on the other hand
+  example:
+  - the first part was easy; the second, however, took hours
+  ili: i18305
+  members:
+  - however
+  partOfSpeech: r
+00041980-r:
+  definition:
+  - forming a hindrance, impediment, or obstruction
+  example:
+  - she might have succeeded in her ambition, had not circumstances been in her way
+  ili: i18382
+  members:
+  - in the way
+  - in someone's way
+  partOfSpeech: r
+00063710-r:
+  definition:
+  - in place of, or as an alternative to
+  example:
+  - Felix became a herpetologist instead
+  - alternatively we could buy a used car
+  ili: i18518
+  members:
+  - alternatively
+  - instead
+  - or else
+  partOfSpeech: r
+00064021-r:
+  definition:
+  - with greater reason; for a still stronger, more certain reason
+  example:
+  - if you are wrong then, a fortiori, so am I
+  ili: i18520
+  members:
+  - a fortiori
+  partOfSpeech: r
+00066363-r:
+  definition:
+  - in addition to all the foregoing
+  example:
+  - last not least, he plays the saxophone
+  ili: i18538
+  members:
+  - last but not least
+  - last not least
+  partOfSpeech: r
+00078316-r:
+  definition:
+  - with the terms of the relation reversed
+  example:
+  - conversely, not all women are mothers
+  ili: i18608
+  members:
+  - conversely
+  partOfSpeech: r
+00099264-r:
+  definition:
+  - on the contrary
+  example:
+  - rather than disappoint the children, he did two quick tricks before he left
+  - he didn't call; rather (or instead), he wrote her a letter
+  - used English terms instead of Latin ones
+  ili: i18757
+  members:
+  - rather
+  - instead
+  partOfSpeech: r
+00118928-r:
+  definition:
+  - in that case or as a consequence
+  example:
+  - if he didn't take it, then who did?
+  - keep it then if you want to
+  - the case, then, is closed
+  - you've made up your mind then?
+  - then you'll be rich
+  ili: i18892
+  members:
+  - then
+  partOfSpeech: r
+00119427-r:
+  definition:
+  - in spite of everything; without regard to drawbacks
+  example:
+  - he carried on regardless of the difficulties
+  ili: i18895
+  members:
+  - regardless
+  - irrespective
+  - disregardless
+  - no matter
+  - disregarding
+  partOfSpeech: r
+00119623-r:
+  definition:
+  - regardless; a combination of irrespective and regardless sometimes used humorously
+  exemplifies:
+  - 07089193-n
+  ili: i18896
+  members:
+  - irregardless
+  partOfSpeech: r
+00120034-r:
+  definition:
+  - (postpositive) however
+  example:
+  - it might be unpleasant, though
+  ili: i18899
+  members:
+  - though
+  partOfSpeech: r
+00120473-r:
+  definition:
+  - (contrastive) from another point of view
+  example:
+  - on the other hand, she is too ambitious for her own good
+  - then again, she might not go
+  ili: i18902
+  members:
+  - on the other hand
+  - then again
+  partOfSpeech: r
+00120682-r:
+  definition:
+  - from one point of view
+  example:
+  - on the one hand, she is a gifted chemist
+  ili: i18903
+  members:
+  - on the one hand
+  - on one hand
+  partOfSpeech: r
+00152363-r:
+  definition:
+  - in spite of expectations
+  example:
+  - came to the party after all
+  - it didn't rain after all
+  ili: i19155
+  members:
+  - after all
+  partOfSpeech: r
+00157956-r:
+  definition:
+  - in spite of all obstacles
+  example:
+  - we'll go to Tibet come hell or high water
+  ili: i19200
+  members:
+  - come hell or high water
+  - no matter what happens
+  - whatever may come
+  partOfSpeech: r
+00165875-r:
+  definition:
+  - absolutely not; never
+  exemplifies:
+  - 07089193-n
+  ili: i19254
+  members:
+  - in a pig's eye
+  partOfSpeech: r
+00171723-r:
+  definition:
+  - contrary to expectations
+  example:
+  - he didn't stay home; on the contrary, he went out with his friends
+  ili: i19298
+  members:
+  - contrarily
+  - to the contrary
+  - contrariwise
+  - on the contrary
+  partOfSpeech: r
+00179172-r:
+  definition:
+  - with the order reversed
+  example:
+  - she hates him and vice versa
+  ili: i19353
+  members:
+  - vice versa
+  - the other way around
+  - contrariwise
+  partOfSpeech: r
+00182242-r:
+  definition:
+  - not taken into account or excluded from consideration
+  example:
+  - these problems apart, the country is doing well
+  - all joking aside, I think you're crazy
+  ili: i19377
+  members:
+  - apart
+  - aside
+  partOfSpeech: r
+00193074-r:
+  definition:
+  - compare
+  ili: i19456
+  members:
+  - cf.
+  - cf
+  partOfSpeech: r
+00249448-r:
+  definition:
+  - in a contrary disobedient manner
+  ili: i19852
+  members:
+  - perversely
+  - contrarily
+  - contrariwise
+  partOfSpeech: r
+00275080-r:
+  definition:
+  - with antithesis; in an antithetical manner
+  ili: i20055
+  members:
+  - antithetically
+  partOfSpeech: r
+00290609-r:
+  definition:
+  - in opposition to a proposition, opinion, etc.
+  example:
+  - much was written pro and con
+  ili: i20163
+  members:
+  - con
+  partOfSpeech: r
+00294567-r:
+  definition:
+  - in the opposite direction
+  example:
+  - run counter
+  ili: i20191
+  members:
+  - counter
+  partOfSpeech: r
+00296680-r:
+  definition:
+  - in a contrasting manner
+  example:
+  - contrastingly, both the rooms leading off it gave an immediate impression of being
+    disgraced
+  ili: i20204
+  members:
+  - contrastingly
+  partOfSpeech: r
+00407778-r:
+  definition:
+  - (often followed by ‘for’) in exchange or in reciprocation
+  example:
+  - gave up our seats on the plane and in return received several hundred dollars
+    and seats on the next plane out
+  - we get many benefits in return for our taxes
+  ili: i20925
+  members:
+  - in return
+  - reciprocally
+  partOfSpeech: r
+00409589-r:
+  definition:
+  - not this merely but also; not only so but
+  example:
+  - each of us is peculiar, nay, in a sense unique
+  ili: i20935
+  members:
+  - nay
+  partOfSpeech: r

--- a/src/yaml/adv.degree.yaml
+++ b/src/yaml/adv.degree.yaml
@@ -1,0 +1,4802 @@
+00002669-r:
+  definition:
+  - only a very short time before
+  example:
+  - we hardly knew them
+  - had scarcely rung the bell when the door flew open
+  - source: W.B.Yeats
+    text: would have scarce arrived before she would have found some excuse to leave
+  ili: i18163
+  members:
+  - barely
+  - hardly
+  - just
+  - scarcely
+  - scarce
+  partOfSpeech: r
+00002935-r:
+  definition:
+  - by a little
+  example:
+  - I only just caught the bus
+  - he finished the marathon in just under 3 hours
+  - it was barely 5 a.m.
+  - the network has barely 5 percent of viewers
+  - the batter just missed being hit
+  members:
+  - barely
+  - just
+  partOfSpeech: r
+00003864-r:
+  definition:
+  - in essence; at bottom or by one's (or its) very nature
+  example:
+  - He is basically dishonest
+  - the argument was essentially a technical one
+  ili: i18168
+  members:
+  - basically
+  - fundamentally
+  - essentially
+  partOfSpeech: r
+00004227-r:
+  definition:
+  - passionately or agitatedly
+  example:
+  - boiling mad
+  exemplifies:
+  - 07089193-n
+  ili: i18170
+  members:
+  - boiling
+  partOfSpeech: r
+00004306-r:
+  definition:
+  - in an enviable manner
+  example:
+  - she was enviably fluent in French
+  ili: i18171
+  members:
+  - enviably
+  partOfSpeech: r
+00005348-r:
+  definition:
+  - absolutely; altogether; really
+  example:
+  - we are simply broke
+  ili: i18178
+  members:
+  - simply
+  partOfSpeech: r
+00006055-r:
+  definition:
+  - in an alarming manner
+  example:
+  - It grew alarmingly fast
+  ili: i18184
+  members:
+  - alarmingly
+  partOfSpeech: r
+00006160-r:
+  definition:
+  - to an exceedingly great extent or degree
+  example:
+  - He had vastly overestimated his resources
+  - was immensely more important to the project as a scientist than as an administrator
+  ili: i18185
+  members:
+  - vastly
+  - immensely
+  partOfSpeech: r
+00006415-r:
+  definition:
+  - in a gross manner
+  ili: i18186
+  members:
+  - grossly
+  partOfSpeech: r
+00006486-r:
+  definition:
+  - in large part; mainly or chiefly
+  example:
+  - These accounts are largely inactive
+  ili: i18187
+  members:
+  - largely
+  - mostly
+  - for the most part
+  partOfSpeech: r
+00006640-r:
+  definition:
+  - in a significant manner
+  example:
+  - our budget will be significantly affected by these new cuts
+  ili: i18188
+  members:
+  - significantly
+  partOfSpeech: r
+00006822-r:
+  definition:
+  - not to a significant degree or amount
+  example:
+  - our budget will only be insignificantly affected by these new cuts
+  ili: i18189
+  members:
+  - insignificantly
+  partOfSpeech: r
+00007009-r:
+  definition:
+  - to a noticeable degree
+  example:
+  - the weather was appreciably colder
+  ili: i18190
+  members:
+  - appreciably
+  partOfSpeech: r
+00007887-r:
+  definition:
+  - totally and definitely; without question
+  example:
+  - we are absolutely opposed to the idea
+  - he forced himself to lie absolutely still
+  - iron is absolutely necessary
+  ili: i18194
+  members:
+  - absolutely
+  partOfSpeech: r
+00008102-r:
+  definition:
+  - to some extent; in some degree; not wholly
+  example:
+  - I felt partly to blame
+  - He was partially paralyzed
+  ili: i18195
+  members:
+  - partially
+  - partly
+  - part
+  - in part
+  partOfSpeech: r
+00008300-r:
+  definition:
+  - partially or to the extent of a half
+  example:
+  - he was half hidden by the bushes
+  ili: i18196
+  members:
+  - half
+  partOfSpeech: r
+00008423-r:
+  definition:
+  - to a complete degree or to the full or entire extent; Completely or entirely
+  example:
+  - he was wholly convinced
+  - entirely satisfied with the meal
+  - it was completely different from what we expected
+  - was completely at fault
+  - a totally new situation
+  - the directions were all wrong
+  - it was not altogether her fault
+  - an altogether new approach
+  - a whole new idea
+  - she felt right at home
+  - he fell right into the trap
+  ili: i19554
+  members:
+  - wholly
+  - entirely
+  - completely
+  - totally
+  - all
+  - altogether
+  - whole
+  - right
+  partOfSpeech: r
+00009062-r:
+  definition:
+  - without any others being included or involved
+  example:
+  - was entirely to blame
+  - a school devoted entirely to the needs of problem children
+  - he works for Mr. Smith exclusively
+  - did it solely for money
+  - the burden of proof rests on the prosecution alone
+  - a privilege granted only to him
+  ili: i18198
+  members:
+  - entirely
+  - exclusively
+  - solely
+  - alone
+  - only
+  partOfSpeech: r
+00009459-r:
+  definition:
+  - completely and without qualification; used informally as intensifiers
+  example:
+  - an absolutely magnificent painting
+  - a perfectly idiotic idea
+  - you're perfectly right
+  - utterly miserable
+  - you can be dead sure of my innocence
+  - was dead tired
+  - dead right
+  ili: i18199
+  members:
+  - absolutely
+  - perfectly
+  - utterly
+  - dead
+  partOfSpeech: r
+00009835-r:
+  definition:
+  - completely; used as intensifiers
+  example:
+  - clean forgot the appointment
+  - I'm plumb (or plum) tuckered out
+  exemplifies:
+  - 07171981-n
+  ili: i18200
+  members:
+  - clean
+  - plumb
+  - plum
+  partOfSpeech: r
+00010003-r:
+  definition:
+  - exactly
+  example:
+  - fell plumb in the middle of the puddle
+  exemplifies:
+  - 07089193-n
+  ili: i18201
+  members:
+  - plumb
+  - plum
+  partOfSpeech: r
+00010321-r:
+  definition:
+  - completely or perfectly
+  example:
+  - he has the lesson pat
+  - had the system down pat
+  ili: i18203
+  members:
+  - pat
+  partOfSpeech: r
+00010928-r:
+  definition:
+  - to the greatest degree or extent; completely or entirely; (‘full’ in this sense
+    is used as a combining form)
+  example:
+  - fully grown
+  - he didn't fully understand
+  - knew full well
+  - full-grown
+  - full-fledged
+  exemplifies:
+  - 06318142-n
+  ili: i18207
+  members:
+  - fully
+  - to the full
+  - full
+  partOfSpeech: r
+00011978-r:
+  definition:
+  - (‘ill’ is often used as a combining form) in a poor or improper or unsatisfactory
+    manner; not well
+  example:
+  - he was ill prepared
+  - it ill befits a man to betray old friends
+  - the car runs badly
+  - he performed badly on the exam
+  - the team played poorly
+  - ill-fitting clothes
+  - an ill-conceived plan
+  exemplifies:
+  - 06318142-n
+  ili: i18212
+  members:
+  - ill
+  - badly
+  - poorly
+  partOfSpeech: r
+00012378-r:
+  definition:
+  - with difficulty or inconvenience; scarcely or hardly
+  example:
+  - we can ill afford to buy a new car just now
+  ili: i18213
+  members:
+  - ill
+  partOfSpeech: r
+00013891-r:
+  definition:
+  - to a suitable or appropriate extent or degree
+  example:
+  - the project was well underway
+  - the fetus has well developed organs
+  - his father was well pleased with his grades
+  ili: i18221
+  members:
+  - well
+  partOfSpeech: r
+00014747-r:
+  definition:
+  - to a great extent or degree
+  example:
+  - I'm afraid the film was well over budget
+  - painting the room white made it seem considerably (or substantially) larger
+  - the house has fallen considerably in value
+  - the price went up substantially
+  ili: i18225
+  members:
+  - well
+  - considerably
+  - substantially
+  partOfSpeech: r
+00015469-r:
+  definition:
+  - with great or especially intimate knowledge
+  example:
+  - we knew them well
+  ili: i18229
+  members:
+  - well
+  - intimately
+  partOfSpeech: r
+00015597-r:
+  definition:
+  - (used for emphasis or as an intensifier) entirely or fully
+  example:
+  - a book well worth reading
+  - was well aware of the difficulties ahead
+  - suspected only too well what might be going on
+  exemplifies:
+  - 06332047-n
+  ili: i18230
+  members:
+  - well
+  partOfSpeech: r
+00016415-r:
+  definition:
+  - to a severe or serious degree
+  example:
+  - fingers so badly frozen they had to be amputated
+  - badly injured
+  - a severely impaired heart
+  - is gravely ill
+  - was seriously ill
+  ili: i18235
+  members:
+  - badly
+  - severely
+  - gravely
+  - seriously
+  partOfSpeech: r
+00016702-r:
+  definition:
+  - very much; strongly
+  example:
+  - I wanted it badly enough to work hard for it
+  - the cables had sagged badly
+  - they were badly in need of help
+  - he wants a bicycle so bad he can taste it
+  ili: i18236
+  members:
+  - badly
+  - bad
+  partOfSpeech: r
+00016920-r:
+  definition:
+  - with great intensity (‘bad’ is a nonstandard variant for ‘badly’)
+  example:
+  - the injury hurt badly
+  - the buildings were badly shaken
+  - it hurts bad
+  - we need water bad
+  ili: i18237
+  members:
+  - badly
+  - bad
+  partOfSpeech: r
+00017539-r:
+  definition:
+  - (comparative of ‘ill’) in a less effective or successful or desirable manner
+  example:
+  - he did worse on the second exam
+  exemplifies:
+  - 06333686-n
+  ili: i18240
+  members:
+  - worse
+  partOfSpeech: r
+00017703-r:
+  definition:
+  - to the highest degree of inferiority or badness
+  example:
+  - She suffered worst of all
+  - schools were the worst hit by government spending cuts
+  - the worst dressed person present
+  ili: i18241
+  members:
+  - worst
+  partOfSpeech: r
+00018764-r:
+  definition:
+  - to some (great or small) extent
+  example:
+  - it was rather cold
+  - the party was rather nice
+  - the knife is rather dull
+  - I rather regret that I cannot attend
+  - He's rather good at playing the cello
+  - he is kind of shy
+  ili: i18248
+  members:
+  - rather
+  - kind of
+  - kinda
+  - sort of
+  partOfSpeech: r
+00019039-r:
+  definition:
+  - to the greatest extent; completely
+  example:
+  - you're quite right
+  - she was quite alone
+  - was quite mistaken
+  - quite the opposite
+  - not quite finished
+  - did not quite make it
+  ili: i18249
+  members:
+  - quite
+  partOfSpeech: r
+00019243-r:
+  definition:
+  - to a degree (not used with a negative)
+  example:
+  - quite tasty
+  - quite soon
+  - quite ill
+  - quite rich
+  ili: i18250
+  members:
+  - quite
+  - rather
+  partOfSpeech: r
+00019380-r:
+  definition:
+  - of an unusually noticeable or exceptional or remarkable kind (not used with a
+    negative)
+  example:
+  - her victory was quite something
+  - she's quite a girl
+  - quite a film
+  - quite a walk
+  - we've had quite an afternoon
+  ili: i18251
+  members:
+  - quite
+  - quite a
+  - quite an
+  partOfSpeech: r
+00019643-r:
+  definition:
+  - actually or truly or to an extreme
+  example:
+  - was quite a sudden change
+  - it's quite the thing to do
+  - quite the rage
+  - Quite so!
+  ili: i18252
+  members:
+  - quite
+  partOfSpeech: r
+00022585-r:
+  definition:
+  - to the same degree (often followed by ‘as’)
+  example:
+  - they were equally beautiful
+  - birds were singing and the child sang as sweetly
+  - sang as sweetly as a nightingale
+  - he is every bit as mean as she is
+  ili: i18267
+  members:
+  - equally
+  - as
+  - every bit
+  partOfSpeech: r
+00023171-r:
+  definition:
+  - to some degree
+  example:
+  - we were pretty much lost when we met the forest ranger
+  ili: i18269
+  members:
+  - pretty much
+  partOfSpeech: r
+00023283-r:
+  definition:
+  - (degree adverb used before a noun phrase) for all practical purposes but not completely
+  example:
+  - much the same thing happened every time
+  - practically everything in Hinduism is the manifestation of a god
+  ili: i18270
+  members:
+  - much
+  - practically
+  partOfSpeech: r
+00024432-r:
+  definition:
+  - negation of a word or group of words
+  example:
+  - he does not speak French
+  - she is not going
+  - they are not friends
+  - not many
+  - not much
+  - not at all
+  ili: i18280
+  members:
+  - not
+  - non
+  partOfSpeech: r
+00024616-r:
+  definition:
+  - in no respect; to no degree
+  example:
+  - he looks nothing like his father
+  ili: i18281
+  members:
+  - nothing
+  partOfSpeech: r
+00024868-r:
+  definition:
+  - to any degree or extent
+  example:
+  - it isn't any better
+  ili: i18283
+  members:
+  - any
+  partOfSpeech: r
+00024946-r:
+  definition:
+  - not in any degree or manner; not at all
+  example:
+  - he is no better today
+  ili: i18284
+  members:
+  - 'no'
+  partOfSpeech: r
+00025041-r:
+  definition:
+  - not at all or in no way
+  example:
+  - seemed none too pleased with his dinner
+  - shirt looked none the worse for having been slept in
+  - none too prosperous
+  - the passage is none too clear
+  ili: i18285
+  members:
+  - none
+  partOfSpeech: r
+00025503-r:
+  definition:
+  - extremely
+  example:
+  - you are bloody right
+  - Why are you so all-fired aggressive?
+  exemplifies:
+  - 06332047-n
+  - 07139048-n
+  ili: i18287
+  members:
+  - bloody
+  - damn
+  - all-fired
+  - all-firedly
+  partOfSpeech: r
+00028974-r:
+  definition:
+  - to whatever degree or extent
+  example:
+  - The results, however general, are important
+  - they have begun, however reluctantly, to acknowledge the legitimacy of some of
+    the opposition's concerns
+  ili: i18304
+  members:
+  - however
+  partOfSpeech: r
+00030381-r:
+  definition:
+  - to or at a greater extent or degree or a more advanced stage (‘further’ is used
+    more often than ‘farther’ in this abstract sense)
+  example:
+  - further complicated by uncertainty about the future
+  - let's not discuss it further
+  - nothing could be further from the truth
+  - they are further along in their research than we expected
+  - the application of the law was extended farther
+  - he is going no farther in his studies
+  ili: i18311
+  members:
+  - further
+  - farther
+  partOfSpeech: r
+00031050-r:
+  definition:
+  - to the greatest distance in space or time (‘farthest’ is used more often than
+    ‘furthest’ in this physical sense)
+  example:
+  - see who could jump the farthest
+  - chose the farthest seat from the door
+  - he swam the furthest
+  ili: i18313
+  members:
+  - farthest
+  - furthest
+  partOfSpeech: r
+00031310-r:
+  definition:
+  - to the greatest degree or extent or most advanced stage (‘furthest’ is used more
+    often than ‘farthest’ in this abstract sense)
+  example:
+  - went the furthest of all the children in her education
+  - furthest removed from reality
+  - she goes farthest in helping us
+  ili: i18314
+  members:
+  - furthest
+  - farthest
+  partOfSpeech: r
+00032295-r:
+  definition:
+  - used to give emphasis
+  example:
+  - she was very gifted
+  - he played very well
+  - a really enjoyable evening
+  - I'm real sorry about it
+  - a rattling good yarn
+  - a most welcome relief
+  - there is precious little time left
+  exemplifies:
+  - 06332047-n
+  ili: i18320
+  members:
+  - very
+  - really
+  - real
+  - rattling
+  - most
+  - precious
+  - preciously
+  partOfSpeech: r
+00032576-r:
+  definition:
+  - exceedingly; extremely
+  example:
+  - she plays fabulously well
+  - behind you the coastal hills plunge to the incredibly blue sea backed by the Turkish
+    mountains
+  ili: i18321
+  members:
+  - fabulously
+  - fantastically
+  - incredibly
+  partOfSpeech: r
+00032793-r:
+  definition:
+  - (Southern regional intensive) very; to a great degree
+  example:
+  - the baby is mighty cute
+  - he's mighty tired
+  - it is powerful humid
+  - that boy is powerful big now
+  - they have a right nice place
+  - they rejoiced mightily
+  exemplifies:
+  - 06332047-n
+  ili: i18322
+  members:
+  - mighty
+  - mightily
+  - powerful
+  - right
+  partOfSpeech: r
+00033092-r:
+  definition:
+  - intensifier, very colloquial
+  example:
+  - what took you so fucking long?
+  exemplifies:
+  - 07139048-n
+  ili: i18324
+  members:
+  - fucking
+  partOfSpeech: r
+00033190-r:
+  definition:
+  - incredibly
+  example:
+  - he was much annoyed
+  ili: i18325
+  members:
+  - much
+  partOfSpeech: r
+00033808-r:
+  definition:
+  - without any delay
+  example:
+  - he was killed outright
+  ili: i18331
+  members:
+  - instantaneously
+  - outright
+  - instantly
+  - in a flash
+  partOfSpeech: r
+00033949-r:
+  definition:
+  - to a moderate degree
+  example:
+  - he was mildly interested
+  ili: i18332
+  members:
+  - mildly
+  partOfSpeech: r
+00034050-r:
+  definition:
+  - to a small degree; somewhat
+  example:
+  - it's a bit warm
+  - felt a little better
+  - a trifle smaller
+  ili: i18333
+  members:
+  - a bit
+  - a little
+  - a trifle
+  partOfSpeech: r
+00036138-r:
+  definition:
+  - to certain extent or degree
+  example:
+  - pretty big
+  - pretty bad
+  - jolly decent of him
+  - the shoes are priced reasonably
+  - he is fairly clever with computers
+  ili: i18350
+  members:
+  - reasonably
+  - moderately
+  - pretty
+  - jolly
+  - somewhat
+  - fairly
+  - middling
+  - passably
+  partOfSpeech: r
+00036472-r:
+  definition:
+  - to a degree that exceeds the bounds of reason or moderation
+  example:
+  - his prices are unreasonably high
+  ili: i18351
+  members:
+  - unreasonably
+  - immoderately
+  partOfSpeech: r
+00036695-r:
+  definition:
+  - to a small degree or extent
+  example:
+  - his arguments were somewhat self-contradictory
+  - the children argued because one slice of cake was slightly larger than the other
+  ili: i18352
+  members:
+  - slightly
+  - somewhat
+  - more or less
+  partOfSpeech: r
+00037013-r:
+  definition:
+  - in a widespread way
+  example:
+  - oxidation ponds are extensively used for sewage treatment in the Midwest
+  ili: i18354
+  members:
+  - extensively
+  partOfSpeech: r
+00037329-r:
+  definition:
+  - without question and beyond doubt
+  example:
+  - it was decidedly too expensive
+  - she told him off in spades
+  - by all odds they should win
+  ili: i18356
+  members:
+  - decidedly
+  - unquestionably
+  - emphatically
+  - definitely
+  - in spades
+  - by all odds
+  partOfSpeech: r
+00037620-r:
+  definition:
+  - in accordance with truth or fact or reality
+  example:
+  - she was now truly American
+  - a genuinely open society
+  - they don't really listen to us
+  ili: i18357
+  members:
+  - truly
+  - genuinely
+  - really
+  partOfSpeech: r
+00045819-r:
+  definition:
+  - perhaps; indicating possibility of being more remarkable (greater or better or
+    sooner) than
+  example:
+  - will yield 10% if not more
+  - pretty if not actually beautiful
+  - let's meet tonight if not sooner
+  ili: i18404
+  members:
+  - if not
+  partOfSpeech: r
+00046739-r:
+  definition:
+  - to an extreme degree
+  example:
+  - extremely cold
+  - extremely unpleasant
+  - she is super smart
+  - the night was deathly cold
+  - as a child, I was deathly afraid of snakes
+  - they all were whopping drunk
+  ili: i18410
+  members:
+  - extremely
+  - exceedingly
+  - super
+  - deathly
+  - whopping
+  partOfSpeech: r
+00046987-r:
+  definition:
+  - stunningly or breathtakingly
+  example:
+  - she was drop-dead gorgeous
+  exemplifies:
+  - 07171981-n
+  ili: i18411
+  members:
+  - drop-dead
+  partOfSpeech: r
+00047083-r:
+  definition:
+  - in excess or without limit
+  example:
+  - amazed beyond measure
+  ili: i18412
+  members:
+  - beyond measure
+  partOfSpeech: r
+00047177-r:
+  definition:
+  - (used as intensives) excessively
+  example:
+  - she was madly in love
+  - deadly dull
+  - deadly earnest
+  - deucedly clever
+  - insanely jealous
+  exemplifies:
+  - 06332047-n
+  ili: i18413
+  members:
+  - madly
+  - insanely
+  - deadly
+  - deucedly
+  - devilishly
+  partOfSpeech: r
+00047401-r:
+  definition:
+  - to a surprising degree
+  example:
+  - she was inordinately smart
+  - it will be an extraordinarily painful step to negotiate
+  ili: i18414
+  members:
+  - inordinately
+  - extraordinarily
+  partOfSpeech: r
+00047594-r:
+  definition:
+  - by a considerable margin
+  example:
+  - she was by far the smartest student
+  - it was far and away the best meal he had ever eaten
+  ili: i18415
+  members:
+  - by far
+  - far and away
+  - out and away
+  partOfSpeech: r
+00047777-r:
+  definition:
+  - outstandingly superior to
+  example:
+  - in intelligence he was head and shoulders above the others in his class
+  ili: i18416
+  members:
+  - head and shoulders above
+  partOfSpeech: r
+00047930-r:
+  definition:
+  - to a degree exceeding normal or proper limits
+  example:
+  - too big
+  ili: i18417
+  members:
+  - excessively
+  - overly
+  - to a fault
+  - too
+  partOfSpeech: r
+00051219-r:
+  definition:
+  - referring to the degree to which a certain quality is present
+  example:
+  - he was no heavier than a child
+  ili: i18436
+  members:
+  - 'no'
+  - no more
+  partOfSpeech: r
+00051355-r:
+  definition:
+  - with resolute determination
+  example:
+  - we firmly believed it
+  - you must stand firm
+  ili: i18437
+  members:
+  - firm
+  - firmly
+  - steadfastly
+  - unwaveringly
+  partOfSpeech: r
+00053420-r:
+  definition:
+  - indicating something hard to accept
+  example:
+  - he was bitterly disappointed
+  ili: i18449
+  members:
+  - bitterly
+  partOfSpeech: r
+00054282-r:
+  definition:
+  - almost; nearly
+  example:
+  - practically the first thing I saw when I got off the train
+  - he was practically the only guest at the party
+  - there was practically no garden at all
+  ili: i18455
+  members:
+  - practically
+  partOfSpeech: r
+00054973-r:
+  definition:
+  - without doubt
+  example:
+  - easily the best book she's written
+  ili: i18460
+  members:
+  - easily
+  partOfSpeech: r
+00055488-r:
+  definition:
+  - used as intensifiers
+  example:
+  - terribly interesting
+  - I'm awful sorry
+  exemplifies:
+  - 07089193-n
+  ili: i18465
+  members:
+  - terribly
+  - awfully
+  - awful
+  - frightfully
+  partOfSpeech: r
+00056056-r:
+  definition:
+  - to an unacceptable degree
+  example:
+  - The percentage of lead in our drinking water is unacceptably high
+  ili: i18468
+  members:
+  - unacceptably
+  - intolerably
+  partOfSpeech: r
+00056878-r:
+  definition:
+  - of a dreadful kind
+  example:
+  - there was a dreadfully bloody accident on the road this morning
+  ili: i18474
+  members:
+  - dreadfully
+  - awfully
+  - horribly
+  partOfSpeech: r
+00057077-r:
+  definition:
+  - to an extraordinary extent or degree
+  example:
+  - he improved greatly
+  ili: i18475
+  members:
+  - greatly
+  partOfSpeech: r
+00057190-r:
+  definition:
+  - in a drastic manner
+  ili: i18476
+  members:
+  - drastically
+  partOfSpeech: r
+00057267-r:
+  definition:
+  - in the slightest degree or in any respect
+  example:
+  - Are you at all interested? No, not at all
+  - was not in the least unfriendly
+  ili: i18477
+  members:
+  - at all
+  - in the least
+  - the least bit
+  partOfSpeech: r
+00057580-r:
+  definition:
+  - definitely not
+  example:
+  - the prize is by no means certain
+  - and that isn't all, not by a long sight
+  exemplifies:
+  - 07089193-n
+  ili: i18479
+  members:
+  - by no means
+  - not by a long sight
+  - not by a blame sight
+  partOfSpeech: r
+00057926-r:
+  definition:
+  - completely and absolutely (‘good’ is sometimes used informally for ‘thoroughly’)
+  example:
+  - he was soundly defeated
+  - we beat him good
+  exemplifies:
+  - 07089193-n
+  ili: i18481
+  members:
+  - thoroughly
+  - soundly
+  - good
+  partOfSpeech: r
+00058164-r:
+  definition:
+  - throughout the entire extent
+  example:
+  - got soaked through in the rain
+  - I'm frozen through
+  - a letter shot through with the writer's personality
+  - knew him through and through
+  - boards rotten through and through
+  ili: i18482
+  members:
+  - through
+  - through and through
+  partOfSpeech: r
+00059205-r:
+  definition:
+  - in an intractable manner
+  ili: i18489
+  members:
+  - intractably
+  partOfSpeech: r
+00059624-r:
+  definition:
+  - to a great degree or extent
+  example:
+  - she's much better now
+  exemplifies:
+  - 06332047-n
+  ili: i18493
+  members:
+  - much
+  partOfSpeech: r
+00059709-r:
+  definition:
+  - to a very great degree or extent
+  example:
+  - I feel a lot better
+  - we enjoyed ourselves very much
+  - she was very much interested
+  - this would help a great deal
+  exemplifies:
+  - 06332047-n
+  ili: i18494
+  members:
+  - a lot
+  - lots
+  - a good deal
+  - a great deal
+  partOfSpeech: r
+00059951-r:
+  definition:
+  - frequently or in great quantities
+  example:
+  - I don't drink much
+  - I don't travel much
+  ili: i18495
+  members:
+  - much
+  - a great deal
+  - often
+  partOfSpeech: r
+00060145-r:
+  definition:
+  - comparative of ‘well’; in a better or more excellent manner or more advantageously
+    or attractively or to a greater degree etc.
+  example:
+  - She had never sung better
+  - a deed better left undone
+  - better suited to the job
+  ili: i18497
+  members:
+  - better
+  partOfSpeech: r
+00060392-r:
+  definition:
+  - advancing in amount or intensity
+  example:
+  - she became increasingly depressed
+  ili: i18498
+  members:
+  - increasingly
+  - progressively
+  - more and more
+  partOfSpeech: r
+00064168-r:
+  definition:
+  - with everything included or counted
+  example:
+  - altogether he earns close to a million dollars
+  ili: i18521
+  members:
+  - altogether
+  - all told
+  - in all
+  partOfSpeech: r
+00065759-r:
+  definition:
+  - on a large scale
+  example:
+  - the sketch was so largely drawn that you could see it from the back row
+  ili: i18533
+  members:
+  - largely
+  partOfSpeech: r
+00073433-r:
+  definition:
+  - (of actions or states) slightly short of or not quite accomplished; all but
+  example:
+  - the job is (just) about done
+  - the baby was almost asleep when the alarm sounded
+  - we're almost finished
+  - the car all but ran her down
+  - he nearly fainted
+  - talked for nigh onto 2 hours
+  - the recording is well-nigh perfect
+  - virtually all the parties signed the contract
+  - I was near exhausted by the run
+  - most everyone agrees
+  ili: i18578
+  members:
+  - about
+  - almost
+  - most
+  - nearly
+  - near
+  - nigh
+  - virtually
+  - well-nigh
+  partOfSpeech: r
+00077885-r:
+  definition:
+  - at a great cost
+  example:
+  - he paid dearly for the food
+  - this cost him dear
+  ili: i18605
+  members:
+  - dearly
+  - dear
+  partOfSpeech: r
+00078013-r:
+  definition:
+  - with affection
+  example:
+  - she loved him dearly
+  - he treats her affectionately
+  ili: i18606
+  members:
+  - dearly
+  - affectionately
+  - dear
+  partOfSpeech: r
+00078178-r:
+  definition:
+  - in a sincere and heartfelt manner
+  example:
+  - I would dearly love to know
+  ili: i18607
+  members:
+  - dearly
+  - in a heartfelt way
+  partOfSpeech: r
+00082389-r:
+  definition:
+  - in a manner or to a degree that dazzles the beholder
+  ili: i18636
+  members:
+  - dazzlingly
+  partOfSpeech: r
+00082925-r:
+  definition:
+  - in a depressing manner or to a depressing degree
+  ili: i18640
+  members:
+  - depressingly
+  partOfSpeech: r
+00083743-r:
+  definition:
+  - to double the degree
+  example:
+  - she was doubly rewarded
+  - his eyes were double bright
+  ili: i18648
+  members:
+  - doubly
+  - double
+  - twice
+  partOfSpeech: r
+00084297-r:
+  definition:
+  - in a twofold manner
+  example:
+  - he was doubly wrong
+  ili: i18652
+  members:
+  - doubly
+  - in two ways
+  partOfSpeech: r
+00084573-r:
+  definition:
+  - to a distinctly greater extent or degree than is common
+  example:
+  - he was particularly fussy about spelling
+  - a particularly gruesome attack
+  - under peculiarly tragic circumstances
+  - an especially (or specially) cautious approach to the danger
+  ili: i18654
+  members:
+  - particularly
+  - peculiarly
+  - especially
+  - specially
+  partOfSpeech: r
+00085109-r:
+  definition:
+  - unusually or exceptionally
+  example:
+  - an extra fast car
+  ili: i18656
+  members:
+  - extra
+  partOfSpeech: r
+00085603-r:
+  definition:
+  - in an exasperating manner
+  ili: i18660
+  members:
+  - exasperatingly
+  partOfSpeech: r
+00087173-r:
+  definition:
+  - most quickly
+  ili: i18670
+  members:
+  - quickest
+  - fastest
+  partOfSpeech: r
+00087268-r:
+  definition:
+  - most slowly
+  ili: i18671
+  members:
+  - slowest
+  partOfSpeech: r
+00087525-r:
+  definition:
+  - not permissibly
+  example:
+  - the radon level in the basement was impermissibly high
+  ili: i18674
+  members:
+  - impermissibly
+  partOfSpeech: r
+00089755-r:
+  definition:
+  - in a high position or level or rank
+  example:
+  - details known by only a few highly placed persons
+  ili: i18689
+  members:
+  - highly
+  partOfSpeech: r
+00089896-r:
+  definition:
+  - to a high degree or extent; favorably or with much respect
+  example:
+  - highly successful
+  - He spoke highly of her
+  - does not think highly of his writing
+  - extremely interesting
+  ili: i18690
+  members:
+  - highly
+  - extremely
+  partOfSpeech: r
+00090131-r:
+  definition:
+  - at a high rate or wage
+  example:
+  - highly paid workers
+  ili: i18691
+  members:
+  - highly
+  partOfSpeech: r
+00090488-r:
+  definition:
+  - in a marginal manner
+  example:
+  - marginally interesting
+  ili: i18694
+  members:
+  - marginally
+  partOfSpeech: r
+00090591-r:
+  definition:
+  - in a geometric fashion
+  example:
+  - it grew geometrically
+  ili: i18695
+  members:
+  - geometrically
+  partOfSpeech: r
+00090716-r:
+  definition:
+  - in a dangerous manner
+  example:
+  - he came dangerously close to falling off the ledge
+  ili: i18696
+  members:
+  - perilously
+  - hazardously
+  - dangerously
+  partOfSpeech: r
+00091039-r:
+  definition:
+  - to a vital degree
+  example:
+  - this is vitally important
+  ili: i18698
+  members:
+  - vitally
+  partOfSpeech: r
+00091627-r:
+  definition:
+  - powerfully or vigorously
+  example:
+  - he strove mightily to achieve a better position in life
+  ili: i18703
+  members:
+  - mightily
+  partOfSpeech: r
+00092328-r:
+  definition:
+  - causing great damage or hardship
+  example:
+  - industries hit hard by the depression
+  - she was severely affected by the bank's failure
+  ili: i18708
+  members:
+  - hard
+  - severely
+  partOfSpeech: r
+00092706-r:
+  definition:
+  - with pain or distress or bitterness
+  example:
+  - he took the rejection very hard
+  ili: i18711
+  members:
+  - hard
+  partOfSpeech: r
+00093000-r:
+  definition:
+  - into a solid condition
+  example:
+  - concrete that sets hard within a few hours
+  ili: i18713
+  members:
+  - hard
+  partOfSpeech: r
+00097561-r:
+  definition:
+  - to a higher intensity
+  example:
+  - he turned up the volume
+  ili: i18744
+  members:
+  - up
+  partOfSpeech: r
+00098072-r:
+  definition:
+  - thoroughgoing
+  example:
+  - he is outright dishonest
+  exemplifies:
+  - 06332047-n
+  ili: i18748
+  members:
+  - downright
+  - outright
+  partOfSpeech: r
+00099509-r:
+  definition:
+  - to the degree or extent that
+  example:
+  - insofar as it can be ascertained, the horse lung is comparable to that of man
+  - so far as it is reasonably practical he should practice restraint
+  ili: i18758
+  members:
+  - insofar
+  - in so far
+  - so far
+  - to that extent
+  - to that degree
+  - in so far as
+  partOfSpeech: r
+00099891-r:
+  definition:
+  - used to form the comparative of some adjectives and adverbs, indicates that the
+    adjective or adverb is more of something
+  example:
+  - more interesting
+  - more beautiful
+  - more quickly
+  ili: i18760
+  members:
+  - more
+  - to a greater extent
+  partOfSpeech: r
+00100077-r:
+  definition:
+  - used to form the comparative of some adjectives and adverbs, indicates that the
+    adjective or adverb is less of something
+  example:
+  - less interesting
+  - less expensive
+  - less quickly
+  ili: i18761
+  members:
+  - less
+  - to a lesser extent
+  partOfSpeech: r
+00100262-r:
+  definition:
+  - comparative of much; to a greater degree or extent
+  example:
+  - he works more now
+  - they eat more than they should
+  ili: i18762
+  members:
+  - more
+  partOfSpeech: r
+00100418-r:
+  definition:
+  - comparative of little
+  example:
+  - she walks less than she should
+  - he works less these days
+  ili: i18763
+  members:
+  - less
+  partOfSpeech: r
+00100552-r:
+  definition:
+  - not much
+  example:
+  - he talked little about his family
+  ili: i18764
+  members:
+  - little
+  partOfSpeech: r
+00101751-r:
+  definition:
+  - remote in time
+  example:
+  - if we could see far into the future
+  - all that happened far in the past
+  ili: i18772
+  members:
+  - far
+  partOfSpeech: r
+00101873-r:
+  definition:
+  - to a considerable degree; very much
+  example:
+  - a far far better thing that I do
+  - felt far worse than yesterday
+  - eyes far too close together
+  ili: i18773
+  members:
+  - far
+  partOfSpeech: r
+00102040-r:
+  definition:
+  - at or to a certain point or degree
+  example:
+  - I can only go so far before I have to give up
+  - how far can we get with this kind of argument?
+  ili: i18774
+  members:
+  - far
+  partOfSpeech: r
+00102205-r:
+  definition:
+  - to an advanced stage or point
+  example:
+  - a young man who will go very far
+  ili: i18775
+  members:
+  - far
+  partOfSpeech: r
+00102302-r:
+  definition:
+  - to a great degree or by a great distance; very much (‘right smart’ is regional
+    in the United States)
+  example:
+  - way over budget
+  - way off base
+  - the other side of the hill is right smart steeper than the side we are on
+  exemplifies:
+  - 07089193-n
+  ili: i18776
+  members:
+  - way
+  - right smart
+  partOfSpeech: r
+00105032-r:
+  definition:
+  - not less than
+  example:
+  - at least two hours studying the manual
+  - a tumor at least as big as an orange
+  ili: i18796
+  members:
+  - at least
+  - at the least
+  partOfSpeech: r
+00105215-r:
+  definition:
+  - not more than
+  example:
+  - spend at most $20 on the lunch
+  ili: i18797
+  members:
+  - at most
+  - at the most
+  partOfSpeech: r
+00106595-r:
+  definition:
+  - under the worst of conditions
+  example:
+  - at worst we'll go to jail
+  ili: i18806
+  members:
+  - at worst
+  - at the worst
+  partOfSpeech: r
+00107917-r:
+  definition:
+  - to a remarkable degree or extent
+  example:
+  - she was unusually tall
+  - Notably missing from the network's fall line-up are any half-hour scripted comedies
+  ili: i18815
+  members:
+  - unusually
+  - remarkably
+  - unco
+  - notably
+  partOfSpeech: r
+00112194-r:
+  definition:
+  - in essence or effect but not in fact
+  example:
+  - the strike virtually paralyzed the city
+  - I'm virtually broke
+  ili: i18845
+  members:
+  - virtually
+  partOfSpeech: r
+00112352-r:
+  definition:
+  - used to form the superlative, greatest in size or degree
+  example:
+  - the king cobra is the most dangerous snake
+  ili: i18846
+  members:
+  - most
+  - to the highest degree
+  partOfSpeech: r
+00112501-r:
+  definition:
+  - used to form the superlative, smallest in size or degree
+  example:
+  - The garter snake is the least dangerous snake
+  ili: i18847
+  members:
+  - least
+  - to the lowest degree
+  partOfSpeech: r
+00113314-r:
+  definition:
+  - in such a manner as could not be otherwise
+  example:
+  - it is necessarily so
+  - we must needs be objective
+  ili: i18852
+  members:
+  - inevitably
+  - necessarily
+  - of necessity
+  - needs
+  partOfSpeech: r
+00114741-r:
+  definition:
+  - without fail
+  ili: i18861
+  members:
+  - unfailingly
+  partOfSpeech: r
+00115516-r:
+  definition:
+  - unpleasantly
+  example:
+  - his ignorance was painfully obvious
+  ili: i18867
+  members:
+  - painfully
+  - distressingly
+  partOfSpeech: r
+00115839-r:
+  definition:
+  - in or at or near a periphery or according to a peripheral role or function or
+    relationship
+  ili: i18869
+  members:
+  - peripherally
+  partOfSpeech: r
+00118279-r:
+  definition:
+  - to an extravagant or immoderate degree
+  example:
+  - atrociously expensive
+  ili: i18888
+  members:
+  - outrageously
+  - atrociously
+  partOfSpeech: r
+00120125-r:
+  definition:
+  - to a feasible extent
+  example:
+  - she helped him as much as possible
+  ili: i18900
+  members:
+  - as far as possible
+  - as much as possible
+  partOfSpeech: r
+00122434-r:
+  definition:
+  - enormously
+  example:
+  - the bill was astronomically high
+  ili: i18914
+  members:
+  - astronomically
+  partOfSpeech: r
+00128333-r:
+  definition:
+  - at the end
+  example:
+  - terminally ill
+  ili: i18963
+  members:
+  - terminally
+  partOfSpeech: r
+00133342-r:
+  definition:
+  - diabolically
+  example:
+  - infernally clever
+  - hellishly dangerous
+  exemplifies:
+  - 06332047-n
+  ili: i19008
+  members:
+  - infernally
+  - hellishly
+  partOfSpeech: r
+00133483-r:
+  definition:
+  - with respect to pathology
+  example:
+  - pathologically interesting results
+  ili: i19009
+  members:
+  - pathologically
+  partOfSpeech: r
+00133731-r:
+  definition:
+  - with unfortunate consequences
+  example:
+  - catastrophically complex
+  ili: i19011
+  members:
+  - catastrophically
+  partOfSpeech: r
+00137680-r:
+  definition:
+  - with respect to material aspects
+  example:
+  - psychologically similar but materially different
+  ili: i19048
+  members:
+  - materially
+  partOfSpeech: r
+00137821-r:
+  definition:
+  - to a significant degree
+  example:
+  - it aided him materially in winning the argument
+  ili: i19049
+  members:
+  - materially
+  partOfSpeech: r
+00139220-r:
+  definition:
+  - of primary import
+  example:
+  - this is primarily a question of economics
+  - it was in the first place a local matter
+  ili: i19059
+  members:
+  - primarily
+  - in the first place
+  partOfSpeech: r
+00141305-r:
+  definition:
+  - by three orders of magnitude
+  example:
+  - this poison is a thousand-fold more toxic
+  ili: i19072
+  members:
+  - thousand-fold
+  - thousand times
+  partOfSpeech: r
+00141793-r:
+  definition:
+  - having a rapid onset
+  example:
+  - an acutely debilitating virus
+  ili: i19075
+  members:
+  - acutely
+  partOfSpeech: r
+00143036-r:
+  definition:
+  - in a glaring manner
+  example:
+  - it was glaringly obvious
+  ili: i19086
+  members:
+  - glaringly
+  partOfSpeech: r
+00143696-r:
+  definition:
+  - in the manner of human beings
+  example:
+  - humanly possible
+  ili: i19092
+  members:
+  - humanly
+  partOfSpeech: r
+00143993-r:
+  definition:
+  - to an inconceivable degree
+  example:
+  - inconceivably small
+  ili: i19095
+  members:
+  - inconceivably
+  partOfSpeech: r
+00146607-r:
+  definition:
+  - to a sufficient degree
+  example:
+  - she was sufficiently fluent in Mandarin
+  ili: i19116
+  members:
+  - sufficiently
+  partOfSpeech: r
+00146749-r:
+  definition:
+  - as much as necessary
+  example:
+  - have I eaten enough?
+  - I've had plenty, thanks (‘plenty’ is nonstandard)
+  ili: i19117
+  members:
+  - enough
+  - plenty
+  partOfSpeech: r
+00146890-r:
+  definition:
+  - to an insufficient degree
+  example:
+  - he was insufficiently prepared
+  ili: i19118
+  members:
+  - insufficiently
+  partOfSpeech: r
+00147630-r:
+  definition:
+  - to a very great extent or degree
+  example:
+  - the idea is so obvious
+  - never been so happy
+  - I love you so
+  - my head aches so!
+  exemplifies:
+  - 06332047-n
+  ili: i19124
+  members:
+  - so
+  partOfSpeech: r
+00147799-r:
+  definition:
+  - (usually followed by ‘that’) to an extent or degree as expressed
+  example:
+  - he was so tired he could hardly stand
+  - so dirty that it smells
+  ili: i19125
+  members:
+  - so
+  partOfSpeech: r
+00148162-r:
+  definition:
+  - to a certain unspecified extent or degree
+  example:
+  - I can only go so far with this student
+  - can do only so much in a day
+  ili: i19127
+  members:
+  - so
+  partOfSpeech: r
+00148422-r:
+  definition:
+  - to so extreme a degree
+  example:
+  - he is such a baby
+  - Such rich people!
+  exemplifies:
+  - 06332047-n
+  ili: i19129
+  members:
+  - such
+  partOfSpeech: r
+00151490-r:
+  definition:
+  - in entirety
+  example:
+  - they bought the business in toto
+  - in recommendations were adopted in toto
+  ili: i19148
+  members:
+  - in toto
+  partOfSpeech: r
+00151616-r:
+  definition:
+  - to any extent at all
+  example:
+  - are you in the least interested?
+  ili: i19149
+  members:
+  - in the least
+  - even a little
+  partOfSpeech: r
+00153124-r:
+  definition:
+  - to the goal
+  example:
+  - she climbed the mountain all the way
+  ili: i19161
+  members:
+  - all the way
+  - the whole way
+  partOfSpeech: r
+00153231-r:
+  definition:
+  - not stopping short of sexual intercourse
+  example:
+  - she went all the way with him
+  ili: i19162
+  members:
+  - all the way
+  partOfSpeech: r
+00153403-r:
+  definition:
+  - an expression of emphatic agreement
+  ili: i19164
+  members:
+  - and how
+  - you bet
+  - you said it
+  partOfSpeech: r
+00153498-r:
+  definition:
+  - and considerably more in addition
+  example:
+  - it cost me a week's salary and then some
+  ili: i19165
+  members:
+  - and then some
+  partOfSpeech: r
+00154174-r:
+  definition:
+  - regardless of the cost involved
+  example:
+  - he wanted to save her life at all cost
+  ili: i19171
+  members:
+  - at all costs
+  - at any cost
+  - at any expense
+  partOfSpeech: r
+00156476-r:
+  definition:
+  - by a great deal
+  example:
+  - he is the best by a long shot
+  - his labors haven't ended there — not by a long shot
+  ili: i19189
+  members:
+  - by a long shot
+  partOfSpeech: r
+00158651-r:
+  definition:
+  - in every way; completely
+  example:
+  - he was every inch a statesman
+  ili: i19206
+  members:
+  - every inch
+  partOfSpeech: r
+00158747-r:
+  definition:
+  - so as to be complete; with everything necessary
+  example:
+  - he had filled out the form completely
+  - the apartment was completely furnished
+  ili: i19207
+  members:
+  - completely
+  partOfSpeech: r
+00158934-r:
+  definition:
+  - not to a full degree or extent
+  example:
+  - words incompletely understood
+  - a form filled out incompletely
+  ili: i19208
+  members:
+  - incompletely
+  partOfSpeech: r
+00159432-r:
+  definition:
+  - indicating exactness or preciseness
+  example:
+  - he was doing precisely (or exactly) what she had told him to do
+  - it was just as he said — the jewel was gone
+  - it has just enough salt
+  - source: Thomas Carlyle
+    text: Properly speaking, all true work is religion.
+  ili: i19211
+  members:
+  - precisely
+  - exactly
+  - just
+  - properly
+  partOfSpeech: r
+00161858-r:
+  definition:
+  - in a close manner
+  example:
+  - the two phenomena are intimately connected
+  - the person most nearly concerned
+  ili: i19228
+  members:
+  - closely
+  - intimately
+  - nearly
+  partOfSpeech: r
+00162033-r:
+  definition:
+  - in a relative manner; by comparison to something else
+  example:
+  - the situation is relatively calm now
+  ili: i19229
+  members:
+  - relatively
+  - comparatively
+  partOfSpeech: r
+00162217-r:
+  definition:
+  - much greater in number or influence
+  example:
+  - the patients are predominantly indigenous
+  ili: i19230
+  members:
+  - predominantly
+  - preponderantly
+  partOfSpeech: r
+00162493-r:
+  definition:
+  - in a clearly noticeable manner
+  example:
+  - sales of luxury cars dropped markedly
+  ili: i19232
+  members:
+  - markedly
+  partOfSpeech: r
+00162619-r:
+  definition:
+  - so as to be palpable
+  example:
+  - she was palpably nervous
+  ili: i19233
+  members:
+  - palpably
+  partOfSpeech: r
+00165665-r:
+  definition:
+  - without reservations
+  example:
+  - he believed her story hook, line, and sinker
+  ili: i19252
+  members:
+  - hook line and sinker
+  partOfSpeech: r
+00166660-r:
+  definition:
+  - proceeding with full vigor
+  example:
+  - the party was in full swing
+  ili: i19259
+  members:
+  - in full swing
+  - in full action
+  partOfSpeech: r
+00167003-r:
+  definition:
+  - by title or repute though not in fact
+  example:
+  - he's a doctor in name only
+  ili: i19262
+  members:
+  - in name
+  - in name only
+  partOfSpeech: r
+00169345-r:
+  definition:
+  - at full speed
+  example:
+  - she tackled the job lickety-split
+  ili: i19281
+  members:
+  - lickety split
+  - lickety cut
+  partOfSpeech: r
+00170319-r:
+  definition:
+  - on and on for a long time
+  example:
+  - the child cried no end
+  ili: i19285
+  members:
+  - no end
+  partOfSpeech: r
+00173980-r:
+  definition:
+  - in full
+  example:
+  - you are in this to the hilt
+  ili: i19315
+  members:
+  - to the hilt
+  - to the limit
+  partOfSpeech: r
+00174785-r:
+  definition:
+  - to a great depth psychologically or emotionally
+  example:
+  - They felt the loss deeply
+  - she loved him intensely
+  ili: i19322
+  members:
+  - profoundly
+  - deeply
+  - intensely
+  partOfSpeech: r
+00176221-r:
+  definition:
+  - to an extreme or greatly exaggerated degree
+  example:
+  - the storyline is wildly unrealistic
+  ili: i19332
+  members:
+  - wildly
+  partOfSpeech: r
+00177869-r:
+  definition:
+  - to a considerable degree
+  example:
+  - he relied heavily on others' data
+  ili: i19344
+  members:
+  - heavily
+  - to a great extent
+  partOfSpeech: r
+00178660-r:
+  definition:
+  - inflexibly; unshakably
+  example:
+  - adamantly opposed to the marriage
+  ili: i19350
+  members:
+  - adamantly
+  partOfSpeech: r
+00178775-r:
+  definition:
+  - with strength or in a strong manner
+  example:
+  - argues very strongly for his proposal
+  - he was strongly opposed to the government
+  ili: i19351
+  members:
+  - strongly
+  partOfSpeech: r
+00179828-r:
+  definition:
+  - in a radical manner
+  example:
+  - she took a radically different approach
+  ili: i19359
+  members:
+  - radically
+  partOfSpeech: r
+00180279-r:
+  definition:
+  - to an exceptional degree
+  example:
+  - it worked exceptionally well
+  ili: i19362
+  members:
+  - exceptionally
+  partOfSpeech: r
+00180395-r:
+  definition:
+  - sufficiently; more than adequately
+  example:
+  - the evidence amply (or fully) confirms our suspicions
+  - they were fully (or amply) fed
+  ili: i19363
+  members:
+  - amply
+  - fully
+  partOfSpeech: r
+00181654-r:
+  definition:
+  - to a slight degree
+  example:
+  - her speech is only lightly accented
+  ili: i19373
+  members:
+  - lightly
+  partOfSpeech: r
+00183387-r:
+  definition:
+  - clear to the mind; with distinct mental discernment
+  example:
+  - it's distinctly possible
+  - I could clearly see myself in his situation
+  ili: i19386
+  members:
+  - distinctly
+  - clearly
+  partOfSpeech: r
+00183685-r:
+  definition:
+  - downright
+  example:
+  - it was positively monumental
+  exemplifies:
+  - 06332047-n
+  ili: i19388
+  members:
+  - positively
+  partOfSpeech: r
+00184008-r:
+  definition:
+  - in a levelheaded manner
+  example:
+  - the answers were healthily individual
+  ili: i19390
+  members:
+  - healthily
+  partOfSpeech: r
+00184128-r:
+  definition:
+  - in a hilarious manner
+  example:
+  - hilariously funny
+  ili: i19391
+  members:
+  - hilariously
+  - uproariously
+  partOfSpeech: r
+00184576-r:
+  definition:
+  - (used as an intensifier) excellently
+  example:
+  - her voice is superbly disciplined
+  - the colors changed wondrously slowly
+  exemplifies:
+  - 06332047-n
+  ili: i19394
+  members:
+  - wonderfully
+  - wondrous
+  - wondrously
+  - superbly
+  - toppingly
+  - marvellously
+  - terrifically
+  - marvelously
+  partOfSpeech: r
+00184950-r:
+  definition:
+  - in a gratifying manner
+  example:
+  - the performance was at a gratifyingly high level
+  ili: i19395
+  members:
+  - gratifyingly
+  - satisfyingly
+  partOfSpeech: r
+00185098-r:
+  definition:
+  - flawlessly
+  example:
+  - the film was impeccably authentic
+  ili: i19396
+  members:
+  - impeccably
+  partOfSpeech: r
+00189865-r:
+  definition:
+  - with respect to dramatic value
+  example:
+  - the play was dramatically interesting, but the direction was bad
+  ili: i19433
+  members:
+  - dramatically
+  partOfSpeech: r
+00190112-r:
+  definition:
+  - in a similar way
+  ili: i19435
+  members:
+  - much as
+  - very much like
+  partOfSpeech: r
+00192221-r:
+  definition:
+  - in coarse pieces
+  example:
+  - the surfaces were coarsely granular
+  ili: i19451
+  members:
+  - coarsely
+  partOfSpeech: r
+00192349-r:
+  definition:
+  - in tiny pieces
+  example:
+  - the surfaces were finely granular
+  ili: i19452
+  members:
+  - finely
+  partOfSpeech: r
+00196734-r:
+  definition:
+  - in every case
+  example:
+  - people universally agree on this
+  ili: i19486
+  members:
+  - universally
+  partOfSpeech: r
+00197952-r:
+  definition:
+  - vastly
+  example:
+  - he was enormously popular
+  ili: i19495
+  members:
+  - enormously
+  - tremendously
+  - hugely
+  - staggeringly
+  partOfSpeech: r
+00198991-r:
+  definition:
+  - in an inconvenient manner
+  example:
+  - he arrived at an inconveniently late hour
+  ili: i19502
+  members:
+  - inconveniently
+  partOfSpeech: r
+00202043-r:
+  definition:
+  - in a hopeless manner
+  example:
+  - the papers were hopelessly jumbled
+  - he is hopelessly romantic
+  exemplifies:
+  - 07089193-n
+  ili: i19523
+  members:
+  - hopelessly
+  partOfSpeech: r
+00206480-r:
+  definition:
+  - precisely, exactly
+  example:
+  - stand right here!
+  ili: i19553
+  members:
+  - right
+  partOfSpeech: r
+00210536-r:
+  definition:
+  - in a bewildering and confusing manner
+  example:
+  - her situation was bewilderingly unclear
+  ili: i19583
+  members:
+  - bewilderingly
+  - confusingly
+  partOfSpeech: r
+00211285-r:
+  definition:
+  - in a spectacular manner
+  example:
+  - the area was spectacularly scenic
+  ili: i19588
+  members:
+  - spectacularly
+  - stunningly
+  partOfSpeech: r
+00212529-r:
+  definition:
+  - in a humiliating manner
+  example:
+  - the painting was reproduced humiliatingly small
+  ili: i19597
+  members:
+  - humiliatingly
+  - demeaningly
+  partOfSpeech: r
+00212949-r:
+  definition:
+  - in a well delineated manner
+  example:
+  - the new style of Minoan pottery was sharply defined
+  ili: i19600
+  members:
+  - sharply
+  - crisply
+  partOfSpeech: r
+00213709-r:
+  definition:
+  - of a minor or subordinate nature
+  example:
+  - these magnificent achievements were only incidentally influenced by Oriental models
+  ili: i19605
+  members:
+  - incidentally
+  - accidentally
+  partOfSpeech: r
+00213902-r:
+  definition:
+  - (intensifier for adjectives) very
+  example:
+  - she was ever so friendly
+  exemplifies:
+  - 06332047-n
+  ili: i19606
+  members:
+  - ever
+  - ever so
+  partOfSpeech: r
+00214822-r:
+  definition:
+  - in an impressive manner
+  example:
+  - the students progressed impressively fast
+  ili: i19613
+  members:
+  - impressively
+  - imposingly
+  partOfSpeech: r
+00215852-r:
+  definition:
+  - in an abundant manner
+  example:
+  - they were abundantly supplied with food
+  - he thanked her profusely
+  ili: i19619
+  members:
+  - abundantly
+  - copiously
+  - profusely
+  - extravagantly
+  partOfSpeech: r
+00216535-r:
+  definition:
+  - with moderation; in a moderate manner
+  example:
+  - he drinks moderately
+  ili: i19623
+  members:
+  - moderately
+  partOfSpeech: r
+00216959-r:
+  definition:
+  - in an unrealistic manner
+  example:
+  - his expectations were unrealistically high
+  ili: i19626
+  members:
+  - unrealistically
+  partOfSpeech: r
+00217783-r:
+  definition:
+  - to the maximum degree
+  example:
+  - he was supremely confident
+  - He seemed irritated at Edouard's questions but, apart from that, sublimely unconcerned
+  - she remained sublimely oblivious to the possible havoc she might have caused
+  ili: i19631
+  members:
+  - supremely
+  - sublimely
+  partOfSpeech: r
+00220590-r:
+  definition:
+  - in an enjoyable manner
+  example:
+  - we spent a pleasantly lazy afternoon
+  ili: i19647
+  members:
+  - pleasantly
+  - agreeably
+  - enjoyably
+  partOfSpeech: r
+00226558-r:
+  definition:
+  - continuing forever without end
+  example:
+  - there are infinitely many possibilities
+  ili: i19683
+  members:
+  - infinitely
+  - endlessly
+  partOfSpeech: r
+00226736-r:
+  definition:
+  - with a finite limit
+  example:
+  - there are finitely many solutions to this problem
+  ili: i19684
+  members:
+  - finitely
+  partOfSpeech: r
+00226881-r:
+  definition:
+  - without bounds
+  example:
+  - he is infinitely wealthy
+  ili: i19685
+  members:
+  - boundlessly
+  - immeasurably
+  - infinitely
+  partOfSpeech: r
+00227422-r:
+  definition:
+  - in a major way
+  example:
+  - the play failed big at the box office
+  ili: i19689
+  members:
+  - big
+  partOfSpeech: r
+00230431-r:
+  definition:
+  - in a round manner
+  example:
+  - she was roundly slim
+  ili: i19714
+  members:
+  - roundly
+  partOfSpeech: r
+00231579-r:
+  definition:
+  - without qualification or limitation
+  ili: i19722
+  members:
+  - unqualifiedly
+  partOfSpeech: r
+00234156-r:
+  definition:
+  - excessively
+  example:
+  - a cruelly bitter winter
+  ili: i19741
+  members:
+  - cruelly
+  partOfSpeech: r
+00234331-r:
+  definition:
+  - in a vague way
+  example:
+  - he looked vaguely familiar
+  - he explained it somewhat mistily
+  ili: i19743
+  members:
+  - vaguely
+  - mistily
+  partOfSpeech: r
+00238879-r:
+  definition:
+  - in a fascinating manner
+  example:
+  - her face became fascinatingly distorted
+  ili: i19774
+  members:
+  - fascinatingly
+  partOfSpeech: r
+00241415-r:
+  definition:
+  - incapable of being resisted
+  example:
+  - the candy looked overwhelmingly desirable to the dieting man
+  ili: i19792
+  members:
+  - overwhelmingly
+  - overpoweringly
+  - irresistibly
+  partOfSpeech: r
+00246246-r:
+  definition:
+  - in an unbelievable manner
+  example:
+  - he was unbelievably angry
+  ili: i19827
+  members:
+  - unbelievably
+  partOfSpeech: r
+00247047-r:
+  definition:
+  - in an emotionally fierce manner
+  example:
+  - she was fiercely proud of her children
+  ili: i19833
+  members:
+  - fiercely
+  partOfSpeech: r
+00247755-r:
+  definition:
+  - (used for emphasis) absolutely
+  example:
+  - I just can't take it anymore
+  - he was just grand as Romeo
+  - it's simply beautiful!
+  exemplifies:
+  - 06332047-n
+  ili: i19839
+  members:
+  - just
+  - simply
+  partOfSpeech: r
+00247934-r:
+  definition:
+  - by ten times as much
+  example:
+  - the population increased tenfold
+  ili: i19840
+  members:
+  - tenfold
+  partOfSpeech: r
+00248281-r:
+  definition:
+  - in a very impressive manner
+  example:
+  - your performance will improve dramatically
+  ili: i19843
+  members:
+  - dramatically
+  partOfSpeech: r
+00249338-r:
+  definition:
+  - deliberately deviant
+  example:
+  - his perversely erotic notions
+  ili: i19851
+  members:
+  - perversely
+  partOfSpeech: r
+00249967-r:
+  definition:
+  - uniquely or characteristically
+  example:
+  - these peculiarly cinematic elements
+  - a peculiarly French phenomenon
+  - source: John Knowles
+    text: everyone has a moment in history which belongs particularly to him
+  ili: i19856
+  members:
+  - peculiarly
+  - particularly
+  partOfSpeech: r
+00251622-r:
+  definition:
+  - in a uniform manner
+  example:
+  - a uniformly bright surface
+  ili: i19868
+  members:
+  - uniformly
+  partOfSpeech: r
+00251727-r:
+  definition:
+  - to a high degree
+  example:
+  - she is all too ready to accept the job
+  ili: i19869
+  members:
+  - all too
+  - only too
+  partOfSpeech: r
+00252542-r:
+  definition:
+  - to a sickening extent
+  example:
+  - he played the song ad nauseam
+  ili: i19876
+  members:
+  - ad nauseam
+  partOfSpeech: r
+00253175-r:
+  definition:
+  - at all points from head to foot
+  example:
+  - he was armed cap-a-pie
+  ili: i19882
+  members:
+  - cap-a-pie
+  - from head to toe
+  partOfSpeech: r
+00255089-r:
+  definition:
+  - as completely as possible
+  example:
+  - it was chock-a-block full
+  ili: i19897
+  members:
+  - chock
+  - chock-a-block
+  partOfSpeech: r
+00255193-r:
+  definition:
+  - in an overly sweet manner
+  ili: i19898
+  members:
+  - cloyingly
+  partOfSpeech: r
+00256007-r:
+  definition:
+  - to a degree resembling death
+  example:
+  - he was deathly pale
+  ili: i19904
+  members:
+  - deathly
+  partOfSpeech: r
+00258220-r:
+  definition:
+  - plus or minus a small amount
+  example:
+  - it is a mile away, give or take a few hundred yards
+  ili: i19923
+  members:
+  - give or take
+  partOfSpeech: r
+00258439-r:
+  definition:
+  - to a degree of excellence
+  example:
+  - he is the honest politician par excellence
+  ili: i19925
+  members:
+  - par excellence
+  partOfSpeech: r
+00262820-r:
+  definition:
+  - in a very painful manner
+  example:
+  - the progress was agonizingly slow
+  ili: i19967
+  members:
+  - agonizingly
+  - excruciatingly
+  - torturously
+  partOfSpeech: r
+00263006-r:
+  definition:
+  - to an appalling extent
+  example:
+  - the prisoners were appallingly thin
+  ili: i19968
+  members:
+  - appallingly
+  partOfSpeech: r
+00263256-r:
+  definition:
+  - in an unappealing manner
+  example:
+  - the kitchen was unappealingly dirty
+  ili: i19970
+  members:
+  - unappealingly
+  partOfSpeech: r
+00270584-r:
+  definition:
+  - genuinely; with authority
+  example:
+  - it is authentically British
+  ili: i20021
+  members:
+  - authentically
+  - genuinely
+  partOfSpeech: r
+00271019-r:
+  definition:
+  - in a grandiose manner
+  example:
+  - the building was bombastically spacious
+  ili: i20024
+  members:
+  - bombastically
+  - grandiosely
+  partOfSpeech: r
+00275453-r:
+  definition:
+  - not in accordance with the season
+  example:
+  - it was unseasonably cold
+  ili: i20058
+  members:
+  - unseasonably
+  partOfSpeech: r
+00276272-r:
+  definition:
+  - in a blissful manner
+  example:
+  - he was blissfully unaware of the danger
+  ili: i20064
+  members:
+  - blissfully
+  partOfSpeech: r
+00280264-r:
+  definition:
+  - in a bewitching manner
+  example:
+  - she was bewitchingly beautiful
+  ili: i20095
+  members:
+  - bewitchingly
+  - captivatingly
+  - enchantingly
+  - enthrallingly
+  partOfSpeech: r
+00283116-r:
+  definition:
+  - unpredictably
+  example:
+  - the weather has been freakishly variable
+  ili: i20115
+  members:
+  - capriciously
+  - freakishly
+  partOfSpeech: r
+00287169-r:
+  definition:
+  - entirely
+  example:
+  - read the book clear to the end
+  - slept clear through the night
+  - there were open fields clear to the horizon
+  ili: i20140
+  members:
+  - clear
+  - all the way
+  partOfSpeech: r
+00293079-r:
+  definition:
+  - in a shameful manner
+  example:
+  - the garden was criminally neglected
+  ili: i20180
+  members:
+  - criminally
+  - reprehensively
+  partOfSpeech: r
+00294248-r:
+  definition:
+  - to a crucial degree
+  example:
+  - crucially important
+  - crucially, he must meet us at the airport
+  ili: i20188
+  members:
+  - crucially
+  partOfSpeech: r
+00298819-r:
+  definition:
+  - in a damnable manner
+  example:
+  - kindly Arthur — so damnably, politely, endlessly persistent!
+  ili: i20214
+  members:
+  - damned
+  - damnably
+  - cursedly
+  partOfSpeech: r
+00299197-r:
+  definition:
+  - to a degree or in a manner that daunts
+  example:
+  - dauntingly difficult
+  ili: i20216
+  members:
+  - dauntingly
+  partOfSpeech: r
+00301007-r:
+  definition:
+  - in a concentrated manner
+  example:
+  - old houses are often so densely packed that perhaps three or four have to be demolished
+    for every new one built
+  - a thickly populated area
+  ili: i20228
+  members:
+  - densely
+  - thickly
+  partOfSpeech: r
+00302054-r:
+  definition:
+  - to a degree impossible of achievement
+  example:
+  - long thought to be an impossibly difficult operation
+  - impossibly far from sources of supply
+  ili: i20233
+  members:
+  - impossibly
+  partOfSpeech: r
+00302411-r:
+  definition:
+  - in an absurd manner or to an absurd degree
+  example:
+  - an absurdly rich young woman
+  ili: i20235
+  members:
+  - absurdly
+  partOfSpeech: r
+00303492-r:
+  definition:
+  - in a playfully devilish manner
+  example:
+  - the socialists are further handicapped if they believe that capitalists are not
+    only wicked but also devilishly clever
+  ili: i20242
+  members:
+  - devilishly
+  - devilish
+  partOfSpeech: r
+00304906-r:
+  definition:
+  - in a crushing manner
+  example:
+  - the team was crushingly defeated
+  ili: i20251
+  members:
+  - crushingly
+  partOfSpeech: r
+00306956-r:
+  definition:
+  - to a great depth; far down or in
+  example:
+  - dived deeply
+  - dug deep
+  ili: i20266
+  members:
+  - deeply
+  - deep
+  partOfSpeech: r
+00308726-r:
+  definition:
+  - in an unpleasantly offensive manner
+  example:
+  - he smelled offensively unwashed
+  ili: i20276
+  members:
+  - offensively
+  partOfSpeech: r
+00308872-r:
+  definition:
+  - to a distinct degree
+  example:
+  - urbanization in Spain is distinctly correlated with a fall in reproductive rate
+  ili: i20277
+  members:
+  - distinctly
+  partOfSpeech: r
+00309032-r:
+  definition:
+  - in a distinct and distinguishable manner
+  example:
+  - the subtleties of this distinctly British occasion
+  ili: i20278
+  members:
+  - distinctly
+  partOfSpeech: r
+00309700-r:
+  definition:
+  - in a delirious manner
+  example:
+  - her answer made him deliriously happy
+  ili: i20283
+  members:
+  - deliriously
+  partOfSpeech: r
+00310309-r:
+  definition:
+  - as a devil; in an evil manner
+  example:
+  - his writing could be diabolically satiric
+  ili: i20287
+  members:
+  - diabolically
+  - devilishly
+  - fiendishly
+  partOfSpeech: r
+00311786-r:
+  definition:
+  - in a devout and pious manner
+  example:
+  - she was devoutly Catholic
+  ili: i20297
+  members:
+  - devoutly
+  - piously
+  partOfSpeech: r
+00314485-r:
+  definition:
+  - in a disastrous manner
+  example:
+  - the real value of the trust capital may be disastrously less than when the trust
+    began
+  ili: i20312
+  members:
+  - disastrously
+  partOfSpeech: r
+00314656-r:
+  definition:
+  - in a disturbing or embarrassing manner
+  example:
+  - he drank some sherry, his eyes disconcertingly keen as he watched her
+  ili: i20313
+  members:
+  - disconcertingly
+  partOfSpeech: r
+00315026-r:
+  definition:
+  - in a dishonorable manner or to a dishonorable degree
+  example:
+  - his grades were disgracefully low
+  ili: i20315
+  members:
+  - disgracefully
+  - ingloriously
+  - ignominiously
+  - discreditably
+  - shamefully
+  - dishonorably
+  - dishonourably
+  partOfSpeech: r
+00315534-r:
+  definition:
+  - in a disgusting manner or to a disgusting degree
+  example:
+  - the beggar was disgustingly filthy
+  ili: i20317
+  members:
+  - disgustingly
+  - distastefully
+  - revoltingly
+  - sickeningly
+  partOfSpeech: r
+00319536-r:
+  definition:
+  - to a disproportionate degree
+  example:
+  - his benefits were disproportionately generous
+  ili: i20337
+  members:
+  - disproportionately
+  partOfSpeech: r
+00319696-r:
+  definition:
+  - to a proportionate degree
+  example:
+  - your salary will rise proportionately to your workload
+  ili: i20338
+  members:
+  - proportionately
+  - proportionally
+  partOfSpeech: r
+00319894-r:
+  definition:
+  - in a manner which is out of proportion
+  example:
+  - this wall is disproportionately long
+  ili: i20339
+  members:
+  - disproportionately
+  partOfSpeech: r
+00320344-r:
+  definition:
+  - in a disquieting manner
+  example:
+  - the disquietingly close sounds of gunfire
+  ili: i20342
+  members:
+  - disquietingly
+  partOfSpeech: r
+00322170-r:
+  definition:
+  - in a disturbing manner
+  example:
+  - the details of the kidnapper's letter had sounded disturbingly convincing
+  ili: i20354
+  members:
+  - disturbingly
+  partOfSpeech: r
+00323217-r:
+  definition:
+  - two together
+  example:
+  - some people sleep better double
+  ili: i20361
+  members:
+  - double
+  partOfSpeech: r
+00323386-r:
+  definition:
+  - at a faster speed
+  example:
+  - now let's play the piece again double-quick
+  ili: i20363
+  members:
+  - double time
+  - double quick
+  partOfSpeech: r
+00329628-r:
+  definition:
+  - causing embarrassment
+  example:
+  - the great man was embarrassingly humble and self-effacing
+  ili: i20405
+  members:
+  - embarrassingly
+  partOfSpeech: r
+00329771-r:
+  definition:
+  - in an eminent manner
+  example:
+  - two subjects on which he was eminently qualified to make an original contribution
+  ili: i20406
+  members:
+  - eminently
+  partOfSpeech: r
+00330223-r:
+  definition:
+  - in a discouraging manner
+  example:
+  - the failure rate on the bar exam is discouragingly high
+  ili: i20409
+  members:
+  - discouragingly
+  partOfSpeech: r
+00331161-r:
+  definition:
+  - in an equable manner
+  example:
+  - he is an equably cheerful fellow
+  ili: i20416
+  members:
+  - equably
+  partOfSpeech: r
+00335065-r:
+  definition:
+  - in an unpardonable manner or to an unpardonable degree
+  example:
+  - he was inexcusably cruel to his wife
+  ili: i20438
+  members:
+  - inexcusably
+  - unpardonably
+  - unforgivably
+  partOfSpeech: r
+00335337-r:
+  definition:
+  - to an exorbitant degree
+  example:
+  - prices are exorbitantly high in the capital
+  ili: i20439
+  members:
+  - exorbitantly
+  - extortionately
+  - usuriously
+  partOfSpeech: r
+00336240-r:
+  definition:
+  - in an explosive manner
+  example:
+  - the political situation in Kashmir and Jammu is explosively unstable
+  ili: i20445
+  members:
+  - explosively
+  partOfSpeech: r
+00336392-r:
+  definition:
+  - in an exponential manner
+  example:
+  - inflation is growing exponentially
+  ili: i20446
+  members:
+  - exponentially
+  partOfSpeech: r
+00337268-r:
+  definition:
+  - in an exuberant manner
+  example:
+  - the exuberantly baroque decoration of the church
+  ili: i20452
+  members:
+  - exuberantly
+  - riotously
+  partOfSpeech: r
+00341323-r:
+  definition:
+  - with passionate fervor
+  example:
+  - both those for and against are fervently convinced they speak for the great majority
+    of the people
+  - a fierily opinionated book
+  ili: i20477
+  members:
+  - fierily
+  - fervently
+  - fervidly
+  partOfSpeech: r
+00342247-r:
+  definition:
+  - quite well
+  example:
+  - she doesn't feel first-rate today
+  ili: i20483
+  members:
+  - first-rate
+  - very well
+  partOfSpeech: r
+00345178-r:
+  definition:
+  - in a formidable manner
+  example:
+  - the constant risk that attends the exchanges of human beings formidably armed
+  ili: i20505
+  members:
+  - formidably
+  partOfSpeech: r
+00346296-r:
+  definition:
+  - by a factor of four
+  example:
+  - the price of gasoline has increased fourfold over the past two years
+  ili: i20513
+  members:
+  - fourfold
+  - four times
+  partOfSpeech: r
+00346455-r:
+  definition:
+  - by a factor of a million
+  example:
+  - it increased a millionfold
+  ili: i20514
+  members:
+  - millionfold
+  - a million times
+  partOfSpeech: r
+00347587-r:
+  definition:
+  - in a terrifying manner
+  example:
+  - the disturbing thing about the Minister's behavior is that far from being artificial,
+    it too often rings frighteningly true
+  ili: i20522
+  members:
+  - frighteningly
+  - scarily
+  partOfSpeech: r
+00350707-r:
+  definition:
+  - blessedly or wonderfully
+  example:
+  - how gloriously happy she had been during those few fleeting moments of time
+  ili: i20543
+  members:
+  - gloriously
+  partOfSpeech: r
+00351763-r:
+  definition:
+  - expressing anger, despair, frustration, approval, or surprise
+  example:
+  - you are goddamn right!
+  exemplifies:
+  - 06332047-n
+  - 07139048-n
+  ili: i20551
+  members:
+  - goddam
+  - goddamn
+  - goddamned
+  partOfSpeech: r
+00352189-r:
+  definition:
+  - in a grand manner
+  example:
+  - the mansion seemed grandly large by today's standards
+  ili: i20554
+  members:
+  - grandly
+  partOfSpeech: r
+00353034-r:
+  definition:
+  - in a grievous manner
+  example:
+  - the resolute but unbroken Germany, grievously wounded but far from destruction,
+    was able to lay the firm foundations for military revival
+  ili: i20560
+  members:
+  - grievously
+  partOfSpeech: r
+00353338-r:
+  definition:
+  - in a grotesque manner
+  example:
+  - behind the house lay two nude figures grotesquely bald, with deliberate knife-slashes
+    marking their bodies
+  ili: i20562
+  members:
+  - grotesquely
+  - monstrously
+  partOfSpeech: r
+00356876-r:
+  definition:
+  - very much
+  example:
+  - thanks heaps
+  exemplifies:
+  - 07089193-n
+  ili: i20588
+  members:
+  - heaps
+  partOfSpeech: r
+00358561-r:
+  definition:
+  - in a hideous manner
+  example:
+  - her face was hideously disfigured after the accident
+  ili: i20601
+  members:
+  - hideously
+  - horridly
+  - monstrously
+  partOfSpeech: r
+00358935-r:
+  definition:
+  - in or to a high position, amount, or degree
+  example:
+  - prices have gone up far too high
+  ili: i20604
+  members:
+  - high
+  partOfSpeech: r
+00361728-r:
+  definition:
+  - by a factor of one hundred
+  example:
+  - their money increased a hundredfold
+  ili: i20624
+  members:
+  - hundredfold
+  - a hundred times
+  partOfSpeech: r
+00362861-r:
+  definition:
+  - with complete identity; in an identical manner
+  example:
+  - he is fitted with an identically similar one
+  ili: i20631
+  members:
+  - identically
+  partOfSpeech: r
+00363013-r:
+  definition:
+  - in an identifiable manner
+  example:
+  - they were identifiably different
+  ili: i20632
+  members:
+  - identifiably
+  partOfSpeech: r
+00365674-r:
+  definition:
+  - in an illustrious manner
+  example:
+  - Einstein, the illustriously famous physicist of the 20th century
+  ili: i20648
+  members:
+  - illustriously
+  partOfSpeech: r
+00367464-r:
+  definition:
+  - in a noticeable manner
+  example:
+  - he changed noticeably over the years
+  ili: i20659
+  members:
+  - perceptibly
+  - noticeably
+  - observably
+  partOfSpeech: r
+00369961-r:
+  definition:
+  - to an impracticable degree
+  example:
+  - this is still impracticably high
+  ili: i20674
+  members:
+  - impracticably
+  partOfSpeech: r
+00370603-r:
+  definition:
+  - in an impregnable manner
+  example:
+  - the sight of that bland, impregnably righteous face has been enough to make their
+    blood run cold
+  ili: i20678
+  members:
+  - impregnably
+  partOfSpeech: r
+00371514-r:
+  definition:
+  - in an adequate manner or to an adequate degree
+  example:
+  - he was adequately prepared
+  ili: i20683
+  members:
+  - adequately
+  partOfSpeech: r
+00371665-r:
+  definition:
+  - in an inadequate manner or to an inadequate degree
+  example:
+  - the temporary camps were inadequately equipped
+  ili: i20684
+  members:
+  - inadequately
+  partOfSpeech: r
+00372217-r:
+  definition:
+  - in an incomparable manner or to an incomparable degree
+  example:
+  - she is incomparably gifted
+  ili: i20688
+  members:
+  - incomparably
+  - uncomparably
+  partOfSpeech: r
+00372393-r:
+  definition:
+  - in a comparable manner or to a comparable degree
+  example:
+  - you will have to work comparably harder
+  ili: i20689
+  members:
+  - comparably
+  partOfSpeech: r
+00373228-r:
+  definition:
+  - in a manner impossible to cure
+  example:
+  - he is incurably ill
+  ili: i20694
+  members:
+  - incurably
+  partOfSpeech: r
+00373337-r:
+  definition:
+  - to an incurable degree
+  example:
+  - she was incurably optimistic
+  ili: i20695
+  members:
+  - incurably
+  partOfSpeech: r
+00373649-r:
+  definition:
+  - to an inexpressible degree
+  example:
+  - she was looking very young tonight, and, as usual, indescribably beautiful, in
+    a simple strapless dress of a green and white silky cotton
+  ili: i20697
+  members:
+  - ineffably
+  - indescribably
+  - unutterably
+  - unspeakably
+  - inexpressibly
+  partOfSpeech: r
+00374004-r:
+  definition:
+  - in an indeterminable manner
+  example:
+  - their relationship was of an indeterminably vague nature
+  ili: i20698
+  members:
+  - indeterminably
+  partOfSpeech: r
+00375046-r:
+  definition:
+  - in a manner or to a degree that could not be doubted
+  example:
+  - it was immediately and indubitably apparent that I had interrupted a scene of
+    lovers
+  - his guilt was established beyond a shadow of a doubt
+  ili: i20704
+  members:
+  - indubitably
+  - beyond doubt
+  - beyond a doubt
+  - beyond a shadow of a doubt
+  partOfSpeech: r
+00376993-r:
+  definition:
+  - in an inherent manner
+  example:
+  - the subject matter is sexual activity of any overt kind, which is depicted as
+    inherently desirable and exciting
+  ili: i20714
+  members:
+  - inherently
+  partOfSpeech: r
+00377186-r:
+  definition:
+  - in an unreproducible manner
+  example:
+  - he has an inimitably verbose style
+  ili: i20715
+  members:
+  - inimitably
+  - unreproducibly
+  partOfSpeech: r
+00377343-r:
+  definition:
+  - in an iniquitous manner
+  example:
+  - they really believed that the treaty of Versailles was iniquitously injust
+  ili: i20716
+  members:
+  - iniquitously
+  partOfSpeech: r
+00378591-r:
+  definition:
+  - to an insatiable degree
+  example:
+  - she was insatiably hungry
+  ili: i20724
+  members:
+  - insatiably
+  - unsatiably
+  partOfSpeech: r
+00381063-r:
+  definition:
+  - to such an extent or degree; so
+  ili: i20738
+  members:
+  - insomuch
+  partOfSpeech: r
+00381262-r:
+  definition:
+  - in a strong substantial way
+  example:
+  - the house was substantially built
+  ili: i20740
+  members:
+  - substantially
+  partOfSpeech: r
+00381646-r:
+  definition:
+  - to an insuperable degree
+  example:
+  - these various courses all seemed insuperably difficult to the student
+  ili: i20743
+  members:
+  - insuperably
+  partOfSpeech: r
+00382065-r:
+  definition:
+  - to an intermediate degree
+  example:
+  - intermediately hot
+  ili: i20746
+  members:
+  - intermediately
+  partOfSpeech: r
+00384736-r:
+  definition:
+  - in an irretrievable manner
+  example:
+  - it is irretrievably lost
+  ili: i20766
+  members:
+  - irretrievably
+  partOfSpeech: r
+00386914-r:
+  definition:
+  - in a keen or penetrating way
+  example:
+  - he was keenly aware of his own shortcomings
+  - she pitied her sister acutely
+  - acutely aware
+  ili: i21654
+  members:
+  - keenly
+  - acutely
+  partOfSpeech: r
+00387120-r:
+  definition:
+  - in a very humorous manner
+  ili: i20782
+  members:
+  - killingly
+  - sidesplittingly
+  partOfSpeech: r
+00388297-r:
+  definition:
+  - at a distance, wide of something (as of a mark)
+  ili: i20791
+  members:
+  - large
+  partOfSpeech: r
+00388921-r:
+  definition:
+  - so as to arouse or deserve laughter
+  example:
+  - her income was laughably small, but she managed to live well
+  ili: i20795
+  members:
+  - laughably
+  - ridiculously
+  - ludicrously
+  - preposterously
+  partOfSpeech: r
+00391862-r:
+  definition:
+  - in a manner marked by complexity and richness of detail
+  example:
+  - this suave, culture-loving and luxuriantly good-looking M.P. represents the car-workers
+    of Coventry
+  ili: i20814
+  members:
+  - luxuriantly
+  partOfSpeech: r
+00392194-r:
+  definition:
+  - so as to be manageable
+  example:
+  - this house is manageably small
+  ili: i20816
+  members:
+  - manageably
+  partOfSpeech: r
+00392325-r:
+  definition:
+  - so as to be unmanageable
+  example:
+  - ‘This house is unmanageably large,’ she complained
+  ili: i20817
+  members:
+  - unmanageably
+  partOfSpeech: r
+00395592-r:
+  definition:
+  - so as to produce a delightful taste
+  example:
+  - I bought some more of these deliciously sweet peaches
+  ili: i20842
+  members:
+  - lusciously
+  - deliciously
+  - scrumptiously
+  partOfSpeech: r
+00397478-r:
+  definition:
+  - to a massive degree or in a massive manner
+  example:
+  - tonight the haddock were shoaling massively in three hundred fathoms
+  ili: i20857
+  members:
+  - massively
+  partOfSpeech: r
+00398267-r:
+  definition:
+  - to a maximal degree
+  example:
+  - the cells maximally responsive to lines in this orientation will fire
+  ili: i20862
+  members:
+  - maximally
+  partOfSpeech: r
+00398433-r:
+  definition:
+  - to a minimal degree
+  example:
+  - the cells minimally responsive to lines in this orientation will not fire
+  ili: i20863
+  members:
+  - minimally
+  partOfSpeech: r
+00398603-r:
+  definition:
+  - to a meager degree or in a meager manner
+  example:
+  - these voices are meagerly represented at the conference
+  - the area is slenderly endowed with natural resources
+  ili: i20864
+  members:
+  - meagerly
+  - sparingly
+  - slenderly
+  - meagrely
+  partOfSpeech: r
+00398920-r:
+  definition:
+  - to an ample degree or in an ample manner
+  example:
+  - these voices were amply represented
+  - we benefited richly
+  ili: i20865
+  members:
+  - amply
+  - richly
+  partOfSpeech: r
+00399919-r:
+  definition:
+  - to an immeasurable degree; beyond measurement
+  example:
+  - the war left him immeasurably fearful of what man can do to man
+  ili: i20872
+  members:
+  - immeasurably
+  partOfSpeech: r
+00400108-r:
+  definition:
+  - to a measurable degree
+  example:
+  - the difference is measurably large
+  ili: i20873
+  members:
+  - measurably
+  partOfSpeech: r
+00405085-r:
+  definition:
+  - much
+  domain_topic:
+  - 07034009-n
+  example:
+  - allegro molto
+  ili: i20906
+  members:
+  - molto
+  partOfSpeech: r
+00405159-r:
+  definition:
+  - in a momentous way
+  ili: i20907
+  members:
+  - momentously
+  partOfSpeech: r
+00405577-r:
+  definition:
+  - in a morbid manner or to a morbid degree
+  example:
+  - he was morbidly fascinated by dead bodies
+  ili: i20910
+  members:
+  - morbidly
+  partOfSpeech: r
+00405983-r:
+  definition:
+  - in such a manner that death ensues (also in reference to hatred, jealousy, fear,
+    etc.)
+  example:
+  - a being of whom the forest Indians are said to be mortally afraid, with a hoof
+    shaped like the heel of a bottle
+  ili: i20913
+  members:
+  - mortally
+  partOfSpeech: r
+00409931-r:
+  definition:
+  - (superlative of ‘near’ or ‘close’) within the shortest distance
+  example:
+  - that was the time he came nearest to death
+  exemplifies:
+  - 06706615-n
+  ili: i20937
+  members:
+  - nearest
+  - nighest
+  - closest
+  partOfSpeech: r
+00412227-r:
+  definition:
+  - by a factor of nine
+  example:
+  - my investment has increased ninefold
+  ili: i20952
+  members:
+  - ninefold
+  - nine times
+  partOfSpeech: r
+00412430-r:
+  definition:
+  - in no manner; in no way
+  example:
+  - We could nohow make out his handwriting
+  ili: i20954
+  members:
+  - nohow
+  partOfSpeech: r
+00413480-r:
+  definition:
+  - in no manner
+  example:
+  - they are nowise different
+  ili: i20961
+  members:
+  - nowise
+  - to no degree
+  partOfSpeech: r
+00414231-r:
+  definition:
+  - to an obscene degree
+  example:
+  - this man is obscenely rich
+  ili: i20968
+  members:
+  - obscenely
+  partOfSpeech: r
+00415559-r:
+  definition:
+  - in an onerous manner
+  ili: i20977
+  members:
+  - onerously
+  partOfSpeech: r
+00415941-r:
+  definition:
+  - in a heavy and oppressive way
+  example:
+  - it was oppressively hot in the office
+  ili: i20980
+  members:
+  - oppressively
+  partOfSpeech: r
+00417873-r:
+  definition:
+  - more than necessary
+  example:
+  - she eats too much
+  - let's not blame them overmuch
+  ili: i20994
+  members:
+  - overmuch
+  - too much
+  partOfSpeech: r
+00418765-r:
+  definition:
+  - in an unpalatable way
+  example:
+  - The vegetables looked unpalatably wilted
+  ili: i21001
+  members:
+  - unpalatably
+  partOfSpeech: r
+00419049-r:
+  definition:
+  - in a manner lacking interest or vitality
+  example:
+  - a palely entertaining show
+  ili: i21003
+  members:
+  - pallidly
+  - palely
+  - dimly
+  partOfSpeech: r
+00419987-r:
+  definition:
+  - arousing scornful pity
+  example:
+  - they had pathetically little money
+  - it was pathetically bad
+  ili: i21011
+  members:
+  - pathetically
+  partOfSpeech: r
+00423540-r:
+  definition:
+  - to a phenomenal degree
+  example:
+  - his reaction was phenomenally quick
+  ili: i21036
+  members:
+  - phenomenally
+  partOfSpeech: r
+00424346-r:
+  definition:
+  - extremely and sharply
+  example:
+  - it was bitterly cold
+  - bitter cold
+  ili: i21042
+  members:
+  - piercingly
+  - bitterly
+  - bitingly
+  - bitter
+  partOfSpeech: r
+00424753-r:
+  definition:
+  - (used of heat) extremely
+  example:
+  - the casserole was piping hot
+  ili: i21045
+  members:
+  - piping
+  - steaming
+  partOfSpeech: r
+00425915-r:
+  definition:
+  - to a recognizable degree
+  example:
+  - he was recognizably slimmer now
+  ili: i21054
+  members:
+  - recognizably
+  partOfSpeech: r
+00426051-r:
+  definition:
+  - beyond recognition; in an unrecognizable manner
+  example:
+  - he had unrecognizably aged
+  ili: i21055
+  members:
+  - unrecognizably
+  - unrecognisable
+  partOfSpeech: r
+00426998-r:
+  definition:
+  - to a pitiful degree
+  example:
+  - wages were pitifully low, particularly the wages of women
+  ili: i21062
+  members:
+  - pitifully
+  partOfSpeech: r
+00427241-r:
+  definition:
+  - in a pernicious or annoying manner
+  example:
+  - it's so plaguey cold!
+  ili: i21064
+  members:
+  - plaguey
+  - plaguy
+  - plaguily
+  partOfSpeech: r
+00427673-r:
+  definition:
+  - in a pleasing manner
+  example:
+  - the room was pleasingly large
+  ili: i21067
+  members:
+  - pleasingly
+  partOfSpeech: r
+00427783-r:
+  definition:
+  - in a plenary manner
+  example:
+  - an empire destined to enter the Commonwealth plenarily
+  ili: i21068
+  members:
+  - plenarily
+  partOfSpeech: r
+00428539-r:
+  definition:
+  - in a pointless manner
+  example:
+  - he spent his life in pointlessly tiresome drudgery
+  ili: i21073
+  members:
+  - pointlessly
+  partOfSpeech: r
+00429154-r:
+  definition:
+  - in an uninterestingly ponderous manner
+  example:
+  - the play was staged with ponderously realistic sets
+  ili: i21078
+  members:
+  - ponderously
+  partOfSpeech: r
+00429855-r:
+  definition:
+  - in a manner having a powerful influence
+  example:
+  - Clytemnestra's ghost crying in the night for vengeance remained most potently
+    in the audience's mind
+  ili: i21084
+  members:
+  - potently
+  - powerfully
+  partOfSpeech: r
+00430156-r:
+  definition:
+  - in a powerful manner
+  example:
+  - the federal government replaced the powerfully pro-settler Sir Godfrey Huggins
+    with the even tougher and more determined ex-trade unionist
+  ili: i21086
+  members:
+  - powerfully
+  - strongly
+  partOfSpeech: r
+00430768-r:
+  definition:
+  - to a preeminent degree; with superiority or distinction above others; in a preeminent
+    manner
+  example:
+  - a wide variety of pre-eminently contemporary scenes
+  ili: i21090
+  members:
+  - pre-eminently
+  - preeminently
+  partOfSpeech: r
+00430990-r:
+  definition:
+  - in a precarious manner
+  example:
+  - being a precariously dominant minority is a difficult position for human nature
+    to cope with
+  ili: i21091
+  members:
+  - precariously
+  partOfSpeech: r
+00433131-r:
+  definition:
+  - in a supernatural manner
+  example:
+  - she was preternaturally beautiful
+  ili: i21106
+  members:
+  - preternaturally
+  - supernaturally
+  partOfSpeech: r
+00434339-r:
+  definition:
+  - to a wasteful manner or to a wasteful degree
+  example:
+  - we are still prodigally rich compared to others
+  ili: i21115
+  members:
+  - wastefully
+  - prodigally
+  partOfSpeech: r
+00434522-r:
+  definition:
+  - to a prodigious degree
+  example:
+  - the prices of farms rose prodigiously
+  ili: i21116
+  members:
+  - prodigiously
+  partOfSpeech: r
+00435140-r:
+  definition:
+  - to a prohibitive degree
+  example:
+  - it is prohibitively expensive
+  ili: i21121
+  members:
+  - prohibitively
+  partOfSpeech: r
+00437765-r:
+  definition:
+  - in a punishing manner
+  ili: i21140
+  members:
+  - punishingly
+  partOfSpeech: r
+00441365-r:
+  definition:
+  - in a raving manner
+  example:
+  - raving mad
+  ili: i21165
+  members:
+  - raving
+  - ravingly
+  partOfSpeech: r
+00441443-r:
+  definition:
+  - in a ravishing manner or to a ravishing degree
+  example:
+  - she was ravishingly beautiful
+  ili: i21166
+  members:
+  - ravishingly
+  partOfSpeech: r
+00442638-r:
+  definition:
+  - to a remote degree
+  example:
+  - it is remotely possible
+  ili: i21176
+  members:
+  - remotely
+  partOfSpeech: r
+00442738-r:
+  definition:
+  - in a remote manner
+  example:
+  - when the measured speech of the chorus passes over into song the tones are, remotely
+    but unmistakably, those taught by the orthodox liturgy
+  ili: i21177
+  members:
+  - remotely
+  partOfSpeech: r
+00444277-r:
+  definition:
+  - to a tolerably worthy extent
+  example:
+  - he did respectably well for his age
+  ili: i21188
+  members:
+  - respectably
+  - creditably
+  partOfSpeech: r
+00445743-r:
+  definition:
+  - positively
+  example:
+  - source: Charles Dickens
+    text: a regular right-down bad 'un
+  ili: i21199
+  members:
+  - right-down
+  partOfSpeech: r
+00446217-r:
+  definition:
+  - extremely (of drunkness)
+  example:
+  - roaring drunk
+  ili: i21203
+  members:
+  - roaring
+  partOfSpeech: r
+00447534-r:
+  definition:
+  - in a ruinous manner or to a ruinous degree
+  example:
+  - ruinously high wages
+  ili: i21213
+  members:
+  - ruinously
+  partOfSpeech: r
+00448735-r:
+  definition:
+  - capable of causing burns
+  example:
+  - it was scorching hot
+  ili: i21221
+  members:
+  - scorching
+  partOfSpeech: r
+00448839-r:
+  definition:
+  - funny to the point where screams of laughter are excited
+  example:
+  - screamingly funny
+  ili: i21222
+  members:
+  - screamingly
+  partOfSpeech: r
+00450751-r:
+  definition:
+  - in a sensational manner
+  example:
+  - in the summer of 1958 the pianist had a sensationally triumphant return
+  ili: i21237
+  members:
+  - sensationally
+  partOfSpeech: r
+00452275-r:
+  definition:
+  - seven times
+  example:
+  - the population of this village increased sevenfold in the past 100 years
+  ili: i21247
+  members:
+  - sevenfold
+  partOfSpeech: r
+00454436-r:
+  definition:
+  - to a shocking degree
+  example:
+  - teachers were shockingly underpaid
+  ili: i21264
+  members:
+  - shockingly
+  partOfSpeech: r
+00454943-r:
+  definition:
+  - at some point or distance before a goal is reached
+  example:
+  - he fell short of our expectations
+  ili: i21268
+  members:
+  - short
+  partOfSpeech: r
+00456645-r:
+  definition:
+  - in a signal manner
+  example:
+  - signally inappropriate methods
+  ili: i21281
+  members:
+  - signally
+  - unmistakably
+  - remarkably
+  partOfSpeech: r
+00457366-r:
+  definition:
+  - in a singular manner or to a singular degree
+  example:
+  - Lord T. was considered singularly licentious even for the courts of Russia and
+    Portugal; he acquired three wives and fourteen children during his Portuguese
+    embassy alone
+  ili: i21287
+  members:
+  - singularly
+  partOfSpeech: r
+00457641-r:
+  definition:
+  - by a factor of six
+  example:
+  - the population of this town increased sixfold when gold was found in the surrounding
+    hills
+  ili: i21288
+  members:
+  - sixfold
+  - six times
+  partOfSpeech: r
+00458383-r:
+  definition:
+  - in a sparse way
+  example:
+  - sparsely inhabited
+  - his beard grew sparsely
+  ili: i21347
+  members:
+  - sparsely
+  partOfSpeech: r
+00458618-r:
+  definition:
+  - to a very high level
+  example:
+  - prices have gone sky-high
+  - garbage was piled sky-high
+  - the men were flung sky-high by the explosion
+  ili: i21294
+  members:
+  - sky-high
+  partOfSpeech: r
+00458782-r:
+  definition:
+  - in a lavish or enthusiastic manner
+  example:
+  - he extolled her virtues sky-high
+  ili: i21295
+  members:
+  - sky-high
+  - enthusiastically
+  partOfSpeech: r
+00458908-r:
+  definition:
+  - (with verb ‘to blow’) destroyed completely; blown apart or to pieces
+  example:
+  - they blew the bridge sky-high
+  - the committee blew the thesis sky-high
+  ili: i21296
+  members:
+  - sky-high
+  partOfSpeech: r
+00459726-r:
+  definition:
+  - with heedless speed
+  example:
+  - yachts ran slap-bang into the convoy at 15 knots an hour
+  ili: i21302
+  members:
+  - slam-bang
+  partOfSpeech: r
+00463703-r:
+  definition:
+  - extremely wet
+  example:
+  - dripping wet
+  - soaking wet
+  ili: i21331
+  members:
+  - soaking
+  - sopping
+  - dripping
+  partOfSpeech: r
+00463915-r:
+  definition:
+  - to a great extent
+  example:
+  - I missed him sorely
+  - we were sorely taxed to keep up with them
+  ili: i21333
+  members:
+  - sorely
+  partOfSpeech: r
+00466561-r:
+  definition:
+  - in a spotless manner
+  example:
+  - spotlessly clean
+  ili: i21357
+  members:
+  - spotlessly
+  partOfSpeech: r
+00467379-r:
+  definition:
+  - to the fullest degree
+  example:
+  - stark mad
+  - mouth stark open
+  ili: i21363
+  members:
+  - stark
+  partOfSpeech: r
+00467456-r:
+  definition:
+  - in a blunt manner
+  example:
+  - in starkly realistic terms
+  ili: i21364
+  members:
+  - starkly
+  partOfSpeech: r
+00467685-r:
+  definition:
+  - in a stark manner
+  example:
+  - He was starkly unable to achieve coherence
+  ili: i21366
+  members:
+  - starkly
+  partOfSpeech: r
+00467802-r:
+  definition:
+  - in a startling manner
+  example:
+  - a startlingly modern voice
+  ili: i21367
+  members:
+  - startlingly
+  partOfSpeech: r
+00468690-r:
+  definition:
+  - to a great degree
+  example:
+  - bored stiff
+  - frightened stiff
+  ili: i21374
+  members:
+  - stiff
+  partOfSpeech: r
+00471530-r:
+  definition:
+  - to a stupendous degree
+  example:
+  - stupendously ignorant people
+  ili: i21398
+  members:
+  - stupendously
+  partOfSpeech: r
+00472327-r:
+  definition:
+  - in a subtle manner
+  example:
+  - late nineteenth-century French opera at its most beautiful, subtly romantic with
+    a twilight melancholy
+  ili: i21404
+  members:
+  - subtly
+  partOfSpeech: r
+00473918-r:
+  definition:
+  - to an extraordinary degree
+  example:
+  - she was a surpassingly beautiful woman
+  - source: Walker Percy
+    text: I will mention only one particular aspect of the current mess because …
+      this one is surely something new and passing strange
+  ili: i21415
+  members:
+  - surpassingly
+  - passing
+  partOfSpeech: r
+00478811-r:
+  definition:
+  - by a factor of three
+  example:
+  - our rent increased threefold in the past five years
+  ili: i21446
+  members:
+  - threefold
+  - three times
+  partOfSpeech: r
+00480952-r:
+  definition:
+  - from beginning to end
+  example:
+  - read this book through
+  ili: i21461
+  members:
+  - through
+  partOfSpeech: r
+00481239-r:
+  definition:
+  - to the highest extent
+  example:
+  - the shoes fit me tip-top
+  ili: i21464
+  members:
+  - tip-top
+  partOfSpeech: r
+00482882-r:
+  definition:
+  - so as to be easily understood or seen through
+  example:
+  - his transparently lucid prose
+  - his transparently deceitful behavior
+  ili: i21478
+  members:
+  - transparently
+  partOfSpeech: r
+00484504-r:
+  definition:
+  - by a factor of two
+  example:
+  - the price increased twofold last year
+  ili: i21490
+  members:
+  - twofold
+  - two times
+  partOfSpeech: r
+00485623-r:
+  definition:
+  - in an unattainable manner or to an unattainable degree
+  example:
+  - this house is unattainably expensive
+  ili: i21497
+  members:
+  - unattainably
+  - unachievably
+  partOfSpeech: r
+00486125-r:
+  definition:
+  - to an unbearable degree
+  example:
+  - it was unbearably hot in the room
+  ili: i21500
+  members:
+  - unbearably
+  partOfSpeech: r
+00486558-r:
+  definition:
+  - in an uncanny manner
+  example:
+  - uncannily human robots
+  ili: i21503
+  members:
+  - uncannily
+  partOfSpeech: r
+00486999-r:
+  definition:
+  - exceptionally
+  example:
+  - a common remedy is uncommonly difficult to find
+  ili: i21506
+  members:
+  - uncommonly
+  partOfSpeech: r
+00488494-r:
+  definition:
+  - below some quantity or limit
+  example:
+  - fifty dollars or under
+  ili: i21519
+  members:
+  - under
+  partOfSpeech: r
+00489957-r:
+  definition:
+  - to an undue degree
+  example:
+  - she was unduly pessimistic about her future
+  ili: i21530
+  members:
+  - unduly
+  partOfSpeech: r
+00490485-r:
+  definition:
+  - to an unimaginable extent
+  ili: i21534
+  members:
+  - unimaginably
+  - unthinkably
+  partOfSpeech: r
+00491178-r:
+  definition:
+  - in an unprecedented manner
+  ili: i21539
+  members:
+  - unprecedentedly
+  partOfSpeech: r
+00491868-r:
+  definition:
+  - in a constant and steadfast manner
+  example:
+  - an unswervingly loyal man
+  ili: i21545
+  members:
+  - unswervingly
+  partOfSpeech: r
+00492170-r:
+  definition:
+  - in an unwarrantable manner or to an unwarranted degree
+  example:
+  - in this painting, the relationship of the upper part of the body to the lower
+    is uneasy and the right thigh seems unwarrantably stressed
+  ili: i21547
+  members:
+  - unwarrantably
+  partOfSpeech: r
+00494467-r:
+  definition:
+  - with variation; in a variable manner or to a variable degree
+  example:
+  - it will be variably cloudy
+  ili: i21566
+  members:
+  - variably
+  partOfSpeech: r
+00495806-r:
+  definition:
+  - in a shapely and voluptuous manner
+  example:
+  - a voluptuously curved woman
+  ili: i21576
+  members:
+  - voluptuously
+  partOfSpeech: r
+00496326-r:
+  definition:
+  - up to the waist
+  example:
+  - the water rose waist-high
+  ili: i21581
+  members:
+  - waist-deep
+  - waist-high
+  partOfSpeech: r
+00496954-r:
+  definition:
+  - to an abnormal extent
+  example:
+  - a whacking good story
+  ili: i21587
+  members:
+  - whacking
+  partOfSpeech: r
+00497327-r:
+  definition:
+  - in a wholesome manner
+  example:
+  - the papers we found shed some valuable light on this question, wholesomely contradicting
+    all lies
+  ili: i21590
+  members:
+  - wholesomely
+  partOfSpeech: r
+00497941-r:
+  definition:
+  - with or by a broad space
+  example:
+  - stand with legs wide apart
+  - ran wide around left end
+  ili: i21596
+  members:
+  - wide
+  partOfSpeech: r
+00498208-r:
+  definition:
+  - to the fullest extent possible
+  example:
+  - open your eyes wide
+  - with the throttle wide open
+  ili: i21598
+  members:
+  - wide
+  partOfSpeech: r
+00499077-r:
+  definition:
+  - in a manner to cause worry
+  ili: i21605
+  members:
+  - worryingly
+  partOfSpeech: r
+00502856-r:
+  definition:
+  - for half the price
+  example:
+  - she bought it half-price during the sale
+  ili: i21639
+  members:
+  - half-price
+  partOfSpeech: r
+00503489-r:
+  definition:
+  - per person; for each person; of each person
+  example:
+  - we are spending $5,000 per capita annually for education in this district
+  ili: i21646
+  members:
+  - per capita
+  partOfSpeech: r
+00503666-r:
+  definition:
+  - in an identifiably distinctive manner
+  example:
+  - the distinctively conservative district of the county
+  ili: i21647
+  members:
+  - distinctively
+  partOfSpeech: r
+00503964-r:
+  definition:
+  - so as to disappear or approach zero
+  example:
+  - errors are vanishingly rare
+  ili: i21649
+  members:
+  - vanishingly
+  partOfSpeech: r
+00504667-r:
+  definition:
+  - in a manner designed for heavy duty
+  example:
+  - a heavily constructed car
+  - heavily armed
+  ili: i21656
+  members:
+  - heavily
+  partOfSpeech: r
+00507076-r:
+  definition:
+  - referring to a quantity
+  example:
+  - the amount was paid in full
+  ili: i21670
+  members:
+  - in full
+  - fully
+  partOfSpeech: r
+00508875-r:
+  definition:
+  - so as to leave much space or distance between
+  example:
+  - widely separated
+  ili: i21685
+  members:
+  - widely
+  partOfSpeech: r
+00509110-r:
+  definition:
+  - with fatal consequences or implications
+  example:
+  - he was fatally ill equipped for the climb
+  ili: i21687
+  members:
+  - fatally
+  partOfSpeech: r
+00509586-r:
+  definition:
+  - in an outstanding manner or to an outstanding degree
+  example:
+  - she was outstandingly successful in her profession
+  ili: i21691
+  members:
+  - outstandingly
+  partOfSpeech: r
+00512503-r:
+  definition:
+  - in a statistically significant way
+  example:
+  - the two groups differed significantly
+  ili: i21714
+  members:
+  - significantly
+  partOfSpeech: r
+00513282-r:
+  definition:
+  - precisely so
+  example:
+  - on the very next page
+  - he expected the very opposite
+  ili: i21720
+  members:
+  - very
+  partOfSpeech: r
+00516613-r:
+  definition:
+  - in an irreparable manner or to an irreparable degree
+  ili: i21753
+  members:
+  - irreparably
+  partOfSpeech: r
+00518934-r:
+  definition:
+  - extremely thin
+  example:
+  - it was cut wafer-thin
+  ili: i21776
+  members:
+  - wafer-thin
+  partOfSpeech: r
+00519421-r:
+  definition:
+  - in an incorrigible manner
+  members:
+  - incorrigibly
+  partOfSpeech: r
+00519615-r:
+  definition:
+  - in an extreme or fanatical manner
+  members:
+  - rabidly
+  partOfSpeech: r
+00519841-r:
+  definition:
+  - to an insufferable degree
+  example:
+  - it was insufferably hot in the room
+  members:
+  - insufferably
+  - unsufferably
+  partOfSpeech: r

--- a/src/yaml/adv.domain.yaml
+++ b/src/yaml/adv.domain.yaml
@@ -1,0 +1,1672 @@
+00024234-r:
+  definition:
+  - in a pathogenic manner
+  ili: i18278
+  members:
+  - pathogenically
+  partOfSpeech: r
+00044486-r:
+  definition:
+  - (in formal usage, especially legal usage) for that or for it
+  domain_topic:
+  - 08458195-n
+  example:
+  - ordering goods and enclosing payment therefor
+  - a refund therefor
+  ili: i18396
+  members:
+  - therefor
+  partOfSpeech: r
+00044672-r:
+  definition:
+  - affecting the pursuit of a vocation or occupation
+  example:
+  - vocationally trained
+  ili: i18397
+  members:
+  - vocationally
+  partOfSpeech: r
+00060838-r:
+  definition:
+  - in every practical sense
+  example:
+  - to all intents and purposes the case is closed
+  - the rest are for all practical purposes useless
+  ili: i18501
+  members:
+  - for all practical purposes
+  - to all intents and purposes
+  - for all intents and purposes
+  partOfSpeech: r
+00062701-r:
+  definition:
+  - by means of an insecticide
+  ili: i18512
+  members:
+  - insecticidally
+  partOfSpeech: r
+00064621-r:
+  definition:
+  - with respect to anatomy
+  example:
+  - anatomically correct
+  ili: i18523
+  members:
+  - anatomically
+  partOfSpeech: r
+00064899-r:
+  definition:
+  - with respect to color
+  example:
+  - chromatically pure
+  ili: i18525
+  members:
+  - chromatically
+  partOfSpeech: r
+00065002-r:
+  definition:
+  - with respect to chronology
+  example:
+  - he is chronologically older
+  ili: i18526
+  members:
+  - chronologically
+  partOfSpeech: r
+00065121-r:
+  definition:
+  - in a clinical manner
+  example:
+  - she is clinically qualified
+  ili: i18527
+  members:
+  - clinically
+  partOfSpeech: r
+00065229-r:
+  definition:
+  - with respect to mathematics
+  example:
+  - mathematically impossible
+  ili: i18529
+  members:
+  - mathematically
+  partOfSpeech: r
+00076947-r:
+  definition:
+  - with regard to sound or the ear
+  example:
+  - the new musical was visually and aurally appealing
+  ili: i18598
+  members:
+  - aurally
+  partOfSpeech: r
+00077763-r:
+  definition:
+  - in a commercial manner
+  example:
+  - the product is commercially available
+  ili: i18604
+  members:
+  - commercially
+  partOfSpeech: r
+00079498-r:
+  definition:
+  - with respect to statistics
+  example:
+  - this is statistically impossible
+  ili: i18616
+  members:
+  - statistically
+  partOfSpeech: r
+00079620-r:
+  definition:
+  - with respect to thermodynamics
+  example:
+  - this phenomenon is thermodynamically impossible
+  ili: i18617
+  members:
+  - thermodynamically
+  partOfSpeech: r
+00081118-r:
+  definition:
+  - by virtue of a contract
+  example:
+  - they were contractually responsible
+  ili: i18628
+  members:
+  - contractually
+  partOfSpeech: r
+00085466-r:
+  definition:
+  - in relation to eschatology
+  example:
+  - even atheists can be eschatologically minded
+  ili: i18659
+  members:
+  - eschatologically
+  partOfSpeech: r
+00087414-r:
+  definition:
+  - in a permissible manner
+  ili: i18673
+  members:
+  - permissibly
+  - allowably
+  partOfSpeech: r
+00090211-r:
+  definition:
+  - involving the use of histology or histological techniques
+  example:
+  - histologically identifiable structures
+  ili: i18692
+  members:
+  - histologically
+  partOfSpeech: r
+00094039-r:
+  definition:
+  - with respect to denomination
+  example:
+  - denominationally diverse audiences
+  ili: i18720
+  members:
+  - denominationally
+  partOfSpeech: r
+00104786-r:
+  definition:
+  - in reality
+  example:
+  - she is very kind at heart
+  ili: i18794
+  members:
+  - at heart
+  - at bottom
+  - deep down
+  - inside
+  - in spite of appearance
+  partOfSpeech: r
+00110206-r:
+  definition:
+  - in that matter; in that respect; on that point
+  example:
+  - I agree with you there
+  ili: i18830
+  members:
+  - there
+  partOfSpeech: r
+00110312-r:
+  definition:
+  - with respect to history
+  example:
+  - this is historically interesting
+  ili: i18831
+  members:
+  - historically
+  partOfSpeech: r
+00110430-r:
+  definition:
+  - throughout history
+  example:
+  - historically they have never coexisted peacefully
+  ili: i18832
+  members:
+  - historically
+  partOfSpeech: r
+00110692-r:
+  definition:
+  - with respect to science; in a scientific way
+  example:
+  - this is scientifically interesting
+  ili: i18834
+  members:
+  - scientifically
+  partOfSpeech: r
+00111759-r:
+  definition:
+  - with respect to the military
+  example:
+  - on a militarily significant scale
+  ili: i18842
+  members:
+  - militarily
+  partOfSpeech: r
+00113197-r:
+  definition:
+  - with respect to the whole earth
+  example:
+  - think globally, not locally
+  members:
+  - globally
+  partOfSpeech: r
+00115099-r:
+  definition:
+  - involving metabolism
+  example:
+  - metabolically important substances
+  ili: i18864
+  members:
+  - metabolically
+  partOfSpeech: r
+00116024-r:
+  definition:
+  - with regard to phylogeny
+  example:
+  - a phylogenetically primitive part of the brain
+  ili: i18870
+  members:
+  - phylogenetically
+  partOfSpeech: r
+00116161-r:
+  definition:
+  - in accord with physical laws
+  example:
+  - it is physically impossible
+  ili: i18871
+  members:
+  - physically
+  partOfSpeech: r
+00116277-r:
+  definition:
+  - of or relating to physiological processes; with respect to physiology
+  example:
+  - physiologically ready
+  - physiologically addicted
+  ili: i18872
+  members:
+  - physiologically
+  partOfSpeech: r
+00116652-r:
+  definition:
+  - with regard to government
+  example:
+  - politically organized units
+  ili: i18874
+  members:
+  - politically
+  partOfSpeech: r
+00116766-r:
+  definition:
+  - with regard to social relationships involving authority
+  example:
+  - politically correct clothing
+  ili: i18875
+  members:
+  - politically
+  partOfSpeech: r
+00122170-r:
+  definition:
+  - in regard to academic matters
+  example:
+  - academically, this is a good school
+  ili: i18912
+  members:
+  - academically
+  partOfSpeech: r
+00122541-r:
+  definition:
+  - on the basis of axioms
+  example:
+  - this is axiomatically given
+  ili: i18915
+  members:
+  - axiomatically
+  partOfSpeech: r
+00123008-r:
+  definition:
+  - according to the constitution
+  example:
+  - this was constitutionally ruled out
+  ili: i18919
+  members:
+  - constitutionally
+  partOfSpeech: r
+00124113-r:
+  definition:
+  - with respect to economic science
+  example:
+  - economically this proposal makes no sense
+  ili: i18926
+  members:
+  - economically
+  partOfSpeech: r
+00124249-r:
+  definition:
+  - with respect to the economic system
+  example:
+  - economically the country is worse off
+  ili: i18927
+  members:
+  - economically
+  partOfSpeech: r
+00124579-r:
+  definition:
+  - with respect to ethnicity
+  example:
+  - the neighborhood is ethnically diverse
+  ili: i18930
+  members:
+  - ethnically
+  partOfSpeech: r
+00124703-r:
+  definition:
+  - by federal government
+  example:
+  - it's federally regulated
+  ili: i18931
+  members:
+  - federally
+  partOfSpeech: r
+00125676-r:
+  definition:
+  - involving medical practice
+  example:
+  - medically trained nurses
+  - medically correct treatment
+  ili: i18941
+  members:
+  - medically
+  partOfSpeech: r
+00125817-r:
+  definition:
+  - in a medicinal manner
+  ili: i18942
+  members:
+  - medicinally
+  partOfSpeech: r
+00125896-r:
+  definition:
+  - in name only
+  example:
+  - nominally he is the boss
+  ili: i18943
+  members:
+  - nominally
+  partOfSpeech: r
+00126242-r:
+  definition:
+  - by the province; through the province
+  example:
+  - provincially controlled
+  ili: i18946
+  members:
+  - provincially
+  partOfSpeech: r
+00127082-r:
+  definition:
+  - with respect to stage scenery
+  example:
+  - scenically stunning
+  ili: i18953
+  members:
+  - scenically
+  partOfSpeech: r
+00127191-r:
+  definition:
+  - with respect to scholastic activities
+  example:
+  - scholastically apt
+  ili: i18954
+  members:
+  - scholastically
+  partOfSpeech: r
+00127411-r:
+  definition:
+  - by or with respect to society
+  example:
+  - socially accepted norms
+  ili: i18956
+  members:
+  - socially
+  partOfSpeech: r
+00127522-r:
+  definition:
+  - in a social manner
+  example:
+  - socially unpopular
+  ili: i18957
+  members:
+  - socially
+  partOfSpeech: r
+00127721-r:
+  definition:
+  - with regard to technical skill and the technology available
+  example:
+  - a technically brilliant solution
+  ili: i18959
+  members:
+  - technically
+  partOfSpeech: r
+00127856-r:
+  definition:
+  - with regard to technique
+  example:
+  - technically lagging behind the Japanese
+  - a technically brilliant boxer
+  ili: i18960
+  members:
+  - technically
+  partOfSpeech: r
+00128014-r:
+  definition:
+  - according to the exact meaning; according to the facts
+  example:
+  - technically, a bank's reserves belong to the stockholders
+  - technically, the term is no longer used by experts
+  ili: i18961
+  members:
+  - technically
+  partOfSpeech: r
+00128524-r:
+  definition:
+  - with respect to territory
+  example:
+  - territorially important
+  ili: i18965
+  members:
+  - territorially
+  partOfSpeech: r
+00128636-r:
+  definition:
+  - with regard to thematic content
+  example:
+  - thematically related
+  ili: i18966
+  members:
+  - thematically
+  partOfSpeech: r
+00128750-r:
+  definition:
+  - for therapeutic purposes
+  ili: i18967
+  members:
+  - therapeutically
+  partOfSpeech: r
+00129866-r:
+  definition:
+  - with respect to chemistry
+  example:
+  - chemically different substances
+  - chemically related
+  ili: i18978
+  members:
+  - chemically
+  partOfSpeech: r
+00130101-r:
+  definition:
+  - by legislation
+  example:
+  - legislatively determined
+  ili: i18980
+  members:
+  - legislatively
+  partOfSpeech: r
+00130777-r:
+  definition:
+  - by the theory of relativity
+  example:
+  - this is relativistically impossible
+  ili: i18986
+  members:
+  - relativistically
+  partOfSpeech: r
+00130906-r:
+  definition:
+  - with respect to race
+  example:
+  - racially integrated
+  ili: i18987
+  members:
+  - racially
+  partOfSpeech: r
+00131004-r:
+  definition:
+  - by municipality
+  example:
+  - municipally funded
+  ili: i18988
+  members:
+  - municipally
+  partOfSpeech: r
+00131099-r:
+  definition:
+  - by government
+  example:
+  - governmentally determined policy
+  ili: i18989
+  members:
+  - governmentally
+  partOfSpeech: r
+00131423-r:
+  definition:
+  - with regard to meaning
+  example:
+  - semantically empty messages
+  ili: i18992
+  members:
+  - semantically
+  partOfSpeech: r
+00131610-r:
+  definition:
+  - with respect to language
+  example:
+  - linguistically impaired children
+  - a lingually diverse population
+  ili: i18994
+  members:
+  - linguistically
+  - lingually
+  partOfSpeech: r
+00131795-r:
+  definition:
+  - with respect to sociolinguistics
+  example:
+  - sociolinguistically fascinating
+  ili: i18995
+  members:
+  - sociolinguistically
+  partOfSpeech: r
+00131928-r:
+  definition:
+  - with respect to the science of linguistics
+  example:
+  - linguistically interesting data
+  ili: i18996
+  members:
+  - linguistically
+  partOfSpeech: r
+00132206-r:
+  definition:
+  - in financial matters
+  example:
+  - fiscally irresponsible
+  ili: i18998
+  members:
+  - fiscally
+  - in fiscal matters
+  partOfSpeech: r
+00132327-r:
+  definition:
+  - in an algebraic manner
+  example:
+  - algebraically determined
+  ili: i18999
+  members:
+  - algebraically
+  partOfSpeech: r
+00132646-r:
+  definition:
+  - by phonetics
+  example:
+  - phonetically realized
+  ili: i19002
+  members:
+  - phonetically
+  partOfSpeech: r
+00133607-r:
+  definition:
+  - with respect to graphic aspects
+  example:
+  - graphically interesting designs
+  ili: i19010
+  members:
+  - graphically
+  partOfSpeech: r
+00133851-r:
+  definition:
+  - in an optical manner
+  example:
+  - optically distorted
+  ili: i19012
+  members:
+  - optically
+  partOfSpeech: r
+00133950-r:
+  definition:
+  - with respect to vision
+  example:
+  - visually distorted
+  ili: i19013
+  members:
+  - visually
+  partOfSpeech: r
+00134423-r:
+  definition:
+  - with respect to biology
+  example:
+  - biologically related
+  ili: i19018
+  members:
+  - biologically
+  partOfSpeech: r
+00134529-r:
+  definition:
+  - with respect to sociobiology
+  example:
+  - explain the behavior sociobiologically
+  ili: i19019
+  members:
+  - sociobiologically
+  partOfSpeech: r
+00134663-r:
+  definition:
+  - with respect to neurobiology
+  example:
+  - explain the phenomenon neurobiologically
+  ili: i19020
+  members:
+  - neurobiological
+  partOfSpeech: r
+00134797-r:
+  definition:
+  - with respect to biochemistry
+  example:
+  - biochemically interesting phenomenon
+  ili: i19021
+  members:
+  - biochemically
+  partOfSpeech: r
+00134925-r:
+  definition:
+  - with respect to musicology
+  ili: i19022
+  members:
+  - musicologically
+  partOfSpeech: r
+00135013-r:
+  definition:
+  - with respect to moral principles
+  example:
+  - morally unjustified
+  ili: i19023
+  members:
+  - morally
+  partOfSpeech: r
+00135104-r:
+  definition:
+  - with respect to the weather
+  example:
+  - meteorologically bad conditions
+  ili: i19024
+  members:
+  - meteorologically
+  partOfSpeech: r
+00135229-r:
+  definition:
+  - in a metaphysical manner
+  example:
+  - he thinks metaphysically
+  ili: i19025
+  members:
+  - metaphysically
+  partOfSpeech: r
+00135423-r:
+  definition:
+  - with respect to melody
+  example:
+  - melodically interesting themes
+  ili: i19027
+  members:
+  - melodically
+  partOfSpeech: r
+00135537-r:
+  definition:
+  - with respect to harmony
+  example:
+  - harmonically interesting piece
+  ili: i19028
+  members:
+  - harmonically
+  partOfSpeech: r
+00135653-r:
+  definition:
+  - with respect to acoustics
+  example:
+  - acoustically ill-equipped studios
+  ili: i19029
+  members:
+  - acoustically
+  partOfSpeech: r
+00136606-r:
+  definition:
+  - with regard to a culture
+  example:
+  - culturally integrated
+  ili: i19037
+  members:
+  - culturally
+  partOfSpeech: r
+00136712-r:
+  definition:
+  - by race
+  example:
+  - interracially restrictive
+  ili: i19038
+  members:
+  - interracially
+  partOfSpeech: r
+00136998-r:
+  definition:
+  - with respect to the face
+  ili: i19041
+  members:
+  - facially
+  partOfSpeech: r
+00137077-r:
+  definition:
+  - with respect to syntax
+  example:
+  - syntactically ill-formed
+  ili: i19042
+  members:
+  - syntactically
+  partOfSpeech: r
+00137371-r:
+  definition:
+  - with respect to sexuality
+  example:
+  - sexually ambiguous
+  ili: i19045
+  members:
+  - sexually
+  partOfSpeech: r
+00137473-r:
+  definition:
+  - by means of words
+  example:
+  - lexically represented
+  ili: i19046
+  members:
+  - lexically
+  partOfSpeech: r
+00140076-r:
+  definition:
+  - especially; in particular
+  example:
+  - notably in the social sciences, the professors teach too much
+  ili: i19065
+  members:
+  - notably
+  partOfSpeech: r
+00142809-r:
+  definition:
+  - with respect to geometry
+  example:
+  - this shape is geometrically interesting
+  ili: i19084
+  members:
+  - geometrically
+  partOfSpeech: r
+00143139-r:
+  definition:
+  - with respect to gravitation
+  example:
+  - gravitationally strong forces
+  ili: i19087
+  members:
+  - gravitationally
+  partOfSpeech: r
+00143610-r:
+  definition:
+  - by means of horticulture
+  ili: i19091
+  members:
+  - horticulturally
+  partOfSpeech: r
+00144291-r:
+  definition:
+  - in a judicial manner
+  example:
+  - judicially controlled process
+  ili: i19098
+  members:
+  - judicially
+  partOfSpeech: r
+00146377-r:
+  definition:
+  - by means of technology
+  example:
+  - technologically impossible
+  ili: i19114
+  members:
+  - technologically
+  partOfSpeech: r
+00146491-r:
+  definition:
+  - by temperament
+  example:
+  - temperamentally suited to each other
+  ili: i19115
+  members:
+  - temperamentally
+  partOfSpeech: r
+00149598-r:
+  definition:
+  - from some points of view
+  example:
+  - she was right in a way
+  ili: i19138
+  members:
+  - in a way
+  partOfSpeech: r
+00149685-r:
+  definition:
+  - as a fact or based on fact
+  example:
+  - they learn much, factually, about the problems of retirement and provision for
+    old age, and, psychologically, in the sharing of their thoughts on retirement
+  ili: i19139
+  members:
+  - factually
+  partOfSpeech: r
+00163964-r:
+  definition:
+  - by the public or the people generally
+  example:
+  - publicly provided medical care
+  - publicly financed schools
+  ili: i19240
+  members:
+  - publicly
+  partOfSpeech: r
+00171356-r:
+  definition:
+  - in theory; according to the assumed facts
+  example:
+  - on paper the candidate seems promising
+  ili: i19295
+  members:
+  - theoretically
+  - on paper
+  partOfSpeech: r
+00173875-r:
+  definition:
+  - with that general meaning
+  example:
+  - she said something to that effect
+  ili: i19314
+  members:
+  - to that effect
+  partOfSpeech: r
+00179946-r:
+  definition:
+  - by religion
+  example:
+  - religiously inspired art
+  ili: i19360
+  members:
+  - religiously
+  - sacredly
+  partOfSpeech: r
+00187053-r:
+  definition:
+  - with regard to emotions
+  example:
+  - emotionally secure
+  ili: i19410
+  members:
+  - emotionally
+  partOfSpeech: r
+00190641-r:
+  definition:
+  - of or relating to the intellect
+  example:
+  - intellectually gifted children
+  - intellectually influenced
+  ili: i19439
+  members:
+  - intellectually
+  partOfSpeech: r
+00199241-r:
+  definition:
+  - in concrete terms
+  example:
+  - concretely, this meant that he was broke
+  ili: i19504
+  members:
+  - concretely
+  partOfSpeech: r
+00204954-r:
+  definition:
+  - with respect to socioeconomic factors
+  example:
+  - they are far apart socioeconomically
+  ili: i19543
+  members:
+  - socioeconomically
+  partOfSpeech: r
+00208454-r:
+  definition:
+  - from a financial point of view
+  example:
+  - this was financially unattractive
+  ili: i19569
+  members:
+  - financially
+  partOfSpeech: r
+00208579-r:
+  definition:
+  - from a psychic point of view
+  example:
+  - he was psychically blind
+  ili: i19570
+  members:
+  - psychically
+  partOfSpeech: r
+00212370-r:
+  definition:
+  - by custom; according to common practice
+  example:
+  - children are customarily expected to be seen but not heard
+  ili: i19596
+  members:
+  - customarily
+  partOfSpeech: r
+00212815-r:
+  definition:
+  - in a spiritual manner
+  example:
+  - the ninth century was the spiritually freest period
+  ili: i19599
+  members:
+  - spiritually
+  partOfSpeech: r
+00228507-r:
+  definition:
+  - by means of an editorial
+  example:
+  - the paper commented editorially on the scandal
+  ili: i19700
+  members:
+  - editorially
+  partOfSpeech: r
+00229728-r:
+  definition:
+  - in an anachronistic manner
+  example:
+  - let's look at this phenomenon anachronistically
+  ili: i19709
+  members:
+  - anachronistically
+  partOfSpeech: r
+00233903-r:
+  definition:
+  - with respect to geography
+  example:
+  - they are geographically closer to the center of town
+  ili: i19739
+  members:
+  - geographically
+  partOfSpeech: r
+00241992-r:
+  definition:
+  - by virtue of analysis
+  example:
+  - assuming that the distinction is maintained, one may ask which is to be analytically
+    prior?
+  ili: i19797
+  members:
+  - analytically
+  partOfSpeech: r
+00245268-r:
+  definition:
+  - with respect to structure
+  example:
+  - structurally, the organization is healthy
+  ili: i19819
+  members:
+  - structurally
+  partOfSpeech: r
+00248026-r:
+  definition:
+  - in a quantitative manner
+  example:
+  - this can be expressed quantitatively
+  ili: i19841
+  members:
+  - quantitatively
+  partOfSpeech: r
+00249583-r:
+  definition:
+  - in a dialectic manner
+  example:
+  - his religiousness is dialectically related to his sinfulness
+  ili: i19853
+  members:
+  - dialectically
+  partOfSpeech: r
+00253080-r:
+  definition:
+  - derived by logic, without observed facts
+  ili: i19881
+  members:
+  - a priori
+  partOfSpeech: r
+00253289-r:
+  definition:
+  - by law; conforming to the law
+  example:
+  - we are lawfully wedded now
+  ili: i19883
+  members:
+  - legally
+  - lawfully
+  - de jure
+  partOfSpeech: r
+00253591-r:
+  definition:
+  - in respect to jurisprudence or the science or philosophy of law
+  ili: i19885
+  members:
+  - jurisprudentially
+  partOfSpeech: r
+00253968-r:
+  definition:
+  - by virtue of position
+  example:
+  - the president sat on the committee ex officio
+  ili: i19889
+  members:
+  - ex officio
+  - by right of office
+  partOfSpeech: r
+00261706-r:
+  definition:
+  - at first sight
+  ili: i19957
+  members:
+  - prima facie
+  partOfSpeech: r
+00262662-r:
+  definition:
+  - in a tasteful way
+  example:
+  - this building is aesthetically very pleasing
+  ili: i19966
+  members:
+  - aesthetically
+  - esthetically
+  partOfSpeech: r
+00266597-r:
+  definition:
+  - by or for an administrator
+  example:
+  - this decision was made administratively
+  ili: i19993
+  members:
+  - administratively
+  partOfSpeech: r
+00269596-r:
+  definition:
+  - with regard to architecture
+  example:
+  - this building is ugly, but architecturally interesting
+  ili: i20014
+  members:
+  - architecturally
+  partOfSpeech: r
+00273056-r:
+  definition:
+  - with respect to arithmetic
+  example:
+  - this problem is arithmetically easy
+  ili: i20039
+  members:
+  - arithmetically
+  partOfSpeech: r
+00282402-r:
+  definition:
+  - with respect to bureaucracy
+  example:
+  - it's bureaucratically complicated
+  ili: i20110
+  members:
+  - bureaucratically
+  partOfSpeech: r
+00287341-r:
+  definition:
+  - with respect to climate
+  example:
+  - they were used to a climatically different environment
+  ili: i20141
+  members:
+  - climatically
+  partOfSpeech: r
+00287982-r:
+  definition:
+  - with the use of colloquial expressions
+  example:
+  - this building is colloquially referred to as The Barn
+  ili: i20146
+  members:
+  - colloquially
+  - conversationally
+  - informally
+  partOfSpeech: r
+00290270-r:
+  definition:
+  - with regard to computation
+  example:
+  - computationally, this is a tricky problem
+  ili: i20160
+  members:
+  - computationally
+  partOfSpeech: r
+00290900-r:
+  definition:
+  - in a conceptual manner
+  example:
+  - he can no longer think conceptually
+  - conceptually, the idea is quite simple
+  ili: i20165
+  members:
+  - conceptually
+  partOfSpeech: r
+00303375-r:
+  definition:
+  - with respect to development
+  example:
+  - developmentally retarded
+  ili: i20241
+  members:
+  - developmentally
+  partOfSpeech: r
+00313044-r:
+  definition:
+  - in a didactic manner
+  example:
+  - this is a didactically sound method
+  ili: i20303
+  members:
+  - didactically
+  - pedagogically
+  partOfSpeech: r
+00322327-r:
+  definition:
+  - as a matter of doctrine
+  ili: i20355
+  members:
+  - doctrinally
+  partOfSpeech: r
+00322759-r:
+  definition:
+  - with respect to home or family
+  example:
+  - the housewife bored us with her domestically limited conversation
+  ili: i20358
+  members:
+  - domestically
+  partOfSpeech: r
+00322917-r:
+  definition:
+  - with respect to the internal affairs of a government
+  example:
+  - domestically, the president proposes a more moderate economic policy
+  ili: i20359
+  members:
+  - domestically
+  partOfSpeech: r
+00326234-r:
+  definition:
+  - in an ecclesiastic manner
+  example:
+  - the candidate was ecclesiastically endorsed
+  ili: i20384
+  members:
+  - ecclesiastically
+  partOfSpeech: r
+00326369-r:
+  definition:
+  - with respect to ecology
+  example:
+  - ecologically speaking, this idea is brilliant; economically, it is a disaster
+  ili: i20385
+  members:
+  - ecologically
+  partOfSpeech: r
+00326996-r:
+  definition:
+  - in an educational manner
+  example:
+  - the assistant masters formed a committee of their own to consider what could be
+    done educationally for the town
+  ili: i20389
+  members:
+  - educationally
+  partOfSpeech: r
+00331028-r:
+  definition:
+  - for the environment
+  example:
+  - the new recycling policy is environmentally safe
+  ili: i20415
+  members:
+  - environmentally
+  partOfSpeech: r
+00332684-r:
+  definition:
+  - in an evolutionary way; from an evolutionary point of view
+  example:
+  - the mutation has been evolutionarily successful
+  ili: i20426
+  members:
+  - evolutionarily
+  partOfSpeech: r
+00347455-r:
+  definition:
+  - with respect to function
+  example:
+  - the two units are functionally interdependent
+  ili: i20521
+  members:
+  - functionally
+  partOfSpeech: r
+00349012-r:
+  definition:
+  - in a genealogical manner
+  example:
+  - he charted his family tree genealogically
+  ili: i20531
+  members:
+  - genealogically
+  partOfSpeech: r
+00349142-r:
+  definition:
+  - as sharing a common genus
+  example:
+  - these animals are not related generically
+  ili: i20532
+  members:
+  - generically
+  partOfSpeech: r
+00349513-r:
+  definition:
+  - with respect to geology
+  example:
+  - geologically speaking, this area is extremely interesting
+  ili: i20535
+  members:
+  - geologically
+  partOfSpeech: r
+00363133-r:
+  definition:
+  - with respect to ideology
+  example:
+  - ideologically, we do not see eye to eye
+  ili: i20633
+  members:
+  - ideologically
+  partOfSpeech: r
+00393380-r:
+  definition:
+  - with regard to or concerning limnology
+  ili: i20824
+  members:
+  - limnologically
+  partOfSpeech: r
+00396942-r:
+  definition:
+  - in a managerial manner
+  ili: i20852
+  members:
+  - managerially
+  partOfSpeech: r
+00403375-r:
+  definition:
+  - with regard to meter
+  example:
+  - metrically, these poems are matched
+  ili: i20894
+  members:
+  - metrically
+  partOfSpeech: r
+00405821-r:
+  definition:
+  - in a morphological manner; with regard to morphology
+  example:
+  - these two plants are morphologically related
+  ili: i20912
+  members:
+  - morphologically
+  partOfSpeech: r
+00406789-r:
+  definition:
+  - in a worldly manner
+  example:
+  - terrestrially changeable
+  ili: i20918
+  members:
+  - mundanely
+  - terrestrially
+  partOfSpeech: r
+00412955-r:
+  definition:
+  - with regard to nutrition
+  example:
+  - nutritionally, her new diet is suicide
+  ili: i20958
+  members:
+  - nutritionally
+  partOfSpeech: r
+00413081-r:
+  definition:
+  - in number; with regard to numbers
+  example:
+  - in ten years' time the Oxbridge mathematicians, scientists, and engineers will
+    not be much more significant numerically than the Oxbridge medical schools are
+    now
+  ili: i20959
+  members:
+  - numerically
+  partOfSpeech: r
+00414088-r:
+  definition:
+  - in a subjective way
+  example:
+  - you cannot look at these facts subjectively
+  ili: i20967
+  members:
+  - subjectively
+  partOfSpeech: r
+00415752-r:
+  definition:
+  - in respect to operation
+  example:
+  - reported the machine operationally satisfactory
+  - a well-trained staff that is operationally adequate
+  ili: i20979
+  members:
+  - operationally
+  partOfSpeech: r
+00416968-r:
+  definition:
+  - with regard to organization
+  example:
+  - organizationally, the conference was a disaster!
+  ili: i20987
+  members:
+  - organizationally
+  partOfSpeech: r
+00421786-r:
+  definition:
+  - with regard to perception
+  example:
+  - this task is perceptually very difficult
+  ili: i21023
+  members:
+  - perceptually
+  partOfSpeech: r
+00423382-r:
+  definition:
+  - with regard to pharmacology
+  example:
+  - pharmacologically, this plant could have important applications
+  ili: i21035
+  members:
+  - pharmacologically
+  partOfSpeech: r
+00423749-r:
+  definition:
+  - in a philatelic manner
+  example:
+  - the Post Office honors great Americans philatelically
+  ili: i21038
+  members:
+  - philatelically
+  partOfSpeech: r
+00436814-r:
+  definition:
+  - with regard to psychology
+  example:
+  - war that caught them in its toils either psychologically or physically
+  - the event was very damaging to the child psychologically
+  ili: i21133
+  members:
+  - psychologically
+  partOfSpeech: r
+00437035-r:
+  definition:
+  - in terms of psychology
+  example:
+  - classify poetry psychologically
+  ili: i21134
+  members:
+  - psychologically
+  partOfSpeech: r
+00438569-r:
+  definition:
+  - in a qualitative manner
+  example:
+  - this discoloration qualitatively suggests that the substance is low in inorganic
+    iron
+  ili: i21146
+  members:
+  - qualitatively
+  partOfSpeech: r
+00463045-r:
+  definition:
+  - with regard to sociology
+  example:
+  - sociologically speaking, this is an interesting phenomenon
+  ili: i21326
+  members:
+  - sociologically
+  partOfSpeech: r
+00467911-r:
+  definition:
+  - according to statute
+  example:
+  - placed statutorily under the council's supervision
+  ili: i21368
+  members:
+  - statutorily
+  partOfSpeech: r
+00470062-r:
+  definition:
+  - of or concerning this or that
+  example:
+  - a problem and the solution thereof
+  ili: i21385
+  members:
+  - thereof
+  partOfSpeech: r
+00470985-r:
+  definition:
+  - with regard to strategy
+  example:
+  - strategically important decisions
+  ili: i21394
+  members:
+  - strategically
+  partOfSpeech: r
+00471848-r:
+  also:
+  - 91001531-r
+  definition:
+  - in a rhetorically stylistic manner
+  example:
+  - stylistically complex
+  ili: i21401
+  members:
+  - stylistically
+  partOfSpeech: r
+00475679-r:
+  definition:
+  - with regard to tactics
+  example:
+  - the tactically useful province is still firmly in the rebels' hands
+  ili: i21424
+  members:
+  - tactically
+  partOfSpeech: r
+00478378-r:
+  definition:
+  - in a theological manner
+  example:
+  - he dealt with the problem of evil theologically, not philosophically
+  ili: i21443
+  members:
+  - theologically
+  partOfSpeech: r
+00478533-r:
+  definition:
+  - as regards theology
+  example:
+  - the candidate was found theologically sound
+  ili: i21444
+  members:
+  - theologically
+  partOfSpeech: r
+00478938-r:
+  definition:
+  - according to tradition; in a traditional manner
+  example:
+  - traditionally, we eat fried foods on Hanukah
+  ili: i21447
+  members:
+  - traditionally
+  partOfSpeech: r
+00481601-r:
+  definition:
+  - with regard to topography
+  example:
+  - the geological environment is the primary factor in determining the character
+    of a country not only topographically but historically
+  ili: i21468
+  members:
+  - topographically
+  partOfSpeech: r
+00483659-r:
+  definition:
+  - in a tropical manner
+  example:
+  - it was tropically hot in the greenhouse
+  ili: i21484
+  members:
+  - tropically
+  partOfSpeech: r
+00484611-r:
+  definition:
+  - in a typographic way
+  ili: i21491
+  members:
+  - typographically
+  partOfSpeech: r
+00484693-r:
+  definition:
+  - beyond the scope or in excess of legal power or authority
+  ili: i21492
+  members:
+  - ultra vires
+  partOfSpeech: r
+00503338-r:
+  definition:
+  - with regard to fundamentals although not concerning details
+  example:
+  - in principle, we agree
+  ili: i21645
+  members:
+  - in principle
+  - in theory
+  - in essence
+  partOfSpeech: r
+00503820-r:
+  definition:
+  - with respect to philosophy
+  example:
+  - the movement is philosophically indebted to Rousseau
+  ili: i21648
+  members:
+  - philosophically
+  partOfSpeech: r
+00508084-r:
+  definition:
+  - in a causal fashion
+  example:
+  - causally efficacious powers
+  ili: i21679
+  members:
+  - causally
+  partOfSpeech: r
+00513385-r:
+  definition:
+  - in a manner dependent on context
+  ili: i21721
+  members:
+  - contextually
+  partOfSpeech: r
+00513476-r:
+  definition:
+  - dependent on a department
+  ili: i21722
+  members:
+  - departmentally
+  partOfSpeech: r
+00513738-r:
+  definition:
+  - used as a residence
+  ili: i21725
+  members:
+  - residentially
+  partOfSpeech: r
+00515407-r:
+  definition:
+  - in a canonical manner
+  example:
+  - the deacon was canonically inducted
+  ili: i21740
+  members:
+  - canonically
+  partOfSpeech: r
+00515525-r:
+  definition:
+  - with regard to cognition
+  example:
+  - cognitively skillful
+  ili: i21741
+  members:
+  - cognitively
+  partOfSpeech: r
+00516364-r:
+  definition:
+  - from the point of view of immunology
+  ili: i21751
+  members:
+  - immunologically
+  partOfSpeech: r
+00516805-r:
+  definition:
+  - as ordered by a court
+  ili: i21755
+  members:
+  - judicially
+  partOfSpeech: r
+00518336-r:
+  definition:
+  - (of group) in a synergistic or cooperative manner
+  ili: i21770
+  members:
+  - synergistically
+  partOfSpeech: r
+00518567-r:
+  definition:
+  - with regard to taxonomy
+  example:
+  - closely related taxonomically
+  ili: i21772
+  members:
+  - taxonomically
+  partOfSpeech: r
+00518683-r:
+  definition:
+  - from the point of view of topology
+  ili: i21773
+  members:
+  - topologically
+  partOfSpeech: r
+91001531-r:
+  also:
+  - 00471848-r
+  definition:
+  - regarding the tone
+  members:
+  - tonally
+  partOfSpeech: r
+  source: Colloquial WordNet

--- a/src/yaml/adv.focus.yaml
+++ b/src/yaml/adv.focus.yaml
@@ -1,0 +1,595 @@
+00005103-r:
+  definition:
+  - and nothing more
+  example:
+  - I was merely asking
+  - it is simply a matter of time
+  - just a scratch
+  - he was only a child
+  - hopes that last but a moment
+  ili: i18177
+  members:
+  - merely
+  - simply
+  - just
+  - only
+  - but
+  partOfSpeech: r
+00011221-r:
+  definition:
+  - with nevertheless the final result
+  example:
+  - He arrived only to find his wife dead
+  - We won only to lose again in the next round
+  ili: i18208
+  members:
+  - only
+  partOfSpeech: r
+00011376-r:
+  definition:
+  - in the final outcome
+  example:
+  - These news will only make you more upset
+  ili: i18209
+  members:
+  - only
+  partOfSpeech: r
+00011473-r:
+  definition:
+  - as recently as
+  example:
+  - I spoke to him only an hour ago
+  ili: i18210
+  members:
+  - only
+  partOfSpeech: r
+00017907-r:
+  definition:
+  - used as an intensive especially to indicate something unexpected
+  example:
+  - even an idiot knows that
+  - declined even to consider the idea
+  - I don't have even a dollar!
+  ili: i18242
+  members:
+  - even
+  partOfSpeech: r
+00018101-r:
+  definition:
+  - to a greater degree or extent; used with comparisons
+  example:
+  - looked sick and felt even worse
+  - an even (or still) more interesting problem
+  - still another problem must be solved
+  - a yet sadder tale
+  ili: i18243
+  members:
+  - even
+  - yet
+  - still
+  partOfSpeech: r
+00018505-r:
+  definition:
+  - in spite of; notwithstanding
+  example:
+  - even when he is sick, he works
+  - even with his head start she caught up with him
+  ili: i18245
+  members:
+  - even
+  partOfSpeech: r
+00018651-r:
+  definition:
+  - to the full extent
+  example:
+  - loyal even unto death
+  ili: i18246
+  members:
+  - even
+  partOfSpeech: r
+00025252-r:
+  definition:
+  - after a negative statement used as an intensive meaning something like ‘likewise’
+    or ‘also’
+  example:
+  - he isn't stupid, but he isn't exactly a genius either
+  - I don't know either
+  - if you don't order dessert I won't either
+  ili: i18286
+  members:
+  - either
+  partOfSpeech: r
+00030839-r:
+  definition:
+  - in addition or furthermore
+  example:
+  - if we further suppose
+  - stated further that he would not cooperate with them
+  - they are definitely coming; further, they should be here already
+  ili: i18312
+  members:
+  - further
+  partOfSpeech: r
+00037166-r:
+  definition:
+  - with respect to its inherent nature
+  example:
+  - this statement is interesting per se
+  ili: i18355
+  members:
+  - intrinsically
+  - per se
+  - in and of itself
+  partOfSpeech: r
+00040906-r:
+  definition:
+  - together with this
+  ili: i18373
+  members:
+  - withal
+  partOfSpeech: r
+00042168-r:
+  definition:
+  - in distinction from others
+  example:
+  - a program specifically for teenagers
+  - he is interested specifically in poisonous snakes
+  ili: i18383
+  members:
+  - specifically
+  partOfSpeech: r
+00046047-r:
+  definition:
+  - over and above
+  example:
+  - agreed to provide essentials but nothing beyond
+  ili: i18405
+  members:
+  - beyond
+  partOfSpeech: r
+00046442-r:
+  definition:
+  - in other respects or ways
+  example:
+  - he is otherwise normal
+  - the funds are not otherwise available
+  - an otherwise hopeless situation
+  ili: i18408
+  members:
+  - otherwise
+  partOfSpeech: r
+00046607-r:
+  definition:
+  - in addition, by way of addition; furthermore
+  example:
+  - he serves additionally as the CEO
+  ili: i18409
+  members:
+  - additionally
+  - to boot
+  partOfSpeech: r
+00048072-r:
+  definition:
+  - in addition
+  example:
+  - he has a Mercedes, too
+  ili: i18418
+  members:
+  - besides
+  - too
+  - also
+  - likewise
+  - as well
+  partOfSpeech: r
+00063907-r:
+  definition:
+  - much less
+  example:
+  - she can't boil potatoes, let alone cook a meal
+  ili: i18519
+  members:
+  - let alone
+  - not to mention
+  partOfSpeech: r
+00068977-r:
+  definition:
+  - in accompaniment or as a companion
+  example:
+  - his little sister came along to the movies
+  - I brought my camera along
+  - working along with his father
+  ili: i18552
+  members:
+  - along
+  partOfSpeech: r
+00069153-r:
+  definition:
+  - in addition (usually followed by ‘with’)
+  example:
+  - we sent them food and some clothing went along in the package
+  - along with the package came a bill
+  - consider the advantages along with the disadvantages
+  ili: i18553
+  members:
+  - along
+  partOfSpeech: r
+00070072-r:
+  definition:
+  - equally
+  example:
+  - parents and teachers alike demanded reforms
+  ili: i18559
+  members:
+  - alike
+  - likewise
+  partOfSpeech: r
+00074163-r:
+  definition:
+  - for the most part
+  example:
+  - he is mainly interested in butterflies
+  ili: i18582
+  members:
+  - chiefly
+  - principally
+  - primarily
+  - mainly
+  - in the main
+  partOfSpeech: r
+00080654-r:
+  definition:
+  - in addition; over and above what is expected
+  example:
+  - He lost his wife in the bargain
+  ili: i18625
+  members:
+  - in the bargain
+  - into the bargain
+  partOfSpeech: r
+00085862-r:
+  definition:
+  - with specific intentions; for the express purpose
+  example:
+  - she needs the money expressly for her patients
+  ili: i18662
+  members:
+  - expressly
+  partOfSpeech: r
+00101323-r:
+  definition:
+  - as far as that is concerned
+  example:
+  - for that matter I don't care either
+  ili: i18769
+  members:
+  - for that matter
+  partOfSpeech: r
+00103536-r:
+  definition:
+  - in the third place
+  example:
+  - third we must consider unemployment
+  ili: i18784
+  members:
+  - third
+  - thirdly
+  partOfSpeech: r
+00104351-r:
+  definition:
+  - continuing in the same way
+  ili: i18790
+  members:
+  - and so forth
+  - and so on
+  - etcetera
+  - etc.
+  partOfSpeech: r
+00105348-r:
+  definition:
+  - if nothing else (‘leastwise’ is informal and ‘leastways’ is colloquial)
+  example:
+  - at least he survived
+  - they felt — at any rate Jim felt — relieved though still wary
+  - the influence of economists — or at any rate of economics — is far-reaching
+  exemplifies:
+  - 07089193-n
+  ili: i18798
+  members:
+  - at least
+  - leastways
+  - leastwise
+  - at any rate
+  partOfSpeech: r
+00112653-r:
+  definition:
+  - especially not
+  example:
+  - nobody, least of all Joe, agreed with me
+  ili: i18848
+  members:
+  - least of all
+  partOfSpeech: r
+00117806-r:
+  definition:
+  - participating in or knowledgeable out
+  example:
+  - was in on the scheme
+  ili: i18885
+  members:
+  - in on
+  partOfSpeech: r
+00132968-r:
+  definition:
+  - in the flesh; without involving anyone else
+  example:
+  - I went there personally
+  - he appeared in person
+  ili: i19005
+  members:
+  - personally
+  - in person
+  partOfSpeech: r
+00138725-r:
+  definition:
+  - in the order given
+  example:
+  - the brothers were called Felix and Max, respectively
+  ili: i19056
+  members:
+  - respectively
+  - severally
+  partOfSpeech: r
+00148308-r:
+  definition:
+  - in the same way; also
+  example:
+  - I was offended and so was he
+  - worked hard and so did she
+  ili: i19128
+  members:
+  - so
+  partOfSpeech: r
+00151729-r:
+  definition:
+  - above and beyond all other consideration
+  example:
+  - above all, you must be independent
+  ili: i19150
+  members:
+  - above all
+  - most importantly
+  - most especially
+  partOfSpeech: r
+00151983-r:
+  definition:
+  - including all
+  example:
+  - we got a pay raise across the board
+  ili: i19152
+  members:
+  - across the board
+  partOfSpeech: r
+00159313-r:
+  definition:
+  - taking everything together
+  example:
+  - she was first and last a scientist
+  ili: i19210
+  members:
+  - first and last
+  - above all
+  partOfSpeech: r
+00160349-r:
+  definition:
+  - in addition (as to close a deal)
+  example:
+  - the car salesman threw in the radio, for good measure
+  ili: i19217
+  members:
+  - for good measure
+  partOfSpeech: r
+00160572-r:
+  definition:
+  - under any circumstances
+  example:
+  - she wouldn't give up her pets for love or money
+  ili: i19219
+  members:
+  - for love or money
+  - for anything
+  - for any price
+  - for all the world
+  partOfSpeech: r
+00160743-r:
+  definition:
+  - as a particular one of several possibilities
+  example:
+  - I for one feel very grateful
+  - her mother for one was worried
+  ili: i19220
+  members:
+  - for one
+  partOfSpeech: r
+00173363-r:
+  definition:
+  - without exception
+  example:
+  - voted for unionization to a man
+  ili: i19309
+  members:
+  - to a man
+  partOfSpeech: r
+00180598-r:
+  definition:
+  - restricted to something
+  example:
+  - we talked strictly business
+  ili: i19364
+  members:
+  - strictly
+  - purely
+  partOfSpeech: r
+00190022-r:
+  definition:
+  - as follows
+  ili: i19434
+  members:
+  - namely
+  - viz.
+  - that is to say
+  - to wit
+  - videlicet
+  partOfSpeech: r
+00192665-r:
+  definition:
+  - and elsewhere (used when referring to other occurrences in a text)
+  ili: i19454
+  members:
+  - et al.
+  - et al
+  - et alibi
+  partOfSpeech: r
+00192785-r:
+  definition:
+  - and others (‘et al.’ is used as an abbreviation of ‘et alii’ (masculine plural)
+    or ‘et aliae’ (feminine plural) or ‘et alia’ (neuter plural) when referring to
+    a number of people)
+  example:
+  - the data reported by Smith et al.
+  ili: i19455
+  members:
+  - et al.
+  - et al
+  - et alii
+  - et aliae
+  - et alia
+  partOfSpeech: r
+00208995-r:
+  definition:
+  - apart from others
+  example:
+  - taken individually, the rooms were, in fact, square
+  - the fine points are treated singly
+  ili: i19574
+  members:
+  - individually
+  - separately
+  - singly
+  - severally
+  - one by one
+  - on an individual basis
+  partOfSpeech: r
+00224618-r:
+  definition:
+  - by title vested in yourself or by virtue of qualifications that you have achieved
+  example:
+  - a peer in his own right
+  - a leading sports figure in his own right
+  - a fine opera in its own right
+  - she's a rich woman in her own right rather than by inheritance
+  - an excellent novel in its own right
+  ili: i19672
+  members:
+  - in one's own right
+  - in his own right
+  - in her own right
+  - in its own right
+  partOfSpeech: r
+00241635-r:
+  definition:
+  - to or from every one of two or more (considered individually)
+  example:
+  - they received $10 each
+  ili: i19793
+  members:
+  - each
+  - to each one
+  - for each one
+  - from each one
+  - apiece
+  partOfSpeech: r
+00245660-r:
+  definition:
+  - without official approval
+  example:
+  - he had made some money on the side
+  ili: i19822
+  members:
+  - unofficially
+  - on the side
+  partOfSpeech: r
+00250244-r:
+  definition:
+  - specifically or especially distinguished from others
+  example:
+  - loves Bach, particularly his partitas
+  - recommended one book in particular
+  - trace major population movements for the Pueblo groups in particular
+  ili: i19857
+  members:
+  - particularly
+  - in particular
+  partOfSpeech: r
+00257022-r:
+  definition:
+  - all other things being equal
+  ili: i19913
+  members:
+  - ceteris paribus
+  partOfSpeech: r
+00257871-r:
+  definition:
+  - among other things
+  example:
+  - the committee recommended, inter alia, that he be promoted
+  ili: i19920
+  members:
+  - inter alia
+  partOfSpeech: r
+00258092-r:
+  definition:
+  - (used when listing or enumerating items) also
+  example:
+  - source: Philip Guedalla
+    text: a length of chain, item a hook
+  ili: i19922
+  members:
+  - item
+  partOfSpeech: r
+00271877-r:
+  definition:
+  - as known or named at another time or place
+  example:
+  - Mr. Smith, alias Mr. Lafayette
+  ili: i20031
+  members:
+  - alias
+  - a.k.a.
+  - also known as
+  partOfSpeech: r
+00301750-r:
+  definition:
+  - possibly (indicating a slight chance of something being true)
+  example:
+  - it might just happen
+  members:
+  - just
+  partOfSpeech: r
+00470504-r:
+  definition:
+  - together with all that; besides
+  example:
+  - source: Shakespeare
+    text: thy slanders I forgive; and therewithal remit thy other forfeits
+  ili: i21390
+  members:
+  - therewithal
+  partOfSpeech: r
+00478108-r:
+  definition:
+  - (in enumerating something, such as topics or points of discussion) in the tenth
+    place
+  ili: i21441
+  members:
+  - tenthly
+  partOfSpeech: r

--- a/src/yaml/adv.frequency.yaml
+++ b/src/yaml/adv.frequency.yaml
@@ -1,0 +1,604 @@
+00003317-r:
+  definition:
+  - almost not
+  example:
+  - he hardly ever goes fishing
+  - he was scarce sixteen years old
+  - they scarcely ever used the emergency generator
+  - I can hardly hear what she is saying
+  - she barely seemed to notice him
+  - we were so far back in the theater we could barely read the subtitles
+  ili: i18165
+  members:
+  - hardly
+  - scarcely
+  - barely
+  - scarce
+  partOfSpeech: r
+00019801-r:
+  definition:
+  - at all times; all the time and on every occasion
+  example:
+  - I will always be there to help you
+  - always arrives on time
+  - there is always some pollution in the air
+  - ever hoping to strike it rich
+  - ever busy
+  ili: i18253
+  members:
+  - always
+  - ever
+  - e'er
+  partOfSpeech: r
+00020071-r:
+  definition:
+  - forever; throughout all time
+  example:
+  - we will always be friends
+  - I shall treasure it always
+  - I will always love you
+  ili: i18254
+  members:
+  - always
+  partOfSpeech: r
+00020219-r:
+  definition:
+  - at any time or in any event
+  example:
+  - you can always resign if you don't like it
+  - you could always take a day off
+  ili: i18255
+  members:
+  - always
+  partOfSpeech: r
+00020735-r:
+  definition:
+  - invariably
+  example:
+  - the world is constantly changing
+  ili: i18259
+  members:
+  - constantly
+  - always
+  - forever
+  - perpetually
+  - incessantly
+  partOfSpeech: r
+00020931-r:
+  definition:
+  - without variation or change, in every case
+  example:
+  - constantly kind and gracious
+  - he always arrives on time
+  ili: i18260
+  members:
+  - constantly
+  - invariably
+  - always
+  partOfSpeech: r
+00021214-r:
+  definition:
+  - not at all; certainly not; not in any circumstances; not ever; at no time in the
+    past or future
+  example:
+  - I have never been to China
+  - I shall never forget this day
+  - had never seen a circus
+  - never on Sunday
+  - I will never marry you!
+  - never fear
+  ili: i18262
+  members:
+  - never
+  - ne'er
+  partOfSpeech: r
+00021667-r:
+  definition:
+  - sporadically and infrequently
+  example:
+  - he was arrogant and occasionally callous
+  - open areas are only occasionally interrupted by clumps of trees
+  - they visit New York on occasion
+  - now and again she would take her favorite book from the shelf and read to us
+  - as we drove along, the beautiful scenery now and then attracted his attention
+  ili: i18264
+  members:
+  - occasionally
+  - on occasion
+  - once in a while
+  - now and then
+  - now and again
+  - at times
+  - from time to time
+  partOfSpeech: r
+00022332-r:
+  definition:
+  - on certain occasions or in certain cases but not always
+  example:
+  - sometimes she wished she were back in England
+  - sometimes her photography is breathtaking
+  - sometimes they come for a month; at other times for six months
+  ili: i18266
+  members:
+  - sometimes
+  partOfSpeech: r
+00035445-r:
+  definition:
+  - many times at short intervals
+  example:
+  - we often met over a cup of coffee
+  ili: i18345
+  members:
+  - frequently
+  - often
+  - oftentimes
+  - oft
+  - ofttimes
+  partOfSpeech: r
+00035642-r:
+  definition:
+  - more often or more frequently
+  ili: i18346
+  members:
+  - oftener
+  partOfSpeech: r
+00035707-r:
+  definition:
+  - at another time
+  example:
+  - ever and anon
+  ili: i18347
+  members:
+  - anon
+  partOfSpeech: r
+00035772-r:
+  definition:
+  - not often
+  example:
+  - we rarely met
+  ili: i18348
+  members:
+  - rarely
+  - seldom
+  partOfSpeech: r
+00040777-r:
+  definition:
+  - anew
+  example:
+  - she tried again
+  - they rehearsed the scene again
+  ili: i18372
+  members:
+  - again
+  - once again
+  - once more
+  - over again
+  partOfSpeech: r
+00060085-r:
+  definition:
+  - in many cases or instances
+  ili: i18496
+  members:
+  - often
+  partOfSpeech: r
+00065694-r:
+  definition:
+  - two times
+  example:
+  - I called her twice
+  ili: i18532
+  members:
+  - twice
+  partOfSpeech: r
+00081836-r:
+  definition:
+  - every day; without missing a day
+  example:
+  - he stops by daily
+  ili: i18632
+  members:
+  - daily
+  partOfSpeech: r
+00081941-r:
+  definition:
+  - without missing a week
+  example:
+  - she visited her aunt weekly
+  ili: i18633
+  members:
+  - hebdomadally
+  - weekly
+  - every week
+  - each week
+  partOfSpeech: r
+00082087-r:
+  definition:
+  - without missing a year
+  example:
+  - they travel to China annually
+  ili: i18634
+  members:
+  - annually
+  - yearly
+  - every year
+  - each year
+  partOfSpeech: r
+00084016-r:
+  definition:
+  - in several ways; in a multiple manner
+  example:
+  - they were multiply checked for errors
+  ili: i18650
+  members:
+  - multiply
+  partOfSpeech: r
+00089419-r:
+  definition:
+  - seemingly without interruption
+  example:
+  - complained continually that there wasn't enough money
+  ili: i18687
+  members:
+  - continually
+  partOfSpeech: r
+00107608-r:
+  definition:
+  - under normal conditions
+  example:
+  - usually she was late
+  ili: i18813
+  members:
+  - normally
+  - usually
+  - unremarkably
+  - commonly
+  - ordinarily
+  partOfSpeech: r
+00142439-r:
+  definition:
+  - in an episodic manner
+  ili: i19080
+  members:
+  - episodically
+  partOfSpeech: r
+00154430-r:
+  definition:
+  - as one chooses or pleases
+  example:
+  - he can roam the neighborhood at will
+  ili: i19173
+  members:
+  - at will
+  partOfSpeech: r
+00158123-r:
+  definition:
+  - without respite
+  example:
+  - he plays chess day in and day out
+  ili: i19201
+  members:
+  - day in and day out
+  - all the time
+  partOfSpeech: r
+00158535-r:
+  definition:
+  - occasionally
+  example:
+  - every so often she visits her father
+  ili: i19205
+  members:
+  - every so often
+  - every now and then
+  partOfSpeech: r
+00170405-r:
+  definition:
+  - not regularly
+  example:
+  - they phone each other off and on
+  ili: i19286
+  members:
+  - off and on
+  - on and off
+  partOfSpeech: r
+00170970-r:
+  definition:
+  - typically
+  example:
+  - on average he watches three movies a week
+  ili: i19291
+  members:
+  - on the average
+  - on average
+  partOfSpeech: r
+00178467-r:
+  definition:
+  - repeatedly
+  example:
+  - the unknown word turned up over and over again in the text
+  ili: i19349
+  members:
+  - over and over
+  - again and again
+  - over and over again
+  - time and again
+  - time and time again
+  - repeatedly
+  partOfSpeech: r
+00179412-r:
+  definition:
+  - for an indefinite number of successive days
+  ili: i19355
+  members:
+  - day in day out
+  - day after day
+  partOfSpeech: r
+00179514-r:
+  definition:
+  - for an indefinite number of successive weeks
+  ili: i19356
+  members:
+  - week after week
+  partOfSpeech: r
+00180072-r:
+  definition:
+  - with extreme conscientiousness
+  example:
+  - he came religiously every morning at 8 o'clock
+  ili: i19361
+  members:
+  - scrupulously
+  - conscientiously
+  - religiously
+  partOfSpeech: r
+00212077-r:
+  definition:
+  - according to habit or custom
+  example:
+  - her habitually severe expression
+  - he habitually keeps his office door closed
+  ili: i19594
+  members:
+  - habitually
+  partOfSpeech: r
+00212244-r:
+  definition:
+  - according to routine or established practice
+  example:
+  - he routinely parked in a no-parking zone
+  ili: i19595
+  members:
+  - routinely
+  partOfSpeech: r
+00214272-r:
+  definition:
+  - in a sporadic manner
+  example:
+  - he only works sporadically
+  ili: i19609
+  members:
+  - sporadically
+  - periodically
+  partOfSpeech: r
+00252039-r:
+  definition:
+  - by the year; every year (usually with reference to a sum of money paid or received)
+  example:
+  - he earned $100,000 per annum
+  - we issue six volumes per annum
+  ili: i19872
+  members:
+  - per annum
+  - p.a.
+  - per year
+  - each year
+  - annually
+  partOfSpeech: r
+00252267-r:
+  definition:
+  - one every day
+  example:
+  - we'll save 100 man-hours per diem
+  ili: i19873
+  members:
+  - per diem
+  - by the day
+  partOfSpeech: r
+00256191-r:
+  definition:
+  - every two weeks
+  example:
+  - he visited his cousins fortnightly
+  ili: i19906
+  members:
+  - fortnightly
+  - biweekly
+  partOfSpeech: r
+00256331-r:
+  definition:
+  - twice a week
+  example:
+  - he called home semiweekly
+  ili: i19907
+  members:
+  - semiweekly
+  - biweekly
+  partOfSpeech: r
+00256458-r:
+  definition:
+  - occurring once a month
+  example:
+  - they meet monthly
+  ili: i19908
+  members:
+  - monthly
+  partOfSpeech: r
+00256555-r:
+  definition:
+  - every two months
+  example:
+  - the bill was payable bimonthly
+  ili: i19909
+  members:
+  - bimonthly
+  partOfSpeech: r
+00256661-r:
+  definition:
+  - twice a month
+  example:
+  - salaries are paid semimonthly
+  ili: i19910
+  members:
+  - semimonthly
+  - bimonthly
+  partOfSpeech: r
+00256795-r:
+  definition:
+  - twice a year
+  example:
+  - we hold our big sale biannually
+  ili: i19911
+  members:
+  - semiannually
+  - biyearly
+  - biannually
+  partOfSpeech: r
+00259294-r:
+  definition:
+  - three times
+  example:
+  - I called you thrice last night
+  ili: i19933
+  members:
+  - thrice
+  partOfSpeech: r
+00280480-r:
+  definition:
+  - every two years
+  example:
+  - this festival takes places biennially
+  ili: i20096
+  members:
+  - biennially
+  - biyearly
+  partOfSpeech: r
+00284883-r:
+  definition:
+  - every hundred years; once in a century
+  example:
+  - the birthday of this city is being celebrated centennially
+  ili: i20124
+  members:
+  - centennially
+  partOfSpeech: r
+00333223-r:
+  definition:
+  - in a regular manner
+  example:
+  - letters arrived regularly from his children
+  ili: i19484
+  members:
+  - regularly
+  - on a regular basis
+  partOfSpeech: r
+00333384-r:
+  definition:
+  - in an inconstant manner, not according to fixed rate or schedule
+  example:
+  - her letters arrived irregularly
+  - the stomach mucosa was irregularly blackened
+  ili: i19485
+  members:
+  - irregularly
+  - on an irregular basis
+  partOfSpeech: r
+00354517-r:
+  definition:
+  - every thirty minutes, every half hour
+  ili: i20570
+  members:
+  - half-hourly
+  partOfSpeech: r
+00354612-r:
+  definition:
+  - every half year, every six months
+  ili: i20571
+  members:
+  - half-yearly
+  partOfSpeech: r
+00360781-r:
+  definition:
+  - every hour; by the hour
+  example:
+  - daily, hourly, I grew stronger
+  ili: i20617
+  members:
+  - hourly
+  partOfSpeech: r
+00376350-r:
+  definition:
+  - not many times
+  example:
+  - in your 1850 church you not infrequently find a dramatic contrast between the
+    sumptuous appointments of the building itself and the inhuman barrack-like living
+    conditions in the church room
+  ili: i20711
+  members:
+  - infrequently
+  partOfSpeech: r
+00382291-r:
+  definition:
+  - in an intermittent manner
+  example:
+  - intermittently we questioned the barometer
+  ili: i20748
+  members:
+  - intermittently
+  partOfSpeech: r
+00411507-r:
+  definition:
+  - at no time hereafter
+  example:
+  - source: E.A. Poe
+    text: Quoth the raven, nevermore!
+  ili: i20948
+  members:
+  - nevermore
+  - never again
+  partOfSpeech: r
+00412120-r:
+  definition:
+  - at the end of each day
+  example:
+  - she checks on her roses nightly
+  ili: i20951
+  members:
+  - nightly
+  - every night
+  partOfSpeech: r
+00438741-r:
+  definition:
+  - in three month intervals
+  example:
+  - interest is compounded quarterly
+  ili: i21147
+  members:
+  - quarterly
+  - every quarter
+  partOfSpeech: r
+00479093-r:
+  definition:
+  - in quick succession
+  example:
+  - misfortunes come fast and thick
+  ili: i21448
+  members:
+  - thick
+  - thickly
+  partOfSpeech: r
+00517422-r:
+  definition:
+  - in a recurrent manner
+  ili: i21761
+  members:
+  - recurrently
+  partOfSpeech: r

--- a/src/yaml/adv.manner.yaml
+++ b/src/yaml/adv.manner.yaml
@@ -8,51 +8,6 @@
   - a cappella
   - a capella
   partOfSpeech: r
-00001885-r:
-  definition:
-  - in the Christian era; used before dates after the supposed year Christ was born
-  example:
-  - in AD 200
-  ili: i18158
-  members:
-  - AD
-  - A.D.
-  - anno Domini
-  partOfSpeech: r
-00002029-r:
-  definition:
-  - of the period coinciding with the Christian era; preferred by some writers who
-    are not Christians
-  example:
-  - in 200 CE
-  ili: i18159
-  members:
-  - CE
-  - C.E.
-  - Common Era
-  partOfSpeech: r
-00002190-r:
-  definition:
-  - before the Christian era; used following dates before the supposed year Christ
-    was born
-  example:
-  - in 200 BC
-  ili: i18160
-  members:
-  - BC
-  - B.C.
-  - before Christ
-  partOfSpeech: r
-00002344-r:
-  definition:
-  - of the period before the Common Era; preferred by some writers who are not Christians
-  example:
-  - in 200 BCE
-  ili: i18161
-  members:
-  - BCE
-  - B.C.E.
-  partOfSpeech: r
 00002484-r:
   definition:
   - on the back of a horse
@@ -66,113 +21,12 @@
   - ahorse
   - ahorseback
   partOfSpeech: r
-00002669-r:
-  definition:
-  - only a very short time before
-  example:
-  - we hardly knew them
-  - had scarcely rung the bell when the door flew open
-  - source: W.B.Yeats
-    text: would have scarce arrived before she would have found some excuse to leave
-  ili: i18163
-  members:
-  - barely
-  - hardly
-  - just
-  - scarcely
-  - scarce
-  partOfSpeech: r
-00002935-r:
-  definition:
-  - by a little
-  example:
-  - I only just caught the bus
-  - he finished the marathon in just under 3 hours
-  - it was barely 5 a.m.
-  - the network has barely 5 percent of viewers
-  - the batter just missed being hit
-  members:
-  - barely
-  - just
-  partOfSpeech: r
-00003175-r:
-  definition:
-  - exactly at this moment or the moment described
-  example:
-  - we've just finished painting the walls, so don't touch them
-  ili: i18164
-  members:
-  - just
-  partOfSpeech: r
-00003317-r:
-  definition:
-  - almost not
-  example:
-  - he hardly ever goes fishing
-  - he was scarce sixteen years old
-  - they scarcely ever used the emergency generator
-  - I can hardly hear what she is saying
-  - she barely seemed to notice him
-  - we were so far back in the theater we could barely read the subtitles
-  ili: i18165
-  members:
-  - hardly
-  - scarcely
-  - barely
-  - scarce
-  partOfSpeech: r
 00003675-r:
   definition:
   - in an anisotropic manner
   ili: i18166
   members:
   - anisotropically
-  partOfSpeech: r
-00003761-r:
-  definition:
-  - in an annoying manner or to an annoying degree
-  ili: i18167
-  members:
-  - annoyingly
-  partOfSpeech: r
-00003864-r:
-  definition:
-  - in essence; at bottom or by one's (or its) very nature
-  example:
-  - He is basically dishonest
-  - the argument was essentially a technical one
-  ili: i18168
-  members:
-  - basically
-  - fundamentally
-  - essentially
-  partOfSpeech: r
-00004152-r:
-  definition:
-  - in a blessed manner
-  ili: i18169
-  members:
-  - blessedly
-  partOfSpeech: r
-00004227-r:
-  definition:
-  - passionately or agitatedly
-  example:
-  - boiling mad
-  exemplifies:
-  - 07089193-n
-  ili: i18170
-  members:
-  - boiling
-  partOfSpeech: r
-00004306-r:
-  definition:
-  - in an enviable manner
-  example:
-  - she was enviably fluent in French
-  ili: i18171
-  members:
-  - enviably
   partOfSpeech: r
 00004419-r:
   definition:
@@ -220,32 +74,6 @@
   members:
   - unkindly
   partOfSpeech: r
-00005103-r:
-  definition:
-  - and nothing more
-  example:
-  - I was merely asking
-  - it is simply a matter of time
-  - just a scratch
-  - he was only a child
-  - hopes that last but a moment
-  ili: i18177
-  members:
-  - merely
-  - simply
-  - just
-  - only
-  - but
-  partOfSpeech: r
-00005348-r:
-  definition:
-  - absolutely; altogether; really
-  example:
-  - we are simply broke
-  ili: i18178
-  members:
-  - simply
-  partOfSpeech: r
 00005436-r:
   definition:
   - in a simple manner; without extravagance or embellishment
@@ -256,24 +84,6 @@
   members:
   - plainly
   - simply
-  partOfSpeech: r
-00005591-r:
-  definition:
-  - in ancient times; long ago
-  example:
-  - a concern with what may have happened anciently
-  ili: i18180
-  members:
-  - anciently
-  partOfSpeech: r
-00005724-r:
-  definition:
-  - as can be shown by argument
-  example:
-  - she is arguably the best
-  ili: i18181
-  members:
-  - arguably
   partOfSpeech: r
 00005834-r:
   definition:
@@ -292,71 +102,6 @@
   ili: i18183
   members:
   - automatically
-  partOfSpeech: r
-00006055-r:
-  definition:
-  - in an alarming manner
-  example:
-  - It grew alarmingly fast
-  ili: i18184
-  members:
-  - alarmingly
-  partOfSpeech: r
-00006160-r:
-  definition:
-  - to an exceedingly great extent or degree
-  example:
-  - He had vastly overestimated his resources
-  - was immensely more important to the project as a scientist than as an administrator
-  ili: i18185
-  members:
-  - vastly
-  - immensely
-  partOfSpeech: r
-00006415-r:
-  definition:
-  - in a gross manner
-  ili: i18186
-  members:
-  - grossly
-  partOfSpeech: r
-00006486-r:
-  definition:
-  - in large part; mainly or chiefly
-  example:
-  - These accounts are largely inactive
-  ili: i18187
-  members:
-  - largely
-  - mostly
-  - for the most part
-  partOfSpeech: r
-00006640-r:
-  definition:
-  - in a significant manner
-  example:
-  - our budget will be significantly affected by these new cuts
-  ili: i18188
-  members:
-  - significantly
-  partOfSpeech: r
-00006822-r:
-  definition:
-  - not to a significant degree or amount
-  example:
-  - our budget will only be insignificantly affected by these new cuts
-  ili: i18189
-  members:
-  - insignificantly
-  partOfSpeech: r
-00007009-r:
-  definition:
-  - to a noticeable degree
-  example:
-  - the weather was appreciably colder
-  ili: i18190
-  members:
-  - appreciably
   partOfSpeech: r
 00007128-r:
   definition:
@@ -378,153 +123,6 @@
   - modishly
   - sprucely
   partOfSpeech: r
-00007414-r:
-  definition:
-  - (of quantities) imprecise but fairly close to correct
-  example:
-  - lasted approximately an hour
-  - in just about a minute
-  - he's about 30 years old
-  - I've had about all I can stand
-  - we meet about once a month
-  - some forty people came
-  - weighs around a hundred pounds
-  - roughly $3,000
-  - holds 3 gallons, more or less
-  - 20 or so people were at the party
-  ili: i18193
-  members:
-  - approximately
-  - about
-  - close to
-  - just about
-  - some
-  - roughly
-  - more or less
-  - around
-  - or so
-  partOfSpeech: r
-00007887-r:
-  definition:
-  - totally and definitely; without question
-  example:
-  - we are absolutely opposed to the idea
-  - he forced himself to lie absolutely still
-  - iron is absolutely necessary
-  ili: i18194
-  members:
-  - absolutely
-  partOfSpeech: r
-00008102-r:
-  definition:
-  - to some extent; in some degree; not wholly
-  example:
-  - I felt partly to blame
-  - He was partially paralyzed
-  ili: i18195
-  members:
-  - partially
-  - partly
-  - part
-  - in part
-  partOfSpeech: r
-00008300-r:
-  definition:
-  - partially or to the extent of a half
-  example:
-  - he was half hidden by the bushes
-  ili: i18196
-  members:
-  - half
-  partOfSpeech: r
-00008423-r:
-  definition:
-  - to a complete degree or to the full or entire extent; Completely or entirely
-  example:
-  - he was wholly convinced
-  - entirely satisfied with the meal
-  - it was completely different from what we expected
-  - was completely at fault
-  - a totally new situation
-  - the directions were all wrong
-  - it was not altogether her fault
-  - an altogether new approach
-  - a whole new idea
-  - she felt right at home
-  - he fell right into the trap
-  ili: i19554
-  members:
-  - wholly
-  - entirely
-  - completely
-  - totally
-  - all
-  - altogether
-  - whole
-  - right
-  partOfSpeech: r
-00009062-r:
-  definition:
-  - without any others being included or involved
-  example:
-  - was entirely to blame
-  - a school devoted entirely to the needs of problem children
-  - he works for Mr. Smith exclusively
-  - did it solely for money
-  - the burden of proof rests on the prosecution alone
-  - a privilege granted only to him
-  ili: i18198
-  members:
-  - entirely
-  - exclusively
-  - solely
-  - alone
-  - only
-  partOfSpeech: r
-00009459-r:
-  definition:
-  - completely and without qualification; used informally as intensifiers
-  example:
-  - an absolutely magnificent painting
-  - a perfectly idiotic idea
-  - you're perfectly right
-  - utterly miserable
-  - you can be dead sure of my innocence
-  - was dead tired
-  - dead right
-  ili: i18199
-  members:
-  - absolutely
-  - perfectly
-  - utterly
-  - dead
-  partOfSpeech: r
-00009835-r:
-  definition:
-  - completely; used as intensifiers
-  example:
-  - clean forgot the appointment
-  - I'm plumb (or plum) tuckered out
-  exemplifies:
-  - 07171981-n
-  ili: i18200
-  members:
-  - clean
-  - plumb
-  - plum
-  partOfSpeech: r
-00010003-r:
-  definition:
-  - exactly
-  example:
-  - fell plumb in the middle of the puddle
-  exemplifies:
-  - 07089193-n
-  ili: i18201
-  members:
-  - plumb
-  - plum
-  partOfSpeech: r
 00010112-r:
   definition:
   - in a perfect or faultless way
@@ -535,25 +133,6 @@
   ili: i18202
   members:
   - perfectly
-  partOfSpeech: r
-00010321-r:
-  definition:
-  - completely or perfectly
-  example:
-  - he has the lesson pat
-  - had the system down pat
-  ili: i18203
-  members:
-  - pat
-  partOfSpeech: r
-00010428-r:
-  definition:
-  - used in polite request
-  example:
-  - please pay attention
-  ili: i18204
-  members:
-  - please
   partOfSpeech: r
 00010509-r:
   definition:
@@ -578,52 +157,6 @@
   members:
   - amiss
   partOfSpeech: r
-00010928-r:
-  definition:
-  - to the greatest degree or extent; completely or entirely; (‘full’ in this sense
-    is used as a combining form)
-  example:
-  - fully grown
-  - he didn't fully understand
-  - knew full well
-  - full-grown
-  - full-fledged
-  exemplifies:
-  - 06318142-n
-  ili: i18207
-  members:
-  - fully
-  - to the full
-  - full
-  partOfSpeech: r
-00011221-r:
-  definition:
-  - with nevertheless the final result
-  example:
-  - He arrived only to find his wife dead
-  - We won only to lose again in the next round
-  ili: i18208
-  members:
-  - only
-  partOfSpeech: r
-00011376-r:
-  definition:
-  - in the final outcome
-  example:
-  - These news will only make you more upset
-  ili: i18209
-  members:
-  - only
-  partOfSpeech: r
-00011473-r:
-  definition:
-  - as recently as
-  example:
-  - I spoke to him only an hour ago
-  ili: i18210
-  members:
-  - only
-  partOfSpeech: r
 00011555-r:
   definition:
   - (often used as a combining form) in a good or proper or satisfactory manner or
@@ -643,35 +176,6 @@
   members:
   - well
   - good
-  partOfSpeech: r
-00011978-r:
-  definition:
-  - (‘ill’ is often used as a combining form) in a poor or improper or unsatisfactory
-    manner; not well
-  example:
-  - he was ill prepared
-  - it ill befits a man to betray old friends
-  - the car runs badly
-  - he performed badly on the exam
-  - the team played poorly
-  - ill-fitting clothes
-  - an ill-conceived plan
-  exemplifies:
-  - 06318142-n
-  ili: i18212
-  members:
-  - ill
-  - badly
-  - poorly
-  partOfSpeech: r
-00012378-r:
-  definition:
-  - with difficulty or inconvenience; scarcely or hardly
-  example:
-  - we can ill afford to buy a new car just now
-  ili: i18213
-  members:
-  - ill
   partOfSpeech: r
 00012509-r:
   definition:
@@ -700,19 +204,6 @@
   ili: i18216
   members:
   - badly
-  partOfSpeech: r
-00012993-r:
-  definition:
-  - indicating high probability; in all likelihood
-  example:
-  - I might well do it
-  - a mistake that could easily have ended in disaster
-  - you may well need your umbrella
-  - he could equally well be trying to deceive us
-  ili: i18217
-  members:
-  - well
-  - easily
   partOfSpeech: r
 00013241-r:
   definition:
@@ -750,17 +241,6 @@
   - ill
   - badly
   partOfSpeech: r
-00013891-r:
-  definition:
-  - to a suitable or appropriate extent or degree
-  example:
-  - the project was well underway
-  - the fetus has well developed organs
-  - his father was well pleased with his grades
-  ili: i18221
-  members:
-  - well
-  partOfSpeech: r
 00014088-r:
   definition:
   - in financial comfort
@@ -794,20 +274,6 @@
   - badly
   - disadvantageously
   partOfSpeech: r
-00014747-r:
-  definition:
-  - to a great extent or degree
-  example:
-  - I'm afraid the film was well over budget
-  - painting the room white made it seem considerably (or substantially) larger
-  - the house has fallen considerably in value
-  - the price went up substantially
-  ili: i18225
-  members:
-  - well
-  - considerably
-  - substantially
-  partOfSpeech: r
 00015078-r:
   definition:
   - with skill or in a pleasing manner
@@ -827,39 +293,6 @@
   ili: i18227
   members:
   - badly
-  partOfSpeech: r
-00015344-r:
-  definition:
-  - with prudence or propriety
-  example:
-  - You would do well to say nothing more
-  - could not well refuse
-  ili: i18228
-  members:
-  - well
-  partOfSpeech: r
-00015469-r:
-  definition:
-  - with great or especially intimate knowledge
-  example:
-  - we knew them well
-  ili: i18229
-  members:
-  - well
-  - intimately
-  partOfSpeech: r
-00015597-r:
-  definition:
-  - (used for emphasis or as an intensifier) entirely or fully
-  example:
-  - a book well worth reading
-  - was well aware of the difficulties ahead
-  - suspected only too well what might be going on
-  exemplifies:
-  - 06332047-n
-  ili: i18230
-  members:
-  - well
   partOfSpeech: r
 00015830-r:
   definition:
@@ -899,48 +332,6 @@
   members:
   - prosperously
   partOfSpeech: r
-00016415-r:
-  definition:
-  - to a severe or serious degree
-  example:
-  - fingers so badly frozen they had to be amputated
-  - badly injured
-  - a severely impaired heart
-  - is gravely ill
-  - was seriously ill
-  ili: i18235
-  members:
-  - badly
-  - severely
-  - gravely
-  - seriously
-  partOfSpeech: r
-00016702-r:
-  definition:
-  - very much; strongly
-  example:
-  - I wanted it badly enough to work hard for it
-  - the cables had sagged badly
-  - they were badly in need of help
-  - he wants a bicycle so bad he can taste it
-  ili: i18236
-  members:
-  - badly
-  - bad
-  partOfSpeech: r
-00016920-r:
-  definition:
-  - with great intensity (‘bad’ is a nonstandard variant for ‘badly’)
-  example:
-  - the injury hurt badly
-  - the buildings were badly shaken
-  - it hurts bad
-  - we need water bad
-  ili: i18237
-  members:
-  - badly
-  - bad
-  partOfSpeech: r
 00017140-r:
   definition:
   - in a disobedient or naughty way
@@ -964,198 +355,6 @@
   members:
   - badly
   partOfSpeech: r
-00017539-r:
-  definition:
-  - (comparative of ‘ill’) in a less effective or successful or desirable manner
-  example:
-  - he did worse on the second exam
-  exemplifies:
-  - 06333686-n
-  ili: i18240
-  members:
-  - worse
-  partOfSpeech: r
-00017703-r:
-  definition:
-  - to the highest degree of inferiority or badness
-  example:
-  - She suffered worst of all
-  - schools were the worst hit by government spending cuts
-  - the worst dressed person present
-  ili: i18241
-  members:
-  - worst
-  partOfSpeech: r
-00017907-r:
-  definition:
-  - used as an intensive especially to indicate something unexpected
-  example:
-  - even an idiot knows that
-  - declined even to consider the idea
-  - I don't have even a dollar!
-  ili: i18242
-  members:
-  - even
-  partOfSpeech: r
-00018101-r:
-  definition:
-  - to a greater degree or extent; used with comparisons
-  example:
-  - looked sick and felt even worse
-  - an even (or still) more interesting problem
-  - still another problem must be solved
-  - a yet sadder tale
-  ili: i18243
-  members:
-  - even
-  - yet
-  - still
-  partOfSpeech: r
-00018343-r:
-  definition:
-  - at the same time as
-  example:
-  - even as he lay dying they argued over his estate
-  - the building collapsed just as he arrived
-  ili: i18244
-  members:
-  - even as
-  - just as
-  partOfSpeech: r
-00018505-r:
-  definition:
-  - in spite of; notwithstanding
-  example:
-  - even when he is sick, he works
-  - even with his head start she caught up with him
-  ili: i18245
-  members:
-  - even
-  partOfSpeech: r
-00018651-r:
-  definition:
-  - to the full extent
-  example:
-  - loyal even unto death
-  ili: i18246
-  members:
-  - even
-  partOfSpeech: r
-00018727-r:
-  definition:
-  - even
-  ili: i18247
-  members:
-  - e'en
-  partOfSpeech: r
-00018764-r:
-  definition:
-  - to some (great or small) extent
-  example:
-  - it was rather cold
-  - the party was rather nice
-  - the knife is rather dull
-  - I rather regret that I cannot attend
-  - He's rather good at playing the cello
-  - he is kind of shy
-  ili: i18248
-  members:
-  - rather
-  - kind of
-  - kinda
-  - sort of
-  partOfSpeech: r
-00019039-r:
-  definition:
-  - to the greatest extent; completely
-  example:
-  - you're quite right
-  - she was quite alone
-  - was quite mistaken
-  - quite the opposite
-  - not quite finished
-  - did not quite make it
-  ili: i18249
-  members:
-  - quite
-  partOfSpeech: r
-00019243-r:
-  definition:
-  - to a degree (not used with a negative)
-  example:
-  - quite tasty
-  - quite soon
-  - quite ill
-  - quite rich
-  ili: i18250
-  members:
-  - quite
-  - rather
-  partOfSpeech: r
-00019380-r:
-  definition:
-  - of an unusually noticeable or exceptional or remarkable kind (not used with a
-    negative)
-  example:
-  - her victory was quite something
-  - she's quite a girl
-  - quite a film
-  - quite a walk
-  - we've had quite an afternoon
-  ili: i18251
-  members:
-  - quite
-  - quite a
-  - quite an
-  partOfSpeech: r
-00019643-r:
-  definition:
-  - actually or truly or to an extreme
-  example:
-  - was quite a sudden change
-  - it's quite the thing to do
-  - quite the rage
-  - Quite so!
-  ili: i18252
-  members:
-  - quite
-  partOfSpeech: r
-00019801-r:
-  definition:
-  - at all times; all the time and on every occasion
-  example:
-  - I will always be there to help you
-  - always arrives on time
-  - there is always some pollution in the air
-  - ever hoping to strike it rich
-  - ever busy
-  ili: i18253
-  members:
-  - always
-  - ever
-  - e'er
-  partOfSpeech: r
-00020071-r:
-  definition:
-  - forever; throughout all time
-  example:
-  - we will always be friends
-  - I shall treasure it always
-  - I will always love you
-  ili: i18254
-  members:
-  - always
-  partOfSpeech: r
-00020219-r:
-  definition:
-  - at any time or in any event
-  example:
-  - you can always resign if you don't like it
-  - you could always take a day off
-  ili: i18255
-  members:
-  - always
-  partOfSpeech: r
 00020362-r:
   definition:
   - (music) with vigor
@@ -1174,154 +373,12 @@
   members:
   - conjecturally
   partOfSpeech: r
-00020597-r:
-  definition:
-  - in a consecutive manner
-  example:
-  - he was consecutively ill, then well, then ill again
-  ili: i18258
-  members:
-  - consecutively
-  partOfSpeech: r
-00020735-r:
-  definition:
-  - invariably
-  example:
-  - the world is constantly changing
-  ili: i18259
-  members:
-  - constantly
-  - always
-  - forever
-  - perpetually
-  - incessantly
-  partOfSpeech: r
-00020931-r:
-  definition:
-  - without variation or change, in every case
-  example:
-  - constantly kind and gracious
-  - he always arrives on time
-  ili: i18260
-  members:
-  - constantly
-  - invariably
-  - always
-  partOfSpeech: r
 00021131-r:
   definition:
   - in a coterminous manner
   ili: i18261
   members:
   - coterminously
-  partOfSpeech: r
-00021214-r:
-  definition:
-  - not at all; certainly not; not in any circumstances; not ever; at no time in the
-    past or future
-  example:
-  - I have never been to China
-  - I shall never forget this day
-  - had never seen a circus
-  - never on Sunday
-  - I will never marry you!
-  - never fear
-  ili: i18262
-  members:
-  - never
-  - ne'er
-  partOfSpeech: r
-00021667-r:
-  definition:
-  - sporadically and infrequently
-  example:
-  - he was arrogant and occasionally callous
-  - open areas are only occasionally interrupted by clumps of trees
-  - they visit New York on occasion
-  - now and again she would take her favorite book from the shelf and read to us
-  - as we drove along, the beautiful scenery now and then attracted his attention
-  ili: i18264
-  members:
-  - occasionally
-  - on occasion
-  - once in a while
-  - now and then
-  - now and again
-  - at times
-  - from time to time
-  partOfSpeech: r
-00022156-r:
-  definition:
-  - at some indefinite or unstated time
-  example:
-  - let's get together sometime
-  - everything has to end sometime
-  - It was to be printed sometime later
-  ili: i18265
-  members:
-  - sometime
-  partOfSpeech: r
-00022332-r:
-  definition:
-  - on certain occasions or in certain cases but not always
-  example:
-  - sometimes she wished she were back in England
-  - sometimes her photography is breathtaking
-  - sometimes they come for a month; at other times for six months
-  ili: i18266
-  members:
-  - sometimes
-  partOfSpeech: r
-00022585-r:
-  definition:
-  - to the same degree (often followed by ‘as’)
-  example:
-  - they were equally beautiful
-  - birds were singing and the child sang as sweetly
-  - sang as sweetly as a nightingale
-  - he is every bit as mean as she is
-  ili: i18267
-  members:
-  - equally
-  - as
-  - every bit
-  partOfSpeech: r
-00022855-r:
-  definition:
-  - of the distant or comparatively distant past
-  example:
-  - We met once long ago
-  - they long ago forsook their nomadic life
-  - left for work long ago
-  - he has long since given up mountain climbing
-  - This name has long since been forgotten
-  - ‘lang syne’ is Scottish
-  ili: i18268
-  members:
-  - long ago
-  - long since
-  - lang syne
-  - langsyne
-  partOfSpeech: r
-00023171-r:
-  definition:
-  - to some degree
-  example:
-  - we were pretty much lost when we met the forest ranger
-  ili: i18269
-  members:
-  - pretty much
-  partOfSpeech: r
-00023283-r:
-  definition:
-  - (degree adverb used before a noun phrase) for all practical purposes but not completely
-  example:
-  - much the same thing happened every time
-  - practically everything in Hinduism is the manifestation of a god
-  ili: i18270
-  members:
-  - much
-  - practically
   partOfSpeech: r
 00023528-r:
   definition:
@@ -1331,15 +388,6 @@
   ili: i18272
   members:
   - palmately
-  partOfSpeech: r
-00023622-r:
-  definition:
-  - in a paradoxical manner
-  example:
-  - paradoxically, ice ages seem to occur when the sun gets hotter
-  ili: i18273
-  members:
-  - paradoxically
   partOfSpeech: r
 00023771-r:
   definition:
@@ -1373,13 +421,6 @@
   members:
   - unconventionally
   partOfSpeech: r
-00024234-r:
-  definition:
-  - in a pathogenic manner
-  ili: i18278
-  members:
-  - pathogenically
-  partOfSpeech: r
 00024317-r:
   definition:
   - in a pictorial manner
@@ -1388,156 +429,6 @@
   ili: i18279
   members:
   - pictorially
-  partOfSpeech: r
-00024432-r:
-  definition:
-  - negation of a word or group of words
-  example:
-  - he does not speak French
-  - she is not going
-  - they are not friends
-  - not many
-  - not much
-  - not at all
-  ili: i18280
-  members:
-  - not
-  - non
-  partOfSpeech: r
-00024616-r:
-  definition:
-  - in no respect; to no degree
-  example:
-  - he looks nothing like his father
-  ili: i18281
-  members:
-  - nothing
-  partOfSpeech: r
-00024715-r:
-  definition:
-  - used to express refusal or denial or disagreement etc. or especially to emphasize
-    a negative statement
-  example:
-  - no, you are wrong
-  ili: i18282
-  members:
-  - 'no'
-  partOfSpeech: r
-00024868-r:
-  definition:
-  - to any degree or extent
-  example:
-  - it isn't any better
-  ili: i18283
-  members:
-  - any
-  partOfSpeech: r
-00024946-r:
-  definition:
-  - not in any degree or manner; not at all
-  example:
-  - he is no better today
-  ili: i18284
-  members:
-  - 'no'
-  partOfSpeech: r
-00025041-r:
-  definition:
-  - not at all or in no way
-  example:
-  - seemed none too pleased with his dinner
-  - shirt looked none the worse for having been slept in
-  - none too prosperous
-  - the passage is none too clear
-  ili: i18285
-  members:
-  - none
-  partOfSpeech: r
-00025252-r:
-  definition:
-  - after a negative statement used as an intensive meaning something like ‘likewise’
-    or ‘also’
-  example:
-  - he isn't stupid, but he isn't exactly a genius either
-  - I don't know either
-  - if you don't order dessert I won't either
-  ili: i18286
-  members:
-  - either
-  partOfSpeech: r
-00025503-r:
-  definition:
-  - extremely
-  example:
-  - you are bloody right
-  - Why are you so all-fired aggressive?
-  exemplifies:
-  - 06332047-n
-  - 07139048-n
-  ili: i18287
-  members:
-  - bloody
-  - damn
-  - all-fired
-  - all-firedly
-  partOfSpeech: r
-00025699-r:
-  definition:
-  - at or in or to any place
-  example:
-  - you can find this food anywhere
-  exemplifies:
-  - 07089193-n
-  ili: i18288
-  members:
-  - anywhere
-  - anyplace
-  partOfSpeech: r
-00025873-r:
-  definition:
-  - not anywhere; in or at or to no place
-  example:
-  - I am going nowhere
-  ili: i18289
-  members:
-  - nowhere
-  partOfSpeech: r
-00025968-r:
-  definition:
-  - in or at or to some place
-  example:
-  - she must be somewhere
-  exemplifies:
-  - 07089193-n
-  ili: i18290
-  members:
-  - somewhere
-  - someplace
-  partOfSpeech: r
-00026137-r:
-  definition:
-  - 'to or in any or all places; pronoun, location; quantifier: universal'
-  example:
-  - You find fast food stores everywhere
-  - people everywhere are becoming aware of the problem
-  - he carried a gun everywhere he went
-  - looked all over for a suitable gift
-  exemplifies:
-  - 07089193-n
-  ili: i18291
-  members:
-  - everywhere
-  - everyplace
-  - all over
-  partOfSpeech: r
-00026470-r:
-  definition:
-  - everywhere
-  example:
-  - searched high and low
-  ili: i18292
-  members:
-  - high and low
   partOfSpeech: r
 00026546-r:
   definition:
@@ -1552,45 +443,6 @@
   - someway
   - someways
   partOfSpeech: r
-00026794-r:
-  definition:
-  - for some unspecified reason
-  example:
-  - It doesn't seem fair somehow
-  - he had me dead to rights but somehow I got away with it
-  ili: i18294
-  members:
-  - somehow
-  partOfSpeech: r
-00026948-r:
-  definition:
-  - used to indicate that a statement explains or supports a previous statement
-  example:
-  - Anyhow, he is dead now
-  - I think they're asleep; anyhow, they're quiet
-  - I don't know what happened to it; anyway, it's gone
-  - anyway, there is another factor to consider
-  - I don't know how it started; in any case, there was a brief scuffle
-  - in any event, the government faced a serious protest
-  - but at any rate he got a knighthood for it
-  ili: i18295
-  members:
-  - anyhow
-  - anyway
-  - anyways
-  - in any case
-  - at any rate
-  - in any event
-  partOfSpeech: r
-00027470-r:
-  definition:
-  - in the actual state of affairs and often contrary to expectations
-  example:
-  - he might have been killed; as it is, he was severely injured
-  ili: i18296
-  members:
-  - as it is
-  partOfSpeech: r
 00027635-r:
   definition:
   - in any way whatsoever
@@ -1602,77 +454,6 @@
   - anyhow
   - anyway
   partOfSpeech: r
-00027761-r:
-  definition:
-  - despite anything to the contrary (usually preceding a concession)
-  example:
-  - although I'm a little afraid, however I'd like to try it
-  - while we disliked each other, nevertheless we agreed
-  - he was a stern yet fair master
-  - granted that it is dangerous, all the same I still want to go
-  ili: i18298
-  members:
-  - however
-  - nevertheless
-  - withal
-  - still
-  - yet
-  - all the same
-  - even so
-  - nonetheless
-  - notwithstanding
-  - at the same time
-  partOfSpeech: r
-00028191-r:
-  definition:
-  - up to the present time
-  example:
-  - I have yet to see the results
-  - details are yet to be worked out
-  ili: i18299
-  members:
-  - yet
-  partOfSpeech: r
-00028314-r:
-  definition:
-  - used in negative statement to describe a situation that has existed up to this
-    point or up to the present time
-  example:
-  - So far he hasn't called
-  - the sun isn't up yet
-  ili: i18300
-  members:
-  - so far
-  - thus far
-  - up to now
-  - hitherto
-  - heretofore
-  - as yet
-  - yet
-  - til now
-  - until now
-  - till now
-  partOfSpeech: r
-00028594-r:
-  definition:
-  - used after a superlative
-  example:
-  - this is the best so far
-  - the largest drug bust yet
-  ili: i18301
-  members:
-  - so far
-  - yet
-  partOfSpeech: r
-00028715-r:
-  definition:
-  - except that
-  example:
-  - It was the same story; only this time she came out better
-  ili: i18302
-  members:
-  - only
-  partOfSpeech: r
 00028820-r:
   definition:
   - in whatever way or manner
@@ -1680,26 +461,6 @@
   - Victory, however it was brought about, was sweet
   - however he did it, it was very clever
   ili: i18303
-  members:
-  - however
-  partOfSpeech: r
-00028974-r:
-  definition:
-  - to whatever degree or extent
-  example:
-  - The results, however general, are important
-  - they have begun, however reluctantly, to acknowledge the legitimacy of some of
-    the opposition's concerns
-  ili: i18304
-  members:
-  - however
-  partOfSpeech: r
-00029193-r:
-  definition:
-  - by contrast; on the other hand
-  example:
-  - the first part was easy; the second, however, took hours
-  ili: i18305
   members:
   - however
   partOfSpeech: r
@@ -1712,18 +473,6 @@
   members:
   - lightly
   partOfSpeech: r
-00029433-r:
-  definition:
-  - making an additional point; anyway
-  example:
-  - I don't want to go to a restaurant; besides, we can't afford it
-  - she couldn't shelter behind him all the time and in any case he wasn't always
-    with her
-  ili: i18307
-  members:
-  - besides
-  - in any case
-  partOfSpeech: r
 00029674-r:
   definition:
   - in a fugal style
@@ -1733,355 +482,12 @@
   members:
   - fugally
   partOfSpeech: r
-00029763-r:
-  definition:
-  - denoting additional information
-  example:
-  - computer chess games are getting cheaper all the time; furthermore, their quality
-    is improving
-  - the cellar was dark; moreover, mice nested there
-  - what is more, there's no sign of a change
-  ili: i18309
-  members:
-  - furthermore
-  - moreover
-  - what is more
-  - in addition
-  partOfSpeech: r
-00030035-r:
-  definition:
-  - to or at a greater distance in time or space (‘farther’ is used more frequently
-    than ‘further’ in this physical sense)
-  example:
-  - farther north
-  - moved farther away
-  - farther down the corridor
-  - the practice may go back still farther to the Druids
-  - went only three miles further
-  - further in the future
-  ili: i18310
-  members:
-  - farther
-  - further
-  partOfSpeech: r
-00030381-r:
-  definition:
-  - to or at a greater extent or degree or a more advanced stage (‘further’ is used
-    more often than ‘farther’ in this abstract sense)
-  example:
-  - further complicated by uncertainty about the future
-  - let's not discuss it further
-  - nothing could be further from the truth
-  - they are further along in their research than we expected
-  - the application of the law was extended farther
-  - he is going no farther in his studies
-  ili: i18311
-  members:
-  - further
-  - farther
-  partOfSpeech: r
-00030839-r:
-  definition:
-  - in addition or furthermore
-  example:
-  - if we further suppose
-  - stated further that he would not cooperate with them
-  - they are definitely coming; further, they should be here already
-  ili: i18312
-  members:
-  - further
-  partOfSpeech: r
-00031050-r:
-  definition:
-  - to the greatest distance in space or time (‘farthest’ is used more often than
-    ‘furthest’ in this physical sense)
-  example:
-  - see who could jump the farthest
-  - chose the farthest seat from the door
-  - he swam the furthest
-  ili: i18313
-  members:
-  - farthest
-  - furthest
-  partOfSpeech: r
-00031310-r:
-  definition:
-  - to the greatest degree or extent or most advanced stage (‘furthest’ is used more
-    often than ‘farthest’ in this abstract sense)
-  example:
-  - went the furthest of all the children in her education
-  - furthest removed from reality
-  - she goes farthest in helping us
-  ili: i18314
-  members:
-  - furthest
-  - farthest
-  partOfSpeech: r
 00031610-r:
   definition:
   - in a futile and unproductive manner
   ili: i18315
   members:
   - futilely
-  partOfSpeech: r
-00031700-r:
-  definition:
-  - with reference to action or condition; without change, interruption, or cessation
-  example:
-  - it's still warm outside
-  - will you still love me when we're old and grey?
-  ili: i18316
-  members:
-  - still
-  partOfSpeech: r
-00031911-r:
-  definition:
-  - not now
-  example:
-  - she is no more
-  ili: i18317
-  members:
-  - no longer
-  - no more
-  partOfSpeech: r
-00032002-r:
-  definition:
-  - at the present or from now on; usually used with a negative
-  example:
-  - Alice doesn't live here anymore
-  - the children promised not to quarrel any more
-  ili: i18318
-  members:
-  - anymore
-  - any longer
-  partOfSpeech: r
-00032194-r:
-  definition:
-  - prior to a specified or implied time
-  example:
-  - she has already graduated
-  ili: i18319
-  members:
-  - already
-  partOfSpeech: r
-00032295-r:
-  definition:
-  - used to give emphasis
-  example:
-  - she was very gifted
-  - he played very well
-  - a really enjoyable evening
-  - I'm real sorry about it
-  - a rattling good yarn
-  - a most welcome relief
-  - there is precious little time left
-  exemplifies:
-  - 06332047-n
-  ili: i18320
-  members:
-  - very
-  - really
-  - real
-  - rattling
-  - most
-  - precious
-  - preciously
-  partOfSpeech: r
-00032576-r:
-  definition:
-  - exceedingly; extremely
-  example:
-  - she plays fabulously well
-  - behind you the coastal hills plunge to the incredibly blue sea backed by the Turkish
-    mountains
-  ili: i18321
-  members:
-  - fabulously
-  - fantastically
-  - incredibly
-  partOfSpeech: r
-00032793-r:
-  definition:
-  - (Southern regional intensive) very; to a great degree
-  example:
-  - the baby is mighty cute
-  - he's mighty tired
-  - it is powerful humid
-  - that boy is powerful big now
-  - they have a right nice place
-  - they rejoiced mightily
-  exemplifies:
-  - 06332047-n
-  ili: i18322
-  members:
-  - mighty
-  - mightily
-  - powerful
-  - right
-  partOfSpeech: r
-00033092-r:
-  definition:
-  - intensifier, very colloquial
-  example:
-  - what took you so fucking long?
-  exemplifies:
-  - 07139048-n
-  ili: i18324
-  members:
-  - fucking
-  partOfSpeech: r
-00033190-r:
-  definition:
-  - incredibly
-  example:
-  - he was much annoyed
-  ili: i18325
-  members:
-  - much
-  partOfSpeech: r
-00033250-r:
-  definition:
-  - from this time forth; from now on
-  example:
-  - henceforth she will be known as Mrs. Smith
-  ili: i18326
-  members:
-  - henceforth
-  - henceforward
-  partOfSpeech: r
-00033383-r:
-  definition:
-  - following this in time or order or place; after this
-  example:
-  - hereafter you will no longer receive an allowance
-  ili: i18327
-  members:
-  - hereafter
-  partOfSpeech: r
-00033526-r:
-  definition:
-  - in a future life or state
-  example:
-  - hope to win salvation hereafter
-  ili: i18328
-  members:
-  - hereafter
-  partOfSpeech: r
-00033624-r:
-  definition:
-  - under the terms of this agreement
-  ili: i18329
-  members:
-  - hereunder
-  partOfSpeech: r
-00033695-r:
-  definition:
-  - only a moment ago
-  example:
-  - he has just arrived
-  - the sun just now came out
-  ili: i18330
-  members:
-  - just
-  - just now
-  partOfSpeech: r
-00033808-r:
-  definition:
-  - without any delay
-  example:
-  - he was killed outright
-  ili: i18331
-  members:
-  - instantaneously
-  - outright
-  - instantly
-  - in a flash
-  partOfSpeech: r
-00033949-r:
-  definition:
-  - to a moderate degree
-  example:
-  - he was mildly interested
-  ili: i18332
-  members:
-  - mildly
-  partOfSpeech: r
-00034050-r:
-  definition:
-  - to a small degree; somewhat
-  example:
-  - it's a bit warm
-  - felt a little better
-  - a trifle smaller
-  ili: i18333
-  members:
-  - a bit
-  - a little
-  - a trifle
-  partOfSpeech: r
-00034196-r:
-  definition:
-  - (old-fashioned or informal) in a little while
-  example:
-  - see you anon
-  exemplifies:
-  - 07089193-n
-  ili: i18334
-  members:
-  - anon
-  partOfSpeech: r
-00034309-r:
-  definition:
-  - in the near future
-  example:
-  - the doctor will soon be here
-  - the book will appear shortly
-  - she will arrive presently
-  - we should have news before long
-  ili: i18335
-  members:
-  - soon
-  - shortly
-  - presently
-  - before long
-  partOfSpeech: r
-00034524-r:
-  definition:
-  - as soon as possible
-  ili: i18336
-  members:
-  - ASAP
-  partOfSpeech: r
-00034576-r:
-  definition:
-  - for a short time
-  example:
-  - he was at the airport shortly before she was expected to arrive
-  - she visited him briefly
-  - was briefly associated with IBM
-  ili: i18337
-  members:
-  - shortly
-  - briefly
-  partOfSpeech: r
-00034695-r:
-  definition:
-  - at a short distance
-  example:
-  - the hem fell shortly below her knees
-  ili: i18338
-  members:
-  - shortly
-  partOfSpeech: r
-00034790-r:
-  definition:
-  - at any moment
-  example:
-  - she will be with you momently
-  ili: i18339
-  members:
-  - momentarily
-  - momently
   partOfSpeech: r
 00034887-r:
   definition:
@@ -2091,16 +497,6 @@
   ili: i18340
   members:
   - shoulder-to-shoulder
-  partOfSpeech: r
-00035028-r:
-  definition:
-  - with the least delay
-  example:
-  - the soonest I can arrive is 3 P.M.
-  ili: i18341
-  members:
-  - soonest
-  - earliest
   partOfSpeech: r
 00035133-r:
   definition:
@@ -2125,100 +521,6 @@
   - turbulently
   - passionately
   partOfSpeech: r
-00035445-r:
-  definition:
-  - many times at short intervals
-  example:
-  - we often met over a cup of coffee
-  ili: i18345
-  members:
-  - frequently
-  - often
-  - oftentimes
-  - oft
-  - ofttimes
-  partOfSpeech: r
-00035642-r:
-  definition:
-  - more often or more frequently
-  ili: i18346
-  members:
-  - oftener
-  partOfSpeech: r
-00035707-r:
-  definition:
-  - at another time
-  example:
-  - ever and anon
-  ili: i18347
-  members:
-  - anon
-  partOfSpeech: r
-00035772-r:
-  definition:
-  - not often
-  example:
-  - we rarely met
-  ili: i18348
-  members:
-  - rarely
-  - seldom
-  partOfSpeech: r
-00035878-r:
-  definition:
-  - in a manner differing from the usual or expected
-  example:
-  - had a curiously husky voice
-  - he's behaving rather peculiarly
-  ili: i18349
-  members:
-  - inexplicably
-  - curiously
-  - oddly
-  - peculiarly
-  partOfSpeech: r
-00036138-r:
-  definition:
-  - to certain extent or degree
-  example:
-  - pretty big
-  - pretty bad
-  - jolly decent of him
-  - the shoes are priced reasonably
-  - he is fairly clever with computers
-  ili: i18350
-  members:
-  - reasonably
-  - moderately
-  - pretty
-  - jolly
-  - somewhat
-  - fairly
-  - middling
-  - passably
-  partOfSpeech: r
-00036472-r:
-  definition:
-  - to a degree that exceeds the bounds of reason or moderation
-  example:
-  - his prices are unreasonably high
-  ili: i18351
-  members:
-  - unreasonably
-  - immoderately
-  partOfSpeech: r
-00036695-r:
-  definition:
-  - to a small degree or extent
-  example:
-  - his arguments were somewhat self-contradictory
-  - the children argued because one slice of cake was slightly larger than the other
-  ili: i18352
-  members:
-  - slightly
-  - somewhat
-  - more or less
-  partOfSpeech: r
 00036919-r:
   definition:
   - in a moving manner
@@ -2228,130 +530,6 @@
   members:
   - movingly
   partOfSpeech: r
-00037013-r:
-  definition:
-  - in a widespread way
-  example:
-  - oxidation ponds are extensively used for sewage treatment in the Midwest
-  ili: i18354
-  members:
-  - extensively
-  partOfSpeech: r
-00037166-r:
-  definition:
-  - with respect to its inherent nature
-  example:
-  - this statement is interesting per se
-  ili: i18355
-  members:
-  - intrinsically
-  - per se
-  - in and of itself
-  partOfSpeech: r
-00037329-r:
-  definition:
-  - without question and beyond doubt
-  example:
-  - it was decidedly too expensive
-  - she told him off in spades
-  - by all odds they should win
-  ili: i18356
-  members:
-  - decidedly
-  - unquestionably
-  - emphatically
-  - definitely
-  - in spades
-  - by all odds
-  partOfSpeech: r
-00037620-r:
-  definition:
-  - in accordance with truth or fact or reality
-  example:
-  - she was now truly American
-  - a genuinely open society
-  - they don't really listen to us
-  ili: i18357
-  members:
-  - truly
-  - genuinely
-  - really
-  partOfSpeech: r
-00037864-r:
-  definition:
-  - (used as an interjection) an expression of surprise or skepticism or irony etc.
-  example:
-  - Wants to marry the butler? Indeed!
-  exemplifies:
-  - 07120931-n
-  ili: i18358
-  members:
-  - indeed
-  partOfSpeech: r
-00038035-r:
-  definition:
-  - in truth (often tends to intensify)
-  example:
-  - they said the car would break down and indeed it did
-  - it is very cold indeed
-  - was indeed grateful
-  - indeed, the rain may still come
-  - he did so do it!
-  ili: i18359
-  members:
-  - indeed
-  - so
-  partOfSpeech: r
-00038270-r:
-  definition:
-  - in a difficult or vulnerable position
-  example:
-  - he resigned and left me in the lurch
-  exemplifies:
-  - 07169038-n
-  ili: i18360
-  members:
-  - in the lurch
-  partOfSpeech: r
-00038407-r:
-  definition:
-  - in fact (used as intensifiers or sentence modifiers)
-  example:
-  - in truth, moral decay hastened the decline of the Roman Empire
-  - really, you shouldn't have done it
-  - a truly awful book
-  exemplifies:
-  - 06332047-n
-  ili: i18361
-  members:
-  - in truth
-  - really
-  - truly
-  partOfSpeech: r
-00038658-r:
-  definition:
-  - an archaic word originally meaning ‘in truth’ but now usually used to express
-    disbelief
-  ili: i18362
-  members:
-  - forsooth
-  partOfSpeech: r
-00038782-r:
-  definition:
-  - in the uterus
-  example:
-  - the child was infected in utero from the mother
-  ili: i18363
-  members:
-  - in utero
-  partOfSpeech: r
-00038883-r:
-  definition:
-  - in a vacuum
-  ili: i18364
-  members:
-  - in vacuo
-  partOfSpeech: r
 00038931-r:
   definition:
   - in isolation and without reference to anything else
@@ -2359,103 +537,12 @@
   members:
   - in vacuo
   partOfSpeech: r
-00039019-r:
-  definition:
-  - as might be expected
-  example:
-  - naturally, the lawyer sent us a huge bill
-  ili: i18366
-  members:
-  - naturally
-  - of course
-  - course
-  partOfSpeech: r
-00039161-r:
-  definition:
-  - in a manner at variance with what is natural or normal
-  example:
-  - The early Church not unnaturally adopted the position that failure to see the
-    messianic character of his work was really caused by the people's own blindness
-  ili: i18367
-  members:
-  - unnaturally
-  partOfSpeech: r
-00039452-r:
-  definition:
-  - without doubt or question
-  example:
-  - they were clearly lost
-  - history has clearly shown the folly of that policy
-  ili: i18368
-  members:
-  - clearly
-  partOfSpeech: r
 00039611-r:
   definition:
   - in a manner that is unclear
   ili: i18369
   members:
   - unclearly
-  partOfSpeech: r
-00039730-r:
-  definition:
-  - unmistakably (‘plain’ is often used informally for ‘plainly’)
-  example:
-  - the answer is obviously wrong
-  - she was in bed and evidently in great pain
-  - he was manifestly too important to leave off the guest list
-  - it is all patently nonsense
-  - she has apparently been living here for some time
-  - I thought he owned the property, but apparently not
-  - You are plainly wrong
-  - he is plain stubborn
-  exemplifies:
-  - 07089193-n
-  ili: i18370
-  members:
-  - obviously
-  - evidently
-  - manifestly
-  - patently
-  - apparently
-  - plainly
-  - plain
-  partOfSpeech: r
-00040353-r:
-  definition:
-  - from appearances alone
-  example:
-  - irrigation often produces bumper crops from apparently desert land
-  - the child is seemingly healthy but the doctor is concerned
-  - source: Thomas Hardy
-    text: had been ostensibly frank as to his purpose while really concealing it
-  - on the face of it the problem seems minor
-  ili: i18371
-  members:
-  - apparently
-  - seemingly
-  - ostensibly
-  - on the face of it
-  partOfSpeech: r
-00040777-r:
-  definition:
-  - anew
-  example:
-  - she tried again
-  - they rehearsed the scene again
-  ili: i18372
-  members:
-  - again
-  - once again
-  - once more
-  - over again
-  partOfSpeech: r
-00040906-r:
-  definition:
-  - together with this
-  ili: i18373
-  members:
-  - withal
   partOfSpeech: r
 00040959-r:
   definition:
@@ -2468,86 +555,6 @@
   - accidentally
   - circumstantially
   - unexpectedly
-  partOfSpeech: r
-00041131-r:
-  definition:
-  - in a way that was not expected
-  example:
-  - her brother showed up at the wedding out of the blue
-  ili: i18375
-  members:
-  - unexpectedly
-  - out of the blue
-  partOfSpeech: r
-00041294-r:
-  definition:
-  - so as not to obstruct or hinder
-  example:
-  - put that box out of the way so that no one trips on it
-  ili: i18377
-  members:
-  - out of the way
-  partOfSpeech: r
-00041426-r:
-  definition:
-  - murdered
-  example:
-  - the mob boss wanted his rival out of the way
-  ili: i18378
-  members:
-  - out of the way
-  partOfSpeech: r
-00041525-r:
-  definition:
-  - in a remote location or at a distance from the usual route
-  ili: i18379
-  members:
-  - out of the way
-  partOfSpeech: r
-00041626-r:
-  definition:
-  - improper; amiss
-  ili: i18380
-  members:
-  - out of the way
-  partOfSpeech: r
-00041684-r:
-  definition:
-  - extraordinary; unusual
-  example:
-  - such erratic behavior was out of the way for him
-  ili: i18381
-  members:
-  - out of the way
-  partOfSpeech: r
-00041802-r:
-  definition:
-  - not along the usual route
-  example:
-  - in order to experience something different, you need to go off the beaten path
-  members:
-  - off the beaten track
-  - off the beaten path
-  partOfSpeech: r
-00041980-r:
-  definition:
-  - forming a hindrance, impediment, or obstruction
-  example:
-  - she might have succeeded in her ambition, had not circumstances been in her way
-  ili: i18382
-  members:
-  - in the way
-  - in someone's way
-  partOfSpeech: r
-00042168-r:
-  definition:
-  - in distinction from others
-  example:
-  - a program specifically for teenagers
-  - he is interested specifically in poisonous snakes
-  ili: i18383
-  members:
-  - specifically
   partOfSpeech: r
 00042364-r:
   definition:
@@ -2568,142 +575,6 @@
   ili: i18385
   members:
   - nonspecifically
-  partOfSpeech: r
-00042664-r:
-  definition:
-  - by good fortune
-  example:
-  - fortunately the weather was good
-  ili: i18386
-  members:
-  - fortunately
-  - fortuitously
-  - luckily
-  - as luck would have it
-  partOfSpeech: r
-00042894-r:
-  definition:
-  - in an unexpectedly lucky way
-  example:
-  - happily he was not injured
-  ili: i18387
-  members:
-  - happily
-  partOfSpeech: r
-00043024-r:
-  definition:
-  - in an unfortunate way
-  example:
-  - sadly he died before he could see his grandchild
-  ili: i18388
-  members:
-  - sadly
-  - unhappily
-  partOfSpeech: r
-00043179-r:
-  definition:
-  - by bad luck
-  example:
-  - unfortunately it rained all day
-  - alas, I cannot stay
-  ili: i18389
-  members:
-  - unfortunately
-  - unluckily
-  - regrettably
-  - alas
-  partOfSpeech: r
-00043413-r:
-  definition:
-  - (used to introduce a logical conclusion) from that fact or reason or as a result
-  example:
-  - therefore X must be true
-  - the eggs were fresh and hence satisfactory
-  - we were young and thence optimistic
-  - it is late and thus we must go
-  - the witness is biased and so cannot be trusted
-  ili: i18390
-  members:
-  - therefore
-  - hence
-  - thence
-  - thus
-  - so
-  partOfSpeech: r
-00043757-r:
-  definition:
-  - (used as a sentence connector) therefore or consequently
-  ili: i18391
-  members:
-  - ergo
-  partOfSpeech: r
-00043846-r:
-  definition:
-  - from this time
-  example:
-  - a year hence it will be forgotten
-  ili: i18392
-  members:
-  - hence
-  partOfSpeech: r
-00043931-r:
-  definition:
-  - from this place
-  example:
-  - get thee hence!
-  exemplifies:
-  - 07087487-n
-  ili: i18393
-  members:
-  - hence
-  partOfSpeech: r
-00044018-r:
-  definition:
-  - from that place or from there
-  example:
-  - proceeded thence directly to college
-  - flew to Helsinki and thence to Moscow
-  - roads that lead therefrom
-  ili: i18394
-  members:
-  - thence
-  - therefrom
-  partOfSpeech: r
-00044204-r:
-  definition:
-  - from that circumstance or source
-  example:
-  - source: W.V.Quine
-    text: atomic formulas and all compounds thence constructible
-  - a natural conclusion follows thence
-  - public interest and a policy deriving therefrom
-  - typhus fever results therefrom
-  ili: i18395
-  members:
-  - thence
-  - therefrom
-  - thereof
-  partOfSpeech: r
-00044486-r:
-  definition:
-  - (in formal usage, especially legal usage) for that or for it
-  domain_topic:
-  - 08458195-n
-  example:
-  - ordering goods and enclosing payment therefor
-  - a refund therefor
-  ili: i18396
-  members:
-  - therefor
-  partOfSpeech: r
-00044672-r:
-  definition:
-  - affecting the pursuit of a vocation or occupation
-  example:
-  - vocationally trained
-  ili: i18397
-  members:
-  - vocationally
   partOfSpeech: r
 00044804-r:
   definition:
@@ -2736,29 +607,6 @@
   - face-to-face
   - face to face
   partOfSpeech: r
-00045286-r:
-  definition:
-  - directly facing each other
-  example:
-  - the two photographs lay face-to-face on the table
-  - lived all their lives in houses face-to-face across the street
-  - they sat opposite at the table
-  ili: i18401
-  members:
-  - face-to-face
-  - face to face
-  - opposite
-  partOfSpeech: r
-00045532-r:
-  definition:
-  - face-to-face with; literally ‘face to face’
-  example:
-  - they sat vis-a-vis at the table
-  - I found myself vis-a-vis a burly policeman
-  ili: i18402
-  members:
-  - vis-a-vis
-  partOfSpeech: r
 00045694-r:
   definition:
   - without the intrusion of a third person; in intimate privacy
@@ -2767,323 +615,6 @@
   ili: i18403
   members:
   - tete a tete
-  partOfSpeech: r
-00045819-r:
-  definition:
-  - perhaps; indicating possibility of being more remarkable (greater or better or
-    sooner) than
-  example:
-  - will yield 10% if not more
-  - pretty if not actually beautiful
-  - let's meet tonight if not sooner
-  ili: i18404
-  members:
-  - if not
-  partOfSpeech: r
-00046047-r:
-  definition:
-  - over and above
-  example:
-  - agreed to provide essentials but nothing beyond
-  ili: i18405
-  members:
-  - beyond
-  partOfSpeech: r
-00046144-r:
-  definition:
-  - farther along in space or time or degree
-  example:
-  - through the valley and beyond
-  - to the eighth grade but not beyond
-  - will be influential in the 1990s and beyond
-  ili: i18406
-  members:
-  - beyond
-  partOfSpeech: r
-00046337-r:
-  definition:
-  - on the farther side from the observer
-  example:
-  - a pond with a hayfield beyond
-  ili: i18407
-  members:
-  - beyond
-  partOfSpeech: r
-00046442-r:
-  definition:
-  - in other respects or ways
-  example:
-  - he is otherwise normal
-  - the funds are not otherwise available
-  - an otherwise hopeless situation
-  ili: i18408
-  members:
-  - otherwise
-  partOfSpeech: r
-00046607-r:
-  definition:
-  - in addition, by way of addition; furthermore
-  example:
-  - he serves additionally as the CEO
-  ili: i18409
-  members:
-  - additionally
-  - to boot
-  partOfSpeech: r
-00046739-r:
-  definition:
-  - to an extreme degree
-  example:
-  - extremely cold
-  - extremely unpleasant
-  - she is super smart
-  - the night was deathly cold
-  - as a child, I was deathly afraid of snakes
-  - they all were whopping drunk
-  ili: i18410
-  members:
-  - extremely
-  - exceedingly
-  - super
-  - deathly
-  - whopping
-  partOfSpeech: r
-00046987-r:
-  definition:
-  - stunningly or breathtakingly
-  example:
-  - she was drop-dead gorgeous
-  exemplifies:
-  - 07171981-n
-  ili: i18411
-  members:
-  - drop-dead
-  partOfSpeech: r
-00047083-r:
-  definition:
-  - in excess or without limit
-  example:
-  - amazed beyond measure
-  ili: i18412
-  members:
-  - beyond measure
-  partOfSpeech: r
-00047177-r:
-  definition:
-  - (used as intensives) excessively
-  example:
-  - she was madly in love
-  - deadly dull
-  - deadly earnest
-  - deucedly clever
-  - insanely jealous
-  exemplifies:
-  - 06332047-n
-  ili: i18413
-  members:
-  - madly
-  - insanely
-  - deadly
-  - deucedly
-  - devilishly
-  partOfSpeech: r
-00047401-r:
-  definition:
-  - to a surprising degree
-  example:
-  - she was inordinately smart
-  - it will be an extraordinarily painful step to negotiate
-  ili: i18414
-  members:
-  - inordinately
-  - extraordinarily
-  partOfSpeech: r
-00047594-r:
-  definition:
-  - by a considerable margin
-  example:
-  - she was by far the smartest student
-  - it was far and away the best meal he had ever eaten
-  ili: i18415
-  members:
-  - by far
-  - far and away
-  - out and away
-  partOfSpeech: r
-00047777-r:
-  definition:
-  - outstandingly superior to
-  example:
-  - in intelligence he was head and shoulders above the others in his class
-  ili: i18416
-  members:
-  - head and shoulders above
-  partOfSpeech: r
-00047930-r:
-  definition:
-  - to a degree exceeding normal or proper limits
-  example:
-  - too big
-  ili: i18417
-  members:
-  - excessively
-  - overly
-  - to a fault
-  - too
-  partOfSpeech: r
-00048072-r:
-  definition:
-  - in addition
-  example:
-  - he has a Mercedes, too
-  ili: i18418
-  members:
-  - besides
-  - too
-  - also
-  - likewise
-  - as well
-  partOfSpeech: r
-00048179-r:
-  definition:
-  - within an indefinite time or at an unspecified future time
-  example:
-  - he longed for the flowers that were yet to show themselves
-  - sooner or later you will have to face the facts
-  - in time they came to accept the harsh reality
-  ili: i18419
-  members:
-  - yet
-  - in time
-  partOfSpeech: r
-00048441-r:
-  definition:
-  - as the end result of a succession or process
-  example:
-  - ultimately he had to give in
-  - at long last the winter was over
-  ili: i18420
-  members:
-  - ultimately
-  - finally
-  - in the end
-  - at last
-  - at long last
-  partOfSpeech: r
-00048676-r:
-  definition:
-  - after an unspecified period of time or an especially long delay
-  ili: i18421
-  members:
-  - finally
-  - eventually
-  partOfSpeech: r
-00048806-r:
-  definition:
-  - at this time or period; now
-  example:
-  - he is presently our ambassador to the United Nations
-  - currently they live in Connecticut
-  ili: i18422
-  members:
-  - presently
-  - currently
-  partOfSpeech: r
-00049013-r:
-  definition:
-  - in these times
-  example:
-  - source: Nancy Mitford
-    text: it is solely by their language that the upper classes nowadays are distinguished
-  - we now rarely see horse-drawn vehicles on city streets
-  - today almost every home has television
-  ili: i18423
-  members:
-  - nowadays
-  - now
-  - today
-  partOfSpeech: r
-00049277-r:
-  definition:
-  - without delay or hesitation; with no time intervening
-  example:
-  - he answered immediately
-  - found an answer straightaway
-  - an official accused of dishonesty should be suspended forthwith
-  - Come here now!
-  ili: i18424
-  members:
-  - immediately
-  - instantly
-  - straightaway
-  - straight off
-  - directly
-  - now
-  - right away
-  - at once
-  - forthwith
-  - like a shot
-  partOfSpeech: r
-00049640-r:
-  definition:
-  - used to preface a command or reproof or request
-  example:
-  - now hear this!
-  - now pay attention
-  ili: i18425
-  members:
-  - now
-  partOfSpeech: r
-00049758-r:
-  definition:
-  - at the present moment
-  example:
-  - goods now on sale
-  - the now-aging dictator
-  - they are now abroad
-  - he is busy at present writing a new novel
-  - it could happen any time now
-  ili: i18426
-  members:
-  - now
-  - at present
-  partOfSpeech: r
-00049971-r:
-  definition:
-  - in the historical present; at this point in the narration of a series of past
-    events
-  example:
-  - President Kennedy now calls in the National Guard
-  - Washington now decides to cross the Delaware
-  - the ship is now listing to port
-  ili: i18427
-  members:
-  - now
-  partOfSpeech: r
-00050223-r:
-  definition:
-  - in the immediate past
-  example:
-  - told me just now
-  ili: i18428
-  members:
-  - now
-  partOfSpeech: r
-00050296-r:
-  definition:
-  - (prefatory or transitional) indicates a change of subject or activity
-  example:
-  - Now the next problem is …
-  ili: i18429
-  members:
-  - now
-  partOfSpeech: r
-00050427-r:
-  definition:
-  - interjection of rebuke
-  ili: i18430
-  members:
-  - now now
   partOfSpeech: r
 00050485-r:
   definition:
@@ -3137,29 +668,6 @@
   members:
   - unhappily
   partOfSpeech: r
-00051219-r:
-  definition:
-  - referring to the degree to which a certain quality is present
-  example:
-  - he was no heavier than a child
-  ili: i18436
-  members:
-  - 'no'
-  - no more
-  partOfSpeech: r
-00051355-r:
-  definition:
-  - with resolute determination
-  example:
-  - we firmly believed it
-  - you must stand firm
-  ili: i18437
-  members:
-  - firm
-  - firmly
-  - steadfastly
-  - unwaveringly
-  partOfSpeech: r
 00051555-r:
   definition:
   - with firmness and conviction; without compromise
@@ -3209,18 +717,6 @@
   - forthrightly
   - forthright
   partOfSpeech: r
-00052386-r:
-  definition:
-  - without deviation
-  example:
-  - the path leads directly to the lake
-  - went direct to the office
-  ili: i18442
-  members:
-  - directly
-  - straight
-  - direct
-  partOfSpeech: r
 00052564-r:
   definition:
   - in a straight direct way
@@ -3231,15 +727,6 @@
   members:
   - squarely
   - square
-  partOfSpeech: r
-00052690-r:
-  definition:
-  - directly or exactly; straight
-  example:
-  - went due North
-  ili: i18444
-  members:
-  - due
   partOfSpeech: r
 00052769-r:
   definition:
@@ -3282,36 +769,6 @@
   members:
   - bitterly
   partOfSpeech: r
-00053420-r:
-  definition:
-  - indicating something hard to accept
-  example:
-  - he was bitterly disappointed
-  ili: i18449
-  members:
-  - bitterly
-  partOfSpeech: r
-00053542-r:
-  definition:
-  - an expression of agreement normally occurring at the beginning of a sentence
-  ili: i18450
-  members:
-  - very well
-  - fine
-  - alright
-  - all right
-  - OK
-  partOfSpeech: r
-00053690-r:
-  definition:
-  - without doubt (used to reinforce an assertion)
-  example:
-  - it's expensive all right
-  ili: i18451
-  members:
-  - all right
-  - alright
-  partOfSpeech: r
 00053812-r:
   definition:
   - in a swift manner
@@ -3342,27 +799,6 @@
   members:
   - practically
   partOfSpeech: r
-00054282-r:
-  definition:
-  - almost; nearly
-  example:
-  - practically the first thing I saw when I got off the train
-  - he was practically the only guest at the party
-  - there was practically no garden at all
-  ili: i18455
-  members:
-  - practically
-  partOfSpeech: r
-00054490-r:
-  definition:
-  - by reasonable assumption
-  example:
-  - presumably, he missed the train
-  ili: i18456
-  members:
-  - presumably
-  - presumptively
-  partOfSpeech: r
 00054622-r:
   definition:
   - in a pyramidal manner or shape
@@ -3371,34 +807,6 @@
   ili: i18457
   members:
   - pyramidically
-  partOfSpeech: r
-00054750-r:
-  definition:
-  - at the time or occasion immediately following
-  example:
-  - next the doctor examined his back
-  ili: i18458
-  members:
-  - next
-  partOfSpeech: r
-00054865-r:
-  definition:
-  - temporarily
-  example:
-  - we'll stop for the time being
-  ili: i18459
-  members:
-  - for the moment
-  - for the time being
-  partOfSpeech: r
-00054973-r:
-  definition:
-  - without doubt
-  example:
-  - easily the best book she's written
-  ili: i18460
-  members:
-  - easily
   partOfSpeech: r
 00055062-r:
   definition:
@@ -3436,21 +844,6 @@
   members:
   - hand to mouth
   partOfSpeech: r
-00055488-r:
-  definition:
-  - used as intensifiers
-  example:
-  - terribly interesting
-  - I'm awful sorry
-  exemplifies:
-  - 07089193-n
-  ili: i18465
-  members:
-  - terribly
-  - awfully
-  - awful
-  - frightfully
-  partOfSpeech: r
 00055639-r:
   definition:
   - in a terrible manner
@@ -3475,16 +868,6 @@
   - acceptably
   - tolerably
   - so-so
-  partOfSpeech: r
-00056056-r:
-  definition:
-  - to an unacceptable degree
-  example:
-  - The percentage of lead in our drinking water is unacceptably high
-  ili: i18468
-  members:
-  - unacceptably
-  - intolerably
   partOfSpeech: r
 00056277-r:
   definition:
@@ -3531,70 +914,6 @@
   members:
   - maladroitly
   partOfSpeech: r
-00056878-r:
-  definition:
-  - of a dreadful kind
-  example:
-  - there was a dreadfully bloody accident on the road this morning
-  ili: i18474
-  members:
-  - dreadfully
-  - awfully
-  - horribly
-  partOfSpeech: r
-00057077-r:
-  definition:
-  - to an extraordinary extent or degree
-  example:
-  - he improved greatly
-  ili: i18475
-  members:
-  - greatly
-  partOfSpeech: r
-00057190-r:
-  definition:
-  - in a drastic manner
-  ili: i18476
-  members:
-  - drastically
-  partOfSpeech: r
-00057267-r:
-  definition:
-  - in the slightest degree or in any respect
-  example:
-  - Are you at all interested? No, not at all
-  - was not in the least unfriendly
-  ili: i18477
-  members:
-  - at all
-  - in the least
-  - the least bit
-  partOfSpeech: r
-00057454-r:
-  definition:
-  - definitely or certainly
-  example:
-  - Visit us by all means
-  exemplifies:
-  - 07089193-n
-  ili: i18478
-  members:
-  - by all means
-  partOfSpeech: r
-00057580-r:
-  definition:
-  - definitely not
-  example:
-  - the prize is by no means certain
-  - and that isn't all, not by a long sight
-  exemplifies:
-  - 07089193-n
-  ili: i18479
-  members:
-  - by no means
-  - not by a long sight
-  - not by a blame sight
-  partOfSpeech: r
 00057795-r:
   definition:
   - in an exhaustive manner
@@ -3604,34 +923,6 @@
   members:
   - thoroughly
   - exhaustively
-  partOfSpeech: r
-00057926-r:
-  definition:
-  - completely and absolutely (‘good’ is sometimes used informally for ‘thoroughly’)
-  example:
-  - he was soundly defeated
-  - we beat him good
-  exemplifies:
-  - 07089193-n
-  ili: i18481
-  members:
-  - thoroughly
-  - soundly
-  - good
-  partOfSpeech: r
-00058164-r:
-  definition:
-  - throughout the entire extent
-  example:
-  - got soaked through in the rain
-  - I'm frozen through
-  - a letter shot through with the writer's personality
-  - knew him through and through
-  - boards rotten through and through
-  ili: i18482
-  members:
-  - through
-  - through and through
   partOfSpeech: r
 00058430-r:
   definition:
@@ -3691,13 +982,6 @@
   members:
   - individualistically
   partOfSpeech: r
-00059205-r:
-  definition:
-  - in an intractable manner
-  ili: i18489
-  members:
-  - intractably
-  partOfSpeech: r
 00059287-r:
   definition:
   - straightforwardly or frankly
@@ -3726,159 +1010,12 @@
   members:
   - thirdhand
   partOfSpeech: r
-00059624-r:
-  definition:
-  - to a great degree or extent
-  example:
-  - she's much better now
-  exemplifies:
-  - 06332047-n
-  ili: i18493
-  members:
-  - much
-  partOfSpeech: r
-00059709-r:
-  definition:
-  - to a very great degree or extent
-  example:
-  - I feel a lot better
-  - we enjoyed ourselves very much
-  - she was very much interested
-  - this would help a great deal
-  exemplifies:
-  - 06332047-n
-  ili: i18494
-  members:
-  - a lot
-  - lots
-  - a good deal
-  - a great deal
-  partOfSpeech: r
-00059951-r:
-  definition:
-  - frequently or in great quantities
-  example:
-  - I don't drink much
-  - I don't travel much
-  ili: i18495
-  members:
-  - much
-  - a great deal
-  - often
-  partOfSpeech: r
-00060085-r:
-  definition:
-  - in many cases or instances
-  ili: i18496
-  members:
-  - often
-  partOfSpeech: r
-00060145-r:
-  definition:
-  - comparative of ‘well’; in a better or more excellent manner or more advantageously
-    or attractively or to a greater degree etc.
-  example:
-  - She had never sung better
-  - a deed better left undone
-  - better suited to the job
-  ili: i18497
-  members:
-  - better
-  partOfSpeech: r
-00060392-r:
-  definition:
-  - advancing in amount or intensity
-  example:
-  - she became increasingly depressed
-  ili: i18498
-  members:
-  - increasingly
-  - progressively
-  - more and more
-  partOfSpeech: r
-00060570-r:
-  definition:
-  - in actuality or reality or fact
-  example:
-  - she is effectively his wife
-  - in effect, they had no choice
-  ili: i18499
-  members:
-  - effectively
-  - in effect
-  partOfSpeech: r
-00060735-r:
-  definition:
-  - in reality or fact
-  example:
-  - the result was, de facto, a one-party system
-  ili: i18500
-  members:
-  - de facto
-  partOfSpeech: r
-00060838-r:
-  definition:
-  - in every practical sense
-  example:
-  - to all intents and purposes the case is closed
-  - the rest are for all practical purposes useless
-  ili: i18501
-  members:
-  - for all practical purposes
-  - to all intents and purposes
-  - for all intents and purposes
-  partOfSpeech: r
 00061079-r:
   definition:
   - in a manner that is reproducible
   ili: i18502
   members:
   - reproducibly
-  partOfSpeech: r
-00061170-r:
-  definition:
-  - at an earlier time or formerly
-  example:
-  - she had previously lived in Chicago
-  - he was previously president of a bank
-  - better than anything previously proposed
-  - a previously unquestioned attitude
-  - antecedently arranged
-  ili: i18503
-  members:
-  - previously
-  - antecedently
-  partOfSpeech: r
-00061477-r:
-  definition:
-  - earlier in time; previously
-  example:
-  - I had known her before
-  - as I said before
-  - he called me the day before but your call had come even earlier
-  - her parents had died four years earlier
-  - I mentioned that problem earlier
-  ili: i18504
-  members:
-  - earlier
-  - before
-  partOfSpeech: r
-00061741-r:
-  definition:
-  - happening at a time subsequent to a reference time
-  example:
-  - he apologized subsequently
-  - he's going to the store but he'll be back here later
-  - it didn't happen until afterward
-  - two hours after that
-  ili: i18505
-  members:
-  - subsequently
-  - later
-  - afterwards
-  - afterward
-  - after
-  - later on
   partOfSpeech: r
 00062352-r:
   definition:
@@ -3912,13 +1049,6 @@
   ili: i18511
   members:
   - inscrutably
-  partOfSpeech: r
-00062701-r:
-  definition:
-  - by means of an insecticide
-  ili: i18512
-  members:
-  - insecticidally
   partOfSpeech: r
 00062788-r:
   definition:
@@ -3954,17 +1084,6 @@
   - unintentionally
   - accidentally
   partOfSpeech: r
-00063395-r:
-  definition:
-  - (sentence connectors) because of the reason given
-  example:
-  - consequently, he didn't do it
-  - continued to have severe headaches and accordingly returned to the doctor
-  ili: i18516
-  members:
-  - consequently
-  - accordingly
-  partOfSpeech: r
 00063627-r:
   definition:
   - in accordance with
@@ -3973,48 +1092,6 @@
   ili: i18517
   members:
   - accordingly
-  partOfSpeech: r
-00063710-r:
-  definition:
-  - in place of, or as an alternative to
-  example:
-  - Felix became a herpetologist instead
-  - alternatively we could buy a used car
-  ili: i18518
-  members:
-  - alternatively
-  - instead
-  - or else
-  partOfSpeech: r
-00063907-r:
-  definition:
-  - much less
-  example:
-  - she can't boil potatoes, let alone cook a meal
-  ili: i18519
-  members:
-  - let alone
-  - not to mention
-  partOfSpeech: r
-00064021-r:
-  definition:
-  - with greater reason; for a still stronger, more certain reason
-  example:
-  - if you are wrong then, a fortiori, so am I
-  ili: i18520
-  members:
-  - a fortiori
-  partOfSpeech: r
-00064168-r:
-  definition:
-  - with everything included or counted
-  example:
-  - altogether he earns close to a million dollars
-  ili: i18521
-  members:
-  - altogether
-  - all told
-  - in all
   partOfSpeech: r
 00064312-r:
   definition:
@@ -4029,15 +1106,6 @@
   members:
   - all together
   partOfSpeech: r
-00064621-r:
-  definition:
-  - with respect to anatomy
-  example:
-  - anatomically correct
-  ili: i18523
-  members:
-  - anatomically
-  partOfSpeech: r
 00064727-r:
   definition:
   - without preparation or reflection; without a rational basis
@@ -4048,82 +1116,6 @@
   members:
   - blindly
   partOfSpeech: r
-00064899-r:
-  definition:
-  - with respect to color
-  example:
-  - chromatically pure
-  ili: i18525
-  members:
-  - chromatically
-  partOfSpeech: r
-00065002-r:
-  definition:
-  - with respect to chronology
-  example:
-  - he is chronologically older
-  ili: i18526
-  members:
-  - chronologically
-  partOfSpeech: r
-00065121-r:
-  definition:
-  - in a clinical manner
-  example:
-  - she is clinically qualified
-  ili: i18527
-  members:
-  - clinically
-  partOfSpeech: r
-00065229-r:
-  definition:
-  - with respect to mathematics
-  example:
-  - mathematically impossible
-  ili: i18529
-  members:
-  - mathematically
-  partOfSpeech: r
-00065346-r:
-  definition:
-  - during the intervening time
-  example:
-  - meanwhile I will not think about the problem
-  - meantime he was attentive to his other interests
-  - in the meantime the police were notified
-  ili: i18530
-  members:
-  - meanwhile
-  - meantime
-  - in the meantime
-  partOfSpeech: r
-00065584-r:
-  definition:
-  - at the same time but in another place
-  example:
-  - meanwhile, back at the ranch …
-  ili: i18531
-  members:
-  - meanwhile
-  partOfSpeech: r
-00065694-r:
-  definition:
-  - two times
-  example:
-  - I called her twice
-  ili: i18532
-  members:
-  - twice
-  partOfSpeech: r
-00065759-r:
-  definition:
-  - on a large scale
-  example:
-  - the sketch was so largely drawn that you could see it from the back row
-  ili: i18533
-  members:
-  - largely
-  partOfSpeech: r
 00065886-r:
   definition:
   - slowly and broadly
@@ -4132,55 +1124,6 @@
   ili: i18534
   members:
   - largo
-  partOfSpeech: r
-00065975-r:
-  definition:
-  - in a lengthy or prolix manner
-  example:
-  - the argument went on lengthily
-  - she talked at length about the problem
-  ili: i18535
-  members:
-  - lengthily
-  - at length
-  partOfSpeech: r
-00066148-r:
-  definition:
-  - most recently
-  example:
-  - I saw him last in London
-  ili: i18536
-  members:
-  - last
-  partOfSpeech: r
-00066222-r:
-  definition:
-  - the item at the end
-  example:
-  - last, I'll discuss family values
-  ili: i18537
-  members:
-  - last
-  - lastly
-  - in conclusion
-  - finally
-  partOfSpeech: r
-00066363-r:
-  definition:
-  - in addition to all the foregoing
-  example:
-  - last not least, he plays the saxophone
-  ili: i18538
-  members:
-  - last but not least
-  - last not least
-  partOfSpeech: r
-00066500-r:
-  definition:
-  - in an enduring or permanent manner
-  ili: i18539
-  members:
-  - lastingly
   partOfSpeech: r
 00066590-r:
   definition:
@@ -4221,135 +1164,6 @@
   - poignantly
   - touchingly
   partOfSpeech: r
-00067181-r:
-  definition:
-  - at or in the front
-  example:
-  - I see the lights of a town ahead
-  - the road ahead is foggy
-  - staring straight ahead
-  - we couldn't see over the heads of the people in front
-  - with the cross of Jesus marching on before
-  ili: i18544
-  members:
-  - ahead
-  - in front
-  - before
-  partOfSpeech: r
-00067445-r:
-  definition:
-  - ahead of time; in anticipation
-  example:
-  - when you pay ahead (or in advance) you receive a discount
-  - We like to plan ahead
-  - should have made reservations beforehand
-  ili: i18545
-  members:
-  - ahead
-  - in advance
-  - beforehand
-  partOfSpeech: r
-00067665-r:
-  definition:
-  - in a forward direction
-  example:
-  - go ahead
-  - the train moved ahead slowly
-  - the boat lurched ahead
-  - moved onward into the forest
-  - they went slowly forward in the mud
-  ili: i18546
-  members:
-  - ahead
-  - onward
-  - onwards
-  - forward
-  - forwards
-  - forrader
-  partOfSpeech: r
-00067913-r:
-  definition:
-  - leading or ahead in a competition
-  example:
-  - the horse was three lengths ahead going into the home stretch
-  - ahead by two pawns
-  - our candidate is in the lead in the polls
-  - way out front in the race
-  - the advertising campaign put them out front in sales
-  ili: i18547
-  members:
-  - ahead
-  - out front
-  - in the lead
-  partOfSpeech: r
-00068223-r:
-  definition:
-  - to a different or a more advanced time (meaning advanced either toward the present
-    or toward the future)
-  example:
-  - moved the appointment ahead from Tuesday to Monday
-  - pushed the deadline ahead from Tuesday to Wednesday
-  ili: i18548
-  members:
-  - ahead
-  partOfSpeech: r
-00068470-r:
-  definition:
-  - to a more advanced or advantageous position
-  example:
-  - a young man sure to get ahead
-  - pushing talented students ahead
-  ili: i18549
-  members:
-  - ahead
-  partOfSpeech: r
-00068615-r:
-  definition:
-  - all the time or over a period of time
-  example:
-  - She had known all along
-  - the hope had been there all along
-  ili: i18550
-  members:
-  - all along
-  - right along
-  partOfSpeech: r
-00068768-r:
-  definition:
-  - with a forward motion
-  example:
-  - we drove along admiring the view
-  - the horse trotted along at a steady pace
-  - the circus traveled on to the next city
-  - move along
-  - march on
-  ili: i18551
-  members:
-  - along
-  - 'on'
-  partOfSpeech: r
-00068977-r:
-  definition:
-  - in accompaniment or as a companion
-  example:
-  - his little sister came along to the movies
-  - I brought my camera along
-  - working along with his father
-  ili: i18552
-  members:
-  - along
-  partOfSpeech: r
-00069153-r:
-  definition:
-  - in addition (usually followed by ‘with’)
-  example:
-  - we sent them food and some clothing went along in the package
-  - along with the package came a bill
-  - consider the advantages along with the disadvantages
-  ili: i18553
-  members:
-  - along
-  partOfSpeech: r
 00069386-r:
   definition:
   - to a more advanced state
@@ -4362,37 +1176,6 @@
   members:
   - along
   partOfSpeech: r
-00069564-r:
-  definition:
-  - in line with a length or direction (often followed by ‘by’ or ‘beside’)
-  example:
-  - pass the word along
-  - ran along beside me
-  - cottages along by the river
-  ili: i18555
-  members:
-  - along
-  partOfSpeech: r
-00069746-r:
-  definition:
-  - indicates continuity or persistence or concentration
-  example:
-  - his spirit lives on
-  - shall I read on?
-  ili: i18556
-  members:
-  - 'on'
-  partOfSpeech: r
-00069872-r:
-  definition:
-  - in a state required for something to function or be effective
-  example:
-  - turn the lights on
-  - get a load on
-  ili: i18557
-  members:
-  - 'on'
-  partOfSpeech: r
 00070003-r:
   definition:
   - in a like manner
@@ -4401,16 +1184,6 @@
   ili: i18558
   members:
   - alike
-  partOfSpeech: r
-00070072-r:
-  definition:
-  - equally
-  example:
-  - parents and teachers alike demanded reforms
-  ili: i18559
-  members:
-  - alike
-  - likewise
   partOfSpeech: r
 00070171-r:
   definition:
@@ -4486,59 +1259,6 @@
   - at random
   - every which way
   partOfSpeech: r
-00071450-r:
-  definition:
-  - in circumference
-  example:
-  - the trunk is ten feet around
-  - the pond is two miles around
-  ili: i18566
-  members:
-  - around
-  partOfSpeech: r
-00071565-r:
-  definition:
-  - in the area or vicinity
-  example:
-  - a few spectators standing about
-  - hanging around
-  - waited around for the next flight
-  ili: i18567
-  members:
-  - about
-  - around
-  partOfSpeech: r
-00071721-r:
-  definition:
-  - not far away in relative terms
-  example:
-  - she works nearby
-  - the planets orbiting nearby are Venus and Mars
-  ili: i18568
-  members:
-  - nearby
-  partOfSpeech: r
-00071856-r:
-  definition:
-  - from beginning to end; throughout
-  example:
-  - It rains all year round on Skye
-  - frigid weather the year around
-  ili: i18569
-  members:
-  - round
-  - around
-  partOfSpeech: r
-00072001-r:
-  definition:
-  - by a circular or circuitous route
-  example:
-  - He came all the way around the base
-  - the road goes around the pond
-  ili: i18570
-  members:
-  - around
-  partOfSpeech: r
 00072141-r:
   definition:
   - in a circle or circular motion
@@ -4547,65 +1267,6 @@
   ili: i18571
   members:
   - around
-  partOfSpeech: r
-00072240-r:
-  definition:
-  - all around or on all sides
-  example:
-  - dirty clothes lying around (or about)
-  - let's look about for help
-  - There were trees growing all around
-  - she looked around her
-  ili: i18572
-  members:
-  - about
-  - around
-  partOfSpeech: r
-00072443-r:
-  definition:
-  - to a particular destination either specified or understood
-  example:
-  - she came around to see me
-  - I invited them around for supper
-  ili: i18573
-  members:
-  - around
-  partOfSpeech: r
-00072601-r:
-  definition:
-  - in or to a reversed position or direction
-  example:
-  - about face
-  - suddenly she turned around
-  ili: i18574
-  members:
-  - about
-  - around
-  partOfSpeech: r
-00072729-r:
-  definition:
-  - used of movement to or among many different places or in no particular direction
-  example:
-  - wandering about with no place to go
-  - people were rushing about
-  - news gets around (or about)
-  - traveled around in Asia
-  - he needs advice from someone who's been around
-  - she sleeps around
-  ili: i18575
-  members:
-  - about
-  - around
-  partOfSpeech: r
-00073049-r:
-  definition:
-  - in or to various places; first this place and then that; location pronoun
-  example:
-  - he worked here and there but never for long in one town
-  - we drove here and there in the darkness
-  ili: i18576
-  members:
-  - here and there
   partOfSpeech: r
 00073249-r:
   definition:
@@ -4617,31 +1278,6 @@
   members:
   - urgently
   - desperately
-  partOfSpeech: r
-00073433-r:
-  definition:
-  - (of actions or states) slightly short of or not quite accomplished; all but
-  example:
-  - the job is (just) about done
-  - the baby was almost asleep when the alarm sounded
-  - we're almost finished
-  - the car all but ran her down
-  - he nearly fainted
-  - talked for nigh onto 2 hours
-  - the recording is well-nigh perfect
-  - virtually all the parties signed the contract
-  - I was near exhausted by the run
-  - most everyone agrees
-  ili: i18578
-  members:
-  - about
-  - almost
-  - most
-  - nearly
-  - near
-  - nigh
-  - virtually
-  - well-nigh
   partOfSpeech: r
 00073946-r:
   definition:
@@ -4661,103 +1297,6 @@
   members:
   - asymptotically
   partOfSpeech: r
-00074163-r:
-  definition:
-  - for the most part
-  example:
-  - he is mainly interested in butterflies
-  ili: i18582
-  members:
-  - chiefly
-  - principally
-  - primarily
-  - mainly
-  - in the main
-  partOfSpeech: r
-00074361-r:
-  definition:
-  - in the past
-  example:
-  - long ago
-  - sixty years ago my grandfather came to the U.S.
-  ili: i18583
-  members:
-  - ago
-  partOfSpeech: r
-00074467-r:
-  definition:
-  - in or to or toward a past time
-  example:
-  - set the clocks back an hour
-  - never look back
-  - lovers of the past looking fondly backward
-  ili: i18584
-  members:
-  - back
-  - backward
-  partOfSpeech: r
-00074673-r:
-  definition:
-  - at or to or toward the back or rear
-  example:
-  - he moved back
-  - tripped when he stepped backward
-  - she looked rearward out the window of the car
-  ili: i18585
-  members:
-  - back
-  - backward
-  - backwards
-  - rearward
-  - rearwards
-  partOfSpeech: r
-00074907-r:
-  definition:
-  - at or to or toward the front; forward
-  example:
-  - he faced forward
-  - step forward
-  - she practiced sewing backward as well as frontward on her new sewing machine
-  exemplifies:
-  - 07170369-n
-  ili: i18586
-  members:
-  - forward
-  - forwards
-  - frontward
-  - frontwards
-  - forrad
-  - forrard
-  partOfSpeech: r
-00075230-r:
-  definition:
-  - in repayment or retaliation
-  example:
-  - we paid back everything we had borrowed
-  - he hit me and I hit him back
-  - I was kept in after school for talking back to the teacher
-  ili: i18587
-  members:
-  - back
-  partOfSpeech: r
-00075427-r:
-  definition:
-  - in or to or toward a former location
-  example:
-  - she went back to her parents' house
-  ili: i18588
-  members:
-  - back
-  partOfSpeech: r
-00075535-r:
-  definition:
-  - in or to or toward an original condition
-  example:
-  - he went back to sleep
-  ili: i18589
-  members:
-  - back
-  partOfSpeech: r
 00075633-r:
   definition:
   - in reply
@@ -4767,17 +1306,6 @@
   members:
   - back
   partOfSpeech: r
-00075708-r:
-  definition:
-  - toward the future; forward in time
-  example:
-  - I like to look ahead in imagination to what the future may bring
-  - I look forward to seeing you
-  ili: i18591
-  members:
-  - ahead
-  - forward
-  partOfSpeech: r
 00075922-r:
   definition:
   - by surprise
@@ -4786,22 +1314,6 @@
   ili: i18592
   members:
   - aback
-  partOfSpeech: r
-00076005-r:
-  definition:
-  - having the wind against the forward side of the sails
-  example:
-  - the ship came up into the wind with all yards aback
-  ili: i18593
-  members:
-  - aback
-  partOfSpeech: r
-00076147-r:
-  definition:
-  - at right angles to the length of a ship or airplane
-  ili: i18594
-  members:
-  - abeam
   partOfSpeech: r
 00076232-r:
   definition:
@@ -4826,34 +1338,6 @@
   - back and forth
   - backward and forward
   - to and fro
-  partOfSpeech: r
-00076778-r:
-  definition:
-  - moving backward and forward along a given course
-  example:
-  - he walked up and down the locker room
-  - all up and down the Eastern seaboard
-  ili: i18597
-  members:
-  - up and down
-  partOfSpeech: r
-00076947-r:
-  definition:
-  - with regard to sound or the ear
-  example:
-  - the new musical was visually and aurally appealing
-  ili: i18598
-  members:
-  - aurally
-  partOfSpeech: r
-00077086-r:
-  definition:
-  - with respect to an axis
-  example:
-  - the jet was directed axially toward the cathode
-  ili: i18599
-  members:
-  - axially
   partOfSpeech: r
 00077214-r:
   definition:
@@ -4893,57 +1377,6 @@
   ili: i18603
   members:
   - catalytically
-  partOfSpeech: r
-00077763-r:
-  definition:
-  - in a commercial manner
-  example:
-  - the product is commercially available
-  ili: i18604
-  members:
-  - commercially
-  partOfSpeech: r
-00077885-r:
-  definition:
-  - at a great cost
-  example:
-  - he paid dearly for the food
-  - this cost him dear
-  ili: i18605
-  members:
-  - dearly
-  - dear
-  partOfSpeech: r
-00078013-r:
-  definition:
-  - with affection
-  example:
-  - she loved him dearly
-  - he treats her affectionately
-  ili: i18606
-  members:
-  - dearly
-  - affectionately
-  - dear
-  partOfSpeech: r
-00078178-r:
-  definition:
-  - in a sincere and heartfelt manner
-  example:
-  - I would dearly love to know
-  ili: i18607
-  members:
-  - dearly
-  - in a heartfelt way
-  partOfSpeech: r
-00078316-r:
-  definition:
-  - with the terms of the relation reversed
-  example:
-  - conversely, not all women are mothers
-  ili: i18608
-  members:
-  - conversely
   partOfSpeech: r
 00078453-r:
   definition:
@@ -5002,46 +1435,6 @@
   members:
   - microscopically
   partOfSpeech: r
-00079373-r:
-  definition:
-  - without doubt; certainly
-  example:
-  - it's undoubtedly very beautiful
-  ili: i18615
-  members:
-  - undoubtedly
-  - doubtless
-  - doubtlessly
-  partOfSpeech: r
-00079498-r:
-  definition:
-  - with respect to statistics
-  example:
-  - this is statistically impossible
-  ili: i18616
-  members:
-  - statistically
-  partOfSpeech: r
-00079620-r:
-  definition:
-  - with respect to thermodynamics
-  example:
-  - this phenomenon is thermodynamically impossible
-  ili: i18617
-  members:
-  - thermodynamically
-  partOfSpeech: r
-00079765-r:
-  definition:
-  - during the night of the present day
-  example:
-  - drop by tonight
-  ili: i18618
-  members:
-  - tonight
-  - this evening
-  - this night
-  partOfSpeech: r
 00079883-r:
   definition:
   - in an active manner
@@ -5060,64 +1453,6 @@
   members:
   - passively
   partOfSpeech: r
-00080132-r:
-  definition:
-  - (in writing) at a later place
-  example:
-  - see below
-  - vide infra
-  ili: i19938
-  members:
-  - below
-  - infra
-  partOfSpeech: r
-00080266-r:
-  definition:
-  - (in writing) at an earlier place
-  example:
-  - see above
-  ili: i18622
-  members:
-  - above
-  - supra
-  partOfSpeech: r
-00080389-r:
-  definition:
-  - in or to a place that is lower
-  ili: i18623
-  members:
-  - below
-  - at a lower place
-  - to a lower place
-  - beneath
-  partOfSpeech: r
-00080519-r:
-  definition:
-  - in or to a place that is higher
-  ili: i18624
-  members:
-  - above
-  - higher up
-  - in a higher place
-  - to a higher place
-  partOfSpeech: r
-00080654-r:
-  definition:
-  - in addition; over and above what is expected
-  example:
-  - He lost his wife in the bargain
-  ili: i18625
-  members:
-  - in the bargain
-  - into the bargain
-  partOfSpeech: r
-00080795-r:
-  definition:
-  - in a manner deserving contempt
-  ili: i18626
-  members:
-  - contemptibly
-  partOfSpeech: r
 00080884-r:
   definition:
   - without respect; in a disdainful manner
@@ -5129,15 +1464,6 @@
   - disdainfully
   - scornfully
   - contumeliously
-  partOfSpeech: r
-00081118-r:
-  definition:
-  - by virtue of a contract
-  example:
-  - they were contractually responsible
-  ili: i18628
-  members:
-  - contractually
   partOfSpeech: r
 00081240-r:
   definition:
@@ -5172,39 +1498,6 @@
   members:
   - comically
   partOfSpeech: r
-00081836-r:
-  definition:
-  - every day; without missing a day
-  example:
-  - he stops by daily
-  ili: i18632
-  members:
-  - daily
-  partOfSpeech: r
-00081941-r:
-  definition:
-  - without missing a week
-  example:
-  - she visited her aunt weekly
-  ili: i18633
-  members:
-  - hebdomadally
-  - weekly
-  - every week
-  - each week
-  partOfSpeech: r
-00082087-r:
-  definition:
-  - without missing a year
-  example:
-  - they travel to China annually
-  ili: i18634
-  members:
-  - annually
-  - yearly
-  - every year
-  - each year
-  partOfSpeech: r
 00082231-r:
   definition:
   - with curiosity
@@ -5215,13 +1508,6 @@
   - curiously
   - inquisitively
   - interrogatively
-  partOfSpeech: r
-00082389-r:
-  definition:
-  - in a manner or to a degree that dazzles the beholder
-  ili: i18636
-  members:
-  - dazzlingly
   partOfSpeech: r
 00082498-r:
   definition:
@@ -5234,31 +1520,12 @@
   - deceivingly
   - misleadingly
   partOfSpeech: r
-00082658-r:
-  definition:
-  - at or in an indicated (usually distant) place (‘yon’ is archaic and dialectal)
-  example:
-  - the house yonder
-  - source: Calder Willingham
-    text: scattered here and yon
-  ili: i18638
-  members:
-  - yonder
-  - yon
-  partOfSpeech: r
 00082842-r:
   definition:
   - in a deprecative manner
   ili: i18639
   members:
   - deprecatively
-  partOfSpeech: r
-00082925-r:
-  definition:
-  - in a depressing manner or to a depressing degree
-  ili: i18640
-  members:
-  - depressingly
   partOfSpeech: r
 00083032-r:
   definition:
@@ -5292,13 +1559,6 @@
   - giddily
   - light-headedly
   partOfSpeech: r
-00083430-r:
-  definition:
-  - in a dorsal location or direction
-  ili: i18645
-  members:
-  - dorsally
-  partOfSpeech: r
 00083518-r:
   definition:
   - in a dorsoventral direction
@@ -5307,25 +1567,6 @@
   ili: i18646
   members:
   - dorsoventrally
-  partOfSpeech: r
-00083653-r:
-  definition:
-  - in a ventral location or direction
-  ili: i18647
-  members:
-  - ventrally
-  partOfSpeech: r
-00083743-r:
-  definition:
-  - to double the degree
-  example:
-  - she was doubly rewarded
-  - his eyes were double bright
-  ili: i18648
-  members:
-  - doubly
-  - double
-  - twice
   partOfSpeech: r
 00083891-r:
   definition:
@@ -5336,15 +1577,6 @@
   members:
   - singly
   partOfSpeech: r
-00084016-r:
-  definition:
-  - in several ways; in a multiple manner
-  example:
-  - they were multiply checked for errors
-  ili: i18650
-  members:
-  - multiply
-  partOfSpeech: r
 00084167-r:
   definition:
   - in a multiplicative manner
@@ -5353,16 +1585,6 @@
   ili: i18651
   members:
   - multiplicatively
-  partOfSpeech: r
-00084297-r:
-  definition:
-  - in a twofold manner
-  example:
-  - he was doubly wrong
-  ili: i18652
-  members:
-  - doubly
-  - in two ways
   partOfSpeech: r
 00084388-r:
   definition:
@@ -5375,21 +1597,6 @@
   - through empirical observation
   - by trial and error
   partOfSpeech: r
-00084573-r:
-  definition:
-  - to a distinctly greater extent or degree than is common
-  example:
-  - he was particularly fussy about spelling
-  - a particularly gruesome attack
-  - under peculiarly tragic circumstances
-  - an especially (or specially) cautious approach to the danger
-  ili: i18654
-  members:
-  - particularly
-  - peculiarly
-  - especially
-  - specially
-  partOfSpeech: r
 00084962-r:
   definition:
   - with the full authority of the office
@@ -5398,15 +1605,6 @@
   ili: i18655
   members:
   - ex cathedra
-  partOfSpeech: r
-00085109-r:
-  definition:
-  - unusually or exceptionally
-  example:
-  - an extra fast car
-  ili: i18656
-  members:
-  - extra
   partOfSpeech: r
 00085190-r:
   definition:
@@ -5419,32 +1617,6 @@
   - intricately
   - in an elaborate way
   partOfSpeech: r
-00085352-r:
-  definition:
-  - in or to another place
-  example:
-  - he went elsewhere
-  - look elsewhere for the answer
-  ili: i18658
-  members:
-  - elsewhere
-  partOfSpeech: r
-00085466-r:
-  definition:
-  - in relation to eschatology
-  example:
-  - even atheists can be eschatologically minded
-  ili: i18659
-  members:
-  - eschatologically
-  partOfSpeech: r
-00085603-r:
-  definition:
-  - in an exasperating manner
-  ili: i18660
-  members:
-  - exasperatingly
-  partOfSpeech: r
 00085689-r:
   definition:
   - in an experimental fashion
@@ -5455,15 +1627,6 @@
   - experimentally
   - by experimentation
   - through an experiment
-  partOfSpeech: r
-00085862-r:
-  definition:
-  - with specific intentions; for the express purpose
-  example:
-  - she needs the money expressly for her patients
-  ili: i18662
-  members:
-  - expressly
   partOfSpeech: r
 00086017-r:
   definition:
@@ -5552,44 +1715,12 @@
   members:
   - slower
   partOfSpeech: r
-00087173-r:
-  definition:
-  - most quickly
-  ili: i18670
-  members:
-  - quickest
-  - fastest
-  partOfSpeech: r
-00087268-r:
-  definition:
-  - most slowly
-  ili: i18671
-  members:
-  - slowest
-  partOfSpeech: r
 00087333-r:
   definition:
   - in a permissive manner
   ili: i18672
   members:
   - permissively
-  partOfSpeech: r
-00087414-r:
-  definition:
-  - in a permissible manner
-  ili: i18673
-  members:
-  - permissibly
-  - allowably
-  partOfSpeech: r
-00087525-r:
-  definition:
-  - not permissibly
-  example:
-  - the radon level in the basement was impermissibly high
-  ili: i18674
-  members:
-  - impermissibly
   partOfSpeech: r
 00087676-r:
   definition:
@@ -5611,87 +1742,6 @@
   members:
   - flush
   partOfSpeech: r
-00087937-r:
-  definition:
-  - in the same plane
-  example:
-  - set it flush with the top of the table
-  ili: i18677
-  members:
-  - flush
-  partOfSpeech: r
-00088030-r:
-  definition:
-  - for a limitless time
-  example:
-  - no one can live forever
-  - source: P.P.Bliss
-    text: brightly beams our Father's mercy from his lighthouse evermore
-  ili: i18678
-  members:
-  - everlastingly
-  - eternally
-  - forever
-  - evermore
-  partOfSpeech: r
-00088265-r:
-  definition:
-  - to infinity; without or seemingly without limit
-  example:
-  - talked on and on ad infinitum
-  ili: i18679
-  members:
-  - ad infinitum
-  partOfSpeech: r
-00088404-r:
-  definition:
-  - for a long time without essential change
-  example:
-  - he is permanently disabled
-  ili: i18680
-  members:
-  - permanently
-  - for good
-  partOfSpeech: r
-00088561-r:
-  definition:
-  - for an indefinitely long time
-  example:
-  - bequeathed to the nation in perpetuity
-  ili: i18681
-  members:
-  - in perpetuity
-  partOfSpeech: r
-00088674-r:
-  definition:
-  - for life
-  example:
-  - desire happiness in perpetuity
-  - an annuity paid in perpetuity
-  ili: i18682
-  members:
-  - in perpetuity
-  partOfSpeech: r
-00088791-r:
-  definition:
-  - for a limited time only; not permanently
-  example:
-  - he will work here temporarily
-  - he was brought out of retirement temporarily
-  - a power failure temporarily darkened the town
-  ili: i18683
-  members:
-  - temporarily
-  partOfSpeech: r
-00089037-r:
-  definition:
-  - for an intervening time; temporarily
-  example:
-  - elected to serve ad interim
-  ili: i18684
-  members:
-  - ad interim
-  partOfSpeech: r
 00089143-r:
   definition:
   - without advance preparation
@@ -5704,78 +1754,6 @@
   - spontaneously
   - impromptu
   partOfSpeech: r
-00089265-r:
-  definition:
-  - temporarily and conditionally
-  example:
-  - they have agreed provisionally
-  - was appointed provisionally
-  ili: i18686
-  members:
-  - provisionally
-  partOfSpeech: r
-00089419-r:
-  definition:
-  - seemingly without interruption
-  example:
-  - complained continually that there wasn't enough money
-  ili: i18687
-  members:
-  - continually
-  partOfSpeech: r
-00089564-r:
-  definition:
-  - for a very long or seemingly endless time
-  example:
-  - she took forever to write the paper
-  - we had to wait forever and a day
-  exemplifies:
-  - 07089193-n
-  ili: i18688
-  members:
-  - forever
-  - forever and a day
-  partOfSpeech: r
-00089755-r:
-  definition:
-  - in a high position or level or rank
-  example:
-  - details known by only a few highly placed persons
-  ili: i18689
-  members:
-  - highly
-  partOfSpeech: r
-00089896-r:
-  definition:
-  - to a high degree or extent; favorably or with much respect
-  example:
-  - highly successful
-  - He spoke highly of her
-  - does not think highly of his writing
-  - extremely interesting
-  ili: i18690
-  members:
-  - highly
-  - extremely
-  partOfSpeech: r
-00090131-r:
-  definition:
-  - at a high rate or wage
-  example:
-  - highly paid workers
-  ili: i18691
-  members:
-  - highly
-  partOfSpeech: r
-00090211-r:
-  definition:
-  - involving the use of histology or histological techniques
-  example:
-  - histologically identifiable structures
-  ili: i18692
-  members:
-  - histologically
-  partOfSpeech: r
 00090371-r:
   definition:
   - as if by magnetism
@@ -5784,35 +1762,6 @@
   ili: i18693
   members:
   - magnetically
-  partOfSpeech: r
-00090488-r:
-  definition:
-  - in a marginal manner
-  example:
-  - marginally interesting
-  ili: i18694
-  members:
-  - marginally
-  partOfSpeech: r
-00090591-r:
-  definition:
-  - in a geometric fashion
-  example:
-  - it grew geometrically
-  ili: i18695
-  members:
-  - geometrically
-  partOfSpeech: r
-00090716-r:
-  definition:
-  - in a dangerous manner
-  example:
-  - he came dangerously close to falling off the ledge
-  ili: i18696
-  members:
-  - perilously
-  - hazardously
-  - dangerously
   partOfSpeech: r
 00090912-r:
   definition:
@@ -5823,15 +1772,6 @@
   members:
   - tiredly
   - wearily
-  partOfSpeech: r
-00091039-r:
-  definition:
-  - to a vital degree
-  example:
-  - this is vitally important
-  ili: i18698
-  members:
-  - vitally
   partOfSpeech: r
 00091139-r:
   definition:
@@ -5870,22 +1810,6 @@
   members:
   - dingdong
   partOfSpeech: r
-00091627-r:
-  definition:
-  - powerfully or vigorously
-  example:
-  - he strove mightily to achieve a better position in life
-  ili: i18703
-  members:
-  - mightily
-  partOfSpeech: r
-00091747-r:
-  definition:
-  - with reluctance
-  ili: i18704
-  members:
-  - reluctantly
-  partOfSpeech: r
 00091820-r:
   definition:
   - with effort or force or vigor
@@ -5921,17 +1845,6 @@
   - hard
   - hardly
   partOfSpeech: r
-00092328-r:
-  definition:
-  - causing great damage or hardship
-  example:
-  - industries hit hard by the depression
-  - she was severely affected by the bank's failure
-  ili: i18708
-  members:
-  - hard
-  - severely
-  partOfSpeech: r
 00092514-r:
   definition:
   - with firmness
@@ -5952,35 +1865,6 @@
   members:
   - hard
   partOfSpeech: r
-00092706-r:
-  definition:
-  - with pain or distress or bitterness
-  example:
-  - he took the rejection very hard
-  ili: i18711
-  members:
-  - hard
-  partOfSpeech: r
-00092809-r:
-  definition:
-  - very near or close in space or time
-  example:
-  - it stands hard by the railroad tracks
-  - they were hard on his heels
-  - a strike followed hard upon the plant's opening
-  ili: i18712
-  members:
-  - hard
-  partOfSpeech: r
-00093000-r:
-  definition:
-  - into a solid condition
-  example:
-  - concrete that sets hard within a few hours
-  ili: i18713
-  members:
-  - hard
-  partOfSpeech: r
 00093119-r:
   definition:
   - securely fixed or fastened
@@ -5989,17 +1873,6 @@
   ili: i18714
   members:
   - tightly
-  partOfSpeech: r
-00093364-r:
-  definition:
-  - for an instant or moment
-  example:
-  - we paused momentarily before proceeding
-  - a cardinal perched momently on the dogwood branch
-  ili: i18716
-  members:
-  - momentarily
-  - momently
   partOfSpeech: r
 00093535-r:
   definition:
@@ -6020,46 +1893,6 @@
   members:
   - inconclusively
   partOfSpeech: r
-00093820-r:
-  definition:
-  - in an unfortunate or deplorable manner
-  example:
-  - he was sadly neglected
-  - it was woefully inadequate
-  ili: i18719
-  members:
-  - deplorably
-  - lamentably
-  - sadly
-  - woefully
-  partOfSpeech: r
-00094039-r:
-  definition:
-  - with respect to denomination
-  example:
-  - denominationally diverse audiences
-  ili: i18720
-  members:
-  - denominationally
-  partOfSpeech: r
-00094168-r:
-  definition:
-  - with respect to the cortex
-  example:
-  - cortically induced arousal
-  ili: i18721
-  members:
-  - cortically
-  partOfSpeech: r
-00094281-r:
-  definition:
-  - in a focal manner
-  example:
-  - the submucosa was focally infiltrated
-  ili: i18722
-  members:
-  - focally
-  partOfSpeech: r
 00094393-r:
   definition:
   - with respect to the hypothalamus
@@ -6068,22 +1901,6 @@
   ili: i18723
   members:
   - hypothalamically
-  partOfSpeech: r
-00094530-r:
-  definition:
-  - into the skin
-  ili: i18724
-  members:
-  - intradermally
-  partOfSpeech: r
-00094603-r:
-  definition:
-  - in an intramuscular way
-  example:
-  - administer the drug intramuscularly
-  ili: i18725
-  members:
-  - intramuscularly
   partOfSpeech: r
 00094727-r:
   definition:
@@ -6096,123 +1913,6 @@
   - amusingly
   - divertingly
   partOfSpeech: r
-00094946-r:
-  definition:
-  - on a floor below
-  example:
-  - the tenants live downstairs
-  ili: i18727
-  members:
-  - downstairs
-  - down the stairs
-  - on a lower floor
-  - below
-  partOfSpeech: r
-00095095-r:
-  definition:
-  - on a floor above
-  example:
-  - they lived upstairs
-  ili: i18728
-  members:
-  - upstairs
-  - up the stairs
-  - on a higher floor
-  partOfSpeech: r
-00095225-r:
-  definition:
-  - with respect to the mind
-  example:
-  - she's a bit weak upstairs
-  ili: i18729
-  members:
-  - upstairs
-  partOfSpeech: r
-00095315-r:
-  definition:
-  - with the wind; in the direction the wind is blowing
-  example:
-  - they flew downwind
-  ili: i18730
-  members:
-  - downwind
-  partOfSpeech: r
-00095443-r:
-  definition:
-  - in the direction opposite to the direction the wind is blowing
-  example:
-  - they flew upwind
-  ili: i18731
-  members:
-  - upwind
-  - against the wind
-  - into the wind
-  partOfSpeech: r
-00095613-r:
-  definition:
-  - toward the wind
-  example:
-  - they were sailing windward
-  ili: i18732
-  members:
-  - windward
-  - downwind
-  partOfSpeech: r
-00095742-r:
-  definition:
-  - away from the wind
-  example:
-  - they were sailing leeward
-  ili: i18733
-  members:
-  - leeward
-  - upwind
-  partOfSpeech: r
-00095870-r:
-  definition:
-  - spatially or metaphorically from a higher to a lower level or position
-  example:
-  - don't fall down
-  - rode the lift up and skied down
-  - prices plunged downward
-  ili: i18734
-  members:
-  - down
-  - downwards
-  - downward
-  - downwardly
-  partOfSpeech: r
-00096162-r:
-  definition:
-  - away from a more central or a more northerly place
-  example:
-  - was sent down to work at the regional office
-  - worked down on the farm
-  - came down for the wedding
-  - flew down to Florida
-  ili: i18735
-  members:
-  - down
-  partOfSpeech: r
-00096391-r:
-  definition:
-  - paid in cash at time of purchase
-  example:
-  - put ten dollars down on the necklace
-  ili: i18736
-  members:
-  - down
-  partOfSpeech: r
-00096496-r:
-  definition:
-  - in an inactive or inoperative state
-  example:
-  - the factory went down during the strike
-  - the computer went down again
-  ili: i18737
-  members:
-  - down
-  partOfSpeech: r
 00096639-r:
   definition:
   - to a lower intensity
@@ -6221,110 +1921,6 @@
   ili: i18738
   members:
   - down
-  partOfSpeech: r
-00096782-r:
-  definition:
-  - from an earlier time
-  example:
-  - the story was passed down from father to son
-  ili: i18739
-  members:
-  - down
-  partOfSpeech: r
-00096883-r:
-  definition:
-  - spatially or metaphorically from a lower to a higher position
-  example:
-  - look up!
-  - the music surged up
-  - the fragments flew upwards
-  - prices soared upwards
-  - upwardly mobile
-  ili: i18740
-  members:
-  - up
-  - upwards
-  - upward
-  - upwardly
-  partOfSpeech: r
-00097186-r:
-  definition:
-  - to a later time
-  example:
-  - they moved the meeting date up
-  - from childhood upward
-  ili: i18741
-  members:
-  - up
-  - upwards
-  - upward
-  partOfSpeech: r
-00097310-r:
-  definition:
-  - to a more central or a more northerly place
-  example:
-  - was transferred up to headquarters
-  - up to Canada for a vacation
-  ili: i18742
-  members:
-  - up
-  partOfSpeech: r
-00097471-r:
-  definition:
-  - nearer to the speaker
-  example:
-  - he walked up and grabbed my lapels
-  ili: i18743
-  members:
-  - up
-  partOfSpeech: r
-00097561-r:
-  definition:
-  - to a higher intensity
-  example:
-  - he turned up the volume
-  ili: i18744
-  members:
-  - up
-  partOfSpeech: r
-00097658-r:
-  definition:
-  - toward the source or against the current
-  ili: i18745
-  members:
-  - upriver
-  - upstream
-  partOfSpeech: r
-00097781-r:
-  definition:
-  - away from the source or with the current
-  ili: i18746
-  members:
-  - downriver
-  - downstream
-  partOfSpeech: r
-00097908-r:
-  definition:
-  - in the direction of the defending team's end of the playing field
-  domain_topic:
-  - 00524569-n
-  example:
-  - he caught the ball and ran downfield 15 yards
-  ili: i18747
-  members:
-  - downfield
-  partOfSpeech: r
-00098072-r:
-  definition:
-  - thoroughgoing
-  example:
-  - he is outright dishonest
-  exemplifies:
-  - 06332047-n
-  ili: i18748
-  members:
-  - downright
-  - outright
   partOfSpeech: r
 00098170-r:
   definition:
@@ -6344,98 +1940,6 @@
   members:
   - outright
   partOfSpeech: r
-00098390-r:
-  definition:
-  - at or to or in the direction of one's home or family
-  example:
-  - He stays home on weekends
-  - after the game the children brought friends home for supper
-  - I'll be home tomorrow
-  - came riding home in style
-  - I hope you will come home for Christmas
-  - I'll take her home
-  - don't forget to write home
-  ili: i18751
-  members:
-  - home
-  partOfSpeech: r
-00098716-r:
-  definition:
-  - at, to, or toward the place where you reside
-  example:
-  - he worked at home
-  ili: i18752
-  members:
-  - at home
-  partOfSpeech: r
-00098817-r:
-  definition:
-  - on the home team's field
-  domain_topic:
-  - 00524569-n
-  example:
-  - they played at home last night
-  ili: i18753
-  members:
-  - at home
-  partOfSpeech: r
-00098930-r:
-  definition:
-  - to the fullest extent; to the heart
-  example:
-  - drove the nail home
-  - drove his point home
-  - his comments hit home
-  ili: i18754
-  members:
-  - home
-  partOfSpeech: r
-00099070-r:
-  definition:
-  - on or to the point aimed at
-  example:
-  - the arrow struck home
-  ili: i18755
-  members:
-  - home
-  partOfSpeech: r
-00099155-r:
-  definition:
-  - toward home
-  example:
-  - fought his way homeward through the deep snow
-  ili: i18756
-  members:
-  - homeward
-  - homewards
-  partOfSpeech: r
-00099264-r:
-  definition:
-  - on the contrary
-  example:
-  - rather than disappoint the children, he did two quick tricks before he left
-  - he didn't call; rather (or instead), he wrote her a letter
-  - used English terms instead of Latin ones
-  ili: i18757
-  members:
-  - rather
-  - instead
-  partOfSpeech: r
-00099509-r:
-  definition:
-  - to the degree or extent that
-  example:
-  - insofar as it can be ascertained, the horse lung is comparable to that of man
-  - so far as it is reasonably practical he should practice restraint
-  ili: i18758
-  members:
-  - insofar
-  - in so far
-  - so far
-  - to that extent
-  - to that degree
-  - in so far as
-  partOfSpeech: r
 00099778-r:
   definition:
   - in a mordacious manner
@@ -6444,207 +1948,6 @@
   ili: i18759
   members:
   - mordaciously
-  partOfSpeech: r
-00099891-r:
-  definition:
-  - used to form the comparative of some adjectives and adverbs, indicates that the
-    adjective or adverb is more of something
-  example:
-  - more interesting
-  - more beautiful
-  - more quickly
-  ili: i18760
-  members:
-  - more
-  - to a greater extent
-  partOfSpeech: r
-00100077-r:
-  definition:
-  - used to form the comparative of some adjectives and adverbs, indicates that the
-    adjective or adverb is less of something
-  example:
-  - less interesting
-  - less expensive
-  - less quickly
-  ili: i18761
-  members:
-  - less
-  - to a lesser extent
-  partOfSpeech: r
-00100262-r:
-  definition:
-  - comparative of much; to a greater degree or extent
-  example:
-  - he works more now
-  - they eat more than they should
-  ili: i18762
-  members:
-  - more
-  partOfSpeech: r
-00100418-r:
-  definition:
-  - comparative of little
-  example:
-  - she walks less than she should
-  - he works less these days
-  ili: i18763
-  members:
-  - less
-  partOfSpeech: r
-00100552-r:
-  definition:
-  - not much
-  example:
-  - he talked little about his family
-  ili: i18764
-  members:
-  - little
-  partOfSpeech: r
-00100632-r:
-  definition:
-  - before the usual time or the time expected
-  example:
-  - she graduated early
-  - the house was completed ahead of time
-  ili: i18765
-  members:
-  - early
-  - ahead of time
-  - too soon
-  partOfSpeech: r
-00100817-r:
-  definition:
-  - later than usual or than expected
-  example:
-  - the train arrived late
-  - we awoke late
-  - the children came late to school
-  - notice came so tardily that we almost missed the deadline
-  - I belatedly wished her a happy birthday
-  ili: i18766
-  members:
-  - late
-  - belatedly
-  - tardily
-  partOfSpeech: r
-00101142-r:
-  definition:
-  - in good time
-  example:
-  - he awoke betimes that morning
-  ili: i18767
-  members:
-  - early
-  - betimes
-  partOfSpeech: r
-00101231-r:
-  definition:
-  - during an early stage
-  example:
-  - early on in her career
-  ili: i18768
-  members:
-  - early on
-  - early
-  partOfSpeech: r
-00101323-r:
-  definition:
-  - as far as that is concerned
-  example:
-  - for that matter I don't care either
-  ili: i18769
-  members:
-  - for that matter
-  partOfSpeech: r
-00101433-r:
-  definition:
-  - (old-fashioned) at or from or to a great distance; far
-  example:
-  - we traveled afar
-  - we could see the ship afar off
-  - the Magi came from afar
-  ili: i18770
-  members:
-  - afar
-  partOfSpeech: r
-00101601-r:
-  definition:
-  - at or to or from a great distance in space
-  example:
-  - he traveled far
-  - strayed far from home
-  - sat far away from each other
-  ili: i18771
-  members:
-  - far
-  partOfSpeech: r
-00101751-r:
-  definition:
-  - remote in time
-  example:
-  - if we could see far into the future
-  - all that happened far in the past
-  ili: i18772
-  members:
-  - far
-  partOfSpeech: r
-00101873-r:
-  definition:
-  - to a considerable degree; very much
-  example:
-  - a far far better thing that I do
-  - felt far worse than yesterday
-  - eyes far too close together
-  ili: i18773
-  members:
-  - far
-  partOfSpeech: r
-00102040-r:
-  definition:
-  - at or to a certain point or degree
-  example:
-  - I can only go so far before I have to give up
-  - how far can we get with this kind of argument?
-  ili: i18774
-  members:
-  - far
-  partOfSpeech: r
-00102205-r:
-  definition:
-  - to an advanced stage or point
-  example:
-  - a young man who will go very far
-  ili: i18775
-  members:
-  - far
-  partOfSpeech: r
-00102302-r:
-  definition:
-  - to a great degree or by a great distance; very much (‘right smart’ is regional
-    in the United States)
-  example:
-  - way over budget
-  - way off base
-  - the other side of the hill is right smart steeper than the side we are on
-  exemplifies:
-  - 07089193-n
-  ili: i18776
-  members:
-  - way
-  - right smart
-  partOfSpeech: r
-00102579-r:
-  definition:
-  - over great areas or distances; everywhere
-  example:
-  - he traveled far and wide
-  - the news spread far and wide
-  - people came from far and near
-  - searched for the child far and near
-  ili: i18777
-  members:
-  - far and wide
-  - far and near
   partOfSpeech: r
 00102808-r:
   definition:
@@ -6682,150 +1985,6 @@
   members:
   - finely
   partOfSpeech: r
-00103286-r:
-  definition:
-  - before anything else
-  example:
-  - first we must consider the garter snake
-  ili: i18782
-  members:
-  - first
-  - firstly
-  - foremost
-  - first of all
-  - first off
-  partOfSpeech: r
-00103431-r:
-  definition:
-  - in the second place
-  example:
-  - second, we must consider the economy
-  ili: i18783
-  members:
-  - second
-  - secondly
-  partOfSpeech: r
-00103536-r:
-  definition:
-  - in the third place
-  example:
-  - third we must consider unemployment
-  ili: i18784
-  members:
-  - third
-  - thirdly
-  partOfSpeech: r
-00103637-r:
-  definition:
-  - from first to last
-  example:
-  - the play was excellent end-to-end
-  ili: i18785
-  members:
-  - throughout
-  - end-to-end
-  partOfSpeech: r
-00103744-r:
-  definition:
-  - at the beginning
-  example:
-  - at first he didn't notice anything strange
-  ili: i18786
-  members:
-  - initially
-  - ab initio
-  - at first
-  partOfSpeech: r
-00103874-r:
-  definition:
-  - on first seeing (someone or something); immediately
-  example:
-  - it was love at first sight
-  ili: i18787
-  members:
-  - at first sight
-  - at first glance
-  partOfSpeech: r
-00104016-r:
-  definition:
-  - after an initial impression, which later proves incorrect
-  members:
-  - at first sight
-  - at first glance
-  partOfSpeech: r
-00104134-r:
-  definition:
-  - as a first impression
-  example:
-  - at first blush the offer seemed attractive
-  ili: i18788
-  members:
-  - at first blush
-  - when first seen
-  partOfSpeech: r
-00104262-r:
-  definition:
-  - the initial time
-  example:
-  - when Felix first saw a garter snake
-  ili: i18789
-  members:
-  - first
-  partOfSpeech: r
-00104351-r:
-  definition:
-  - continuing in the same way
-  ili: i18790
-  members:
-  - and so forth
-  - and so on
-  - etcetera
-  - etc.
-  partOfSpeech: r
-00104448-r:
-  definition:
-  - out into view
-  example:
-  - came forth from the crowd
-  - put my ideas forth
-  ili: i18791
-  members:
-  - forth
-  partOfSpeech: r
-00104546-r:
-  definition:
-  - forward in time or order or degree
-  example:
-  - from that time forth
-  - from the sixth century onward
-  ili: i18792
-  members:
-  - forth
-  - forward
-  - onward
-  partOfSpeech: r
-00104690-r:
-  definition:
-  - to or in a foreign country
-  example:
-  - they had never travelled abroad
-  ili: i18793
-  members:
-  - abroad
-  partOfSpeech: r
-00104786-r:
-  definition:
-  - in reality
-  example:
-  - she is very kind at heart
-  ili: i18794
-  members:
-  - at heart
-  - at bottom
-  - deep down
-  - inside
-  - in spite of appearance
-  partOfSpeech: r
 00104920-r:
   definition:
   - in a general fashion
@@ -6835,43 +1994,6 @@
   members:
   - at large
   - in a broad way
-  partOfSpeech: r
-00105032-r:
-  definition:
-  - not less than
-  example:
-  - at least two hours studying the manual
-  - a tumor at least as big as an orange
-  ili: i18796
-  members:
-  - at least
-  - at the least
-  partOfSpeech: r
-00105215-r:
-  definition:
-  - not more than
-  example:
-  - spend at most $20 on the lunch
-  ili: i18797
-  members:
-  - at most
-  - at the most
-  partOfSpeech: r
-00105348-r:
-  definition:
-  - if nothing else (‘leastwise’ is informal and ‘leastways’ is colloquial)
-  example:
-  - at least he survived
-  - they felt — at any rate Jim felt — relieved though still wary
-  - the influence of economists — or at any rate of economics — is far-reaching
-  exemplifies:
-  - 07089193-n
-  ili: i18798
-  members:
-  - at least
-  - leastways
-  - leastwise
-  - at any rate
   partOfSpeech: r
 00105677-r:
   definition:
@@ -6884,24 +2006,6 @@
   - at leisure
   - leisurely
   partOfSpeech: r
-00105849-r:
-  definition:
-  - immediately
-  example:
-  - she called right after dinner
-  ili: i18800
-  members:
-  - right
-  partOfSpeech: r
-00105927-r:
-  definition:
-  - at a particular time in the past
-  example:
-  - just then the bugle sounded
-  ili: i18801
-  members:
-  - just then
-  partOfSpeech: r
 00106028-r:
   definition:
   - in a punctual manner
@@ -6912,48 +2016,6 @@
   - promptly
   - readily
   - pronto
-  partOfSpeech: r
-00106154-r:
-  definition:
-  - at once (usually modifies an undesirable occurrence)
-  example:
-  - he promptly forgot the address
-  ili: i18803
-  members:
-  - promptly
-  - right away
-  partOfSpeech: r
-00106290-r:
-  definition:
-  - with little or no delay
-  example:
-  - the rescue squad arrived promptly
-  - come here, quick!
-  ili: i18804
-  members:
-  - promptly
-  - quickly
-  - quick
-  partOfSpeech: r
-00106462-r:
-  definition:
-  - under the best of conditions
-  example:
-  - at best we'll lose only the money
-  ili: i18805
-  members:
-  - at best
-  - at the best
-  partOfSpeech: r
-00106595-r:
-  definition:
-  - under the worst of conditions
-  example:
-  - at worst we'll go to jail
-  ili: i18806
-  members:
-  - at worst
-  - at the worst
   partOfSpeech: r
 00106723-r:
   definition:
@@ -7014,58 +2076,6 @@
   - fair
   - evenhandedly
   partOfSpeech: r
-00107608-r:
-  definition:
-  - under normal conditions
-  example:
-  - usually she was late
-  ili: i18813
-  members:
-  - normally
-  - usually
-  - unremarkably
-  - commonly
-  - ordinarily
-  partOfSpeech: r
-00107831-r:
-  definition:
-  - in the usual manner
-  example:
-  - as usual, she arrived late
-  ili: i18814
-  members:
-  - as usual
-  partOfSpeech: r
-00107917-r:
-  definition:
-  - to a remarkable degree or extent
-  example:
-  - she was unusually tall
-  - Notably missing from the network's fall line-up are any half-hour scripted comedies
-  ili: i18815
-  members:
-  - unusually
-  - remarkably
-  - unco
-  - notably
-  partOfSpeech: r
-00108184-r:
-  definition:
-  - in the recent past
-  example:
-  - he was in Paris recently
-  - lately the rules have been enforced
-  - as late as yesterday she was fine
-  - feeling better of late
-  - the spelling was first affected, but latterly the meaning also
-  ili: i18816
-  members:
-  - recently
-  - late
-  - lately
-  - of late
-  - latterly
-  partOfSpeech: r
 00108490-r:
   definition:
   - in an erratic unpredictable manner
@@ -7114,113 +2124,6 @@
   members:
   - hell-for-leather
   partOfSpeech: r
-00109134-r:
-  definition:
-  - in this general vicinity
-  example:
-  - the people are friendly hereabouts
-  ili: i18822
-  members:
-  - hereabout
-  - hereabouts
-  partOfSpeech: r
-00109247-r:
-  definition:
-  - in or at this place; where the speaker or writer is
-  example:
-  - I work here
-  - turn here
-  - radio waves received here on Earth
-  ili: i18823
-  members:
-  - here
-  partOfSpeech: r
-00109415-r:
-  definition:
-  - to this place (especially toward the speaker)
-  example:
-  - come here, please
-  ili: i18824
-  members:
-  - here
-  - hither
-  partOfSpeech: r
-00109541-r:
-  definition:
-  - in this circumstance or respect or on this point or detail
-  example:
-  - what do we have here?
-  - here I must disagree
-  ili: i18825
-  members:
-  - here
-  partOfSpeech: r
-00109681-r:
-  definition:
-  - in this place or thing or document
-  example:
-  - I shall discuss the question herein
-  ili: i18826
-  members:
-  - herein
-  partOfSpeech: r
-00109789-r:
-  definition:
-  - at this time; now
-  example:
-  - we'll adjourn here for lunch and discuss the remaining issues this afternoon
-  ili: i18827
-  members:
-  - here
-  partOfSpeech: r
-00109919-r:
-  definition:
-  - in or at that place or location
-  example:
-  - they have lived there for years
-  - it's not there
-  - that man there
-  ili: i18828
-  members:
-  - there
-  partOfSpeech: r
-00110073-r:
-  definition:
-  - to or toward that place; away from the speaker
-  example:
-  - go there around noon!
-  ili: i18829
-  members:
-  - there
-  - thither
-  partOfSpeech: r
-00110206-r:
-  definition:
-  - in that matter; in that respect; on that point
-  example:
-  - I agree with you there
-  ili: i18830
-  members:
-  - there
-  partOfSpeech: r
-00110312-r:
-  definition:
-  - with respect to history
-  example:
-  - this is historically interesting
-  ili: i18831
-  members:
-  - historically
-  partOfSpeech: r
-00110430-r:
-  definition:
-  - throughout history
-  example:
-  - historically they have never coexisted peacefully
-  ili: i18832
-  members:
-  - historically
-  partOfSpeech: r
 00110560-r:
   definition:
   - in a peaceful manner
@@ -7229,15 +2132,6 @@
   ili: i18833
   members:
   - peacefully
-  partOfSpeech: r
-00110692-r:
-  definition:
-  - with respect to science; in a scientific way
-  example:
-  - this is scientifically interesting
-  ili: i18834
-  members:
-  - scientifically
   partOfSpeech: r
 00110835-r:
   definition:
@@ -7267,56 +2161,6 @@
   members:
   - meekly
   partOfSpeech: r
-00111276-r:
-  definition:
-  - within a building
-  example:
-  - in winter we play inside
-  ili: i18838
-  members:
-  - inside
-  - indoors
-  partOfSpeech: r
-00111402-r:
-  definition:
-  - outside a building
-  example:
-  - in summer we play outside
-  ili: i18839
-  members:
-  - outside
-  - outdoors
-  - out of doors
-  - alfresco
-  partOfSpeech: r
-00111558-r:
-  definition:
-  - on the inside
-  example:
-  - inside, the car is a mess
-  ili: i18840
-  members:
-  - inside
-  - within
-  partOfSpeech: r
-00111662-r:
-  definition:
-  - on the outside
-  example:
-  - outside, the box is black
-  ili: i18841
-  members:
-  - outside
-  partOfSpeech: r
-00111759-r:
-  definition:
-  - with respect to the military
-  example:
-  - on a militarily significant scale
-  ili: i18842
-  members:
-  - militarily
-  partOfSpeech: r
 00111881-r:
   definition:
   - without using a microscope
@@ -7325,56 +2169,6 @@
   ili: i18843
   members:
   - macroscopically
-  partOfSpeech: r
-00112012-r:
-  definition:
-  - (intensifier before a figurative expression) without exaggeration
-  example:
-  - our eyes were literally pinned to TV during the Gulf War
-  exemplifies:
-  - 06332047-n
-  ili: i18844
-  members:
-  - literally
-  partOfSpeech: r
-00112194-r:
-  definition:
-  - in essence or effect but not in fact
-  example:
-  - the strike virtually paralyzed the city
-  - I'm virtually broke
-  ili: i18845
-  members:
-  - virtually
-  partOfSpeech: r
-00112352-r:
-  definition:
-  - used to form the superlative, greatest in size or degree
-  example:
-  - the king cobra is the most dangerous snake
-  ili: i18846
-  members:
-  - most
-  - to the highest degree
-  partOfSpeech: r
-00112501-r:
-  definition:
-  - used to form the superlative, smallest in size or degree
-  example:
-  - The garter snake is the least dangerous snake
-  ili: i18847
-  members:
-  - least
-  - to the lowest degree
-  partOfSpeech: r
-00112653-r:
-  definition:
-  - especially not
-  example:
-  - nobody, least of all Joe, agreed with me
-  ili: i18848
-  members:
-  - least of all
   partOfSpeech: r
 00112833-r:
   definition:
@@ -7387,55 +2181,6 @@
   - wordlessly
   - silently
   - taciturnly
-  partOfSpeech: r
-00113022-r:
-  definition:
-  - worldwide
-  example:
-  - She is internationally known
-  - this is globally significant
-  ili: i18976
-  members:
-  - internationally
-  - globally
-  partOfSpeech: r
-00113197-r:
-  definition:
-  - with respect to the whole earth
-  example:
-  - think globally, not locally
-  members:
-  - globally
-  partOfSpeech: r
-00113314-r:
-  definition:
-  - in such a manner as could not be otherwise
-  example:
-  - it is necessarily so
-  - we must needs be objective
-  ili: i18852
-  members:
-  - inevitably
-  - necessarily
-  - of necessity
-  - needs
-  partOfSpeech: r
-00113522-r:
-  definition:
-  - very recently
-  example:
-  - they are newly married
-  - newly raised objections
-  - a newly arranged hairdo
-  - grass new washed by the rain
-  - a freshly cleaned floor
-  - we are fresh out of tomatoes
-  ili: i18853
-  members:
-  - newly
-  - freshly
-  - fresh
-  - new
   partOfSpeech: r
 00113764-r:
   definition:
@@ -7506,13 +2251,6 @@
   members:
   - organically
   partOfSpeech: r
-00114741-r:
-  definition:
-  - without fail
-  ili: i18861
-  members:
-  - unfailingly
-  partOfSpeech: r
 00114811-r:
   definition:
   - in a machinelike manner; without feeling
@@ -7532,25 +2270,6 @@
   - mechanically
   - automatically
   partOfSpeech: r
-00115099-r:
-  definition:
-  - involving metabolism
-  example:
-  - metabolically important substances
-  ili: i18864
-  members:
-  - metabolically
-  partOfSpeech: r
-00115217-r:
-  definition:
-  - in an official role
-  example:
-  - officially, he is in charge
-  - officially responsible
-  ili: i18865
-  members:
-  - officially
-  partOfSpeech: r
 00115368-r:
   definition:
   - not in an official capacity
@@ -7560,105 +2279,12 @@
   members:
   - unofficially
   partOfSpeech: r
-00115516-r:
-  definition:
-  - unpleasantly
-  example:
-  - his ignorance was painfully obvious
-  ili: i18867
-  members:
-  - painfully
-  - distressingly
-  partOfSpeech: r
-00115657-r:
-  definition:
-  - in or near or toward a center or according to a central role or function
-  example:
-  - The theater is centrally located
-  ili: i18868
-  members:
-  - centrally
-  partOfSpeech: r
-00115839-r:
-  definition:
-  - in or at or near a periphery or according to a peripheral role or function or
-    relationship
-  ili: i18869
-  members:
-  - peripherally
-  partOfSpeech: r
-00116024-r:
-  definition:
-  - with regard to phylogeny
-  example:
-  - a phylogenetically primitive part of the brain
-  ili: i18870
-  members:
-  - phylogenetically
-  partOfSpeech: r
-00116161-r:
-  definition:
-  - in accord with physical laws
-  example:
-  - it is physically impossible
-  ili: i18871
-  members:
-  - physically
-  partOfSpeech: r
-00116277-r:
-  definition:
-  - of or relating to physiological processes; with respect to physiology
-  example:
-  - physiologically ready
-  - physiologically addicted
-  ili: i18872
-  members:
-  - physiologically
-  partOfSpeech: r
-00116461-r:
-  definition:
-  - more readily or willingly
-  example:
-  - clean it well, preferably with warm water
-  - I'd rather be in Philadelphia
-  - I'd sooner die than give up
-  ili: i18873
-  members:
-  - preferably
-  - sooner
-  - rather
-  partOfSpeech: r
-00116652-r:
-  definition:
-  - with regard to government
-  example:
-  - politically organized units
-  ili: i18874
-  members:
-  - politically
-  partOfSpeech: r
-00116766-r:
-  definition:
-  - with regard to social relationships involving authority
-  example:
-  - politically correct clothing
-  ili: i18875
-  members:
-  - politically
-  partOfSpeech: r
 00116911-r:
   definition:
   - in a pornographic manner
   ili: i18876
   members:
   - pornographically
-  partOfSpeech: r
-00116998-r:
-  definition:
-  - in a self-indulgent manner
-  ili: i18877
-  members:
-  - self-indulgently
   partOfSpeech: r
 00117087-r:
   definition:
@@ -7725,15 +2351,6 @@
   members:
   - together
   partOfSpeech: r
-00117806-r:
-  definition:
-  - participating in or knowledgeable out
-  example:
-  - was in on the scheme
-  ili: i18885
-  members:
-  - in on
-  partOfSpeech: r
 00117901-r:
   definition:
   - assembled in one place
@@ -7757,16 +2374,6 @@
   - conjointly
   - together with
   partOfSpeech: r
-00118279-r:
-  definition:
-  - to an extravagant or immoderate degree
-  example:
-  - atrociously expensive
-  ili: i18888
-  members:
-  - outrageously
-  - atrociously
-  partOfSpeech: r
 00118415-r:
   definition:
   - in a very offensive manner
@@ -7775,45 +2382,6 @@
   ili: i18889
   members:
   - outrageously
-  partOfSpeech: r
-00118527-r:
-  definition:
-  - subsequently or soon afterward (often used as sentence connectors)
-  example:
-  - then he left
-  - go left first, then right
-  - first came lightning, then thunder
-  - we watched the late movie and then went to bed
-  - and so home and to bed
-  ili: i18890
-  members:
-  - then
-  - so
-  - and so
-  partOfSpeech: r
-00118799-r:
-  definition:
-  - at that time
-  example:
-  - I was young then
-  - prices were lower back then
-  - science as it was then taught
-  ili: i18891
-  members:
-  - then
-  partOfSpeech: r
-00118928-r:
-  definition:
-  - in that case or as a consequence
-  example:
-  - if he didn't take it, then who did?
-  - keep it then if you want to
-  - the case, then, is closed
-  - you've made up your mind then?
-  - then you'll be rich
-  ili: i18892
-  members:
-  - then
   partOfSpeech: r
 00119149-r:
   definition:
@@ -7834,105 +2402,6 @@
   members:
   - so
   partOfSpeech: r
-00119427-r:
-  definition:
-  - in spite of everything; without regard to drawbacks
-  example:
-  - he carried on regardless of the difficulties
-  ili: i18895
-  members:
-  - regardless
-  - irrespective
-  - disregardless
-  - no matter
-  - disregarding
-  partOfSpeech: r
-00119623-r:
-  definition:
-  - regardless; a combination of irrespective and regardless sometimes used humorously
-  exemplifies:
-  - 07089193-n
-  ili: i18896
-  members:
-  - irregardless
-  partOfSpeech: r
-00119765-r:
-  definition:
-  - on one occasion
-  example:
-  - once I ran into her
-  ili: i18897
-  members:
-  - once
-  - one time
-  - in one case
-  partOfSpeech: r
-00119861-r:
-  definition:
-  - at a previous time
-  example:
-  - at one time he loved her
-  - her erstwhile writing
-  - she was a dancer once
-  ili: i18898
-  members:
-  - once
-  - formerly
-  - at one time
-  - erstwhile
-  - erst
-  partOfSpeech: r
-00120034-r:
-  definition:
-  - (postpositive) however
-  example:
-  - it might be unpleasant, though
-  ili: i18899
-  members:
-  - though
-  partOfSpeech: r
-00120125-r:
-  definition:
-  - to a feasible extent
-  example:
-  - she helped him as much as possible
-  ili: i18900
-  members:
-  - as far as possible
-  - as much as possible
-  partOfSpeech: r
-00120252-r:
-  definition:
-  - immediately following or undeservedly benefiting from
-  example:
-  - the CEO resigned on the coattails of the scandal
-  - he was elected on his predecessor's coattails
-  ili: i18901
-  members:
-  - on the coattails
-  - on one's coattails
-  partOfSpeech: r
-00120473-r:
-  definition:
-  - (contrastive) from another point of view
-  example:
-  - on the other hand, she is too ambitious for her own good
-  - then again, she might not go
-  ili: i18902
-  members:
-  - on the other hand
-  - then again
-  partOfSpeech: r
-00120682-r:
-  definition:
-  - from one point of view
-  example:
-  - on the one hand, she is a gifted chemist
-  ili: i18903
-  members:
-  - on the one hand
-  - on one hand
-  partOfSpeech: r
 00120824-r:
   definition:
   - with success; in a successful manner
@@ -7941,28 +2410,6 @@
   ili: i18904
   members:
   - successfully
-  partOfSpeech: r
-00120979-r:
-  definition:
-  - at the same instant
-  example:
-  - they spoke simultaneously
-  ili: i18905
-  members:
-  - simultaneously
-  - at the same time
-  partOfSpeech: r
-00121107-r:
-  definition:
-  - overlapping in duration
-  example:
-  - concurrently with the conference an exhibition of things associated with Rutherford
-    was held
-  - going to school and holding a job at the same time
-  ili: i18906
-  members:
-  - concurrently
-  - at the same time
   partOfSpeech: r
 00121358-r:
   definition:
@@ -8013,15 +2460,6 @@
   - thusly
   - so
   partOfSpeech: r
-00122170-r:
-  definition:
-  - in regard to academic matters
-  example:
-  - academically, this is a good school
-  ili: i18912
-  members:
-  - academically
-  partOfSpeech: r
 00122297-r:
   definition:
   - in an appositive manner
@@ -8031,24 +2469,6 @@
   members:
   - appositively
   - in apposition
-  partOfSpeech: r
-00122434-r:
-  definition:
-  - enormously
-  example:
-  - the bill was astronomically high
-  ili: i18914
-  members:
-  - astronomically
-  partOfSpeech: r
-00122541-r:
-  definition:
-  - on the basis of axioms
-  example:
-  - this is axiomatically given
-  ili: i18915
-  members:
-  - axiomatically
   partOfSpeech: r
 00122654-r:
   definition:
@@ -8077,15 +2497,6 @@
   members:
   - photometrically
   partOfSpeech: r
-00123008-r:
-  definition:
-  - according to the constitution
-  example:
-  - this was constitutionally ruled out
-  ili: i18919
-  members:
-  - constitutionally
-  partOfSpeech: r
 00123157-r:
   definition:
   - in an unconstitutional manner
@@ -8104,15 +2515,6 @@
   ili: i18921
   members:
   - democratically
-  partOfSpeech: r
-00123514-r:
-  definition:
-  - in an undemocratic manner
-  example:
-  - undemocratically, he made all the important decisions without his colleagues
-  ili: i18922
-  members:
-  - undemocratically
   partOfSpeech: r
 00123700-r:
   definition:
@@ -8142,24 +2544,6 @@
   members:
   - digitally
   partOfSpeech: r
-00124113-r:
-  definition:
-  - with respect to economic science
-  example:
-  - economically this proposal makes no sense
-  ili: i18926
-  members:
-  - economically
-  partOfSpeech: r
-00124249-r:
-  definition:
-  - with respect to the economic system
-  example:
-  - economically the country is worse off
-  ili: i18927
-  members:
-  - economically
-  partOfSpeech: r
 00124384-r:
   definition:
   - in an economical manner
@@ -8175,24 +2559,6 @@
   ili: i18929
   members:
   - electronically
-  partOfSpeech: r
-00124579-r:
-  definition:
-  - with respect to ethnicity
-  example:
-  - the neighborhood is ethnically diverse
-  ili: i18930
-  members:
-  - ethnically
-  partOfSpeech: r
-00124703-r:
-  definition:
-  - by federal government
-  example:
-  - it's federally regulated
-  ili: i18931
-  members:
-  - federally
   partOfSpeech: r
 00124808-r:
   definition:
@@ -8269,32 +2635,6 @@
   members:
   - manually
   partOfSpeech: r
-00125676-r:
-  definition:
-  - involving medical practice
-  example:
-  - medically trained nurses
-  - medically correct treatment
-  ili: i18941
-  members:
-  - medically
-  partOfSpeech: r
-00125817-r:
-  definition:
-  - in a medicinal manner
-  ili: i18942
-  members:
-  - medicinally
-  partOfSpeech: r
-00125896-r:
-  definition:
-  - in name only
-  example:
-  - nominally he is the boss
-  ili: i18943
-  members:
-  - nominally
-  partOfSpeech: r
 00125992-r:
   definition:
   - occurring within the predicate phrase
@@ -8312,15 +2652,6 @@
   ili: i18945
   members:
   - professorially
-  partOfSpeech: r
-00126242-r:
-  definition:
-  - by the province; through the province
-  example:
-  - provincially controlled
-  ili: i18946
-  members:
-  - provincially
   partOfSpeech: r
 00126365-r:
   definition:
@@ -8378,24 +2709,6 @@
   members:
   - sacrilegiously
   partOfSpeech: r
-00127082-r:
-  definition:
-  - with respect to stage scenery
-  example:
-  - scenically stunning
-  ili: i18953
-  members:
-  - scenically
-  partOfSpeech: r
-00127191-r:
-  definition:
-  - with respect to scholastic activities
-  example:
-  - scholastically apt
-  ili: i18954
-  members:
-  - scholastically
-  partOfSpeech: r
 00127311-r:
   definition:
   - in a serial manner
@@ -8404,24 +2717,6 @@
   ili: i18955
   members:
   - serially
-  partOfSpeech: r
-00127411-r:
-  definition:
-  - by or with respect to society
-  example:
-  - socially accepted norms
-  ili: i18956
-  members:
-  - socially
-  partOfSpeech: r
-00127522-r:
-  definition:
-  - in a social manner
-  example:
-  - socially unpopular
-  ili: i18957
-  members:
-  - socially
   partOfSpeech: r
 00127617-r:
   definition:
@@ -8432,35 +2727,6 @@
   members:
   - symbolically
   partOfSpeech: r
-00127721-r:
-  definition:
-  - with regard to technical skill and the technology available
-  example:
-  - a technically brilliant solution
-  ili: i18959
-  members:
-  - technically
-  partOfSpeech: r
-00127856-r:
-  definition:
-  - with regard to technique
-  example:
-  - technically lagging behind the Japanese
-  - a technically brilliant boxer
-  ili: i18960
-  members:
-  - technically
-  partOfSpeech: r
-00128014-r:
-  definition:
-  - according to the exact meaning; according to the facts
-  example:
-  - technically, a bank's reserves belong to the stockholders
-  - technically, the term is no longer used by experts
-  ili: i18961
-  members:
-  - technically
-  partOfSpeech: r
 00128223-r:
   definition:
   - with regard to temporal order
@@ -8469,49 +2735,6 @@
   ili: i18962
   members:
   - temporally
-  partOfSpeech: r
-00128333-r:
-  definition:
-  - at the end
-  example:
-  - terminally ill
-  ili: i18963
-  members:
-  - terminally
-  partOfSpeech: r
-00128418-r:
-  definition:
-  - to a land environment
-  example:
-  - terrestrially adapted
-  ili: i18964
-  members:
-  - terrestrially
-  partOfSpeech: r
-00128524-r:
-  definition:
-  - with respect to territory
-  example:
-  - territorially important
-  ili: i18965
-  members:
-  - territorially
-  partOfSpeech: r
-00128636-r:
-  definition:
-  - with regard to thematic content
-  example:
-  - thematically related
-  ili: i18966
-  members:
-  - thematically
-  partOfSpeech: r
-00128750-r:
-  definition:
-  - for therapeutic purposes
-  ili: i18967
-  members:
-  - therapeutically
   partOfSpeech: r
 00128836-r:
   definition:
@@ -8526,25 +2749,6 @@
   ili: i18969
   members:
   - thermally
-  partOfSpeech: r
-00129052-r:
-  definition:
-  - in a typical manner
-  example:
-  - Tom was typically hostile
-  ili: i18970
-  members:
-  - typically
-  partOfSpeech: r
-00129174-r:
-  definition:
-  - in a manner that is not typical
-  example:
-  - she was atypically quiet
-  ili: i18971
-  members:
-  - atypically
-  - untypically
   partOfSpeech: r
 00129340-r:
   definition:
@@ -8592,16 +2796,6 @@
   members:
   - electrically
   partOfSpeech: r
-00129866-r:
-  definition:
-  - with respect to chemistry
-  example:
-  - chemically different substances
-  - chemically related
-  ili: i18978
-  members:
-  - chemically
-  partOfSpeech: r
 00130005-r:
   definition:
   - with chemicals
@@ -8610,15 +2804,6 @@
   ili: i18979
   members:
   - chemically
-  partOfSpeech: r
-00130101-r:
-  definition:
-  - by legislation
-  example:
-  - legislatively determined
-  ili: i18980
-  members:
-  - legislatively
   partOfSpeech: r
 00130203-r:
   definition:
@@ -8639,15 +2824,6 @@
   members:
   - linearly
   partOfSpeech: r
-00130452-r:
-  definition:
-  - with respect to longitude
-  example:
-  - longitudinally measured
-  ili: i18983
-  members:
-  - longitudinally
-  partOfSpeech: r
 00130565-r:
   definition:
   - in a magical manner
@@ -8667,42 +2843,6 @@
   members:
   - bacterially
   partOfSpeech: r
-00130777-r:
-  definition:
-  - by the theory of relativity
-  example:
-  - this is relativistically impossible
-  ili: i18986
-  members:
-  - relativistically
-  partOfSpeech: r
-00130906-r:
-  definition:
-  - with respect to race
-  example:
-  - racially integrated
-  ili: i18987
-  members:
-  - racially
-  partOfSpeech: r
-00131004-r:
-  definition:
-  - by municipality
-  example:
-  - municipally funded
-  ili: i18988
-  members:
-  - municipally
-  partOfSpeech: r
-00131099-r:
-  definition:
-  - by government
-  example:
-  - governmentally determined policy
-  ili: i18989
-  members:
-  - governmentally
-  partOfSpeech: r
 00131209-r:
   definition:
   - in a professional manner
@@ -8712,59 +2852,12 @@
   members:
   - professionally
   partOfSpeech: r
-00131326-r:
-  definition:
-  - with regard to space
-  example:
-  - spatially limited
-  ili: i18991
-  members:
-  - spatially
-  partOfSpeech: r
-00131423-r:
-  definition:
-  - with regard to meaning
-  example:
-  - semantically empty messages
-  ili: i18992
-  members:
-  - semantically
-  partOfSpeech: r
 00131535-r:
   definition:
   - in a limited manner
   ili: i18993
   members:
   - limitedly
-  partOfSpeech: r
-00131610-r:
-  definition:
-  - with respect to language
-  example:
-  - linguistically impaired children
-  - a lingually diverse population
-  ili: i18994
-  members:
-  - linguistically
-  - lingually
-  partOfSpeech: r
-00131795-r:
-  definition:
-  - with respect to sociolinguistics
-  example:
-  - sociolinguistically fascinating
-  ili: i18995
-  members:
-  - sociolinguistically
-  partOfSpeech: r
-00131928-r:
-  definition:
-  - with respect to the science of linguistics
-  example:
-  - linguistically interesting data
-  ili: i18996
-  members:
-  - linguistically
   partOfSpeech: r
 00132066-r:
   definition:
@@ -8774,25 +2867,6 @@
   ili: i18997
   members:
   - cross-linguistically
-  partOfSpeech: r
-00132206-r:
-  definition:
-  - in financial matters
-  example:
-  - fiscally irresponsible
-  ili: i18998
-  members:
-  - fiscally
-  - in fiscal matters
-  partOfSpeech: r
-00132327-r:
-  definition:
-  - in an algebraic manner
-  example:
-  - algebraically determined
-  ili: i18999
-  members:
-  - algebraically
   partOfSpeech: r
 00132437-r:
   definition:
@@ -8812,15 +2886,6 @@
   members:
   - poetically
   partOfSpeech: r
-00132646-r:
-  definition:
-  - by phonetics
-  example:
-  - phonetically realized
-  ili: i19002
-  members:
-  - phonetically
-  partOfSpeech: r
 00132742-r:
   definition:
   - by phonemics
@@ -8831,35 +2896,6 @@
   - phonemic
   - phonemically
   partOfSpeech: r
-00132870-r:
-  definition:
-  - as a person
-  example:
-  - he is personally repulsive
-  ili: i19004
-  members:
-  - personally
-  partOfSpeech: r
-00132968-r:
-  definition:
-  - in the flesh; without involving anyone else
-  example:
-  - I went there personally
-  - he appeared in person
-  ili: i19005
-  members:
-  - personally
-  - in person
-  partOfSpeech: r
-00133132-r:
-  definition:
-  - concerning the speaker
-  example:
-  - personally, I find him stupid
-  ili: i19006
-  members:
-  - personally
-  partOfSpeech: r
 00133226-r:
   definition:
   - in a philosophic manner
@@ -8868,82 +2904,6 @@
   ili: i19007
   members:
   - philosophically
-  partOfSpeech: r
-00133342-r:
-  definition:
-  - diabolically
-  example:
-  - infernally clever
-  - hellishly dangerous
-  exemplifies:
-  - 06332047-n
-  ili: i19008
-  members:
-  - infernally
-  - hellishly
-  partOfSpeech: r
-00133483-r:
-  definition:
-  - with respect to pathology
-  example:
-  - pathologically interesting results
-  ili: i19009
-  members:
-  - pathologically
-  partOfSpeech: r
-00133607-r:
-  definition:
-  - with respect to graphic aspects
-  example:
-  - graphically interesting designs
-  ili: i19010
-  members:
-  - graphically
-  partOfSpeech: r
-00133731-r:
-  definition:
-  - with unfortunate consequences
-  example:
-  - catastrophically complex
-  ili: i19011
-  members:
-  - catastrophically
-  partOfSpeech: r
-00133851-r:
-  definition:
-  - in an optical manner
-  example:
-  - optically distorted
-  ili: i19012
-  members:
-  - optically
-  partOfSpeech: r
-00133950-r:
-  definition:
-  - with respect to vision
-  example:
-  - visually distorted
-  ili: i19013
-  members:
-  - visually
-  partOfSpeech: r
-00134031-r:
-  definition:
-  - in the viscera
-  example:
-  - he is bleeding viscerally
-  ili: i19014
-  members:
-  - viscerally
-  partOfSpeech: r
-00134131-r:
-  definition:
-  - in the brain
-  example:
-  - bleeding cerebrally
-  ili: i19015
-  members:
-  - cerebrally
   partOfSpeech: r
 00134223-r:
   definition:
@@ -8963,109 +2923,12 @@
   members:
   - mystically
   partOfSpeech: r
-00134423-r:
-  definition:
-  - with respect to biology
-  example:
-  - biologically related
-  ili: i19018
-  members:
-  - biologically
-  partOfSpeech: r
-00134529-r:
-  definition:
-  - with respect to sociobiology
-  example:
-  - explain the behavior sociobiologically
-  ili: i19019
-  members:
-  - sociobiologically
-  partOfSpeech: r
-00134663-r:
-  definition:
-  - with respect to neurobiology
-  example:
-  - explain the phenomenon neurobiologically
-  ili: i19020
-  members:
-  - neurobiological
-  partOfSpeech: r
-00134797-r:
-  definition:
-  - with respect to biochemistry
-  example:
-  - biochemically interesting phenomenon
-  ili: i19021
-  members:
-  - biochemically
-  partOfSpeech: r
-00134925-r:
-  definition:
-  - with respect to musicology
-  ili: i19022
-  members:
-  - musicologically
-  partOfSpeech: r
-00135013-r:
-  definition:
-  - with respect to moral principles
-  example:
-  - morally unjustified
-  ili: i19023
-  members:
-  - morally
-  partOfSpeech: r
-00135104-r:
-  definition:
-  - with respect to the weather
-  example:
-  - meteorologically bad conditions
-  ili: i19024
-  members:
-  - meteorologically
-  partOfSpeech: r
-00135229-r:
-  definition:
-  - in a metaphysical manner
-  example:
-  - he thinks metaphysically
-  ili: i19025
-  members:
-  - metaphysically
-  partOfSpeech: r
 00135342-r:
   definition:
   - in a metonymic manner
   ili: i19026
   members:
   - metonymically
-  partOfSpeech: r
-00135423-r:
-  definition:
-  - with respect to melody
-  example:
-  - melodically interesting themes
-  ili: i19027
-  members:
-  - melodically
-  partOfSpeech: r
-00135537-r:
-  definition:
-  - with respect to harmony
-  example:
-  - harmonically interesting piece
-  ili: i19028
-  members:
-  - harmonically
-  partOfSpeech: r
-00135653-r:
-  definition:
-  - with respect to acoustics
-  example:
-  - acoustically ill-equipped studios
-  ili: i19029
-  members:
-  - acoustically
   partOfSpeech: r
 00135774-r:
   definition:
@@ -9094,61 +2957,6 @@
   members:
   - allegorically
   partOfSpeech: r
-00136124-r:
-  definition:
-  - by a particular locality
-  example:
-  - it was locally decided
-  ili: i19033
-  members:
-  - locally
-  partOfSpeech: r
-00136228-r:
-  definition:
-  - to a restricted area of the body
-  example:
-  - apply this medicine topically
-  ili: i19034
-  members:
-  - locally
-  - topically
-  partOfSpeech: r
-00136377-r:
-  definition:
-  - in a regional manner
-  example:
-  - regionally governed
-  ili: i19035
-  members:
-  - regionally
-  partOfSpeech: r
-00136477-r:
-  definition:
-  - with regard to a nation taken as a whole
-  example:
-  - a nationally uniform culture
-  ili: i19036
-  members:
-  - nationally
-  partOfSpeech: r
-00136606-r:
-  definition:
-  - with regard to a culture
-  example:
-  - culturally integrated
-  ili: i19037
-  members:
-  - culturally
-  partOfSpeech: r
-00136712-r:
-  definition:
-  - by race
-  example:
-  - interracially restrictive
-  ili: i19038
-  members:
-  - interracially
-  partOfSpeech: r
 00136808-r:
   definition:
   - by a chorus
@@ -9157,40 +2965,6 @@
   ili: i19039
   members:
   - chorally
-  partOfSpeech: r
-00136898-r:
-  definition:
-  - below the skin
-  example:
-  - inject subcutaneously
-  ili: i19040
-  members:
-  - subcutaneously
-  partOfSpeech: r
-00136998-r:
-  definition:
-  - with respect to the face
-  ili: i19041
-  members:
-  - facially
-  partOfSpeech: r
-00137077-r:
-  definition:
-  - with respect to syntax
-  example:
-  - syntactically ill-formed
-  ili: i19042
-  members:
-  - syntactically
-  partOfSpeech: r
-00137187-r:
-  definition:
-  - in the spine
-  example:
-  - spinally administered
-  ili: i19043
-  members:
-  - spinally
   partOfSpeech: r
 00137279-r:
   definition:
@@ -9201,24 +2975,6 @@
   members:
   - sexually
   partOfSpeech: r
-00137371-r:
-  definition:
-  - with respect to sexuality
-  example:
-  - sexually ambiguous
-  ili: i19045
-  members:
-  - sexually
-  partOfSpeech: r
-00137473-r:
-  definition:
-  - by means of words
-  example:
-  - lexically represented
-  ili: i19046
-  members:
-  - lexically
-  partOfSpeech: r
 00137571-r:
   definition:
   - without the use of words
@@ -9227,24 +2983,6 @@
   ili: i19047
   members:
   - nonlexically
-  partOfSpeech: r
-00137680-r:
-  definition:
-  - with respect to material aspects
-  example:
-  - psychologically similar but materially different
-  ili: i19048
-  members:
-  - materially
-  partOfSpeech: r
-00137821-r:
-  definition:
-  - to a significant degree
-  example:
-  - it aided him materially in winning the argument
-  ili: i19049
-  members:
-  - materially
   partOfSpeech: r
 00137952-r:
   definition:
@@ -9261,15 +2999,6 @@
   ili: i19051
   members:
   - operatively
-  partOfSpeech: r
-00138162-r:
-  definition:
-  - after the operation
-  example:
-  - remove postoperatively
-  ili: i19052
-  members:
-  - postoperatively
   partOfSpeech: r
 00138269-r:
   definition:
@@ -9298,16 +3027,6 @@
   - transversely
   - transversally
   partOfSpeech: r
-00138725-r:
-  definition:
-  - in the order given
-  example:
-  - the brothers were called Felix and Max, respectively
-  ili: i19056
-  members:
-  - respectively
-  - severally
-  partOfSpeech: r
 00138870-r:
   definition:
   - in like or similar manner
@@ -9329,31 +3048,6 @@
   ili: i19058
   members:
   - secondarily
-  partOfSpeech: r
-00139220-r:
-  definition:
-  - of primary import
-  example:
-  - this is primarily a question of economics
-  - it was in the first place a local matter
-  ili: i19059
-  members:
-  - primarily
-  - in the first place
-  partOfSpeech: r
-00139421-r:
-  definition:
-  - with considerable certainty; without much doubt
-  example:
-  - He is probably out of the country
-  - in all likelihood we are headed for war
-  ili: i19060
-  members:
-  - probably
-  - likely
-  - in all likelihood
-  - in all probability
-  - belike
   partOfSpeech: r
 00139662-r:
   definition:
@@ -9379,24 +3073,6 @@
   ili: i19063
   members:
   - undramatically
-  partOfSpeech: r
-00139983-r:
-  definition:
-  - towards the shore from the water
-  example:
-  - we invited them ashore
-  ili: i19064
-  members:
-  - ashore
-  partOfSpeech: r
-00140076-r:
-  definition:
-  - especially; in particular
-  example:
-  - notably in the social sciences, the professors teach too much
-  ili: i19065
-  members:
-  - notably
   partOfSpeech: r
 00140202-r:
   definition:
@@ -9443,34 +3119,6 @@
   members:
   - inalienably
   partOfSpeech: r
-00141083-r:
-  definition:
-  - away from shore; away from land
-  example:
-  - cruising three miles offshore
-  ili: i19070
-  members:
-  - offshore
-  partOfSpeech: r
-00141202-r:
-  definition:
-  - on or toward the land
-  example:
-  - they were living onshore
-  ili: i19071
-  members:
-  - onshore
-  partOfSpeech: r
-00141305-r:
-  definition:
-  - by three orders of magnitude
-  example:
-  - this poison is a thousand-fold more toxic
-  ili: i19072
-  members:
-  - thousand-fold
-  - thousand times
-  partOfSpeech: r
 00141437-r:
   definition:
   - according to nature; by natural means; without artificial help
@@ -9491,34 +3139,6 @@
   - unnaturally
   - by artificial means
   partOfSpeech: r
-00141793-r:
-  definition:
-  - having a rapid onset
-  example:
-  - an acutely debilitating virus
-  ili: i19075
-  members:
-  - acutely
-  partOfSpeech: r
-00141918-r:
-  definition:
-  - in a slowly developing and long lasting manner
-  example:
-  - chronically ill persons
-  ili: i19076
-  members:
-  - chronically
-  partOfSpeech: r
-00142067-r:
-  definition:
-  - in a habitual and longstanding manner
-  example:
-  - smoking chronically
-  ili: i19077
-  members:
-  - chronically
-  - inveterate
-  partOfSpeech: r
 00142180-r:
   definition:
   - in a contradictory manner
@@ -9536,13 +3156,6 @@
   ili: i19079
   members:
   - electrostatically
-  partOfSpeech: r
-00142439-r:
-  definition:
-  - in an episodic manner
-  ili: i19080
-  members:
-  - episodically
   partOfSpeech: r
 00142519-r:
   definition:
@@ -9569,15 +3182,6 @@
   members:
   - frontally
   partOfSpeech: r
-00142809-r:
-  definition:
-  - with respect to geometry
-  example:
-  - this shape is geometrically interesting
-  ili: i19084
-  members:
-  - geometrically
-  partOfSpeech: r
 00142936-r:
   definition:
   - by a glacier
@@ -9586,24 +3190,6 @@
   ili: i19085
   members:
   - glacially
-  partOfSpeech: r
-00143036-r:
-  definition:
-  - in a glaring manner
-  example:
-  - it was glaringly obvious
-  ili: i19086
-  members:
-  - glaringly
-  partOfSpeech: r
-00143139-r:
-  definition:
-  - with respect to gravitation
-  example:
-  - gravitationally strong forces
-  ili: i19087
-  members:
-  - gravitationally
   partOfSpeech: r
 00143261-r:
   definition:
@@ -9632,22 +3218,6 @@
   members:
   - homeostatically
   partOfSpeech: r
-00143610-r:
-  definition:
-  - by means of horticulture
-  ili: i19091
-  members:
-  - horticulturally
-  partOfSpeech: r
-00143696-r:
-  definition:
-  - in the manner of human beings
-  example:
-  - humanly possible
-  ili: i19092
-  members:
-  - humanly
-  partOfSpeech: r
 00143799-r:
   definition:
   - in an imperial manner
@@ -9666,15 +3236,6 @@
   members:
   - incestuously
   partOfSpeech: r
-00143993-r:
-  definition:
-  - to an inconceivable degree
-  example:
-  - inconceivably small
-  ili: i19095
-  members:
-  - inconceivably
-  partOfSpeech: r
 00144102-r:
   definition:
   - in an insistent manner
@@ -9691,15 +3252,6 @@
   members:
   - institutionally
   partOfSpeech: r
-00144291-r:
-  definition:
-  - in a judicial manner
-  example:
-  - judicially controlled process
-  ili: i19098
-  members:
-  - judicially
-  partOfSpeech: r
 00144401-r:
   definition:
   - in a nasal manner
@@ -9708,22 +3260,6 @@
   ili: i19099
   members:
   - nasally
-  partOfSpeech: r
-00144491-r:
-  definition:
-  - at night
-  example:
-  - nocturnally active bird
-  ili: i19100
-  members:
-  - nocturnally
-  partOfSpeech: r
-00144584-r:
-  definition:
-  - in a rural manner
-  ili: i19101
-  members:
-  - rurally
   partOfSpeech: r
 00144655-r:
   definition:
@@ -9791,18 +3327,6 @@
   members:
   - volcanically
   partOfSpeech: r
-00145441-r:
-  definition:
-  - for a brief period
-  example:
-  - sit down and stay awhile
-  - they settled awhile in Virginia before moving West
-  - the baby was quiet for a while
-  ili: i19110
-  members:
-  - awhile
-  - for a while
-  partOfSpeech: r
 00145622-r:
   definition:
   - in a wicked evil manner
@@ -9813,86 +3337,6 @@
   members:
   - wickedly
   - evilly
-  partOfSpeech: r
-00145758-r:
-  definition:
-  - definitely or positively (‘sure’ is sometimes used informally for ‘surely’)
-  example:
-  - the results are surely encouraging
-  - she certainly is a hard worker
-  - it's going to be a good day for sure
-  - they are coming, for certain
-  - they thought he had been killed sure enough
-  - he'll win sure as shooting
-  - they sure smell good
-  - sure he'll come
-  exemplifies:
-  - 07089193-n
-  ili: i19112
-  members:
-  - surely
-  - certainly
-  - sure
-  - for sure
-  - for certain
-  - sure enough
-  - sure as shooting
-  partOfSpeech: r
-00146264-r:
-  definition:
-  - in a surprising manner
-  example:
-  - he was surprisingly friendly
-  ili: i19113
-  members:
-  - surprisingly
-  partOfSpeech: r
-00146377-r:
-  definition:
-  - by means of technology
-  example:
-  - technologically impossible
-  ili: i19114
-  members:
-  - technologically
-  partOfSpeech: r
-00146491-r:
-  definition:
-  - by temperament
-  example:
-  - temperamentally suited to each other
-  ili: i19115
-  members:
-  - temperamentally
-  partOfSpeech: r
-00146607-r:
-  definition:
-  - to a sufficient degree
-  example:
-  - she was sufficiently fluent in Mandarin
-  ili: i19116
-  members:
-  - sufficiently
-  partOfSpeech: r
-00146749-r:
-  definition:
-  - as much as necessary
-  example:
-  - have I eaten enough?
-  - I've had plenty, thanks (‘plenty’ is nonstandard)
-  ili: i19117
-  members:
-  - enough
-  - plenty
-  partOfSpeech: r
-00146890-r:
-  definition:
-  - to an insufficient degree
-  example:
-  - he was insufficiently prepared
-  ili: i19118
-  members:
-  - insufficiently
   partOfSpeech: r
 00147028-r:
   definition:
@@ -9913,57 +3357,12 @@
   - hesitantly
   - hesitatingly
   partOfSpeech: r
-00147317-r:
-  definition:
-  - from that time on
-  example:
-  - thereafter he never called again
-  ili: i19121
-  members:
-  - thereafter
-  - thenceforth
-  partOfSpeech: r
-00147423-r:
-  definition:
-  - at any time
-  example:
-  - did you ever smoke?
-  - the best con man of all time
-  ili: i19122
-  members:
-  - ever
-  - of all time
-  partOfSpeech: r
 00147536-r:
   definition:
   - intentionally so written (used after a printed word or phrase)
   ili: i19123
   members:
   - sic
-  partOfSpeech: r
-00147630-r:
-  definition:
-  - to a very great extent or degree
-  example:
-  - the idea is so obvious
-  - never been so happy
-  - I love you so
-  - my head aches so!
-  exemplifies:
-  - 06332047-n
-  ili: i19124
-  members:
-  - so
-  partOfSpeech: r
-00147799-r:
-  definition:
-  - (usually followed by ‘that’) to an extent or degree as expressed
-  example:
-  - he was so tired he could hardly stand
-  - so dirty that it smells
-  ili: i19125
-  members:
-  - so
   partOfSpeech: r
 00147962-r:
   definition:
@@ -9974,38 +3373,6 @@
   ili: i19126
   members:
   - so
-  partOfSpeech: r
-00148162-r:
-  definition:
-  - to a certain unspecified extent or degree
-  example:
-  - I can only go so far with this student
-  - can do only so much in a day
-  ili: i19127
-  members:
-  - so
-  partOfSpeech: r
-00148308-r:
-  definition:
-  - in the same way; also
-  example:
-  - I was offended and so was he
-  - worked hard and so did she
-  ili: i19128
-  members:
-  - so
-  partOfSpeech: r
-00148422-r:
-  definition:
-  - to so extreme a degree
-  example:
-  - he is such a baby
-  - Such rich people!
-  exemplifies:
-  - 06332047-n
-  ili: i19129
-  members:
-  - such
   partOfSpeech: r
 00148538-r:
   definition:
@@ -10073,15 +3440,6 @@
   - easy
   - soft
   partOfSpeech: r
-00149387-r:
-  definition:
-  - under control
-  example:
-  - the riots were in hand
-  ili: i19136
-  members:
-  - in hand
-  partOfSpeech: r
 00149480-r:
   definition:
   - out of control
@@ -10092,166 +3450,6 @@
   - out of hand
   - beyond control
   partOfSpeech: r
-00149598-r:
-  definition:
-  - from some points of view
-  example:
-  - she was right in a way
-  ili: i19138
-  members:
-  - in a way
-  partOfSpeech: r
-00149685-r:
-  definition:
-  - as a fact or based on fact
-  example:
-  - they learn much, factually, about the problems of retirement and provision for
-    old age, and, psychologically, in the sharing of their thoughts on retirement
-  ili: i19139
-  members:
-  - factually
-  partOfSpeech: r
-00149927-r:
-  definition:
-  - in reality or actuality
-  example:
-  - in fact, it was a wonder anyone survived
-  - painters who are in fact anything but unsophisticated
-  - as a matter of fact, he is several inches taller than his father
-  ili: i19140
-  members:
-  - in fact
-  - in point of fact
-  - as a matter of fact
-  partOfSpeech: r
-00150196-r:
-  definition:
-  - used to imply that one would expect the fact to be the opposite of that stated;
-    surprisingly
-  example:
-  - you may actually be doing the right thing by walking out
-  - she actually spoke Latin
-  - they thought they made the rules but in reality they were only puppets
-  - people who seem stand-offish are in reality often simply nervous
-  ili: i19141
-  members:
-  - actually
-  - in reality
-  partOfSpeech: r
-00150568-r:
-  definition:
-  - in actual fact
-  example:
-  - to be nominally but not actually independent
-  - no one actually saw the shark
-  - large meteorites actually come from the asteroid belt
-  - properly speaking, they are not husband and wife
-  ili: i19142
-  members:
-  - actually
-  - really
-  - properly speaking
-  - strictly speaking
-  - to be precise
-  partOfSpeech: r
-00150802-r:
-  definition:
-  - as a sentence modifier to add slight emphasis; as a modifier to add slight emphasis
-  example:
-  - actually, we all help clear up after a meal
-  - actually, I haven't seen the film
-  - I'm not all that surprised actually
-  - she hasn't proved to be too satisfactory, actually
-  ili: i19143
-  members:
-  - actually
-  partOfSpeech: r
-00151061-r:
-  definition:
-  - at present
-  example:
-  - the transmission screen shows the picture that is actually on the air
-  ili: i19144
-  members:
-  - actually
-  partOfSpeech: r
-00151192-r:
-  definition:
-  - admittedly
-  example:
-  - to be sure, he is no Einstein
-  ili: i19145
-  members:
-  - to be sure
-  - without doubt
-  - no doubt
-  partOfSpeech: r
-00151301-r:
-  definition:
-  - as supposed or expected
-  example:
-  - sure enough, he asked her for money again
-  ili: i19146
-  members:
-  - sure enough
-  partOfSpeech: r
-00151409-r:
-  definition:
-  - an interjection expressing agreement; Yes, you are indeed correct
-  ili: i19147
-  members:
-  - right
-  - right on
-  partOfSpeech: r
-00151490-r:
-  definition:
-  - in entirety
-  example:
-  - they bought the business in toto
-  - in recommendations were adopted in toto
-  ili: i19148
-  members:
-  - in toto
-  partOfSpeech: r
-00151616-r:
-  definition:
-  - to any extent at all
-  example:
-  - are you in the least interested?
-  ili: i19149
-  members:
-  - in the least
-  - even a little
-  partOfSpeech: r
-00151729-r:
-  definition:
-  - above and beyond all other consideration
-  example:
-  - above all, you must be independent
-  ili: i19150
-  members:
-  - above all
-  - most importantly
-  - most especially
-  partOfSpeech: r
-00151882-r:
-  definition:
-  - while absent; although absent
-  example:
-  - he was sentenced in absentia
-  ili: i19151
-  members:
-  - in absentia
-  partOfSpeech: r
-00151983-r:
-  definition:
-  - including all
-  example:
-  - we got a pay raise across the board
-  ili: i19152
-  members:
-  - across the board
-  partOfSpeech: r
 00152098-r:
   definition:
   - to some extent; not very well
@@ -10260,35 +3458,6 @@
   ili: i19153
   members:
   - after a fashion
-  partOfSpeech: r
-00152207-r:
-  definition:
-  - emphasizes something to be considered
-  example:
-  - after all, she is your boss, so invite her
-  - he is, after all, our president
-  ili: i19154
-  members:
-  - after all
-  partOfSpeech: r
-00152363-r:
-  definition:
-  - in spite of expectations
-  example:
-  - came to the party after all
-  - it didn't rain after all
-  ili: i19155
-  members:
-  - after all
-  partOfSpeech: r
-00152484-r:
-  definition:
-  - not during regular hours
-  example:
-  - he often worked after hours
-  ili: i19156
-  members:
-  - after hours
   partOfSpeech: r
 00152579-r:
   definition:
@@ -10300,92 +3469,12 @@
   - against the clock
   - against time
   partOfSpeech: r
-00152713-r:
-  definition:
-  - in an advantageous position
-  example:
-  - she's ahead of the game
-  ili: i19158
-  members:
-  - ahead of the game
-  partOfSpeech: r
-00152813-r:
-  definition:
-  - with everything considered (and neglecting details)
-  example:
-  - altogether, I'm sorry it happened
-  - all in all, it's not so bad
-  ili: i19159
-  members:
-  - all in all
-  - on the whole
-  - altogether
-  - tout ensemble
-  partOfSpeech: r
-00153015-r:
-  definition:
-  - suddenly
-  example:
-  - all at once, he started shouting
-  ili: i19160
-  members:
-  - all of a sudden
-  - all at once
-  partOfSpeech: r
-00153124-r:
-  definition:
-  - to the goal
-  example:
-  - she climbed the mountain all the way
-  ili: i19161
-  members:
-  - all the way
-  - the whole way
-  partOfSpeech: r
-00153231-r:
-  definition:
-  - not stopping short of sexual intercourse
-  example:
-  - she went all the way with him
-  ili: i19162
-  members:
-  - all the way
-  partOfSpeech: r
 00153344-r:
   definition:
   - thoroughly
   ili: i19163
   members:
   - from start to finish
-  partOfSpeech: r
-00153403-r:
-  definition:
-  - an expression of emphatic agreement
-  ili: i19164
-  members:
-  - and how
-  - you bet
-  - you said it
-  partOfSpeech: r
-00153498-r:
-  definition:
-  - and considerably more in addition
-  example:
-  - it cost me a week's salary and then some
-  ili: i19165
-  members:
-  - and then some
-  partOfSpeech: r
-00153617-r:
-  definition:
-  - endlessly
-  example:
-  - she worked around the clock
-  ili: i19166
-  members:
-  - around the clock
-  - for 24 hours
-  - round the clock
   partOfSpeech: r
 00153742-r:
   definition:
@@ -10395,46 +3484,6 @@
   ili: i19167
   members:
   - as follows
-  partOfSpeech: r
-00153834-r:
-  definition:
-  - as if it were really so
-  example:
-  - she lives here, as it were
-  ili: i19168
-  members:
-  - as it were
-  - so to speak
-  partOfSpeech: r
-00153940-r:
-  definition:
-  - in a manner of speaking
-  example:
-  - the feeling is, as we say, quite dead
-  ili: i19169
-  members:
-  - as we say
-  - so to speak
-  partOfSpeech: r
-00154056-r:
-  definition:
-  - by the shortest and most direct route
-  example:
-  - it's 10 miles as the crow flies
-  ili: i19170
-  members:
-  - as the crow flies
-  partOfSpeech: r
-00154174-r:
-  definition:
-  - regardless of the cost involved
-  example:
-  - he wanted to save her life at all cost
-  ili: i19171
-  members:
-  - at all costs
-  - at any cost
-  - at any expense
   partOfSpeech: r
 00154319-r:
   definition:
@@ -10446,15 +3495,6 @@
   - at a time
   - at once
   - at one time
-  partOfSpeech: r
-00154430-r:
-  definition:
-  - as one chooses or pleases
-  example:
-  - he can roam the neighborhood at will
-  ili: i19173
-  members:
-  - at will
   partOfSpeech: r
 00154531-r:
   definition:
@@ -10519,23 +3559,6 @@
   members:
   - safely
   partOfSpeech: r
-00155440-r:
-  definition:
-  - according to what has been alleged
-  example:
-  - he was on trial for allegedly murdering his wife
-  ili: i19181
-  members:
-  - allegedly
-  partOfSpeech: r
-00155582-r:
-  definition:
-  - believed or reputed to be the case
-  ili: i19182
-  members:
-  - purportedly
-  - supposedly
-  partOfSpeech: r
 00155669-r:
   definition:
   - in an illegal manner
@@ -10546,13 +3569,6 @@
   - illegally
   - illicitly
   - lawlessly
-  partOfSpeech: r
-00155858-r:
-  definition:
-  - in an manner suggesting originality
-  ili: i19184
-  members:
-  - originally
   partOfSpeech: r
 00155936-r:
   definition:
@@ -10587,39 +3603,6 @@
   ili: i19188
   members:
   - uncomfortably
-  partOfSpeech: r
-00156476-r:
-  definition:
-  - by a great deal
-  example:
-  - he is the best by a long shot
-  - his labors haven't ended there — not by a long shot
-  ili: i19189
-  members:
-  - by a long shot
-  partOfSpeech: r
-00156621-r:
-  definition:
-  - at some eventual time in the future
-  example:
-  - By and by he'll understand
-  - I'll see you later
-  ili: i19190
-  members:
-  - by and by
-  - later
-  partOfSpeech: r
-00156754-r:
-  definition:
-  - usually; as a rule
-  example:
-  - by and large it doesn't rain much here
-  ili: i19191
-  members:
-  - by and large
-  - generally
-  - more often than not
-  - mostly
   partOfSpeech: r
 00156898-r:
   definition:
@@ -10660,18 +3643,6 @@
   members:
   - by fits and starts
   partOfSpeech: r
-00157363-r:
-  definition:
-  - introducing a different topic
-  example:
-  - incidentally, I won't go to the party
-  ili: i19196
-  members:
-  - by the way
-  - by the bye
-  - incidentally
-  - apropos
-  partOfSpeech: r
 00157510-r:
   definition:
   - one piece at a time
@@ -10703,36 +3674,6 @@
   members:
   - orally
   partOfSpeech: r
-00157956-r:
-  definition:
-  - in spite of all obstacles
-  example:
-  - we'll go to Tibet come hell or high water
-  ili: i19200
-  members:
-  - come hell or high water
-  - no matter what happens
-  - whatever may come
-  partOfSpeech: r
-00158123-r:
-  definition:
-  - without respite
-  example:
-  - he plays chess day in and day out
-  ili: i19201
-  members:
-  - day in and day out
-  - all the time
-  partOfSpeech: r
-00158237-r:
-  definition:
-  - exactly ahead or in front
-  example:
-  - the laboratory is dead ahead
-  ili: i19202
-  members:
-  - dead ahead
-  partOfSpeech: r
 00158333-r:
   definition:
   - without betraying any feeling
@@ -10753,45 +3694,6 @@
   - en bloc
   - as a group
   partOfSpeech: r
-00158535-r:
-  definition:
-  - occasionally
-  example:
-  - every so often she visits her father
-  ili: i19205
-  members:
-  - every so often
-  - every now and then
-  partOfSpeech: r
-00158651-r:
-  definition:
-  - in every way; completely
-  example:
-  - he was every inch a statesman
-  ili: i19206
-  members:
-  - every inch
-  partOfSpeech: r
-00158747-r:
-  definition:
-  - so as to be complete; with everything necessary
-  example:
-  - he had filled out the form completely
-  - the apartment was completely furnished
-  ili: i19207
-  members:
-  - completely
-  partOfSpeech: r
-00158934-r:
-  definition:
-  - not to a full degree or extent
-  example:
-  - words incompletely understood
-  - a form filled out incompletely
-  ili: i19208
-  members:
-  - incompletely
-  partOfSpeech: r
 00159090-r:
   definition:
   - without anybody else or anything else
@@ -10804,32 +3706,6 @@
   - alone
   - solo
   - unaccompanied
-  partOfSpeech: r
-00159313-r:
-  definition:
-  - taking everything together
-  example:
-  - she was first and last a scientist
-  ili: i19210
-  members:
-  - first and last
-  - above all
-  partOfSpeech: r
-00159432-r:
-  definition:
-  - indicating exactness or preciseness
-  example:
-  - he was doing precisely (or exactly) what she had told him to do
-  - it was just as he said — the jewel was gone
-  - it has just enough salt
-  - source: Thomas Carlyle
-    text: Properly speaking, all true work is religion.
-  ili: i19211
-  members:
-  - precisely
-  - exactly
-  - just
-  - properly
   partOfSpeech: r
 00159774-r:
   definition:
@@ -10851,44 +3727,6 @@
   members:
   - for dear life
   partOfSpeech: r
-00160030-r:
-  definition:
-  - to be won or lost; at risk
-  example:
-  - perhaps a million dollars are at stake
-  ili: i19214
-  members:
-  - at stake
-  partOfSpeech: r
-00160135-r:
-  definition:
-  - in question or at issue
-  example:
-  - there is more at stake than your modesty
-  ili: i19215
-  members:
-  - at stake
-  partOfSpeech: r
-00160239-r:
-  definition:
-  - as an example
-  example:
-  - take ribbon snakes, for example
-  ili: i19216
-  members:
-  - for example
-  - for instance
-  - e.g.
-  partOfSpeech: r
-00160349-r:
-  definition:
-  - in addition (as to close a deal)
-  example:
-  - the car salesman threw in the radio, for good measure
-  ili: i19217
-  members:
-  - for good measure
-  partOfSpeech: r
 00160483-r:
   definition:
   - for the winner to keep all
@@ -10897,28 +3735,6 @@
   ili: i19218
   members:
   - for keeps
-  partOfSpeech: r
-00160572-r:
-  definition:
-  - under any circumstances
-  example:
-  - she wouldn't give up her pets for love or money
-  ili: i19219
-  members:
-  - for love or money
-  - for anything
-  - for any price
-  - for all the world
-  partOfSpeech: r
-00160743-r:
-  definition:
-  - as a particular one of several possibilities
-  example:
-  - I for one feel very grateful
-  - her mother for one was worried
-  ili: i19220
-  members:
-  - for one
   partOfSpeech: r
 00160889-r:
   definition:
@@ -10949,24 +3765,6 @@
   members:
   - from scratch
   partOfSpeech: r
-00161285-r:
-  definition:
-  - written formula for ending a letter
-  ili: i19224
-  members:
-  - sincerely
-  - sincerely yours
-  partOfSpeech: r
-00161376-r:
-  definition:
-  - since long ago
-  example:
-  - she knows him from way back
-  ili: i19225
-  members:
-  - from way back
-  - since a long time ago
-  partOfSpeech: r
 00161487-r:
   definition:
   - nearly opposite to the direction from which wind is coming
@@ -10989,38 +3787,6 @@
   members:
   - closely
   partOfSpeech: r
-00161858-r:
-  definition:
-  - in a close manner
-  example:
-  - the two phenomena are intimately connected
-  - the person most nearly concerned
-  ili: i19228
-  members:
-  - closely
-  - intimately
-  - nearly
-  partOfSpeech: r
-00162033-r:
-  definition:
-  - in a relative manner; by comparison to something else
-  example:
-  - the situation is relatively calm now
-  ili: i19229
-  members:
-  - relatively
-  - comparatively
-  partOfSpeech: r
-00162217-r:
-  definition:
-  - much greater in number or influence
-  example:
-  - the patients are predominantly indigenous
-  ili: i19230
-  members:
-  - predominantly
-  - preponderantly
-  partOfSpeech: r
 00162392-r:
   definition:
   - without much difficulty
@@ -11029,24 +3795,6 @@
   ili: i19231
   members:
   - readily
-  partOfSpeech: r
-00162493-r:
-  definition:
-  - in a clearly noticeable manner
-  example:
-  - sales of luxury cars dropped markedly
-  ili: i19232
-  members:
-  - markedly
-  partOfSpeech: r
-00162619-r:
-  definition:
-  - so as to be palpable
-  example:
-  - she was palpably nervous
-  ili: i19233
-  members:
-  - palpably
   partOfSpeech: r
 00162722-r:
   definition:
@@ -11073,17 +3821,6 @@
   - slow
   - easy
   - tardily
-  partOfSpeech: r
-00163131-r:
-  definition:
-  - in a manner accessible to or observable by the public; openly
-  example:
-  - she admitted publicly to being a communist
-  ili: i19236
-  members:
-  - publicly
-  - publically
-  - in public
   partOfSpeech: r
 00163336-r:
   definition:
@@ -11117,16 +3854,6 @@
   ili: i19239
   members:
   - privately
-  partOfSpeech: r
-00163964-r:
-  definition:
-  - by the public or the people generally
-  example:
-  - publicly provided medical care
-  - publicly financed schools
-  ili: i19240
-  members:
-  - publicly
   partOfSpeech: r
 00164137-r:
   definition:
@@ -11166,15 +3893,6 @@
   - hand in glove
   - hand and glove
   - cooperatively
-  partOfSpeech: r
-00164679-r:
-  definition:
-  - in close proximity
-  example:
-  - the houses were jumbled together cheek by jowl
-  ili: i19245
-  members:
-  - cheek by jowl
   partOfSpeech: r
 00164789-r:
   definition:
@@ -11237,15 +3955,6 @@
   - heart and soul
   - body and soul
   partOfSpeech: r
-00165665-r:
-  definition:
-  - without reservations
-  example:
-  - he believed her story hook, line, and sinker
-  ili: i19252
-  members:
-  - hook line and sinker
-  partOfSpeech: r
 00165777-r:
   definition:
   - without making progress
@@ -11254,26 +3963,6 @@
   ili: i19253
   members:
   - in circles
-  partOfSpeech: r
-00165875-r:
-  definition:
-  - absolutely not; never
-  exemplifies:
-  - 07089193-n
-  ili: i19254
-  members:
-  - in a pig's eye
-  partOfSpeech: r
-00165958-r:
-  definition:
-  - if there happens to be need
-  example:
-  - in case of trouble call 911
-  - I have money, just in case
-  ili: i19255
-  members:
-  - in case
-  - just in case
   partOfSpeech: r
 00166097-r:
   definition:
@@ -11297,29 +3986,6 @@
   - earnestly
   - in earnest
   partOfSpeech: r
-00166484-r:
-  definition:
-  - at the appropriate time
-  example:
-  - we'll get to this question in due course
-  ili: i19258
-  members:
-  - in due course
-  - in due season
-  - in good time
-  - in due time
-  - when the time comes
-  partOfSpeech: r
-00166660-r:
-  definition:
-  - proceeding with full vigor
-  example:
-  - the party was in full swing
-  ili: i19259
-  members:
-  - in full swing
-  - in full action
-  partOfSpeech: r
 00166776-r:
   definition:
   - with something of the same kind
@@ -11329,57 +3995,6 @@
   members:
   - in kind
   - in a similar way
-  partOfSpeech: r
-00166891-r:
-  definition:
-  - one behind another in a line or queue
-  example:
-  - they waited in line for the tickets
-  ili: i19261
-  members:
-  - in line
-  partOfSpeech: r
-00167003-r:
-  definition:
-  - by title or repute though not in fact
-  example:
-  - he's a doctor in name only
-  ili: i19262
-  members:
-  - in name
-  - in name only
-  partOfSpeech: r
-00167121-r:
-  definition:
-  - in a relatively short time
-  example:
-  - she finished the assignment in no time
-  ili: i19263
-  members:
-  - in no time
-  - very fast
-  partOfSpeech: r
-00167240-r:
-  definition:
-  - for an extended time or at a distant time
-  example:
-  - a promotion long overdue
-  - something long hoped for
-  - his name has long been forgotten
-  - talked all night long
-  - how long will you be gone?
-  - arrived long before he was expected
-  - it is long after your bedtime
-  ili: i19264
-  members:
-  - long
-  partOfSpeech: r
-00167533-r:
-  definition:
-  - for an extended distance
-  ili: i19265
-  members:
-  - long
   partOfSpeech: r
 00167590-r:
   definition:
@@ -11424,48 +4039,6 @@
   members:
   - inside out
   partOfSpeech: r
-00168205-r:
-  definition:
-  - on everybody's mind
-  example:
-  - Christmas was in the air
-  ili: i19272
-  members:
-  - in the air
-  - in everyone's thoughts
-  partOfSpeech: r
-00168316-r:
-  definition:
-  - before now
-  example:
-  - why didn't you tell me in the first place?
-  ili: i19273
-  members:
-  - in the first place
-  - earlier
-  - in the beginning
-  - to begin with
-  - originally
-  partOfSpeech: r
-00168477-r:
-  definition:
-  - eventually or after a lengthy period of time
-  example:
-  - she will succeed in the end
-  ili: i19274
-  members:
-  - in the end
-  partOfSpeech: r
-00168591-r:
-  definition:
-  - at the last possible moment
-  example:
-  - she was saved in the nick of time
-  ili: i19275
-  members:
-  - in the nick of time
-  - just in time
-  partOfSpeech: r
 00168718-r:
   definition:
   - almost simultaneously
@@ -11474,16 +4047,6 @@
   ili: i19276
   members:
   - in the same breath
-  partOfSpeech: r
-00168839-r:
-  definition:
-  - without being tardy
-  example:
-  - we made it to the party in time
-  ili: i19277
-  members:
-  - in time
-  - soon enough
   partOfSpeech: r
 00168943-r:
   definition:
@@ -11513,16 +4076,6 @@
   ili: i19280
   members:
   - just so
-  partOfSpeech: r
-00169345-r:
-  definition:
-  - at full speed
-  example:
-  - she tackled the job lickety-split
-  ili: i19281
-  members:
-  - lickety split
-  - lickety cut
   partOfSpeech: r
 00169451-r:
   definition:
@@ -11556,16 +4109,6 @@
   - like thunder
   - like the devil
   partOfSpeech: r
-00169954-r:
-  definition:
-  - used ironically to indicate the opposite of what is stated
-  example:
-  - says he'll help me? Like hell he will!
-  ili: i19284
-  members:
-  - like hell
-  - like fun
-  partOfSpeech: r
 00170122-r:
   definition:
   - not intended seriously; meant as a joke
@@ -11575,25 +4118,6 @@
   members:
   - in fun
   - for fun
-  partOfSpeech: r
-00170319-r:
-  definition:
-  - on and on for a long time
-  example:
-  - the child cried no end
-  ili: i19285
-  members:
-  - no end
-  partOfSpeech: r
-00170405-r:
-  definition:
-  - not regularly
-  example:
-  - they phone each other off and on
-  ili: i19286
-  members:
-  - off and on
-  - on and off
   partOfSpeech: r
 00170506-r:
   definition:
@@ -11622,25 +4146,6 @@
   members:
   - off the record
   partOfSpeech: r
-00170857-r:
-  definition:
-  - on hands and knees
-  example:
-  - he got down on all fours to play with his grandson
-  ili: i19290
-  members:
-  - on all fours
-  partOfSpeech: r
-00170970-r:
-  definition:
-  - typically
-  example:
-  - on average he watches three movies a week
-  ili: i19291
-  members:
-  - on the average
-  - on average
-  partOfSpeech: r
 00171080-r:
   definition:
   - for examination (with an option to buy)
@@ -11659,23 +4164,6 @@
   members:
   - on faith
   partOfSpeech: r
-00171282-r:
-  definition:
-  - by hypothesis
-  ili: i19294
-  members:
-  - hypothetically
-  partOfSpeech: r
-00171356-r:
-  definition:
-  - in theory; according to the assumed facts
-  example:
-  - on paper the candidate seems promising
-  ili: i19295
-  members:
-  - theoretically
-  - on paper
-  partOfSpeech: r
 00171499-r:
   definition:
   - in a theoretical manner
@@ -11691,18 +4179,6 @@
   ili: i19297
   members:
   - oppositely
-  partOfSpeech: r
-00171723-r:
-  definition:
-  - contrary to expectations
-  example:
-  - he didn't stay home; on the contrary, he went out with his friends
-  ili: i19298
-  members:
-  - contrarily
-  - to the contrary
-  - contrariwise
-  - on the contrary
   partOfSpeech: r
 00171925-r:
   definition:
@@ -11721,67 +4197,6 @@
   - he caught the punt on the fly
   members:
   - on the fly
-  partOfSpeech: r
-00172124-r:
-  definition:
-  - without delay or immediately
-  example:
-  - we hired her on the spot
-  - thought they were going to shoot us down on the spot
-  ili: i19300
-  members:
-  - on the spot
-  partOfSpeech: r
-00172276-r:
-  definition:
-  - at the place in question; there
-  example:
-  - they were on the spot when it happened
-  - it had to be decided by the man on the spot
-  ili: i19301
-  members:
-  - on the spot
-  partOfSpeech: r
-00172436-r:
-  definition:
-  - in a difficult situation
-  example:
-  - that question really put him on the spot
-  ili: i19302
-  members:
-  - on the spot
-  partOfSpeech: r
-00172731-r:
-  definition:
-  - on a route to some place
-  example:
-  - help is on the way
-  - we saw him on the way to California
-  ili: i19304
-  members:
-  - on the way
-  - en route
-  partOfSpeech: r
-00172866-r:
-  definition:
-  - at the expected or proper time
-  example:
-  - she always arrives on time
-  ili: i19305
-  members:
-  - on time
-  - punctually
-  partOfSpeech: r
-00172975-r:
-  definition:
-  - without warning
-  example:
-  - your cousin arrived out of thin air
-  ili: i19306
-  members:
-  - out of thin air
-  - out of nothing
-  - from nowhere
   partOfSpeech: r
 00173105-r:
   definition:
@@ -11802,15 +4217,6 @@
   members:
   - to advantage
   partOfSpeech: r
-00173363-r:
-  definition:
-  - without exception
-  example:
-  - voted for unionization to a man
-  ili: i19309
-  members:
-  - to a man
-  partOfSpeech: r
 00173452-r:
   definition:
   - in every detail
@@ -11822,16 +4228,6 @@
   - to the letter
   - just right
   - to perfection
-  partOfSpeech: r
-00173583-r:
-  definition:
-  - prior to the present time
-  example:
-  - no suspect has been found to date
-  ili: i19311
-  members:
-  - up to now
-  - to date
   partOfSpeech: r
 00173693-r:
   definition:
@@ -11850,88 +4246,6 @@
   ili: i19313
   members:
   - tooth and nail
-  partOfSpeech: r
-00173875-r:
-  definition:
-  - with that general meaning
-  example:
-  - she said something to that effect
-  ili: i19314
-  members:
-  - to that effect
-  partOfSpeech: r
-00173980-r:
-  definition:
-  - in full
-  example:
-  - you are in this to the hilt
-  ili: i19315
-  members:
-  - to the hilt
-  - to the limit
-  partOfSpeech: r
-00174073-r:
-  definition:
-  - because of prevailing conditions
-  example:
-  - under the circumstances I cannot buy the house
-  ili: i19316
-  members:
-  - under the circumstances
-  partOfSpeech: r
-00174207-r:
-  definition:
-  - toward the mouth or oral region
-  ili: i19317
-  members:
-  - orad
-  partOfSpeech: r
-00174307-r:
-  definition:
-  - away from the mouth or oral region
-  ili: i19318
-  members:
-  - aborad
-  partOfSpeech: r
-00174412-r:
-  definition:
-  - in a courageous manner
-  example:
-  - bravely he went into the burning house
-  ili: i19319
-  members:
-  - bravely
-  - courageously
-  partOfSpeech: r
-00174563-r:
-  definition:
-  - from on board a vessel into the water
-  example:
-  - they dropped their garbage overboard
-  ili: i19320
-  members:
-  - overboard
-  partOfSpeech: r
-00174678-r:
-  definition:
-  - in or toward the northern parts of a state
-  example:
-  - he lives upstate New York
-  ili: i19321
-  members:
-  - upstate
-  partOfSpeech: r
-00174785-r:
-  definition:
-  - to a great depth psychologically or emotionally
-  example:
-  - They felt the loss deeply
-  - she loved him intensely
-  ili: i19322
-  members:
-  - profoundly
-  - deeply
-  - intensely
   partOfSpeech: r
 00174984-r:
   definition:
@@ -12018,15 +4332,6 @@
   members:
   - haughtily
   partOfSpeech: r
-00176221-r:
-  definition:
-  - to an extreme or greatly exaggerated degree
-  example:
-  - the storyline is wildly unrealistic
-  ili: i19332
-  members:
-  - wildly
-  partOfSpeech: r
 00176356-r:
   definition:
   - in a wild or undomesticated manner
@@ -12063,16 +4368,6 @@
   ili: i19336
   members:
   - bleakly
-  partOfSpeech: r
-00176830-r:
-  definition:
-  - in a stupid manner
-  example:
-  - he had stupidly bought a one way ticket
-  ili: i19337
-  members:
-  - stupidly
-  - doltishly
   partOfSpeech: r
 00176976-r:
   definition:
@@ -12124,27 +4419,6 @@
   members:
   - creatively
   partOfSpeech: r
-00177739-r:
-  definition:
-  - far from the center
-  domain_topic:
-  - 06067070-n
-  example:
-  - the bronchus is situated distally
-  ili: i19343
-  members:
-  - distally
-  partOfSpeech: r
-00177869-r:
-  definition:
-  - to a considerable degree
-  example:
-  - he relied heavily on others' data
-  ili: i19344
-  members:
-  - heavily
-  - to a great extent
-  partOfSpeech: r
 00178004-r:
   definition:
   - indulging excessively
@@ -12174,39 +4448,6 @@
   members:
   - lightly
   partOfSpeech: r
-00178467-r:
-  definition:
-  - repeatedly
-  example:
-  - the unknown word turned up over and over again in the text
-  ili: i19349
-  members:
-  - over and over
-  - again and again
-  - over and over again
-  - time and again
-  - time and time again
-  - repeatedly
-  partOfSpeech: r
-00178660-r:
-  definition:
-  - inflexibly; unshakably
-  example:
-  - adamantly opposed to the marriage
-  ili: i19350
-  members:
-  - adamantly
-  partOfSpeech: r
-00178775-r:
-  definition:
-  - with strength or in a strong manner
-  example:
-  - argues very strongly for his proposal
-  - he was strongly opposed to the government
-  ili: i19351
-  members:
-  - strongly
-  partOfSpeech: r
 00178969-r:
   definition:
   - in a weak or feeble manner or to a minor degree
@@ -12218,120 +4459,6 @@
   members:
   - weakly
   partOfSpeech: r
-00179172-r:
-  definition:
-  - with the order reversed
-  example:
-  - she hates him and vice versa
-  ili: i19353
-  members:
-  - vice versa
-  - the other way around
-  - contrariwise
-  partOfSpeech: r
-00179304-r:
-  definition:
-  - gradually and progressively
-  example:
-  - his health weakened day by day
-  ili: i19354
-  members:
-  - day by day
-  - daily
-  partOfSpeech: r
-00179412-r:
-  definition:
-  - for an indefinite number of successive days
-  ili: i19355
-  members:
-  - day in day out
-  - day after day
-  partOfSpeech: r
-00179514-r:
-  definition:
-  - for an indefinite number of successive weeks
-  ili: i19356
-  members:
-  - week after week
-  partOfSpeech: r
-00179602-r:
-  definition:
-  - weekly
-  example:
-  - week by week, the betrayal gnawed at his heart
-  ili: i19357
-  members:
-  - week by week
-  partOfSpeech: r
-00179699-r:
-  definition:
-  - for an indefinite number of months
-  example:
-  - month by month, the betrayal gnawed at his heart
-  ili: i19358
-  members:
-  - month by month
-  partOfSpeech: r
-00179828-r:
-  definition:
-  - in a radical manner
-  example:
-  - she took a radically different approach
-  ili: i19359
-  members:
-  - radically
-  partOfSpeech: r
-00179946-r:
-  definition:
-  - by religion
-  example:
-  - religiously inspired art
-  ili: i19360
-  members:
-  - religiously
-  - sacredly
-  partOfSpeech: r
-00180072-r:
-  definition:
-  - with extreme conscientiousness
-  example:
-  - he came religiously every morning at 8 o'clock
-  ili: i19361
-  members:
-  - scrupulously
-  - conscientiously
-  - religiously
-  partOfSpeech: r
-00180279-r:
-  definition:
-  - to an exceptional degree
-  example:
-  - it worked exceptionally well
-  ili: i19362
-  members:
-  - exceptionally
-  partOfSpeech: r
-00180395-r:
-  definition:
-  - sufficiently; more than adequately
-  example:
-  - the evidence amply (or fully) confirms our suspicions
-  - they were fully (or amply) fed
-  ili: i19363
-  members:
-  - amply
-  - fully
-  partOfSpeech: r
-00180598-r:
-  definition:
-  - restricted to something
-  example:
-  - we talked strictly business
-  ili: i19364
-  members:
-  - strictly
-  - purely
-  partOfSpeech: r
 00180698-r:
   definition:
   - in a tentative manner
@@ -12340,16 +4467,6 @@
   ili: i19365
   members:
   - tentatively
-  partOfSpeech: r
-00180819-r:
-  definition:
-  - otherwise stated
-  example:
-  - in other words, we are broke
-  ili: i19366
-  members:
-  - in other words
-  - put differently
   partOfSpeech: r
 00180928-r:
   definition:
@@ -12369,15 +4486,6 @@
   ili: i19368
   members:
   - fussily
-  partOfSpeech: r
-00181163-r:
-  definition:
-  - without any necessity
-  example:
-  - this marathon would exhaust him unnecessarily
-  ili: i19369
-  members:
-  - unnecessarily
   partOfSpeech: r
 00181293-r:
   definition:
@@ -12405,15 +4513,6 @@
   ili: i19372
   members:
   - neatly
-  partOfSpeech: r
-00181654-r:
-  definition:
-  - to a slight degree
-  example:
-  - her speech is only lightly accented
-  ili: i19373
-  members:
-  - lightly
   partOfSpeech: r
 00181765-r:
   definition:
@@ -12446,17 +4545,6 @@
   members:
   - independently
   partOfSpeech: r
-00182242-r:
-  definition:
-  - not taken into account or excluded from consideration
-  example:
-  - these problems apart, the country is doing well
-  - all joking aside, I think you're crazy
-  ili: i19377
-  members:
-  - apart
-  - aside
-  partOfSpeech: r
 00182430-r:
   definition:
   - into parts or pieces
@@ -12469,47 +4557,6 @@
   - apart
   - asunder
   partOfSpeech: r
-00182561-r:
-  definition:
-  - separated or at a distance in place or position or time
-  example:
-  - These towns are many miles apart
-  - stood with his legs apart
-  - born two years apart
-  ili: i19379
-  members:
-  - apart
-  partOfSpeech: r
-00182739-r:
-  definition:
-  - one from the other
-  example:
-  - people can't tell the twins apart
-  ili: i19380
-  members:
-  - apart
-  partOfSpeech: r
-00182828-r:
-  definition:
-  - as soon as
-  example:
-  - once we are home, we can rest
-  ili: i19381
-  members:
-  - once
-  partOfSpeech: r
-00182904-r:
-  definition:
-  - according to need (physicians use PRN in writing prescriptions)
-  example:
-  - add water as needed
-  ili: i19382
-  members:
-  - as needed
-  - as required
-  - pro re nata
-  - PRN
-  partOfSpeech: r
 00183062-r:
   definition:
   - gradually
@@ -12518,14 +4565,6 @@
   ili: i19383
   members:
   - gently
-  partOfSpeech: r
-00183162-r:
-  definition:
-  - in a place across an ocean
-  ili: i19384
-  members:
-  - overseas
-  - abroad
   partOfSpeech: r
 00183234-r:
   definition:
@@ -12536,37 +4575,6 @@
   members:
   - vigorously
   - smartly
-  partOfSpeech: r
-00183387-r:
-  definition:
-  - clear to the mind; with distinct mental discernment
-  example:
-  - it's distinctly possible
-  - I could clearly see myself in his situation
-  ili: i19386
-  members:
-  - distinctly
-  - clearly
-  partOfSpeech: r
-00183580-r:
-  definition:
-  - in the living organism
-  example:
-  - studies conducted in vivo
-  ili: i19387
-  members:
-  - in vivo
-  partOfSpeech: r
-00183685-r:
-  definition:
-  - downright
-  example:
-  - it was positively monumental
-  exemplifies:
-  - 06332047-n
-  ili: i19388
-  members:
-  - positively
   partOfSpeech: r
 00183802-r:
   definition:
@@ -12580,81 +4588,6 @@
   - magnificently
   - splendidly
   - famously
-  partOfSpeech: r
-00184008-r:
-  definition:
-  - in a levelheaded manner
-  example:
-  - the answers were healthily individual
-  ili: i19390
-  members:
-  - healthily
-  partOfSpeech: r
-00184128-r:
-  definition:
-  - in a hilarious manner
-  example:
-  - hilariously funny
-  ili: i19391
-  members:
-  - hilariously
-  - uproariously
-  partOfSpeech: r
-00184261-r:
-  definition:
-  - in a considerate manner
-  example:
-  - they considerately withdrew
-  ili: i19392
-  members:
-  - considerately
-  partOfSpeech: r
-00184393-r:
-  definition:
-  - without consideration; in an inconsiderate manner
-  example:
-  - inconsiderately, he asked to be invited for dinner
-  ili: i19393
-  members:
-  - inconsiderately
-  partOfSpeech: r
-00184576-r:
-  definition:
-  - (used as an intensifier) excellently
-  example:
-  - her voice is superbly disciplined
-  - the colors changed wondrously slowly
-  exemplifies:
-  - 06332047-n
-  ili: i19394
-  members:
-  - wonderfully
-  - wondrous
-  - wondrously
-  - superbly
-  - toppingly
-  - marvellously
-  - terrifically
-  - marvelously
-  partOfSpeech: r
-00184950-r:
-  definition:
-  - in a gratifying manner
-  example:
-  - the performance was at a gratifyingly high level
-  ili: i19395
-  members:
-  - gratifyingly
-  - satisfyingly
-  partOfSpeech: r
-00185098-r:
-  definition:
-  - flawlessly
-  example:
-  - the film was impeccably authentic
-  ili: i19396
-  members:
-  - impeccably
   partOfSpeech: r
 00185202-r:
   definition:
@@ -12693,18 +4626,6 @@
   ili: i19400
   members:
   - unhelpfully
-  partOfSpeech: r
-00185770-r:
-  definition:
-  - as acknowledged
-  example:
-  - true, she is the smartest in her class
-  ili: i19401
-  members:
-  - 'true'
-  - admittedly
-  - avowedly
-  - confessedly
   partOfSpeech: r
 00185898-r:
   definition:
@@ -12781,15 +4702,6 @@
   members:
   - incompetently
   - displaying incompetence
-  partOfSpeech: r
-00187053-r:
-  definition:
-  - with regard to emotions
-  example:
-  - emotionally secure
-  ili: i19410
-  members:
-  - emotionally
   partOfSpeech: r
 00187156-r:
   definition:
@@ -12945,38 +4857,6 @@
   - richly
   - extravagantly
   partOfSpeech: r
-00189276-r:
-  definition:
-  - toward or in the upper part of town
-  ili: i19427
-  members:
-  - uptown
-  partOfSpeech: r
-00189364-r:
-  definition:
-  - toward or in the lower or central part of town
-  ili: i19428
-  members:
-  - downtown
-  partOfSpeech: r
-00189465-r:
-  definition:
-  - especially fortunate
-  example:
-  - best of all, we don't have any homework!
-  ili: i19429
-  members:
-  - best of all
-  partOfSpeech: r
-00189569-r:
-  definition:
-  - it would be sensible
-  example:
-  - you'd best stay at home
-  ili: i19430
-  members:
-  - best
-  partOfSpeech: r
 00189649-r:
   definition:
   - in a most excellent way or manner
@@ -12994,34 +4874,6 @@
   ili: i19432
   members:
   - theatrically
-  partOfSpeech: r
-00189865-r:
-  definition:
-  - with respect to dramatic value
-  example:
-  - the play was dramatically interesting, but the direction was bad
-  ili: i19433
-  members:
-  - dramatically
-  partOfSpeech: r
-00190022-r:
-  definition:
-  - as follows
-  ili: i19434
-  members:
-  - namely
-  - viz.
-  - that is to say
-  - to wit
-  - videlicet
-  partOfSpeech: r
-00190112-r:
-  definition:
-  - in a similar way
-  ili: i19435
-  members:
-  - much as
-  - very much like
   partOfSpeech: r
 00190181-r:
   definition:
@@ -13049,34 +4901,6 @@
   ili: i19438
   members:
   - unenthusiastically
-  partOfSpeech: r
-00190641-r:
-  definition:
-  - of or relating to the intellect
-  example:
-  - intellectually gifted children
-  - intellectually influenced
-  ili: i19439
-  members:
-  - intellectually
-  partOfSpeech: r
-00190790-r:
-  definition:
-  - with pretense or intention to deceive
-  example:
-  - is only professedly poor
-  ili: i19440
-  members:
-  - professedly
-  partOfSpeech: r
-00190913-r:
-  definition:
-  - some unspecified time in the future
-  example:
-  - someday you will understand my actions
-  ili: i19441
-  members:
-  - someday
   partOfSpeech: r
 00191026-r:
   definition:
@@ -13125,15 +4949,6 @@
   members:
   - divinely
   partOfSpeech: r
-00191723-r:
-  definition:
-  - by some means not understood by the speaker
-  example:
-  - God knows how he did it, but he did climbed that steep wall
-  ili: i19447
-  members:
-  - God knows how
-  partOfSpeech: r
 00191871-r:
   definition:
   - in a clumsy manner
@@ -13152,24 +4967,6 @@
   members:
   - diffusely
   partOfSpeech: r
-00192221-r:
-  definition:
-  - in coarse pieces
-  example:
-  - the surfaces were coarsely granular
-  ili: i19451
-  members:
-  - coarsely
-  partOfSpeech: r
-00192349-r:
-  definition:
-  - in tiny pieces
-  example:
-  - the surfaces were finely granular
-  ili: i19452
-  members:
-  - finely
-  partOfSpeech: r
 00192471-r:
   definition:
   - to a high degree; extremely; in high concentration or density
@@ -13180,50 +4977,6 @@
   ili: i19453
   members:
   - intensely
-  partOfSpeech: r
-00192665-r:
-  definition:
-  - and elsewhere (used when referring to other occurrences in a text)
-  ili: i19454
-  members:
-  - et al.
-  - et al
-  - et alibi
-  partOfSpeech: r
-00192785-r:
-  definition:
-  - and others (‘et al.’ is used as an abbreviation of ‘et alii’ (masculine plural)
-    or ‘et aliae’ (feminine plural) or ‘et alia’ (neuter plural) when referring to
-    a number of people)
-  example:
-  - the data reported by Smith et al.
-  ili: i19455
-  members:
-  - et al.
-  - et al
-  - et alii
-  - et aliae
-  - et alia
-  partOfSpeech: r
-00193074-r:
-  definition:
-  - compare
-  ili: i19456
-  members:
-  - cf.
-  - cf
-  partOfSpeech: r
-00193186-r:
-  also:
-  - 91000331-r
-  definition:
-  - a figure of speech used as a way to provide further information, or to be more
-    specific or exact about something
-  ili: i19457
-  members:
-  - i.e.
-  - ie
-  - id est
   partOfSpeech: r
 00193263-r:
   definition:
@@ -13334,16 +5087,6 @@
   members:
   - thievishly
   partOfSpeech: r
-00194904-r:
-  definition:
-  - no longer on or in contact or attached
-  example:
-  - clean off the dirt
-  - he shaved off his mustache
-  ili: i19470
-  members:
-  - 'off'
-  partOfSpeech: r
 00195026-r:
   definition:
   - fitting closely
@@ -13379,15 +5122,6 @@
   ili: i19474
   members:
   - visibly
-  partOfSpeech: r
-00195469-r:
-  definition:
-  - within the realm of possibility
-  example:
-  - the weather may conceivably change
-  ili: i19475
-  members:
-  - conceivably
   partOfSpeech: r
 00195596-r:
   definition:
@@ -13467,34 +5201,6 @@
   members:
   - triumphantly
   partOfSpeech: r
-00196734-r:
-  definition:
-  - in every case
-  example:
-  - people universally agree on this
-  ili: i19486
-  members:
-  - universally
-  partOfSpeech: r
-00196820-r:
-  definition:
-  - in an ideal manner
-  example:
-  - ideally, this will remove all problems
-  ili: i19487
-  members:
-  - ideally
-  partOfSpeech: r
-00196934-r:
-  definition:
-  - in a mistaken or erroneous manner
-  example:
-  - he mistakenly believed it
-  ili: i19488
-  members:
-  - mistakenly
-  - erroneously
-  partOfSpeech: r
 00197085-r:
   definition:
   - in a childlike manner
@@ -13554,18 +5260,6 @@
   members:
   - attentively
   partOfSpeech: r
-00197952-r:
-  definition:
-  - vastly
-  example:
-  - he was enormously popular
-  ili: i19495
-  members:
-  - enormously
-  - tremendously
-  - hugely
-  - staggeringly
-  partOfSpeech: r
 00198104-r:
   definition:
   - in a generous manner
@@ -13596,15 +5290,6 @@
   members:
   - effortlessly
   partOfSpeech: r
-00198594-r:
-  definition:
-  - according to the clock
-  example:
-  - it's three o'clock in Tokyo now
-  ili: i19499
-  members:
-  - o'clock
-  partOfSpeech: r
 00198687-r:
   definition:
   - thoroughly (including all important particulars)
@@ -13624,15 +5309,6 @@
   - handily
   - conveniently
   partOfSpeech: r
-00198991-r:
-  definition:
-  - in an inconvenient manner
-  example:
-  - he arrived at an inconveniently late hour
-  ili: i19502
-  members:
-  - inconveniently
-  partOfSpeech: r
 00199140-r:
   also:
   - 00117989-r
@@ -13644,33 +5320,12 @@
   members:
   - jointly
   partOfSpeech: r
-00199241-r:
-  definition:
-  - in concrete terms
-  example:
-  - concretely, this meant that he was broke
-  ili: i19504
-  members:
-  - concretely
-  partOfSpeech: r
 00199377-r:
   definition:
   - in abstract terms
   ili: i19505
   members:
   - abstractly
-  partOfSpeech: r
-00199469-r:
-  definition:
-  - over the entire area
-  example:
-  - the wallpaper was covered all over with flowers
-  - she ached all over
-  - everything was dusted over with a fine layer of soot
-  ili: i19506
-  members:
-  - all over
-  - over
   partOfSpeech: r
 00199662-r:
   definition:
@@ -13711,27 +5366,6 @@
   - rebelliously
   - contumaciously
   - defiantly
-  partOfSpeech: r
-00200274-r:
-  definition:
-  - in a stubborn unregenerate manner
-  example:
-  - she remained stubbornly in the same position
-  ili: i19511
-  members:
-  - stubbornly
-  - pig-headedly
-  - obdurately
-  - mulishly
-  - obstinately
-  - cussedly
-  partOfSpeech: r
-00200566-r:
-  definition:
-  - in a wrongheaded manner
-  ili: i19512
-  members:
-  - wrongheadedly
   partOfSpeech: r
 00200649-r:
   definition:
@@ -13780,15 +5414,6 @@
   - dauntlessly
   - intrepidly
   partOfSpeech: r
-00201311-r:
-  definition:
-  - let us be thankful that
-  example:
-  - thankfully he didn't come to the party
-  ili: i19518
-  members:
-  - thankfully
-  partOfSpeech: r
 00201415-r:
   definition:
   - in a thankful manner; with thanks
@@ -13798,15 +5423,6 @@
   members:
   - thankfully
   - gratefully
-  partOfSpeech: r
-00201575-r:
-  definition:
-  - it is hoped
-  example:
-  - hopefully the weather will be fine on Sunday
-  ili: i19520
-  members:
-  - hopefully
   partOfSpeech: r
 00201672-r:
   definition:
@@ -13827,18 +5443,6 @@
   members:
   - hopelessly
   partOfSpeech: r
-00202043-r:
-  definition:
-  - in a hopeless manner
-  example:
-  - the papers were hopelessly jumbled
-  - he is hopelessly romantic
-  exemplifies:
-  - 07089193-n
-  ili: i19523
-  members:
-  - hopelessly
-  partOfSpeech: r
 00202206-r:
   definition:
   - with eagerness; in an eager manner
@@ -13848,15 +5452,6 @@
   members:
   - eagerly
   - thirstily
-  partOfSpeech: r
-00202356-r:
-  definition:
-  - according to reports or other information
-  example:
-  - she was reportedly his mistress for many years
-  ili: i19525
-  members:
-  - reportedly
   partOfSpeech: r
 00202504-r:
   definition:
@@ -13895,16 +5490,6 @@
   ili: i19529
   members:
   - savagely
-  partOfSpeech: r
-00202999-r:
-  definition:
-  - in a wise manner
-  example:
-  - she acted wisely when she invited her parents
-  ili: i19530
-  members:
-  - wisely
-  - sagely
   partOfSpeech: r
 00203162-r:
   definition:
@@ -13963,15 +5548,6 @@
   - unintelligibly
   - ununderstandably
   partOfSpeech: r
-00204147-r:
-  definition:
-  - by means of aircraft
-  example:
-  - the survey was carried out aerially
-  ili: i19537
-  members:
-  - aerially
-  partOfSpeech: r
 00204261-r:
   definition:
   - in alphabetical order
@@ -14017,15 +5593,6 @@
   members:
   - undiplomatically
   partOfSpeech: r
-00204954-r:
-  definition:
-  - with respect to socioeconomic factors
-  example:
-  - they are far apart socioeconomically
-  ili: i19543
-  members:
-  - socioeconomically
-  partOfSpeech: r
 00205095-r:
   definition:
   - in a resolute manner
@@ -14034,15 +5601,6 @@
   ili: i19544
   members:
   - stoutly
-  partOfSpeech: r
-00205211-r:
-  definition:
-  - to an indefinite extent; for an indefinite time
-  example:
-  - this could go on indefinitely
-  ili: i19545
-  members:
-  - indefinitely
   partOfSpeech: r
 00205350-r:
   definition:
@@ -14114,37 +5672,6 @@
   members:
   - wrongly
   partOfSpeech: r
-00206480-r:
-  definition:
-  - precisely, exactly
-  example:
-  - stand right here!
-  ili: i19553
-  members:
-  - right
-  partOfSpeech: r
-00206553-r:
-  definition:
-  - in accordance with moral or social standards
-  example:
-  - that serves him right
-  - do right by him
-  ili: i19555
-  members:
-  - justly
-  - right
-  partOfSpeech: r
-00206702-r:
-  definition:
-  - with honesty
-  example:
-  - he was rightly considered the greatest singer of his time
-  ili: i19556
-  members:
-  - rightly
-  - justly
-  - justifiedly
-  partOfSpeech: r
 00206888-r:
   definition:
   - in an unjust manner
@@ -14209,15 +5736,6 @@
   members:
   - darkly
   partOfSpeech: r
-00207713-r:
-  definition:
-  - away from the right path or direction
-  example:
-  - he was led astray
-  ili: i19564
-  members:
-  - astray
-  partOfSpeech: r
 00207806-r:
   definition:
   - in a hurried or hasty manner
@@ -14260,33 +5778,6 @@
   members:
   - restlessly
   partOfSpeech: r
-00208454-r:
-  definition:
-  - from a financial point of view
-  example:
-  - this was financially unattractive
-  ili: i19569
-  members:
-  - financially
-  partOfSpeech: r
-00208579-r:
-  definition:
-  - from a psychic point of view
-  example:
-  - he was psychically blind
-  ili: i19570
-  members:
-  - psychically
-  partOfSpeech: r
-00208693-r:
-  definition:
-  - on this day as distinct from yesterday or tomorrow
-  example:
-  - I can't meet with you today
-  ili: i19571
-  members:
-  - today
-  partOfSpeech: r
 00208808-r:
   definition:
   - in an ornamental, nonfunctional manner
@@ -14302,21 +5793,6 @@
   ili: i19573
   members:
   - ornately
-  partOfSpeech: r
-00208995-r:
-  definition:
-  - apart from others
-  example:
-  - taken individually, the rooms were, in fact, square
-  - the fine points are treated singly
-  ili: i19574
-  members:
-  - individually
-  - separately
-  - singly
-  - severally
-  - one by one
-  - on an individual basis
   partOfSpeech: r
 00209272-r:
   definition:
@@ -14399,16 +5875,6 @@
   members:
   - unimaginatively
   partOfSpeech: r
-00210536-r:
-  definition:
-  - in a bewildering and confusing manner
-  example:
-  - her situation was bewilderingly unclear
-  ili: i19583
-  members:
-  - bewilderingly
-  - confusingly
-  partOfSpeech: r
 00210690-r:
   definition:
   - with gusto and without reservation
@@ -14446,16 +5912,6 @@
   ili: i19587
   members:
   - passionately
-  partOfSpeech: r
-00211285-r:
-  definition:
-  - in a spectacular manner
-  example:
-  - the area was spectacularly scenic
-  ili: i19588
-  members:
-  - spectacularly
-  - stunningly
   partOfSpeech: r
 00211436-r:
   definition:
@@ -14504,44 +5960,6 @@
   members:
   - freely
   partOfSpeech: r
-00212077-r:
-  definition:
-  - according to habit or custom
-  example:
-  - her habitually severe expression
-  - he habitually keeps his office door closed
-  ili: i19594
-  members:
-  - habitually
-  partOfSpeech: r
-00212244-r:
-  definition:
-  - according to routine or established practice
-  example:
-  - he routinely parked in a no-parking zone
-  ili: i19595
-  members:
-  - routinely
-  partOfSpeech: r
-00212370-r:
-  definition:
-  - by custom; according to common practice
-  example:
-  - children are customarily expected to be seen but not heard
-  ili: i19596
-  members:
-  - customarily
-  partOfSpeech: r
-00212529-r:
-  definition:
-  - in a humiliating manner
-  example:
-  - the painting was reproduced humiliatingly small
-  ili: i19597
-  members:
-  - humiliatingly
-  - demeaningly
-  partOfSpeech: r
 00212695-r:
   definition:
   - in a protective manner
@@ -14550,25 +5968,6 @@
   ili: i19598
   members:
   - protectively
-  partOfSpeech: r
-00212815-r:
-  definition:
-  - in a spiritual manner
-  example:
-  - the ninth century was the spiritually freest period
-  ili: i19599
-  members:
-  - spiritually
-  partOfSpeech: r
-00212949-r:
-  definition:
-  - in a well delineated manner
-  example:
-  - the new style of Minoan pottery was sharply defined
-  ili: i19600
-  members:
-  - sharply
-  - crisply
   partOfSpeech: r
 00213113-r:
   definition:
@@ -14590,15 +5989,6 @@
   - dimly
   - murkily
   partOfSpeech: r
-00213360-r:
-  definition:
-  - without possibility of mistake
-  example:
-  - this watercolor is unmistakably a synthesis of nature
-  ili: i19603
-  members:
-  - unmistakably
-  partOfSpeech: r
 00213506-r:
   definition:
   - with determination; in a determined manner
@@ -14610,28 +6000,6 @@
   - unfalteringly
   - unshakably
   partOfSpeech: r
-00213709-r:
-  definition:
-  - of a minor or subordinate nature
-  example:
-  - these magnificent achievements were only incidentally influenced by Oriental models
-  ili: i19605
-  members:
-  - incidentally
-  - accidentally
-  partOfSpeech: r
-00213902-r:
-  definition:
-  - (intensifier for adjectives) very
-  example:
-  - she was ever so friendly
-  exemplifies:
-  - 06332047-n
-  ili: i19606
-  members:
-  - ever
-  - ever so
-  partOfSpeech: r
 00214025-r:
   definition:
   - with confidence; in a confident manner
@@ -14640,25 +6008,6 @@
   ili: i19607
   members:
   - confidently
-  partOfSpeech: r
-00214164-r:
-  definition:
-  - after the fact
-  example:
-  - he will get paid retroactively
-  ili: i19608
-  members:
-  - retroactively
-  partOfSpeech: r
-00214272-r:
-  definition:
-  - in a sporadic manner
-  example:
-  - he only works sporadically
-  ili: i19609
-  members:
-  - sporadically
-  - periodically
   partOfSpeech: r
 00214414-r:
   definition:
@@ -14677,27 +6026,6 @@
   ili: i19611
   members:
   - half-and-half
-  partOfSpeech: r
-00214599-r:
-  definition:
-  - in an amazing manner; to everyone's surprise
-  example:
-  - amazingly, he finished medical school in three years
-  ili: i19612
-  members:
-  - amazingly
-  - surprisingly
-  - astonishingly
-  partOfSpeech: r
-00214822-r:
-  definition:
-  - in an impressive manner
-  example:
-  - the students progressed impressively fast
-  ili: i19613
-  members:
-  - impressively
-  - imposingly
   partOfSpeech: r
 00214998-r:
   definition:
@@ -14747,29 +6075,6 @@
   members:
   - amateurishly
   partOfSpeech: r
-00215852-r:
-  definition:
-  - in an abundant manner
-  example:
-  - they were abundantly supplied with food
-  - he thanked her profusely
-  ili: i19619
-  members:
-  - abundantly
-  - copiously
-  - profusely
-  - extravagantly
-  partOfSpeech: r
-00216059-r:
-  definition:
-  - in an interesting manner
-  example:
-  - source: Time
-    text: when he ceases to be just interestingly neurotic and … gets locked up
-  ili: i19620
-  members:
-  - interestingly
-  partOfSpeech: r
 00216240-r:
   definition:
   - in an uninteresting manner
@@ -14789,15 +6094,6 @@
   - tediously
   - tiresomely
   partOfSpeech: r
-00216535-r:
-  definition:
-  - with moderation; in a moderate manner
-  example:
-  - he drinks moderately
-  ili: i19623
-  members:
-  - moderately
-  partOfSpeech: r
 00216671-r:
   definition:
   - without moderation; in an immoderate manner
@@ -14815,15 +6111,6 @@
   ili: i19625
   members:
   - realistically
-  partOfSpeech: r
-00216959-r:
-  definition:
-  - in an unrealistic manner
-  example:
-  - his expectations were unrealistically high
-  ili: i19626
-  members:
-  - unrealistically
   partOfSpeech: r
 00217109-r:
   definition:
@@ -14866,18 +6153,6 @@
   members:
   - stolidly
   partOfSpeech: r
-00217783-r:
-  definition:
-  - to the maximum degree
-  example:
-  - he was supremely confident
-  - He seemed irritated at Edouard's questions but, apart from that, sublimely unconcerned
-  - she remained sublimely oblivious to the possible havoc she might have caused
-  ili: i19631
-  members:
-  - supremely
-  - sublimely
-  partOfSpeech: r
 00218072-r:
   definition:
   - in a petulant manner
@@ -14889,15 +6164,6 @@
   - irritably
   - petulantly
   - pettishly
-  partOfSpeech: r
-00218268-r:
-  definition:
-  - showing consideration and thoughtfulness
-  example:
-  - he had thoughtfully brought with him some food to share
-  ili: i19633
-  members:
-  - thoughtfully
   partOfSpeech: r
 00218444-r:
   definition:
@@ -14958,17 +6224,6 @@
   - relentlessly
   - unrelentingly
   partOfSpeech: r
-00219478-r:
-  definition:
-  - in a rueful manner
-  example:
-  - ‘I made a big mistake,’ he said ruefully
-  ili: i19640
-  members:
-  - ruefully
-  - contritely
-  - remorsefully
-  partOfSpeech: r
 00219659-r:
   definition:
   - with the front foremost
@@ -15017,29 +6272,6 @@
   - discourteously
   - rudely
   partOfSpeech: r
-00220366-r:
-  definition:
-  - in an admirable manner
-  example:
-  - the children's responses were admirably normal
-  ili: i19646
-  members:
-  - admirably
-  - laudably
-  - praiseworthily
-  - commendable
-  partOfSpeech: r
-00220590-r:
-  definition:
-  - in an enjoyable manner
-  example:
-  - we spent a pleasantly lazy afternoon
-  ili: i19647
-  members:
-  - pleasantly
-  - agreeably
-  - enjoyably
-  partOfSpeech: r
 00220805-r:
   definition:
   - in a good-humoured manner
@@ -15059,15 +6291,6 @@
   ili: i19649
   members:
   - unpleasantly
-  partOfSpeech: r
-00221121-r:
-  definition:
-  - in an inverted manner
-  example:
-  - the box was lying on the floor upside down
-  ili: i19650
-  members:
-  - upside down
   partOfSpeech: r
 00221228-r:
   definition:
@@ -15219,90 +6442,6 @@
   members:
   - twirlingly
   partOfSpeech: r
-00223465-r:
-  definition:
-  - in or to or toward the rear
-  example:
-  - he followed behind
-  - seen from behind, the house is more imposing than it is from the front
-  - the final runners were far behind
-  ili: i19666
-  members:
-  - behind
-  partOfSpeech: r
-00223660-r:
-  definition:
-  - remaining in a place or condition that has been left or departed from
-  example:
-  - when he died he left much unfinished work behind
-  - left a large family behind
-  - the children left their books behind
-  - he took off with a squeal of tires and left the other cars far behind
-  ili: i19667
-  members:
-  - behind
-  partOfSpeech: r
-00223959-r:
-  definition:
-  - in debt
-  example:
-  - he fell behind with his mortgage payments
-  - a month behind in the rent
-  - a company that has been run behindhand for years
-  - in arrears with their utility bills
-  ili: i19668
-  members:
-  - behind
-  - behindhand
-  - in arrears
-  partOfSpeech: r
-00224193-r:
-  definition:
-  - in or into an inferior position
-  example:
-  - fell behind in his studies
-  - their business was lagging behind in the competition for customers
-  ili: i19669
-  members:
-  - behind
-  partOfSpeech: r
-00224359-r:
-  definition:
-  - showing a time that is earlier than the actual time
-  example:
-  - the clock is almost an hour slow
-  - my watch is running behind
-  ili: i19670
-  members:
-  - behind
-  - slow
-  partOfSpeech: r
-00224480-r:
-  definition:
-  - by right
-  example:
-  - baseball rightfully is the nation's pastime
-  ili: i19671
-  members:
-  - rightfully
-  - truly
-  partOfSpeech: r
-00224618-r:
-  definition:
-  - by title vested in yourself or by virtue of qualifications that you have achieved
-  example:
-  - a peer in his own right
-  - a leading sports figure in his own right
-  - a fine opera in its own right
-  - she's a rich woman in her own right rather than by inheritance
-  - an excellent novel in its own right
-  ili: i19672
-  members:
-  - in one's own right
-  - in his own right
-  - in her own right
-  - in its own right
-  partOfSpeech: r
 00225012-r:
   definition:
   - in a faithful manner
@@ -15397,36 +6536,6 @@
   members:
   - wryly
   partOfSpeech: r
-00226558-r:
-  definition:
-  - continuing forever without end
-  example:
-  - there are infinitely many possibilities
-  ili: i19683
-  members:
-  - infinitely
-  - endlessly
-  partOfSpeech: r
-00226736-r:
-  definition:
-  - with a finite limit
-  example:
-  - there are finitely many solutions to this problem
-  ili: i19684
-  members:
-  - finitely
-  partOfSpeech: r
-00226881-r:
-  definition:
-  - without bounds
-  example:
-  - he is infinitely wealthy
-  ili: i19685
-  members:
-  - boundlessly
-  - immeasurably
-  - infinitely
-  partOfSpeech: r
 00227027-r:
   definition:
   - in a rigorous manner
@@ -15457,15 +6566,6 @@
   - vauntingly
   - big
   - large
-  partOfSpeech: r
-00227422-r:
-  definition:
-  - in a major way
-  example:
-  - the play failed big at the box office
-  ili: i19689
-  members:
-  - big
   partOfSpeech: r
 00227509-r:
   definition:
@@ -15519,53 +6619,6 @@
   members:
   - bodily
   partOfSpeech: r
-00228075-r:
-  definition:
-  - throughout a period of time
-  example:
-  - stay over the weekend
-  ili: i19696
-  members:
-  - over
-  - o'er
-  partOfSpeech: r
-00228167-r:
-  definition:
-  - at or to a point across intervening space etc.
-  example:
-  - come over and see us some time
-  - over there
-  ili: i19697
-  members:
-  - over
-  partOfSpeech: r
-00228294-r:
-  definition:
-  - throughout an area
-  example:
-  - he is known the world over
-  ili: i19698
-  members:
-  - over
-  partOfSpeech: r
-00228375-r:
-  definition:
-  - beyond the top or upper surface or edge; forward from an upright position
-  example:
-  - a roof that hangs over
-  ili: i19699
-  members:
-  - over
-  partOfSpeech: r
-00228507-r:
-  definition:
-  - by means of an editorial
-  example:
-  - the paper commented editorially on the scandal
-  ili: i19700
-  members:
-  - editorially
-  partOfSpeech: r
 00228787-r:
   definition:
   - in an abnormal manner
@@ -15613,34 +6666,6 @@
   members:
   - tenuously
   partOfSpeech: r
-00229434-r:
-  definition:
-  - in a perennial manner; repeatedly
-  example:
-  - We want to know what is perennially new about the world
-  ili: i19707
-  members:
-  - perennially
-  partOfSpeech: r
-00229584-r:
-  definition:
-  - everlastingly; for all time
-  example:
-  - source: Stuart Chase
-    text: rays … streaming perpetually from the sun
-  ili: i19708
-  members:
-  - perpetually
-  partOfSpeech: r
-00229728-r:
-  definition:
-  - in an anachronistic manner
-  example:
-  - let's look at this phenomenon anachronistically
-  ili: i19709
-  members:
-  - anachronistically
-  partOfSpeech: r
 00229869-r:
   definition:
   - with ineptitude; in an incompetent manner
@@ -15679,15 +6704,6 @@
   members:
   - mentally
   partOfSpeech: r
-00230431-r:
-  definition:
-  - in a round manner
-  example:
-  - she was roundly slim
-  ili: i19714
-  members:
-  - roundly
-  partOfSpeech: r
 00230526-r:
   definition:
   - in a shy or timid or bashful manner
@@ -15708,13 +6724,6 @@
   members:
   - fondly
   - lovingly
-  partOfSpeech: r
-00230832-r:
-  definition:
-  - in bed
-  ili: i19717
-  members:
-  - abed
   partOfSpeech: r
 00230871-r:
   definition:
@@ -15755,13 +6764,6 @@
   members:
   - unquietly
   partOfSpeech: r
-00231579-r:
-  definition:
-  - without qualification or limitation
-  ili: i19722
-  members:
-  - unqualifiedly
-  partOfSpeech: r
 00231674-r:
   definition:
   - in outward appearance
@@ -15780,16 +6782,6 @@
   members:
   - inwardly
   - inside
-  partOfSpeech: r
-00231947-r:
-  definition:
-  - with respect to the outside
-  example:
-  - outwardly, the figure is smooth
-  ili: i19725
-  members:
-  - outwardly
-  - externally
   partOfSpeech: r
 00232060-r:
   definition:
@@ -15879,16 +6871,6 @@
   - dryly
   - drily
   partOfSpeech: r
-00233351-r:
-  definition:
-  - in accommodation
-  example:
-  - obligingly, he lowered his voice
-  ili: i19735
-  members:
-  - obligingly
-  - accommodatingly
-  partOfSpeech: r
 00233496-r:
   definition:
   - out of your own free will
@@ -15916,15 +6898,6 @@
   members:
   - unerringly
   partOfSpeech: r
-00233903-r:
-  definition:
-  - with respect to geography
-  example:
-  - they are geographically closer to the center of town
-  ili: i19739
-  members:
-  - geographically
-  partOfSpeech: r
 00234045-r:
   definition:
   - with gloom
@@ -15933,15 +6906,6 @@
   ili: i19740
   members:
   - gloomily
-  partOfSpeech: r
-00234156-r:
-  definition:
-  - excessively
-  example:
-  - a cruelly bitter winter
-  ili: i19741
-  members:
-  - cruelly
   partOfSpeech: r
 00234230-r:
   definition:
@@ -15952,17 +6916,6 @@
   members:
   - cruelly
   partOfSpeech: r
-00234331-r:
-  definition:
-  - in a vague way
-  example:
-  - he looked vaguely familiar
-  - he explained it somewhat mistily
-  ili: i19743
-  members:
-  - vaguely
-  - mistily
-  partOfSpeech: r
 00234475-r:
   definition:
   - in a pompous manner
@@ -15971,55 +6924,6 @@
   ili: i19744
   members:
   - pompously
-  partOfSpeech: r
-00234593-r:
-  definition:
-  - away from home
-  example:
-  - they went out last night
-  ili: i19745
-  members:
-  - out
-  partOfSpeech: r
-00234667-r:
-  definition:
-  - from a particular thing or place or position (‘forth’ is obsolete)
-  example:
-  - ran away from the lion
-  - wanted to get away from there
-  - sent the children away to boarding school
-  - the teacher waved the children away from the dead animal
-  - went off to school
-  - they drove off
-  - go forth and preach
-  exemplifies:
-  - 07087487-n
-  ili: i19746
-  members:
-  - away
-  - 'off'
-  - forth
-  partOfSpeech: r
-00235026-r:
-  definition:
-  - from one's possession
-  example:
-  - he gave out money to the poor
-  - gave away the tickets
-  ili: i19747
-  members:
-  - away
-  - out
-  partOfSpeech: r
-00235144-r:
-  definition:
-  - moving or appearing to move away from a place, especially one that is enclosed
-    or hidden
-  example:
-  - the cat came out from under the bed
-  ili: i19748
-  members:
-  - out
   partOfSpeech: r
 00235303-r:
   definition:
@@ -16030,78 +6934,6 @@
   members:
   - out of
   partOfSpeech: r
-00235417-r:
-  definition:
-  - in reserve; not for immediate use
-  example:
-  - started setting aside money to buy a car
-  - put something by for her old age
-  - has a nest egg tucked away for a rainy day
-  ili: i19750
-  members:
-  - aside
-  - by
-  - away
-  partOfSpeech: r
-00235622-r:
-  definition:
-  - on or to one side
-  example:
-  - step aside
-  - stood aside to let him pass
-  - threw the book aside
-  - put her sewing aside when he entered
-  ili: i19751
-  members:
-  - aside
-  partOfSpeech: r
-00235782-r:
-  definition:
-  - out of the way (especially away from one's thoughts)
-  example:
-  - brush the objections aside
-  - pushed all doubts away
-  ili: i19752
-  members:
-  - aside
-  - away
-  partOfSpeech: r
-00235931-r:
-  definition:
-  - placed or kept separate and distinct as for a purpose
-  example:
-  - had a feeling of being set apart
-  - quality sets it apart
-  - a day set aside for relaxing
-  ili: i19753
-  members:
-  - aside
-  - apart
-  partOfSpeech: r
-00236119-r:
-  definition:
-  - away from another or others
-  example:
-  - they grew apart over the years
-  - kept apart from the group out of shyness
-  - decided to live apart
-  ili: i19754
-  members:
-  - apart
-  partOfSpeech: r
-00236283-r:
-  definition:
-  - out of existence
-  example:
-  - the music faded away
-  - source: H.E.Scudder
-    text: tried to explain away the affair of the letter
-  - idled the hours away
-  - her fingernails were worn away
-  ili: i19755
-  members:
-  - away
-  partOfSpeech: r
 00236477-r:
   definition:
   - indicating continuing action; continuously or steadily
@@ -16109,51 +6941,6 @@
   - he worked away at the project for more than a year
   - the child kept hammering away as if his life depended on it
   ili: i19756
-  members:
-  - away
-  partOfSpeech: r
-00236681-r:
-  definition:
-  - in a different direction
-  example:
-  - turn aside
-  - turn away one's face
-  - glanced away
-  ili: i19757
-  members:
-  - away
-  - aside
-  partOfSpeech: r
-00236800-r:
-  definition:
-  - in or into a proper place (especially for storage or safekeeping)
-  example:
-  - put the toys away
-  - her jewels are locked away in a safe
-  - filed the letter away
-  ili: i19758
-  members:
-  - away
-  partOfSpeech: r
-00236984-r:
-  definition:
-  - at a distance in space or time
-  example:
-  - the boat was 5 miles off (or away)
-  - the party is still 2 weeks off (or away)
-  - away back in the 18th century
-  ili: i19759
-  members:
-  - 'off'
-  - away
-  partOfSpeech: r
-00237168-r:
-  definition:
-  - so as to be removed or gotten rid of
-  example:
-  - cleared the mess away
-  - the rotted wood had to be cut away
-  ili: i19760
   members:
   - away
   partOfSpeech: r
@@ -16267,25 +7054,6 @@
   - winsomely
   - engagingly
   partOfSpeech: r
-00238709-r:
-  definition:
-  - in a tragic manner; with tragic consequences
-  example:
-  - the adventure ended tragically
-  - tragically, she contracted AIDS
-  ili: i19773
-  members:
-  - tragically
-  partOfSpeech: r
-00238879-r:
-  definition:
-  - in a fascinating manner
-  example:
-  - her face became fascinatingly distorted
-  ili: i19774
-  members:
-  - fascinatingly
-  partOfSpeech: r
 00239005-r:
   definition:
   - in a curvaceous way
@@ -16373,44 +7141,6 @@
   - glibly
   - slickly
   partOfSpeech: r
-00240256-r:
-  definition:
-  - in a callous way
-  example:
-  - he callously exploited their feelings
-  ili: i19784
-  members:
-  - callously
-  - unfeelingly
-  partOfSpeech: r
-00240401-r:
-  definition:
-  - with good reason
-  example:
-  - he is justifiably bitter
-  ili: i19785
-  members:
-  - justifiably
-  partOfSpeech: r
-00240521-r:
-  definition:
-  - without any excuse
-  example:
-  - he is unjustifiably harsh on her
-  ili: i19786
-  members:
-  - unjustifiably
-  - inexcusably
-  partOfSpeech: r
-00240685-r:
-  definition:
-  - in motion; set in motion
-  example:
-  - the ship got under way
-  ili: i19787
-  members:
-  - under way
-  partOfSpeech: r
 00240791-r:
   definition:
   - on foot; walking
@@ -16420,15 +7150,6 @@
   ili: i19788
   members:
   - afoot
-  partOfSpeech: r
-00240942-r:
-  definition:
-  - with modesty; in a modest manner
-  example:
-  - the dissertation was entitled, modestly, ‘Remarks about a play by Shakespeare’
-  ili: i19789
-  members:
-  - modestly
   partOfSpeech: r
 00241129-r:
   definition:
@@ -16447,64 +7168,6 @@
   ili: i19791
   members:
   - frowningly
-  partOfSpeech: r
-00241415-r:
-  definition:
-  - incapable of being resisted
-  example:
-  - the candy looked overwhelmingly desirable to the dieting man
-  ili: i19792
-  members:
-  - overwhelmingly
-  - overpoweringly
-  - irresistibly
-  partOfSpeech: r
-00241635-r:
-  definition:
-  - to or from every one of two or more (considered individually)
-  example:
-  - they received $10 each
-  ili: i19793
-  members:
-  - each
-  - to each one
-  - for each one
-  - from each one
-  - apiece
-  partOfSpeech: r
-00241809-r:
-  definition:
-  - at or in or to the adjacent residence
-  example:
-  - the criminal had been living next door all this time
-  ili: i19794
-  members:
-  - next door
-  - in the adjacent house
-  - in the adjacent apartment
-  partOfSpeech: r
-00241992-r:
-  definition:
-  - by virtue of analysis
-  example:
-  - assuming that the distinction is maintained, one may ask which is to be analytically
-    prior?
-  ili: i19797
-  members:
-  - analytically
-  partOfSpeech: r
-00242166-r:
-  definition:
-  - (formal) in or into that thing or place
-  example:
-  - they can read therein what our plans are
-  exemplifies:
-  - 01206545-n
-  ili: i19798
-  members:
-  - therein
-  - in this
-  - in that
   partOfSpeech: r
 00242324-r:
   definition:
@@ -16692,67 +7355,6 @@
   - obsessively
   - obsessionally
   partOfSpeech: r
-00245268-r:
-  definition:
-  - with respect to structure
-  example:
-  - structurally, the organization is healthy
-  ili: i19819
-  members:
-  - structurally
-  partOfSpeech: r
-00245397-r:
-  definition:
-  - in a southern direction
-  example:
-  - we moved south
-  ili: i19820
-  members:
-  - south
-  - to the south
-  - in the south
-  partOfSpeech: r
-00245502-r:
-  definition:
-  - in a northern direction
-  example:
-  - they earn more up north
-  - Let's go north!
-  ili: i19821
-  members:
-  - north
-  - northerly
-  - northwards
-  - northward
-  partOfSpeech: r
-00245660-r:
-  definition:
-  - without official approval
-  example:
-  - he had made some money on the side
-  ili: i19822
-  members:
-  - unofficially
-  - on the side
-  partOfSpeech: r
-00245801-r:
-  definition:
-  - during or for the length of one night
-  example:
-  - the fish marinates overnight
-  ili: i19823
-  members:
-  - overnight
-  partOfSpeech: r
-00245908-r:
-  definition:
-  - happening in a short time or with great speed
-  example:
-  - these solutions cannot be found overnight!
-  ili: i19824
-  members:
-  - overnight
-  partOfSpeech: r
 00246037-r:
   definition:
   - without having a choice
@@ -16768,34 +7370,6 @@
   ili: i19826
   members:
   - believably
-  partOfSpeech: r
-00246246-r:
-  definition:
-  - in an unbelievable manner
-  example:
-  - he was unbelievably angry
-  ili: i19827
-  members:
-  - unbelievably
-  partOfSpeech: r
-00246377-r:
-  definition:
-  - under the feet
-  example:
-  - trampled the beans underfoot
-  - green grass growing underfoot
-  ili: i19828
-  members:
-  - underfoot
-  partOfSpeech: r
-00246494-r:
-  definition:
-  - in the way and hindering progress
-  example:
-  - a house with children and pets and toys always underfoot
-  ili: i19829
-  members:
-  - underfoot
   partOfSpeech: r
 00246625-r:
   definition:
@@ -16825,15 +7399,6 @@
   ili: i19832
   members:
   - ferociously
-  - fiercely
-  partOfSpeech: r
-00247047-r:
-  definition:
-  - in an emotionally fierce manner
-  example:
-  - she was fiercely proud of her children
-  ili: i19833
-  members:
   - fiercely
   partOfSpeech: r
 00247175-r:
@@ -16881,57 +7446,6 @@
   members:
   - lustily
   partOfSpeech: r
-00247755-r:
-  definition:
-  - (used for emphasis) absolutely
-  example:
-  - I just can't take it anymore
-  - he was just grand as Romeo
-  - it's simply beautiful!
-  exemplifies:
-  - 06332047-n
-  ili: i19839
-  members:
-  - just
-  - simply
-  partOfSpeech: r
-00247934-r:
-  definition:
-  - by ten times as much
-  example:
-  - the population increased tenfold
-  ili: i19840
-  members:
-  - tenfold
-  partOfSpeech: r
-00248026-r:
-  definition:
-  - in a quantitative manner
-  example:
-  - this can be expressed quantitatively
-  ili: i19841
-  members:
-  - quantitatively
-  partOfSpeech: r
-00248151-r:
-  definition:
-  - as written or printed
-  example:
-  - this is exactly what the composer had set down on paper
-  ili: i19842
-  members:
-  - on paper
-  - in writing
-  partOfSpeech: r
-00248281-r:
-  definition:
-  - in a very impressive manner
-  example:
-  - your performance will improve dramatically
-  ili: i19843
-  members:
-  - dramatically
-  partOfSpeech: r
 00248413-r:
   definition:
   - in the manner of Greek and Roman culture
@@ -16977,60 +7491,6 @@
   members:
   - horrifyingly
   partOfSpeech: r
-00249046-r:
-  definition:
-  - in characteristic manner
-  example:
-  - he arrived characteristically late
-  ili: i19849
-  members:
-  - characteristically
-  partOfSpeech: r
-00249191-r:
-  definition:
-  - in uncharacteristic manner
-  example:
-  - he was uncharacteristically cool
-  ili: i19850
-  members:
-  - uncharacteristically
-  partOfSpeech: r
-00249338-r:
-  definition:
-  - deliberately deviant
-  example:
-  - his perversely erotic notions
-  ili: i19851
-  members:
-  - perversely
-  partOfSpeech: r
-00249448-r:
-  definition:
-  - in a contrary disobedient manner
-  ili: i19852
-  members:
-  - perversely
-  - contrarily
-  - contrariwise
-  partOfSpeech: r
-00249583-r:
-  definition:
-  - in a dialectic manner
-  example:
-  - his religiousness is dialectically related to his sinfulness
-  ili: i19853
-  members:
-  - dialectically
-  partOfSpeech: r
-00249728-r:
-  definition:
-  - in a prophetic manner
-  example:
-  - he prophetically anticipated the disaster
-  ili: i19854
-  members:
-  - prophetically
-  partOfSpeech: r
 00249854-r:
   definition:
   - in an artistic manner
@@ -17039,31 +7499,6 @@
   ili: i19855
   members:
   - artistically
-  partOfSpeech: r
-00249967-r:
-  definition:
-  - uniquely or characteristically
-  example:
-  - these peculiarly cinematic elements
-  - a peculiarly French phenomenon
-  - source: John Knowles
-    text: everyone has a moment in history which belongs particularly to him
-  ili: i19856
-  members:
-  - peculiarly
-  - particularly
-  partOfSpeech: r
-00250244-r:
-  definition:
-  - specifically or especially distinguished from others
-  example:
-  - loves Bach, particularly his partitas
-  - recommended one book in particular
-  - trace major population movements for the Pueblo groups in particular
-  ili: i19857
-  members:
-  - particularly
-  - in particular
   partOfSpeech: r
 00250522-r:
   definition:
@@ -17074,157 +7509,12 @@
   members:
   - instinctively
   partOfSpeech: r
-00250643-r:
-  definition:
-  - on or from the inside
-  example:
-  - an internally controlled environment
-  ili: i19859
-  members:
-  - internally
-  partOfSpeech: r
-00250779-r:
-  definition:
-  - on or from the outside
-  example:
-  - the candidate needs to be externally evaluated
-  ili: i19860
-  members:
-  - externally
-  partOfSpeech: r
-00250926-r:
-  definition:
-  - above the head; over the head
-  example:
-  - bring the legs together overhead
-  ili: i19861
-  members:
-  - overhead
-  partOfSpeech: r
-00251028-r:
-  definition:
-  - at some distance
-  example:
-  - keep someone at arm's length
-  ili: i19862
-  members:
-  - at arm's length
-  partOfSpeech: r
-00251120-r:
-  definition:
-  - above your head; in the sky
-  example:
-  - planes were flying overhead
-  ili: i19863
-  members:
-  - overhead
-  partOfSpeech: r
-00251215-r:
-  definition:
-  - on first or second or third base
-  domain_topic:
-  - 00472688-n
-  example:
-  - Their second homer with Bob Allison aboard
-  ili: i19864
-  members:
-  - aboard
-  partOfSpeech: r
-00251347-r:
-  definition:
-  - on a ship, train, plane or other vehicle
-  ili: i19865
-  members:
-  - aboard
-  - on board
-  partOfSpeech: r
-00251433-r:
-  definition:
-  - part of a group
-  example:
-  - Bill's been aboard for three years now
-  ili: i19866
-  members:
-  - aboard
-  partOfSpeech: r
-00251525-r:
-  definition:
-  - side by side
-  example:
-  - anchored close aboard another ship
-  ili: i19867
-  members:
-  - aboard
-  - alongside
-  partOfSpeech: r
-00251622-r:
-  definition:
-  - in a uniform manner
-  example:
-  - a uniformly bright surface
-  ili: i19868
-  members:
-  - uniformly
-  partOfSpeech: r
-00251727-r:
-  definition:
-  - to a high degree
-  example:
-  - she is all too ready to accept the job
-  ili: i19869
-  members:
-  - all too
-  - only too
-  partOfSpeech: r
-00251832-r:
-  definition:
-  - in an enduring manner
-  example:
-  - Roman culture was enduringly fertilized
-  ili: i19870
-  members:
-  - enduringly
-  partOfSpeech: r
 00251953-r:
   definition:
   - alongside each other, facing in the same direction
   ili: i19871
   members:
   - abreast
-  partOfSpeech: r
-00252039-r:
-  definition:
-  - by the year; every year (usually with reference to a sum of money paid or received)
-  example:
-  - he earned $100,000 per annum
-  - we issue six volumes per annum
-  ili: i19872
-  members:
-  - per annum
-  - p.a.
-  - per year
-  - each year
-  - annually
-  partOfSpeech: r
-00252267-r:
-  definition:
-  - one every day
-  example:
-  - we'll save 100 man-hours per diem
-  ili: i19873
-  members:
-  - per diem
-  - by the day
-  partOfSpeech: r
-00252367-r:
-  definition:
-  - in between
-  example:
-  - two houses with a tree between
-  ili: i19874
-  members:
-  - between
-  - '''tween'
   partOfSpeech: r
 00252456-r:
   definition:
@@ -17234,15 +7524,6 @@
   ili: i19875
   members:
   - ad hoc
-  partOfSpeech: r
-00252542-r:
-  definition:
-  - to a sickening extent
-  example:
-  - he played the song ad nauseam
-  ili: i19876
-  members:
-  - ad nauseam
   partOfSpeech: r
 00252635-r:
   definition:
@@ -17254,70 +7535,12 @@
   - ad val
   - ad valorem
   partOfSpeech: r
-00252773-r:
-  definition:
-  - before 12 noon
-  domain_topic:
-  - 06975340-n
-  example:
-  - let's meet at 11 A.M.
-  ili: i19878
-  members:
-  - ante meridiem
-  - A.M.
-  - a.m.
-  - am
-  - AM
-  partOfSpeech: r
-00252877-r:
-  definition:
-  - between noon and midnight
-  domain_topic:
-  - 06975340-n
-  example:
-  - let's meet at 8 P.M.
-  ili: i19879
-  members:
-  - post meridiem
-  - P.M.
-  - p.m.
-  - pm
-  - PM
-  partOfSpeech: r
 00252994-r:
   definition:
   - derived from observed facts
   ili: i19880
   members:
   - a posteriori
-  partOfSpeech: r
-00253080-r:
-  definition:
-  - derived by logic, without observed facts
-  ili: i19881
-  members:
-  - a priori
-  partOfSpeech: r
-00253175-r:
-  definition:
-  - at all points from head to foot
-  example:
-  - he was armed cap-a-pie
-  ili: i19882
-  members:
-  - cap-a-pie
-  - from head to toe
-  partOfSpeech: r
-00253289-r:
-  definition:
-  - by law; conforming to the law
-  example:
-  - we are lawfully wedded now
-  ili: i19883
-  members:
-  - legally
-  - lawfully
-  - de jure
   partOfSpeech: r
 00253459-r:
   definition:
@@ -17327,13 +7550,6 @@
   ili: i19884
   members:
   - unlawfully
-  partOfSpeech: r
-00253591-r:
-  definition:
-  - in respect to jurisprudence or the science or philosophy of law
-  ili: i19885
-  members:
-  - jurisprudentially
   partOfSpeech: r
 00253718-r:
   definition:
@@ -17352,34 +7568,6 @@
   ili: i19887
   members:
   - en clair
-  partOfSpeech: r
-00253874-r:
-  definition:
-  - in a casual way at home
-  example:
-  - we'll have dinner en famille
-  ili: i19888
-  members:
-  - en famille
-  partOfSpeech: r
-00253968-r:
-  definition:
-  - by virtue of position
-  example:
-  - the president sat on the committee ex officio
-  ili: i19889
-  members:
-  - ex officio
-  - by right of office
-  partOfSpeech: r
-00254098-r:
-  definition:
-  - for the standard number of hours
-  example:
-  - she works full-time
-  ili: i19890
-  members:
-  - full-time
   partOfSpeech: r
 00254209-r:
   definition:
@@ -17436,23 +7624,6 @@
   members:
   - blatantly
   partOfSpeech: r
-00255089-r:
-  definition:
-  - as completely as possible
-  example:
-  - it was chock-a-block full
-  ili: i19897
-  members:
-  - chock
-  - chock-a-block
-  partOfSpeech: r
-00255193-r:
-  definition:
-  - in an overly sweet manner
-  ili: i19898
-  members:
-  - cloyingly
-  partOfSpeech: r
 00255274-r:
   definition:
   - make a telephone call or mail a package so that the recipient pays
@@ -17474,139 +7645,6 @@
   - COD
   - cash on delivery
   partOfSpeech: r
-00255539-r:
-  definition:
-  - in a direction opposite to the direction in which the hands of a clock move
-  example:
-  - please move counterclockwise in a circle!
-  ili: i19901
-  members:
-  - counterclockwise
-  - anticlockwise
-  partOfSpeech: r
-00255756-r:
-  definition:
-  - in a counterintuitive manner
-  ili: i19902
-  members:
-  - counterintuitively
-  partOfSpeech: r
-00255849-r:
-  definition:
-  - in the direction that the hands of a clock move
-  example:
-  - please move clockwise in a circle
-  ili: i19903
-  members:
-  - clockwise
-  partOfSpeech: r
-00256007-r:
-  definition:
-  - to a degree resembling death
-  example:
-  - he was deathly pale
-  ili: i19904
-  members:
-  - deathly
-  partOfSpeech: r
-00256094-r:
-  definition:
-  - prominently forward
-  example:
-  - he put his best foot foremost
-  ili: i19905
-  members:
-  - foremost
-  - first
-  partOfSpeech: r
-00256191-r:
-  definition:
-  - every two weeks
-  example:
-  - he visited his cousins fortnightly
-  ili: i19906
-  members:
-  - fortnightly
-  - biweekly
-  partOfSpeech: r
-00256331-r:
-  definition:
-  - twice a week
-  example:
-  - he called home semiweekly
-  ili: i19907
-  members:
-  - semiweekly
-  - biweekly
-  partOfSpeech: r
-00256458-r:
-  definition:
-  - occurring once a month
-  example:
-  - they meet monthly
-  ili: i19908
-  members:
-  - monthly
-  partOfSpeech: r
-00256555-r:
-  definition:
-  - every two months
-  example:
-  - the bill was payable bimonthly
-  ili: i19909
-  members:
-  - bimonthly
-  partOfSpeech: r
-00256661-r:
-  definition:
-  - twice a month
-  example:
-  - salaries are paid semimonthly
-  ili: i19910
-  members:
-  - semimonthly
-  - bimonthly
-  partOfSpeech: r
-00256795-r:
-  definition:
-  - twice a year
-  example:
-  - we hold our big sale biannually
-  ili: i19911
-  members:
-  - semiannually
-  - biyearly
-  - biannually
-  partOfSpeech: r
-00256895-r:
-  definition:
-  - at half the distance; at the middle
-  example:
-  - he was halfway down the ladder when he fell
-  ili: i19912
-  members:
-  - halfway
-  - midway
-  partOfSpeech: r
-00257022-r:
-  definition:
-  - all other things being equal
-  ili: i19913
-  members:
-  - ceteris paribus
-  partOfSpeech: r
-00257094-r:
-  definition:
-  - (formal) by means of this
-  example:
-  - I hereby declare you man and wife
-  exemplifies:
-  - 01206545-n
-  ili: i19914
-  members:
-  - hereby
-  - herewith
-  partOfSpeech: r
 00257221-r:
   definition:
   - in a hierarchical manner
@@ -17626,15 +7664,6 @@
   - higgledy-piggledy
   - topsy-turvy
   partOfSpeech: r
-00257456-r:
-  definition:
-  - in the same place (used when citing a reference)
-  ili: i19917
-  members:
-  - ibid.
-  - ib.
-  - ibidem
-  partOfSpeech: r
 00257553-r:
   definition:
   - in place of the parents
@@ -17644,75 +7673,12 @@
   members:
   - in loco parentis
   partOfSpeech: r
-00257669-r:
-  definition:
-  - in the original or natural place or site
-  example:
-  - carcinoma in situ
-  - the archeologists left the pottery in place
-  ili: i19919
-  members:
-  - in situ
-  - in place
-  partOfSpeech: r
-00257824-r:
-  definition:
-  - in position
-  members:
-  - in situ
-  partOfSpeech: r
-00257871-r:
-  definition:
-  - among other things
-  example:
-  - the committee recommended, inter alia, that he be promoted
-  ili: i19920
-  members:
-  - inter alia
-  partOfSpeech: r
-00257990-r:
-  definition:
-  - by the fact itself
-  example:
-  - ipso facto, her innocence was established
-  ili: i19921
-  members:
-  - ipso facto
-  partOfSpeech: r
-00258092-r:
-  definition:
-  - (used when listing or enumerating items) also
-  example:
-  - source: Philip Guedalla
-    text: a length of chain, item a hook
-  ili: i19922
-  members:
-  - item
-  partOfSpeech: r
-00258220-r:
-  definition:
-  - plus or minus a small amount
-  example:
-  - it is a mile away, give or take a few hundred yards
-  ili: i19923
-  members:
-  - give or take
-  partOfSpeech: r
 00258344-r:
   definition:
   - with the necessary changes having been carried out
   ili: i19924
   members:
   - mutatis mutandis
-  partOfSpeech: r
-00258439-r:
-  definition:
-  - to a degree of excellence
-  example:
-  - he is the honest politician par excellence
-  ili: i19925
-  members:
-  - par excellence
   partOfSpeech: r
 00258553-r:
   definition:
@@ -17721,32 +7687,6 @@
   members:
   - pari passu
   - at an equal rate
-  partOfSpeech: r
-00258633-r:
-  definition:
-  - used to refer to cited works
-  ili: i19927
-  members:
-  - passim
-  - throughout
-  partOfSpeech: r
-00258709-r:
-  definition:
-  - for the time being; temporarily
-  example:
-  - source: J.W.Krutch
-    text: accepting pro tem that hypothesis consistent with the facts
-  ili: i19928
-  members:
-  - pro tem
-  - pro tempore
-  partOfSpeech: r
-00258865-r:
-  definition:
-  - without a date fixed (as of an adjournment)
-  ili: i19929
-  members:
-  - sine die
   partOfSpeech: r
 00258945-r:
   definition:
@@ -17776,15 +7716,6 @@
   members:
   - tandem
   - in tandem
-  partOfSpeech: r
-00259294-r:
-  definition:
-  - three times
-  example:
-  - I called you thrice last night
-  ili: i19933
-  members:
-  - thrice
   partOfSpeech: r
 00259374-r:
   definition:
@@ -17826,64 +7757,6 @@
   - for free
   - free of charge
   partOfSpeech: r
-00259792-r:
-  definition:
-  - towards or into the interior of a region
-  example:
-  - the town is five miles inland
-  ili: i19939
-  members:
-  - inland
-  partOfSpeech: r
-00259900-r:
-  definition:
-  - toward the shore
-  example:
-  - we swam two miles inshore
-  ili: i19940
-  members:
-  - inshore
-  partOfSpeech: r
-00259981-r:
-  definition:
-  - toward the center or interior
-  example:
-  - move the needle further inwards!
-  ili: i19941
-  members:
-  - inward
-  - inwards
-  partOfSpeech: r
-00260109-r:
-  definition:
-  - toward the outside
-  example:
-  - move the needle further outward!
-  ili: i19942
-  members:
-  - outward
-  - outwards
-  partOfSpeech: r
-00260228-r:
-  definition:
-  - up to the knees
-  example:
-  - we were standing knee-deep in the water
-  ili: i19943
-  members:
-  - knee-deep
-  - knee-high
-  partOfSpeech: r
-00260336-r:
-  definition:
-  - up to the breast
-  example:
-  - we were standing breast-high in the water
-  ili: i19944
-  members:
-  - breast-deep
-  - breast-high
-  partOfSpeech: r
 00260451-r:
   definition:
   - not recorded
@@ -17892,35 +7765,6 @@
   ili: i19945
   members:
   - live
-  partOfSpeech: r
-00260528-r:
-  definition:
-  - comparatives of ‘soon’ or ‘early’
-  example:
-  - Come a little sooner, if you can
-  - came earlier than I expected
-  ili: i19946
-  members:
-  - sooner
-  - earlier
-  partOfSpeech: r
-00260674-r:
-  definition:
-  - at the point of death
-  ili: i19947
-  members:
-  - in extremis
-  partOfSpeech: r
-00260735-r:
-  definition:
-  - the middle or central part or point
-  example:
-  - in the midst of the forest
-  - could he walk out in the midst of his piece?
-  ili: i19948
-  members:
-  - midmost
-  - in the midst
   partOfSpeech: r
 00260899-r:
   definition:
@@ -17931,74 +7775,6 @@
   members:
   - off-hand
   - ex tempore
-  partOfSpeech: r
-00261005-r:
-  definition:
-  - not in public
-  example:
-  - the deal was done offstage
-  ili: i19950
-  members:
-  - offstage
-  partOfSpeech: r
-00261085-r:
-  definition:
-  - behind the scenes; not on stage
-  example:
-  - the actors were waiting offstage
-  ili: i19951
-  members:
-  - offstage
-  partOfSpeech: r
-00261207-r:
-  definition:
-  - on the stage
-  example:
-  - it was time for her to go onstage
-  ili: i19952
-  members:
-  - onstage
-  partOfSpeech: r
-00261310-r:
-  definition:
-  - overtime without extra compensation
-  example:
-  - she often has to work off-the-clock
-  ili: i19953
-  members:
-  - off-the-clock
-  partOfSpeech: r
-00261426-r:
-  definition:
-  - beyond the regular time
-  example:
-  - she often has to work overtime
-  ili: i19954
-  members:
-  - overtime
-  partOfSpeech: r
-00261520-r:
-  definition:
-  - by necessity; by force of circumstance
-  ili: i19955
-  members:
-  - perforce
-  partOfSpeech: r
-00261595-r:
-  definition:
-  - as fast as possible; with all possible haste
-  example:
-  - send it to me post-haste
-  ili: i19956
-  members:
-  - post-haste
-  partOfSpeech: r
-00261706-r:
-  definition:
-  - at first sight
-  ili: i19957
-  members:
-  - prima facie
   partOfSpeech: r
 00261760-r:
   definition:
@@ -18048,26 +7824,6 @@
   - scot free
   - scot-free
   partOfSpeech: r
-00262350-r:
-  definition:
-  - toward the sky
-  example:
-  - look skywards!
-  ili: i19963
-  members:
-  - skyward
-  - skywards
-  partOfSpeech: r
-00262429-r:
-  definition:
-  - in a specified area or place
-  example:
-  - you shouldn't be up here
-  ili: i19964
-  members:
-  - up here
-  - over here
-  partOfSpeech: r
 00262533-r:
   definition:
   - in an adverse manner
@@ -18077,36 +7833,6 @@
   members:
   - adversely
   partOfSpeech: r
-00262662-r:
-  definition:
-  - in a tasteful way
-  example:
-  - this building is aesthetically very pleasing
-  ili: i19966
-  members:
-  - aesthetically
-  - esthetically
-  partOfSpeech: r
-00262820-r:
-  definition:
-  - in a very painful manner
-  example:
-  - the progress was agonizingly slow
-  ili: i19967
-  members:
-  - agonizingly
-  - excruciatingly
-  - torturously
-  partOfSpeech: r
-00263006-r:
-  definition:
-  - to an appalling extent
-  example:
-  - the prisoners were appallingly thin
-  ili: i19968
-  members:
-  - appallingly
-  partOfSpeech: r
 00263125-r:
   definition:
   - in an appealing manner
@@ -18115,15 +7841,6 @@
   ili: i19969
   members:
   - appealingly
-  partOfSpeech: r
-00263256-r:
-  definition:
-  - in an unappealing manner
-  example:
-  - the kitchen was unappealingly dirty
-  ili: i19970
-  members:
-  - unappealingly
   partOfSpeech: r
 00263397-r:
   definition:
@@ -18189,36 +7906,6 @@
   members:
   - at a loss
   partOfSpeech: r
-00264278-r:
-  definition:
-  - off the subject; beyond the point at issue
-  example:
-  - such digressions can lead us too far afield
-  ili: i19978
-  members:
-  - afield
-  partOfSpeech: r
-00264402-r:
-  definition:
-  - in or into a field (especially a field of battle)
-  example:
-  - the armies were afield, challenging the enemy's advance
-  - unlawful to carry hunting rifles afield until the season opens
-  ili: i19979
-  members:
-  - afield
-  partOfSpeech: r
-00264611-r:
-  definition:
-  - far away from home or one's usual surroundings
-  example:
-  - source: R.A.Hall
-    text: looking afield for new lands to conquer
-  ili: i19980
-  members:
-  - afield
-  - abroad
-  partOfSpeech: r
 00264754-r:
   definition:
   - in an animated manner
@@ -18261,28 +7948,6 @@
   ili: i19984
   members:
   - casually
-  partOfSpeech: r
-00265458-r:
-  definition:
-  - at or toward the rear of the stage
-  domain_topic:
-  - 07019235-n
-  example:
-  - the dancers were directed to move upstage
-  ili: i19985
-  members:
-  - upstage
-  partOfSpeech: r
-00265610-r:
-  definition:
-  - at or toward the front of the stage
-  domain_topic:
-  - 07019235-n
-  example:
-  - the actors moved further and further downstage
-  ili: i19986
-  members:
-  - downstage
   partOfSpeech: r
 00265770-r:
   definition:
@@ -18343,15 +8008,6 @@
   members:
   - adagio
   partOfSpeech: r
-00266597-r:
-  definition:
-  - by or for an administrator
-  example:
-  - this decision was made administratively
-  ili: i19993
-  members:
-  - administratively
-  partOfSpeech: r
 00266729-r:
   definition:
   - in an adorable manner
@@ -18371,13 +8027,6 @@
   members:
   - antagonistically
   partOfSpeech: r
-00267010-r:
-  definition:
-  - in an anterior direction
-  ili: i19996
-  members:
-  - anteriorly
-  partOfSpeech: r
 00267091-r:
   definition:
   - in an apathetic manner
@@ -18396,16 +8045,6 @@
   ili: i19998
   members:
   - ardently
-  partOfSpeech: r
-00267447-r:
-  definition:
-  - in an arrogant manner
-  example:
-  - in the old days she had been harsh and stiff; afraid of her husband and yet arrogantly
-    proud that she had a husband strong and fierce enough to make her afraid
-  ili: i19999
-  members:
-  - arrogantly
   partOfSpeech: r
 00267688-r:
   definition:
@@ -18440,15 +8079,6 @@
   ili: i20003
   members:
   - unassertively
-  partOfSpeech: r
-00268242-r:
-  definition:
-  - without a doubt
-  example:
-  - the grammar schools were assuredly not intended for the gentry alone
-  ili: i20004
-  members:
-  - assuredly
   partOfSpeech: r
 00268385-r:
   definition:
@@ -18488,24 +8118,6 @@
   members:
   - adverbially
   partOfSpeech: r
-00268988-r:
-  definition:
-  - off course, wandering aimlessly
-  example:
-  - there was a search for beauty that had somehow gone adrift
-  ili: i20009
-  members:
-  - adrift
-  partOfSpeech: r
-00269134-r:
-  definition:
-  - floating freely; not anchored
-  example:
-  - the boat was set adrift
-  ili: i20010
-  members:
-  - adrift
-  partOfSpeech: r
 00269243-r:
   definition:
   - at a moderately slow tempo
@@ -18534,15 +8146,6 @@
   ili: i20013
   members:
   - angelically
-  partOfSpeech: r
-00269596-r:
-  definition:
-  - with regard to architecture
-  example:
-  - this building is ugly, but architecturally interesting
-  ili: i20014
-  members:
-  - architecturally
   partOfSpeech: r
 00269743-r:
   definition:
@@ -18601,16 +8204,6 @@
   members:
   - beastly
   partOfSpeech: r
-00270584-r:
-  definition:
-  - genuinely; with authority
-  example:
-  - it is authentically British
-  ili: i20021
-  members:
-  - authentically
-  - genuinely
-  partOfSpeech: r
 00270730-r:
   definition:
   - without bloodshed; in a bloodless manner; without shedding blood
@@ -18626,16 +8219,6 @@
   ili: i20023
   members:
   - bloodily
-  partOfSpeech: r
-00271019-r:
-  definition:
-  - in a grandiose manner
-  example:
-  - the building was bombastically spacious
-  ili: i20024
-  members:
-  - bombastically
-  - grandiosely
   partOfSpeech: r
 00271157-r:
   definition:
@@ -18657,15 +8240,6 @@
   - boyishly
   - boylike
   partOfSpeech: r
-00271442-r:
-  definition:
-  - with the bottom lodged on the ground
-  example:
-  - he ran the ship aground
-  ili: i20027
-  members:
-  - aground
-  partOfSpeech: r
 00271541-r:
   definition:
   - with hands on hips and elbows extending outward
@@ -18675,15 +8249,6 @@
   members:
   - akimbo
   partOfSpeech: r
-00271649-r:
-  definition:
-  - on or toward the lee
-  example:
-  - put the helm alee
-  ili: i20029
-  members:
-  - alee
-  partOfSpeech: r
 00271723-r:
   definition:
   - in mentally perceptive and responsive way
@@ -18692,17 +8257,6 @@
   ili: i20030
   members:
   - alertly
-  partOfSpeech: r
-00271877-r:
-  definition:
-  - as known or named at another time or place
-  example:
-  - Mr. Smith, alias Mr. Lafayette
-  ili: i20031
-  members:
-  - alias
-  - a.k.a.
-  - also known as
   partOfSpeech: r
 00272012-r:
   definition:
@@ -18735,16 +8289,6 @@
   members:
   - alliteratively
   partOfSpeech: r
-00272405-r:
-  definition:
-  - in an altruistic manner
-  example:
-  - he acted selflessly when he helped the old lady in distress
-  ili: i20035
-  members:
-  - altruistically
-  - selflessly
-  partOfSpeech: r
 00272583-r:
   definition:
   - in an anomalous manner
@@ -18763,23 +8307,6 @@
   members:
   - appreciatively
   - gratefully
-  partOfSpeech: r
-00272901-r:
-  definition:
-  - in an ungrateful manner
-  ili: i20038
-  members:
-  - ungratefully
-  - unappreciatively
-  partOfSpeech: r
-00273056-r:
-  definition:
-  - with respect to arithmetic
-  example:
-  - this problem is arithmetically easy
-  ili: i20039
-  members:
-  - arithmetically
   partOfSpeech: r
 00273182-r:
   definition:
@@ -18859,26 +8386,6 @@
   - sapiently
   - acutely
   partOfSpeech: r
-00274275-r:
-  definition:
-  - transversely
-  example:
-  - the marble slabs were cut across
-  ili: i20048
-  members:
-  - across
-  - crosswise
-  - crossways
-  partOfSpeech: r
-00274382-r:
-  definition:
-  - to the opposite side
-  example:
-  - the football field was 300 feet across
-  ili: i20049
-  members:
-  - across
-  partOfSpeech: r
 00274479-r:
   definition:
   - with all your strength
@@ -18896,13 +8403,6 @@
   ili: i20051
   members:
   - amain
-  partOfSpeech: r
-00274669-r:
-  definition:
-  - at or near or toward the middle
-  ili: i20052
-  members:
-  - amidship
   partOfSpeech: r
 00274737-r:
   definition:
@@ -18924,43 +8424,6 @@
   members:
   - amok
   - amuck
-  partOfSpeech: r
-00275080-r:
-  definition:
-  - with antithesis; in an antithetical manner
-  ili: i20055
-  members:
-  - antithetically
-  partOfSpeech: r
-00275183-r:
-  definition:
-  - at an opportune time
-  example:
-  - your letter arrived apropos
-  ili: i20056
-  members:
-  - seasonably
-  - timely
-  - well-timed
-  - apropos
-  partOfSpeech: r
-00275323-r:
-  definition:
-  - in accordance with the season
-  example:
-  - it was seasonably cold
-  ili: i20057
-  members:
-  - seasonably
-  partOfSpeech: r
-00275453-r:
-  definition:
-  - not in accordance with the season
-  example:
-  - it was unseasonably cold
-  ili: i20058
-  members:
-  - unseasonably
   partOfSpeech: r
 00275591-r:
   definition:
@@ -19010,15 +8473,6 @@
   - aslant
   - athwart
   partOfSpeech: r
-00276272-r:
-  definition:
-  - in a blissful manner
-  example:
-  - he was blissfully unaware of the danger
-  ili: i20064
-  members:
-  - blissfully
-  partOfSpeech: r
 00276392-r:
   definition:
   - over or across in a slanting direction
@@ -19026,97 +8480,12 @@
   members:
   - aslant
   partOfSpeech: r
-00276465-r:
-  definition:
-  - into a sleeping state
-  example:
-  - he fell asleep
-  ili: i20066
-  members:
-  - asleep
-  partOfSpeech: r
 00276557-r:
   definition:
   - in the sleep of death
   ili: i20067
   members:
   - asleep
-  partOfSpeech: r
-00276631-r:
-  definition:
-  - (of a ship or an airplane) behind
-  domain_topic:
-  - 04201332-n
-  - 02694015-n
-  example:
-  - we dropped her astern on the end of a seven-inch manilla, and she laid comfortably
-    on the ebb tide
-  ili: i20068
-  members:
-  - astern
-  partOfSpeech: r
-00276839-r:
-  definition:
-  - at or near or toward the stern of a ship or tail of an airplane
-  example:
-  - stow the luggage aft
-  - ships with square sails sail fairly efficiently with the wind abaft
-  - the captain looked astern to see what the fuss was about
-  ili: i20069
-  members:
-  - aft
-  - abaft
-  - astern
-  partOfSpeech: r
-00277124-r:
-  definition:
-  - near or toward the bow of a ship or cockpit of a plane
-  example:
-  - the captain went fore (or forward) to check the instruments
-  ili: i20070
-  members:
-  - fore
-  - forward
-  partOfSpeech: r
-00277302-r:
-  definition:
-  - stern foremost or backward
-  example:
-  - the steamer went astern at half speed
-  ili: i20071
-  members:
-  - astern
-  partOfSpeech: r
-00277404-r:
-  definition:
-  - with one leg on each side
-  example:
-  - she sat astride the chair
-  ili: i20072
-  members:
-  - astride
-  - astraddle
-  partOfSpeech: r
-00277506-r:
-  definition:
-  - with the legs stretched far apart
-  ili: i20073
-  members:
-  - astride
-  partOfSpeech: r
-00277575-r:
-  definition:
-  - at right angles to the center line of a ship
-  ili: i20074
-  members:
-  - athwart
-  partOfSpeech: r
-00277655-r:
-  definition:
-  - on, to, or at the top
-  ili: i20075
-  members:
-  - atop
   partOfSpeech: r
 00277709-r:
   definition:
@@ -19147,25 +8516,6 @@
   - avowedly
   - professedly
   partOfSpeech: r
-00278159-r:
-  definition:
-  - in or to a backstage area of a theater
-  example:
-  - costumes were changed backstage
-  ili: i20079
-  members:
-  - backstage
-  partOfSpeech: r
-00278270-r:
-  definition:
-  - out of view of the public; behind the scenes
-  example:
-  - Working backstage to gain political support for his proposal
-  - many private deals were made backstage at the convention
-  ili: i20080
-  members:
-  - backstage
-  partOfSpeech: r
 00278494-r:
   definition:
   - confidentially or in secret
@@ -19176,15 +8526,6 @@
   ili: i20081
   members:
   - privily
-  partOfSpeech: r
-00278639-r:
-  definition:
-  - in a bald manner
-  example:
-  - this book is, to put it baldly, an uneven work.
-  ili: i20082
-  members:
-  - baldly
   partOfSpeech: r
 00278759-r:
   definition:
@@ -19308,28 +8649,6 @@
   - pleadingly
   - entreatingly
   partOfSpeech: r
-00280264-r:
-  definition:
-  - in a bewitching manner
-  example:
-  - she was bewitchingly beautiful
-  ili: i20095
-  members:
-  - bewitchingly
-  - captivatingly
-  - enchantingly
-  - enthrallingly
-  partOfSpeech: r
-00280480-r:
-  definition:
-  - every two years
-  example:
-  - this festival takes places biennially
-  ili: i20096
-  members:
-  - biennially
-  - biyearly
-  partOfSpeech: r
 00280708-r:
   definition:
   - in a blank and uncomprehending manner
@@ -19442,24 +8761,6 @@
   - buoyantly
   - chirpily
   partOfSpeech: r
-00282316-r:
-  definition:
-  - very happily
-  example:
-  - we were floating on air at the news
-  ili: i20109
-  members:
-  - on air
-  partOfSpeech: r
-00282402-r:
-  definition:
-  - with respect to bureaucracy
-  example:
-  - it's bureaucratically complicated
-  ili: i20110
-  members:
-  - bureaucratically
-  partOfSpeech: r
 00282529-r:
   definition:
   - in a bureaucratic manner
@@ -19497,16 +8798,6 @@
   ili: i20114
   members:
   - capriciously
-  partOfSpeech: r
-00283116-r:
-  definition:
-  - unpredictably
-  example:
-  - the weather has been freakishly variable
-  ili: i20115
-  members:
-  - capriciously
-  - freakishly
   partOfSpeech: r
 00283263-r:
   definition:
@@ -19582,26 +8873,6 @@
   - unendingly
   - continuously
   partOfSpeech: r
-00284664-r:
-  definition:
-  - all the time; seemingly without stopping
-  example:
-  - a theological student with whom I argued interminably
-  - her nagging went on endlessly
-  ili: i20123
-  members:
-  - interminably
-  - endlessly
-  partOfSpeech: r
-00284883-r:
-  definition:
-  - every hundred years; once in a century
-  example:
-  - the birthday of this city is being celebrated centennially
-  ili: i20124
-  members:
-  - centennially
-  partOfSpeech: r
 00285042-r:
   definition:
   - in a manner suggestive of chaos
@@ -19649,17 +8920,6 @@
   members:
   - cheaply
   - inexpensively
-  partOfSpeech: r
-00285748-r:
-  definition:
-  - in a brash cheeky manner
-  example:
-  - brashly, she asked for a rebate
-  ili: i20130
-  members:
-  - cheekily
-  - nervily
-  - brashly
   partOfSpeech: r
 00285918-r:
   definition:
@@ -19741,36 +9001,6 @@
   - clearly
   - clear
   partOfSpeech: r
-00287169-r:
-  definition:
-  - entirely
-  example:
-  - read the book clear to the end
-  - slept clear through the night
-  - there were open fields clear to the horizon
-  ili: i20140
-  members:
-  - clear
-  - all the way
-  partOfSpeech: r
-00287341-r:
-  definition:
-  - with respect to climate
-  example:
-  - they were used to a climatically different environment
-  ili: i20141
-  members:
-  - climatically
-  partOfSpeech: r
-00287481-r:
-  definition:
-  - by way of, or along the coast
-  example:
-  - we were travelling coastwise
-  ili: i20142
-  members:
-  - coastwise
-  partOfSpeech: r
 00287580-r:
   definition:
   - in a cajoling manner
@@ -19798,17 +9028,6 @@
   ili: i20145
   members:
   - incoherently
-  partOfSpeech: r
-00287982-r:
-  definition:
-  - with the use of colloquial expressions
-  example:
-  - this building is colloquially referred to as The Barn
-  ili: i20146
-  members:
-  - colloquially
-  - conversationally
-  - informally
   partOfSpeech: r
 00288204-r:
   definition:
@@ -19872,15 +9091,6 @@
   members:
   - incompatibly
   partOfSpeech: r
-00289255-r:
-  definition:
-  - in a self-satisfied manner
-  example:
-  - he complacently lived out his life as a village school teacher
-  ili: i20154
-  members:
-  - complacently
-  partOfSpeech: r
 00289406-r:
   definition:
   - without complaining
@@ -19926,15 +9136,6 @@
   - obligatorily
   - mandatorily
   partOfSpeech: r
-00290270-r:
-  definition:
-  - with regard to computation
-  example:
-  - computationally, this is a tricky problem
-  ili: i20160
-  members:
-  - computationally
-  partOfSpeech: r
 00290403-r:
   definition:
   - (archaic as adverb) in a manner characteristic of a brother
@@ -19951,15 +9152,6 @@
   members:
   - pro
   partOfSpeech: r
-00290609-r:
-  definition:
-  - in opposition to a proposition, opinion, etc.
-  example:
-  - much was written pro and con
-  ili: i20163
-  members:
-  - con
-  partOfSpeech: r
 00290736-r:
   definition:
   - with conceit; in a conceited manner
@@ -19969,16 +9161,6 @@
   members:
   - conceitedly
   - self-conceitedly
-  partOfSpeech: r
-00290900-r:
-  definition:
-  - in a conceptual manner
-  example:
-  - he can no longer think conceptually
-  - conceptually, the idea is quite simple
-  ili: i20165
-  members:
-  - conceptually
   partOfSpeech: r
 00291062-r:
   definition:
@@ -20052,13 +9234,6 @@
   members:
   - cytophotometrically
   partOfSpeech: r
-00292166-r:
-  definition:
-  - by means of cytoplasm
-  ili: i20173
-  members:
-  - cytoplasmically
-  partOfSpeech: r
 00292249-r:
   definition:
   - without taking pains
@@ -20114,16 +9289,6 @@
   ili: i20179
   members:
   - criminally
-  partOfSpeech: r
-00293079-r:
-  definition:
-  - in a shameful manner
-  example:
-  - the garden was criminally neglected
-  ili: i20180
-  members:
-  - criminally
-  - reprehensively
   partOfSpeech: r
 00293230-r:
   definition:
@@ -20193,16 +9358,6 @@
   members:
   - unconditionally
   partOfSpeech: r
-00294248-r:
-  definition:
-  - to a crucial degree
-  example:
-  - crucially important
-  - crucially, he must meet us at the airport
-  ili: i20188
-  members:
-  - crucially
-  partOfSpeech: r
 00294391-r:
   definition:
   - not in the intended manner
@@ -20219,40 +9374,12 @@
   members:
   - crisscross
   partOfSpeech: r
-00294567-r:
-  definition:
-  - in the opposite direction
-  example:
-  - run counter
-  ili: i20191
-  members:
-  - counter
-  partOfSpeech: r
 00294643-r:
   definition:
   - in a counteractive manner
   ili: i20192
   members:
   - counteractively
-  partOfSpeech: r
-00294730-r:
-  definition:
-  - across the countryside
-  example:
-  - the river runs cross-country
-  - the road runs cross-country
-  ili: i20193
-  members:
-  - cross-country
-  partOfSpeech: r
-00294857-r:
-  definition:
-  - not following tracks or roads
-  example:
-  - they liked to race cross-country
-  ili: i20194
-  members:
-  - cross-country
   partOfSpeech: r
 00294964-r:
   definition:
@@ -20265,31 +9392,6 @@
   - grouchily
   - grumpily
   partOfSpeech: r
-00295138-r:
-  definition:
-  - across a town or city
-  example:
-  - he traveled crosstown
-  ili: i20196
-  members:
-  - crosstown
-  partOfSpeech: r
-00295240-r:
-  definition:
-  - in an subtle, cunning manner
-  example:
-  - he craftily arranged to be there when the decision was announced
-  - had ever circumstances conspired so cunningly?
-  ili: i20197
-  members:
-  - craftily
-  - cunningly
-  - foxily
-  - knavishly
-  - slyly
-  - trickily
-  - artfully
-  partOfSpeech: r
 00295603-r:
   definition:
   - in a confused manner
@@ -20299,24 +9401,6 @@
   ili: i20198
   members:
   - confusedly
-  partOfSpeech: r
-00295773-r:
-  definition:
-  - as a consequence
-  example:
-  - he had good reason to be grateful for the opportunities which they had made available
-    to him and which consequently led to the good position he now held
-  ili: i20199
-  members:
-  - consequently
-  - therefore
-  partOfSpeech: r
-00296016-r:
-  definition:
-  - having the result that
-  ili: i20200
-  members:
-  - consequentially
   partOfSpeech: r
 00296096-r:
   definition:
@@ -20338,26 +9422,6 @@
   members:
   - constructively
   partOfSpeech: r
-00296490-r:
-  definition:
-  - during the same period of time
-  example:
-  - contemporaneously, or possibly a little later, there developed a great Sumerian
-    civilisation
-  ili: i20203
-  members:
-  - contemporaneously
-  partOfSpeech: r
-00296680-r:
-  definition:
-  - in a contrasting manner
-  example:
-  - contrastingly, both the rooms leading off it gave an immediate impression of being
-    disgraced
-  ili: i20204
-  members:
-  - contrastingly
-  partOfSpeech: r
 00296859-r:
   definition:
   - in a composed and unconcerned manner
@@ -20369,18 +9433,6 @@
   - coolly
   - nervelessly
   - nonchalantly
-  partOfSpeech: r
-00297139-r:
-  definition:
-  - not easy to believe
-  example:
-  - incredibly, she survived the crash
-  ili: i20206
-  members:
-  - incredibly
-  - improbably
-  - implausibly
-  - unbelievably
   partOfSpeech: r
 00297385-r:
   definition:
@@ -20458,17 +9510,6 @@
   - short
   - shortly
   partOfSpeech: r
-00298819-r:
-  definition:
-  - in a damnable manner
-  example:
-  - kindly Arthur — so damnably, politely, endlessly persistent!
-  ili: i20214
-  members:
-  - damned
-  - damnably
-  - cursedly
-  partOfSpeech: r
 00298995-r:
   definition:
   - in a damp manner
@@ -20479,15 +9520,6 @@
   members:
   - damply
   - moistly
-  partOfSpeech: r
-00299197-r:
-  definition:
-  - to a degree or in a manner that daunts
-  example:
-  - dauntingly difficult
-  ili: i20216
-  members:
-  - dauntingly
   partOfSpeech: r
 00299316-r:
   definition:
@@ -20593,18 +9625,6 @@
   members:
   - demurely
   partOfSpeech: r
-00301007-r:
-  definition:
-  - in a concentrated manner
-  example:
-  - old houses are often so densely packed that perhaps three or four have to be demolished
-    for every new one built
-  - a thickly populated area
-  ili: i20228
-  members:
-  - densely
-  - thickly
-  partOfSpeech: r
 00301256-r:
   definition:
   - in a compact manner or state
@@ -20622,68 +9642,6 @@
   ili: i20230
   members:
   - tightly
-  partOfSpeech: r
-00301501-r:
-  definition:
-  - by chance
-  example:
-  - perhaps she will call tomorrow
-  - we may possibly run into them at the concert
-  - it may peradventure be thought that there never was such a time
-  ili: i20231
-  members:
-  - possibly
-  - perchance
-  - perhaps
-  - maybe
-  - mayhap
-  - peradventure
-  partOfSpeech: r
-00301750-r:
-  definition:
-  - possibly (indicating a slight chance of something being true)
-  example:
-  - it might just happen
-  members:
-  - just
-  partOfSpeech: r
-00301868-r:
-  definition:
-  - to a degree possible of achievement or by possible means
-  example:
-  - they can't possibly get here in time for the funeral?
-  ili: i20232
-  members:
-  - possibly
-  partOfSpeech: r
-00302054-r:
-  definition:
-  - to a degree impossible of achievement
-  example:
-  - long thought to be an impossibly difficult operation
-  - impossibly far from sources of supply
-  ili: i20233
-  members:
-  - impossibly
-  partOfSpeech: r
-00302263-r:
-  definition:
-  - with a possibility of becoming actual
-  example:
-  - he is potentially dangerous
-  - potentially useful
-  ili: i20234
-  members:
-  - potentially
-  partOfSpeech: r
-00302411-r:
-  definition:
-  - in an absurd manner or to an absurd degree
-  example:
-  - an absurdly rich young woman
-  ili: i20235
-  members:
-  - absurdly
   partOfSpeech: r
 00302540-r:
   definition:
@@ -20706,25 +9664,6 @@
   members:
   - descriptively
   partOfSpeech: r
-00302867-r:
-  definition:
-  - as deserved
-  example:
-  - he chalked up two goals which deservedly gave Bolton their second victory of the
-    season
-  ili: i20238
-  members:
-  - deservedly
-  partOfSpeech: r
-00303026-r:
-  definition:
-  - in an unmerited manner
-  example:
-  - the team chalked up another victory, the last one quite undeservedly, in my opinion
-  ili: i20239
-  members:
-  - undeservedly
-  partOfSpeech: r
 00303212-r:
   definition:
   - with desperation
@@ -20734,26 +9673,6 @@
   members:
   - despairingly
   - despondently
-  partOfSpeech: r
-00303375-r:
-  definition:
-  - with respect to development
-  example:
-  - developmentally retarded
-  ili: i20241
-  members:
-  - developmentally
-  partOfSpeech: r
-00303492-r:
-  definition:
-  - in a playfully devilish manner
-  example:
-  - the socialists are further handicapped if they believe that capitalists are not
-    only wicked but also devilishly clever
-  ili: i20242
-  members:
-  - devilishly
-  - devilish
   partOfSpeech: r
 00303712-r:
   definition:
@@ -20783,13 +9702,6 @@
   members:
   - controversially
   - polemically
-  partOfSpeech: r
-00304163-r:
-  definition:
-  - not involving any controversy
-  ili: i20246
-  members:
-  - uncontroversially
   partOfSpeech: r
 00304274-r:
   definition:
@@ -20831,15 +9743,6 @@
   - creakily
   - creakingly
   - screakily
-  partOfSpeech: r
-00304906-r:
-  definition:
-  - in a crushing manner
-  example:
-  - the team was crushingly defeated
-  ili: i20251
-  members:
-  - crushingly
   partOfSpeech: r
 00305019-r:
   definition:
@@ -20890,15 +9793,6 @@
   members:
   - daintily
   partOfSpeech: r
-00305811-r:
-  definition:
-  - in an adventurous manner
-  example:
-  - daringly, he set out on a camping trip in East Africa
-  ili: i20257
-  members:
-  - daringly
-  partOfSpeech: r
 00305947-r:
   definition:
   - in an original manner
@@ -20916,16 +9810,6 @@
   ili: i20259
   members:
   - dashingly
-  partOfSpeech: r
-00306173-r:
-  definition:
-  - during the entire day
-  example:
-  - light pours daylong into the parlor
-  ili: i20260
-  members:
-  - daylong
-  - all day long
   partOfSpeech: r
 00306284-r:
   definition:
@@ -20952,16 +9836,6 @@
   - indecorously
   - unbecomingly
   partOfSpeech: r
-00306669-r:
-  definition:
-  - in a willing manner
-  example:
-  - I willingly accept
-  ili: i20264
-  members:
-  - willingly
-  - volitionally
-  partOfSpeech: r
 00306817-r:
   definition:
   - in an unwilling manner
@@ -20970,48 +9844,6 @@
   ili: i20265
   members:
   - unwillingly
-  partOfSpeech: r
-00306956-r:
-  definition:
-  - to a great depth; far down or in
-  example:
-  - dived deeply
-  - dug deep
-  ili: i20266
-  members:
-  - deeply
-  - deep
-  partOfSpeech: r
-00307076-r:
-  definition:
-  - to a great distance
-  example:
-  - penetrated deep into enemy territory
-  - went deep into the woods
-  ili: i20267
-  members:
-  - deep
-  partOfSpeech: r
-00307214-r:
-  definition:
-  - to an advanced time
-  example:
-  - deep into the night
-  - talked late into the evening
-  ili: i20268
-  members:
-  - deep
-  - late
-  partOfSpeech: r
-00307328-r:
-  definition:
-  - at an advanced age or stage
-  example:
-  - she married late
-  - undertook the project late in her career
-  ili: i20269
-  members:
-  - late
   partOfSpeech: r
 00307452-r:
   definition:
@@ -21074,33 +9906,6 @@
   members:
   - inoffensively
   partOfSpeech: r
-00308726-r:
-  definition:
-  - in an unpleasantly offensive manner
-  example:
-  - he smelled offensively unwashed
-  ili: i20276
-  members:
-  - offensively
-  partOfSpeech: r
-00308872-r:
-  definition:
-  - to a distinct degree
-  example:
-  - urbanization in Spain is distinctly correlated with a fall in reproductive rate
-  ili: i20277
-  members:
-  - distinctly
-  partOfSpeech: r
-00309032-r:
-  definition:
-  - in a distinct and distinguishable manner
-  example:
-  - the subtleties of this distinctly British occasion
-  ili: i20278
-  members:
-  - distinctly
-  partOfSpeech: r
 00309183-r:
   definition:
   - in a distracted manner
@@ -21138,15 +9943,6 @@
   members:
   - deliriously
   partOfSpeech: r
-00309700-r:
-  definition:
-  - in a delirious manner
-  example:
-  - her answer made him deliriously happy
-  ili: i20283
-  members:
-  - deliriously
-  partOfSpeech: r
 00309820-r:
   definition:
   - in a deceptive and unrealistic manner
@@ -21156,17 +9952,6 @@
   members:
   - delusively
   partOfSpeech: r
-00309952-r:
-  definition:
-  - in an obvious and provable manner
-  example:
-  - his documentary sources are demonstrably wrong
-  ili: i20285
-  members:
-  - demonstrably
-  - provably
-  - incontrovertibly
-  partOfSpeech: r
 00310160-r:
   definition:
   - in grief-stricken loneliness; without comforting circumstances or prospects
@@ -21174,17 +9959,6 @@
   members:
   - desolately
   - disconsolately
-  partOfSpeech: r
-00310309-r:
-  definition:
-  - as a devil; in an evil manner
-  example:
-  - his writing could be diabolically satiric
-  ili: i20287
-  members:
-  - diabolically
-  - devilishly
-  - fiendishly
   partOfSpeech: r
 00310504-r:
   definition:
@@ -21271,16 +10045,6 @@
   members:
   - devotedly
   partOfSpeech: r
-00311786-r:
-  definition:
-  - in a devout and pious manner
-  example:
-  - she was devoutly Catholic
-  ili: i20297
-  members:
-  - devoutly
-  - piously
-  partOfSpeech: r
 00311926-r:
   definition:
   - with dexterity; in a dexterous manner
@@ -21291,15 +10055,6 @@
   - dexterously
   - dextrously
   - deftly
-  partOfSpeech: r
-00312113-r:
-  definition:
-  - in a diagonal manner
-  example:
-  - she lives diagonally across the street from us
-  ili: i20299
-  members:
-  - diagonally
   partOfSpeech: r
 00312240-r:
   definition:
@@ -21334,16 +10089,6 @@
   - dictatorially
   - autocratically
   - magisterially
-  partOfSpeech: r
-00313044-r:
-  definition:
-  - in a didactic manner
-  example:
-  - this is a didactically sound method
-  ili: i20303
-  members:
-  - didactically
-  - pedagogically
   partOfSpeech: r
 00313196-r:
   definition:
@@ -21411,34 +10156,6 @@
   members:
   - disappointedly
   partOfSpeech: r
-00314318-r:
-  definition:
-  - in a disappointing manner
-  example:
-  - the discoverer of argon, Sir William Ramsay, looked disappointingly ordinary
-  ili: i20311
-  members:
-  - disappointingly
-  partOfSpeech: r
-00314485-r:
-  definition:
-  - in a disastrous manner
-  example:
-  - the real value of the trust capital may be disastrously less than when the trust
-    began
-  ili: i20312
-  members:
-  - disastrously
-  partOfSpeech: r
-00314656-r:
-  definition:
-  - in a disturbing or embarrassing manner
-  example:
-  - he drank some sherry, his eyes disconcertingly keen as he watched her
-  ili: i20313
-  members:
-  - disconcertingly
-  partOfSpeech: r
 00314829-r:
   definition:
   - with discontent; in a discontented manner
@@ -21449,21 +10166,6 @@
   members:
   - discontentedly
   partOfSpeech: r
-00315026-r:
-  definition:
-  - in a dishonorable manner or to a dishonorable degree
-  example:
-  - his grades were disgracefully low
-  ili: i20315
-  members:
-  - disgracefully
-  - ingloriously
-  - ignominiously
-  - discreditably
-  - shamefully
-  - dishonorably
-  - dishonourably
-  partOfSpeech: r
 00315374-r:
   definition:
   - with disgust
@@ -21473,18 +10175,6 @@
   ili: i20316
   members:
   - disgustedly
-  partOfSpeech: r
-00315534-r:
-  definition:
-  - in a disgusting manner or to a disgusting degree
-  example:
-  - the beggar was disgustingly filthy
-  ili: i20317
-  members:
-  - disgustingly
-  - distastefully
-  - revoltingly
-  - sickeningly
   partOfSpeech: r
 00315777-r:
   definition:
@@ -21508,31 +10198,6 @@
   - venally
   - deceitfully
   partOfSpeech: r
-00316228-r:
-  definition:
-  - (used as intensives reflecting the speaker's attitude) it is sincerely the case
-    that
-  example:
-  - honestly, I don't believe it
-  - candidly, I think she doesn't have a conscience
-  - frankly, my dear, I don't give a damn
-  exemplifies:
-  - 06332047-n
-  ili: i20320
-  members:
-  - honestly
-  - candidly
-  - frankly
-  partOfSpeech: r
-00316567-r:
-  definition:
-  - in a hypocritical manner
-  example:
-  - he behaved hypocritically by praying piously when people were watching
-  ili: i20321
-  members:
-  - hypocritically
-  partOfSpeech: r
 00316726-r:
   definition:
   - with dishonor
@@ -21551,16 +10216,6 @@
   members:
   - honorably
   - honourably
-  partOfSpeech: r
-00316988-r:
-  definition:
-  - in a disingenuous manner
-  example:
-  - disingenuously, he asked leading questions about his opponent's work
-  ili: i20324
-  members:
-  - disingenuously
-  - artfully
   partOfSpeech: r
 00317174-r:
   definition:
@@ -21683,34 +10338,6 @@
   members:
   - displeasingly
   partOfSpeech: r
-00319536-r:
-  definition:
-  - to a disproportionate degree
-  example:
-  - his benefits were disproportionately generous
-  ili: i20337
-  members:
-  - disproportionately
-  partOfSpeech: r
-00319696-r:
-  definition:
-  - to a proportionate degree
-  example:
-  - your salary will rise proportionately to your workload
-  ili: i20338
-  members:
-  - proportionately
-  - proportionally
-  partOfSpeech: r
-00319894-r:
-  definition:
-  - in a manner which is out of proportion
-  example:
-  - this wall is disproportionately long
-  ili: i20339
-  members:
-  - disproportionately
-  partOfSpeech: r
 00320034-r:
   definition:
   - in a way that is in correspondence among the constituents of another entity
@@ -21729,15 +10356,6 @@
   - disputatiously
   - argumentatively
   partOfSpeech: r
-00320344-r:
-  definition:
-  - in a disquieting manner
-  example:
-  - the disquietingly close sounds of gunfire
-  ili: i20342
-  members:
-  - disquietingly
-  partOfSpeech: r
 00320472-r:
   definition:
   - in a disreputable manner
@@ -21751,16 +10369,6 @@
   ili: i20344
   members:
   - reputably
-  partOfSpeech: r
-00320668-r:
-  definition:
-  - in a respectful manner
-  example:
-  - might I respectfully suggest to the Town Council that they should adopt a policy
-    of masterly inactivity?
-  ili: i20345
-  members:
-  - respectfully
   partOfSpeech: r
 00320875-r:
   definition:
@@ -21837,22 +10445,6 @@
   - trustingly
   - confidingly
   partOfSpeech: r
-00322170-r:
-  definition:
-  - in a disturbing manner
-  example:
-  - the details of the kidnapper's letter had sounded disturbingly convincing
-  ili: i20354
-  members:
-  - disturbingly
-  partOfSpeech: r
-00322327-r:
-  definition:
-  - as a matter of doctrine
-  ili: i20355
-  members:
-  - doctrinally
-  partOfSpeech: r
 00322408-r:
   definition:
   - in a narrow-minded dogmatic manner
@@ -21872,24 +10464,6 @@
   - dolefully
   - sorrowfully
   partOfSpeech: r
-00322759-r:
-  definition:
-  - with respect to home or family
-  example:
-  - the housewife bored us with her domestically limited conversation
-  ili: i20358
-  members:
-  - domestically
-  partOfSpeech: r
-00322917-r:
-  definition:
-  - with respect to the internal affairs of a government
-  example:
-  - domestically, the president proposes a more moderate economic policy
-  ili: i20359
-  members:
-  - domestically
-  partOfSpeech: r
 00323100-r:
   definition:
   - in a domineering manner
@@ -21899,15 +10473,6 @@
   members:
   - domineeringly
   partOfSpeech: r
-00323217-r:
-  definition:
-  - two together
-  example:
-  - some people sleep better double
-  ili: i20361
-  members:
-  - double
-  partOfSpeech: r
 00323299-r:
   definition:
   - downward and forward
@@ -21916,16 +10481,6 @@
   ili: i20362
   members:
   - double
-  partOfSpeech: r
-00323386-r:
-  definition:
-  - at a faster speed
-  example:
-  - now let's play the piece again double-quick
-  ili: i20363
-  members:
-  - double time
-  - double quick
   partOfSpeech: r
 00323505-r:
   definition:
@@ -21947,15 +10502,6 @@
   - dowdily
   - frumpily
   - frumpishly
-  partOfSpeech: r
-00323816-r:
-  definition:
-  - toward the bottom of a hill
-  example:
-  - running downhill, he gained a lot of speed
-  ili: i20366
-  members:
-  - downhill
   partOfSpeech: r
 00323926-r:
   definition:
@@ -22043,74 +10589,6 @@
   members:
   - dynamically
   partOfSpeech: r
-00325179-r:
-  definition:
-  - to, toward, or in the east
-  example:
-  - we travelled east for several miles
-  - located east of Rome
-  ili: i20376
-  members:
-  - east
-  partOfSpeech: r
-00325301-r:
-  definition:
-  - to, toward, or in the west
-  example:
-  - we moved west to Arizona
-  - situated west of Boston
-  ili: i20377
-  members:
-  - west
-  partOfSpeech: r
-00325415-r:
-  definition:
-  - toward the west
-  example:
-  - they traveled westward toward the setting sun
-  ili: i20378
-  members:
-  - westward
-  - westwards
-  partOfSpeech: r
-00325528-r:
-  definition:
-  - toward the east
-  example:
-  - they migrated eastward to Sweden
-  ili: i20379
-  members:
-  - eastward
-  - eastwards
-  partOfSpeech: r
-00325628-r:
-  definition:
-  - from the east
-  example:
-  - the winds blew easterly all night
-  ili: i20380
-  members:
-  - easterly
-  partOfSpeech: r
-00325751-r:
-  definition:
-  - from the west
-  example:
-  - the wind blew westerly
-  ili: i20381
-  members:
-  - westerly
-  partOfSpeech: r
-00325863-r:
-  definition:
-  - in a westward direction
-  example:
-  - source: Daniel Defoe
-    text: we began to steer away westerly
-  ili: i20382
-  members:
-  - westerly
-  partOfSpeech: r
 00325982-r:
   definition:
   - in an ebullient manner
@@ -22122,24 +10600,6 @@
   - ebulliently
   - exuberantly
   - expansively
-  partOfSpeech: r
-00326234-r:
-  definition:
-  - in an ecclesiastic manner
-  example:
-  - the candidate was ecclesiastically endorsed
-  ili: i20384
-  members:
-  - ecclesiastically
-  partOfSpeech: r
-00326369-r:
-  definition:
-  - with respect to ecology
-  example:
-  - ecologically speaking, this idea is brilliant; economically, it is a disaster
-  ili: i20385
-  members:
-  - ecologically
   partOfSpeech: r
 00326532-r:
   definition:
@@ -22172,16 +10632,6 @@
   members:
   - edgewise
   - edgeways
-  partOfSpeech: r
-00326996-r:
-  definition:
-  - in an educational manner
-  example:
-  - the assistant masters formed a committee of their own to consider what could be
-    done educationally for the town
-  ili: i20389
-  members:
-  - educationally
   partOfSpeech: r
 00327195-r:
   definition:
@@ -22322,24 +10772,6 @@
   - ineloquently
   - inarticulately
   partOfSpeech: r
-00329628-r:
-  definition:
-  - causing embarrassment
-  example:
-  - the great man was embarrassingly humble and self-effacing
-  ili: i20405
-  members:
-  - embarrassingly
-  partOfSpeech: r
-00329771-r:
-  definition:
-  - in an eminent manner
-  example:
-  - two subjects on which he was eminently qualified to make an original contribution
-  ili: i20406
-  members:
-  - eminently
-  partOfSpeech: r
 00329932-r:
   definition:
   - in a competitively imitative manner
@@ -22357,26 +10789,6 @@
   ili: i20408
   members:
   - encouragingly
-  partOfSpeech: r
-00330223-r:
-  definition:
-  - in a discouraging manner
-  example:
-  - the failure rate on the bar exam is discouragingly high
-  ili: i20409
-  members:
-  - discouragingly
-  partOfSpeech: r
-00330385-r:
-  definition:
-  - with the end forward or toward the observer
-  example:
-  - houses built endways
-  ili: i20410
-  members:
-  - endways
-  - endwise
-  - end on
   partOfSpeech: r
 00330507-r:
   definition:
@@ -22416,24 +10828,6 @@
   ili: i20414
   members:
   - entertainingly
-  partOfSpeech: r
-00331028-r:
-  definition:
-  - for the environment
-  example:
-  - the new recycling policy is environmentally safe
-  ili: i20415
-  members:
-  - environmentally
-  partOfSpeech: r
-00331161-r:
-  definition:
-  - in an equable manner
-  example:
-  - he is an equably cheerful fellow
-  ili: i20416
-  members:
-  - equably
   partOfSpeech: r
 00331271-r:
   definition:
@@ -22518,15 +10912,6 @@
   members:
   - evenly
   partOfSpeech: r
-00332684-r:
-  definition:
-  - in an evolutionary way; from an evolutionary point of view
-  example:
-  - the mutation has been evolutionarily successful
-  ili: i20426
-  members:
-  - evolutionarily
-  partOfSpeech: r
 00332854-r:
   definition:
   - in an uneven and irregular way
@@ -22551,27 +10936,6 @@
   ili: i20429
   members:
   - irregularly
-  partOfSpeech: r
-00333223-r:
-  definition:
-  - in a regular manner
-  example:
-  - letters arrived regularly from his children
-  ili: i19484
-  members:
-  - regularly
-  - on a regular basis
-  partOfSpeech: r
-00333384-r:
-  definition:
-  - in an inconstant manner, not according to fixed rate or schedule
-  example:
-  - her letters arrived irregularly
-  - the stomach mucosa was irregularly blackened
-  ili: i19485
-  members:
-  - irregularly
-  - on an irregular basis
   partOfSpeech: r
 00333541-r:
   definition:
@@ -22614,16 +10978,6 @@
   - unevenly
   - unequally
   partOfSpeech: r
-00334320-r:
-  definition:
-  - at any future time; in the future
-  example:
-  - lead a blameless life evermore
-  ili: i20434
-  members:
-  - evermore
-  - forevermore
-  partOfSpeech: r
 00334438-r:
   definition:
   - in an exciting manner
@@ -22643,39 +10997,6 @@
   ili: i20436
   members:
   - unexcitingly
-  partOfSpeech: r
-00334820-r:
-  definition:
-  - in an excusable manner or to an excusable degree
-  example:
-  - he was excusably late
-  ili: i20437
-  members:
-  - excusably
-  - forgivably
-  - pardonably
-  partOfSpeech: r
-00335065-r:
-  definition:
-  - in an unpardonable manner or to an unpardonable degree
-  example:
-  - he was inexcusably cruel to his wife
-  ili: i20438
-  members:
-  - inexcusably
-  - unpardonably
-  - unforgivably
-  partOfSpeech: r
-00335337-r:
-  definition:
-  - to an exorbitant degree
-  example:
-  - prices are exorbitantly high in the capital
-  ili: i20439
-  members:
-  - exorbitantly
-  - extortionately
-  - usuriously
   partOfSpeech: r
 00335532-r:
   definition:
@@ -22720,24 +11041,6 @@
   ili: i20444
   members:
   - explosively
-  partOfSpeech: r
-00336240-r:
-  definition:
-  - in an explosive manner
-  example:
-  - the political situation in Kashmir and Jammu is explosively unstable
-  ili: i20445
-  members:
-  - explosively
-  partOfSpeech: r
-00336392-r:
-  definition:
-  - in an exponential manner
-  example:
-  - inflation is growing exponentially
-  ili: i20446
-  members:
-  - exponentially
   partOfSpeech: r
 00336514-r:
   definition:
@@ -22787,16 +11090,6 @@
   members:
   - extravagantly
   - lavishly
-  partOfSpeech: r
-00337268-r:
-  definition:
-  - in an exuberant manner
-  example:
-  - the exuberantly baroque decoration of the church
-  ili: i20452
-  members:
-  - exuberantly
-  - riotously
   partOfSpeech: r
 00337430-r:
   definition:
@@ -23000,15 +11293,6 @@
   members:
   - feelingly
   partOfSpeech: r
-00340873-r:
-  definition:
-  - without compassionate feelings
-  example:
-  - unfeelingly, she required her maid to work on Christmas Day
-  ili: i20474
-  members:
-  - unfeelingly
-  partOfSpeech: r
 00341042-r:
   definition:
   - in a felicitous manner
@@ -23026,37 +11310,6 @@
   ili: i20476
   members:
   - infelicitously
-  partOfSpeech: r
-00341323-r:
-  definition:
-  - with passionate fervor
-  example:
-  - both those for and against are fervently convinced they speak for the great majority
-    of the people
-  - a fierily opinionated book
-  ili: i20477
-  members:
-  - fierily
-  - fervently
-  - fervidly
-  partOfSpeech: r
-00341590-r:
-  definition:
-  - in the fifth place
-  example:
-  - fifthly, we must adhere to the rules set by the local government
-  ili: i20478
-  members:
-  - fifthly
-  partOfSpeech: r
-00341730-r:
-  definition:
-  - in a figurative sense
-  example:
-  - figuratively speaking, …
-  ili: i20479
-  members:
-  - figuratively
   partOfSpeech: r
 00341857-r:
   definition:
@@ -23086,16 +11339,6 @@
   members:
   - firsthand
   - at first hand
-  partOfSpeech: r
-00342247-r:
-  definition:
-  - quite well
-  example:
-  - she doesn't feel first-rate today
-  ili: i20483
-  members:
-  - first-rate
-  - very well
   partOfSpeech: r
 00342345-r:
   definition:
@@ -23291,15 +11534,6 @@
   members:
   - forlornly
   partOfSpeech: r
-00345178-r:
-  definition:
-  - in a formidable manner
-  example:
-  - the constant risk that attends the exchanges of human beings formidably armed
-  ili: i20505
-  members:
-  - formidably
-  partOfSpeech: r
 00345338-r:
   definition:
   - in a formless manner
@@ -23360,36 +11594,6 @@
   - foully
   - insultingly
   partOfSpeech: r
-00346296-r:
-  definition:
-  - by a factor of four
-  example:
-  - the price of gasoline has increased fourfold over the past two years
-  ili: i20513
-  members:
-  - fourfold
-  - four times
-  partOfSpeech: r
-00346455-r:
-  definition:
-  - by a factor of a million
-  example:
-  - it increased a millionfold
-  ili: i20514
-  members:
-  - millionfold
-  - a million times
-  partOfSpeech: r
-00346567-r:
-  definition:
-  - in the fourth place
-  example:
-  - fourthly, you must pay the rent on the first of the month
-  ili: i20515
-  members:
-  - fourthly
-  - fourth
-  partOfSpeech: r
 00346729-r:
   definition:
   - in a fractious manner
@@ -23434,26 +11638,6 @@
   ili: i20520
   members:
   - frugally
-  partOfSpeech: r
-00347455-r:
-  definition:
-  - with respect to function
-  example:
-  - the two units are functionally interdependent
-  ili: i20521
-  members:
-  - functionally
-  partOfSpeech: r
-00347587-r:
-  definition:
-  - in a terrifying manner
-  example:
-  - the disturbing thing about the Minister's behavior is that far from being artificial,
-    it too often rings frighteningly true
-  ili: i20522
-  members:
-  - frighteningly
-  - scarily
   partOfSpeech: r
 00347823-r:
   definition:
@@ -23531,24 +11715,6 @@
   - tawdrily
   - gaudily
   partOfSpeech: r
-00349012-r:
-  definition:
-  - in a genealogical manner
-  example:
-  - he charted his family tree genealogically
-  ili: i20531
-  members:
-  - genealogically
-  partOfSpeech: r
-00349142-r:
-  definition:
-  - as sharing a common genus
-  example:
-  - these animals are not related generically
-  ili: i20532
-  members:
-  - generically
-  partOfSpeech: r
 00349270-r:
   definition:
   - without a trademark or brand name
@@ -23566,15 +11732,6 @@
   ili: i20534
   members:
   - genteelly
-  partOfSpeech: r
-00349513-r:
-  definition:
-  - with respect to geology
-  example:
-  - geologically speaking, this area is extremely interesting
-  ili: i20535
-  members:
-  - geologically
   partOfSpeech: r
 00349656-r:
   definition:
@@ -23647,15 +11804,6 @@
   members:
   - gloatingly
   partOfSpeech: r
-00350707-r:
-  definition:
-  - blessedly or wonderfully
-  example:
-  - how gloriously happy she had been during those few fleeting moments of time
-  ili: i20543
-  members:
-  - gloriously
-  partOfSpeech: r
 00350849-r:
   definition:
   - with glory or in a glorious manner
@@ -23723,20 +11871,6 @@
   members:
   - gluttonously
   partOfSpeech: r
-00351763-r:
-  definition:
-  - expressing anger, despair, frustration, approval, or surprise
-  example:
-  - you are goddamn right!
-  exemplifies:
-  - 06332047-n
-  - 07139048-n
-  ili: i20551
-  members:
-  - goddam
-  - goddamn
-  - goddamned
-  partOfSpeech: r
 00351874-r:
   definition:
   - in a good-natured manner
@@ -23755,15 +11889,6 @@
   - splendidly
   - resplendently
   - magnificently
-  partOfSpeech: r
-00352189-r:
-  definition:
-  - in a grand manner
-  example:
-  - the mansion seemed grandly large by today's standards
-  ili: i20554
-  members:
-  - grandly
   partOfSpeech: r
 00352317-r:
   definition:
@@ -23813,42 +11938,12 @@
   - grayly
   - greyly
   partOfSpeech: r
-00353034-r:
-  definition:
-  - in a grievous manner
-  example:
-  - the resolute but unbroken Germany, grievously wounded but far from destruction,
-    was able to lay the firm foundations for military revival
-  ili: i20560
-  members:
-  - grievously
-  partOfSpeech: r
 00353252-r:
   definition:
   - in an uncertain groping manner
   ili: i20561
   members:
   - gropingly
-  partOfSpeech: r
-00353338-r:
-  definition:
-  - in a grotesque manner
-  example:
-  - behind the house lay two nude figures grotesquely bald, with deliberate knife-slashes
-    marking their bodies
-  ili: i20562
-  members:
-  - grotesquely
-  - monstrously
-  partOfSpeech: r
-00353559-r:
-  definition:
-  - in a grudging manner
-  example:
-  - he grudgingly agreed to have a drink in a hotel close by
-  ili: i20563
-  members:
-  - grudgingly
   partOfSpeech: r
 00353714-r:
   definition:
@@ -23905,20 +12000,6 @@
   members:
   - half-heartedly
   partOfSpeech: r
-00354517-r:
-  definition:
-  - every thirty minutes, every half hour
-  ili: i20570
-  members:
-  - half-hourly
-  partOfSpeech: r
-00354612-r:
-  definition:
-  - every half year, every six months
-  ili: i20571
-  members:
-  - half-yearly
-  partOfSpeech: r
 00354703-r:
   definition:
   - in a generously handsome manner
@@ -23948,17 +12029,6 @@
   members:
   - haphazard
   - haphazardly
-  partOfSpeech: r
-00355281-r:
-  definition:
-  - by accident
-  example:
-  - betrayed by a word haply overheard
-  ili: i20575
-  members:
-  - haply
-  - by chance
-  - by luck
   partOfSpeech: r
 00355386-r:
   definition:
@@ -24047,13 +12117,6 @@
   - headlong
   - rashly
   partOfSpeech: r
-00356577-r:
-  definition:
-  - in an unadvised manner
-  ili: i20585
-  members:
-  - unadvisedly
-  partOfSpeech: r
 00356657-r:
   definition:
   - in a reckless manner
@@ -24070,17 +12133,6 @@
   members:
   - headlong
   - precipitately
-  partOfSpeech: r
-00356876-r:
-  definition:
-  - very much
-  example:
-  - thanks heaps
-  exemplifies:
-  - 07089193-n
-  ili: i20588
-  members:
-  - heaps
   partOfSpeech: r
 00356954-r:
   definition:
@@ -24102,17 +12154,6 @@
   - heatedly
   - hotly
   partOfSpeech: r
-00357305-r:
-  definition:
-  - toward heaven
-  example:
-  - he pointed heavenward
-  ili: i20591
-  members:
-  - heavenward
-  - heavenwards
-  - heavenwardly
-  partOfSpeech: r
 00357411-r:
   definition:
   - slowly as if burdened by much weight
@@ -24133,53 +12174,6 @@
   - heinously
   - monstrously
   partOfSpeech: r
-00357692-r:
-  definition:
-  - in a subsequent part of this document or statement or matter etc.
-  example:
-  - the landlord demises unto the tenant the premises hereinafter called the demised
-    premises
-  - the terms specified hereunder
-  ili: i20594
-  members:
-  - hereinafter
-  - hereafter
-  - hereunder
-  partOfSpeech: r
-00357947-r:
-  definition:
-  - in the preceding part of the current text
-  ili: i20595
-  members:
-  - hereinbefore
-  partOfSpeech: r
-00358029-r:
-  definition:
-  - of or concerning this
-  example:
-  - the twigs hereof are physic
-  ili: i20596
-  members:
-  - hereof
-  partOfSpeech: r
-00358116-r:
-  definition:
-  - to this writing or document
-  example:
-  - the charts hereto attached
-  ili: i20597
-  members:
-  - hereto
-  partOfSpeech: r
-00358208-r:
-  definition:
-  - immediately after this
-  example:
-  - hereupon, the passengers stumbled aboard
-  ili: i20598
-  members:
-  - hereupon
-  partOfSpeech: r
 00358311-r:
   definition:
   - in an airtight manner
@@ -24197,56 +12191,6 @@
   ili: i20600
   members:
   - heroically
-  partOfSpeech: r
-00358561-r:
-  definition:
-  - in a hideous manner
-  example:
-  - her face was hideously disfigured after the accident
-  ili: i20601
-  members:
-  - hideously
-  - horridly
-  - monstrously
-  partOfSpeech: r
-00358753-r:
-  definition:
-  - at a great altitude
-  example:
-  - he climbed high on the ladder
-  ili: i20602
-  members:
-  - high
-  - high up
-  partOfSpeech: r
-00358848-r:
-  definition:
-  - far up toward the source
-  example:
-  - he lives high up the river
-  ili: i20603
-  members:
-  - high
-  partOfSpeech: r
-00358935-r:
-  definition:
-  - in or to a high position, amount, or degree
-  example:
-  - prices have gone up far too high
-  ili: i20604
-  members:
-  - high
-  partOfSpeech: r
-00359047-r:
-  definition:
-  - in a rich manner
-  example:
-  - he lives high
-  ili: i20605
-  members:
-  - high
-  - richly
-  - luxuriously
   partOfSpeech: r
 00359172-r:
   definition:
@@ -24295,15 +12239,6 @@
   - loose
   - free
   partOfSpeech: r
-00359910-r:
-  definition:
-  - in rotation or succession
-  example:
-  - turn about is fair play
-  ili: i20611
-  members:
-  - about
-  partOfSpeech: r
 00359996-r:
   definition:
   - in a hoarse or husky voice
@@ -24313,24 +12248,6 @@
   members:
   - hoarsely
   - huskily
-  partOfSpeech: r
-00360138-r:
-  definition:
-  - in a horizontal direction
-  example:
-  - a gallery quite often is added to make use of space vertically as well as horizontally
-  ili: i20613
-  members:
-  - horizontally
-  partOfSpeech: r
-00360312-r:
-  definition:
-  - in a vertical direction
-  example:
-  - a gallery quite often is added to make use of space vertically as well as horizontally
-  ili: i20614
-  members:
-  - vertically
   partOfSpeech: r
 00360482-r:
   definition:
@@ -24349,15 +12266,6 @@
   ili: i20616
   members:
   - inhospitably
-  partOfSpeech: r
-00360781-r:
-  definition:
-  - every hour; by the hour
-  example:
-  - daily, hourly, I grew stronger
-  ili: i20617
-  members:
-  - hourly
   partOfSpeech: r
 00360891-r:
   definition:
@@ -24414,16 +12322,6 @@
   members:
   - humorlessly
   - humourlessly
-  partOfSpeech: r
-00361728-r:
-  definition:
-  - by a factor of one hundred
-  example:
-  - their money increased a hundredfold
-  ili: i20624
-  members:
-  - hundredfold
-  - a hundred times
   partOfSpeech: r
 00361850-r:
   definition:
@@ -24482,33 +12380,6 @@
   ili: i20630
   members:
   - icily
-  partOfSpeech: r
-00362861-r:
-  definition:
-  - with complete identity; in an identical manner
-  example:
-  - he is fitted with an identically similar one
-  ili: i20631
-  members:
-  - identically
-  partOfSpeech: r
-00363013-r:
-  definition:
-  - in an identifiable manner
-  example:
-  - they were identifiably different
-  ili: i20632
-  members:
-  - identifiably
-  partOfSpeech: r
-00363133-r:
-  definition:
-  - with respect to ideology
-  example:
-  - ideologically, we do not see eye to eye
-  ili: i20633
-  members:
-  - ideologically
   partOfSpeech: r
 00363242-r:
   definition:
@@ -24638,24 +12509,6 @@
   members:
   - illogically
   partOfSpeech: r
-00365540-r:
-  definition:
-  - according to logical reasoning
-  example:
-  - logically, you should now do the same to him
-  ili: i20647
-  members:
-  - logically
-  partOfSpeech: r
-00365674-r:
-  definition:
-  - in an illustrious manner
-  example:
-  - Einstein, the illustriously famous physicist of the 20th century
-  ili: i20648
-  members:
-  - illustriously
-  partOfSpeech: r
 00365826-r:
   definition:
   - in an immaculate manner
@@ -24713,16 +12566,6 @@
   members:
   - impassively
   partOfSpeech: r
-00366712-r:
-  definition:
-  - in an impenitent manner
-  example:
-  - he repeated his position unrepentantly
-  ili: i20655
-  members:
-  - impenitently
-  - unrepentantly
-  partOfSpeech: r
 00366906-r:
   definition:
   - showing remorse
@@ -24749,17 +12592,6 @@
   members:
   - imperceptibly
   - unnoticeably
-  partOfSpeech: r
-00367464-r:
-  definition:
-  - in a noticeable manner
-  example:
-  - he changed noticeably over the years
-  ili: i20659
-  members:
-  - perceptibly
-  - noticeably
-  - observably
   partOfSpeech: r
 00367664-r:
   definition:
@@ -24794,15 +12626,6 @@
   example:
   - he took her comments personally
   ili: i20663
-  members:
-  - personally
-  partOfSpeech: r
-00368189-r:
-  definition:
-  - as yourself
-  example:
-  - speaking personally, I would not want to go
-  ili: i20664
   members:
   - personally
   partOfSpeech: r
@@ -24885,26 +12708,6 @@
   members:
   - importantly
   partOfSpeech: r
-00369664-r:
-  definition:
-  - in an important way or to an important degree
-  example:
-  - more importantly, Weber held that the manifold meaning attached to the event by
-    the social scientist could alter his definition of the concrete event itself
-  ili: i20673
-  members:
-  - importantly
-  - significantly
-  partOfSpeech: r
-00369961-r:
-  definition:
-  - to an impracticable degree
-  example:
-  - this is still impracticably high
-  ili: i20674
-  members:
-  - impracticably
-  partOfSpeech: r
 00370083-r:
   definition:
   - in a precise manner
@@ -24926,29 +12729,6 @@
   - imprecisely
   - inexactly
   partOfSpeech: r
-00370459-r:
-  definition:
-  - just as it should be
-  example:
-  - ‘Precisely, my lord,’ he said
-  ili: i20677
-  members:
-  - precisely
-  - exactly
-  - on the nose
-  - on the dot
-  - on the button
-  partOfSpeech: r
-00370603-r:
-  definition:
-  - in an impregnable manner
-  example:
-  - the sight of that bland, impregnably righteous face has been enough to make their
-    blood run cold
-  ili: i20678
-  members:
-  - impregnably
-  partOfSpeech: r
 00370785-r:
   definition:
   - in an improvident manner
@@ -24957,53 +12737,6 @@
   ili: i20679
   members:
   - improvidently
-  partOfSpeech: r
-00370928-r:
-  definition:
-  - in a provident manner
-  example:
-  - providently, he had saved up some money for emergencies
-  ili: i20680
-  members:
-  - providently
-  partOfSpeech: r
-00371084-r:
-  definition:
-  - in a prudent manner
-  example:
-  - I had allotted my own bedroom for necking, prudently removing both the bed and
-    the key, and taken both myself and my typewriter into my son's bedroom.
-  ili: i20681
-  members:
-  - prudently
-  - providentially
-  partOfSpeech: r
-00371348-r:
-  definition:
-  - in an imprudent manner
-  example:
-  - imprudently, he downed tools and ran home to make his wife happy
-  ili: i20682
-  members:
-  - imprudently
-  partOfSpeech: r
-00371514-r:
-  definition:
-  - in an adequate manner or to an adequate degree
-  example:
-  - he was adequately prepared
-  ili: i20683
-  members:
-  - adequately
-  partOfSpeech: r
-00371665-r:
-  definition:
-  - in an inadequate manner or to an inadequate degree
-  example:
-  - the temporary camps were inadequately equipped
-  ili: i20684
-  members:
-  - inadequately
   partOfSpeech: r
 00371842-r:
   definition:
@@ -25033,25 +12766,6 @@
   members:
   - incognito
   partOfSpeech: r
-00372217-r:
-  definition:
-  - in an incomparable manner or to an incomparable degree
-  example:
-  - she is incomparably gifted
-  ili: i20688
-  members:
-  - incomparably
-  - uncomparably
-  partOfSpeech: r
-00372393-r:
-  definition:
-  - in a comparable manner or to a comparable degree
-  example:
-  - you will have to work comparably harder
-  ili: i20689
-  members:
-  - comparably
-  partOfSpeech: r
 00372559-r:
   definition:
   - in an incongruous manner
@@ -25060,16 +12774,6 @@
   ili: i20690
   members:
   - incongruously
-  partOfSpeech: r
-00372716-r:
-  definition:
-  - in a manner tending to attract attention
-  example:
-  - there have been plenty of general declarations about willingness to meet and talk,
-    but conspicuously no mention of time and place
-  ili: i20691
-  members:
-  - conspicuously
   partOfSpeech: r
 00372967-r:
   definition:
@@ -25087,24 +12791,6 @@
   members:
   - incriminatingly
   partOfSpeech: r
-00373228-r:
-  definition:
-  - in a manner impossible to cure
-  example:
-  - he is incurably ill
-  ili: i20694
-  members:
-  - incurably
-  partOfSpeech: r
-00373337-r:
-  definition:
-  - to an incurable degree
-  example:
-  - she was incurably optimistic
-  ili: i20695
-  members:
-  - incurably
-  partOfSpeech: r
 00373447-r:
   definition:
   - in an indelible manner
@@ -25114,29 +12800,6 @@
   ili: i20696
   members:
   - indelibly
-  partOfSpeech: r
-00373649-r:
-  definition:
-  - to an inexpressible degree
-  example:
-  - she was looking very young tonight, and, as usual, indescribably beautiful, in
-    a simple strapless dress of a green and white silky cotton
-  ili: i20697
-  members:
-  - ineffably
-  - indescribably
-  - unutterably
-  - unspeakably
-  - inexpressibly
-  partOfSpeech: r
-00374004-r:
-  definition:
-  - in an indeterminable manner
-  example:
-  - their relationship was of an indeterminably vague nature
-  ili: i20698
-  members:
-  - indeterminably
   partOfSpeech: r
 00374152-r:
   definition:
@@ -25167,15 +12830,6 @@
   members:
   - discreetly
   partOfSpeech: r
-00374744-r:
-  definition:
-  - without discretion or wisdom or self-restraint
-  example:
-  - she inquired indiscreetly after the state of his health
-  ili: i20702
-  members:
-  - indiscreetly
-  partOfSpeech: r
 00374926-r:
   definition:
   - in an indolent manner
@@ -25184,20 +12838,6 @@
   ili: i20703
   members:
   - indolently
-  partOfSpeech: r
-00375046-r:
-  definition:
-  - in a manner or to a degree that could not be doubted
-  example:
-  - it was immediately and indubitably apparent that I had interrupted a scene of
-    lovers
-  - his guilt was established beyond a shadow of a doubt
-  ili: i20704
-  members:
-  - indubitably
-  - beyond doubt
-  - beyond a doubt
-  - beyond a shadow of a doubt
   partOfSpeech: r
 00375361-r:
   definition:
@@ -25253,17 +12893,6 @@
   - uninformatively
   - uninstructively
   partOfSpeech: r
-00376350-r:
-  definition:
-  - not many times
-  example:
-  - in your 1850 church you not infrequently find a dramatic contrast between the
-    sumptuous appointments of the building itself and the inhuman barrack-like living
-    conditions in the church room
-  ili: i20711
-  members:
-  - infrequently
-  partOfSpeech: r
 00376634-r:
   definition:
   - in an ingenious manner
@@ -25283,35 +12912,6 @@
   members:
   - ingratiatingly
   partOfSpeech: r
-00376993-r:
-  definition:
-  - in an inherent manner
-  example:
-  - the subject matter is sexual activity of any overt kind, which is depicted as
-    inherently desirable and exciting
-  ili: i20714
-  members:
-  - inherently
-  partOfSpeech: r
-00377186-r:
-  definition:
-  - in an unreproducible manner
-  example:
-  - he has an inimitably verbose style
-  ili: i20715
-  members:
-  - inimitably
-  - unreproducibly
-  partOfSpeech: r
-00377343-r:
-  definition:
-  - in an iniquitous manner
-  example:
-  - they really believed that the treaty of Versailles was iniquitously injust
-  ili: i20716
-  members:
-  - iniquitously
-  partOfSpeech: r
 00377503-r:
   definition:
   - in an innate manner
@@ -25330,15 +12930,6 @@
   members:
   - innocently
   partOfSpeech: r
-00377757-r:
-  definition:
-  - in a not unlawful manner
-  example:
-  - he claimed to have purchased the contraband innocently
-  ili: i20719
-  members:
-  - innocently
-  partOfSpeech: r
 00377896-r:
   definition:
   - at an inconvenient time
@@ -25349,15 +12940,6 @@
   members:
   - inopportunely
   - malapropos
-  partOfSpeech: r
-00378096-r:
-  definition:
-  - conveniently
-  example:
-  - he arrived rather opportunely just when we needed a new butler
-  ili: i20721
-  members:
-  - opportunely
   partOfSpeech: r
 00378258-r:
   definition:
@@ -25375,16 +12957,6 @@
   example:
   - he clawed insatiably at the traditional precepts
   ili: i20723
-  members:
-  - insatiably
-  - unsatiably
-  partOfSpeech: r
-00378591-r:
-  definition:
-  - to an insatiable degree
-  example:
-  - she was insatiably hungry
-  ili: i20724
   members:
   - insatiably
   - unsatiably
@@ -25515,13 +13087,6 @@
   members:
   - insipidly
   partOfSpeech: r
-00381063-r:
-  definition:
-  - to such an extent or degree; so
-  ili: i20738
-  members:
-  - insomuch
-  partOfSpeech: r
 00381131-r:
   definition:
   - with inspiration; in an inspiring manner
@@ -25530,15 +13095,6 @@
   ili: i20739
   members:
   - inspirationally
-  partOfSpeech: r
-00381262-r:
-  definition:
-  - in a strong substantial way
-  example:
-  - the house was substantially built
-  ili: i20740
-  members:
-  - substantially
   partOfSpeech: r
 00381386-r:
   definition:
@@ -25556,15 +13112,6 @@
   ili: i20742
   members:
   - insultingly
-  partOfSpeech: r
-00381646-r:
-  definition:
-  - to an insuperable degree
-  example:
-  - these various courses all seemed insuperably difficult to the student
-  ili: i20743
-  members:
-  - insuperably
   partOfSpeech: r
 00381801-r:
   definition:
@@ -25584,15 +13131,6 @@
   members:
   - interdepartmental
   partOfSpeech: r
-00382065-r:
-  definition:
-  - to an intermediate degree
-  example:
-  - intermediately hot
-  ili: i20746
-  members:
-  - intermediately
-  partOfSpeech: r
 00382155-r:
   definition:
   - (spatial sense) seeming to have no bounds
@@ -25601,15 +13139,6 @@
   ili: i20747
   members:
   - endlessly
-  partOfSpeech: r
-00382291-r:
-  definition:
-  - in an intermittent manner
-  example:
-  - intermittently we questioned the barometer
-  ili: i20748
-  members:
-  - intermittently
   partOfSpeech: r
 00382423-r:
   definition:
@@ -25742,15 +13271,6 @@
   members:
   - ironically
   partOfSpeech: r
-00384453-r:
-  definition:
-  - contrary to plan or expectation
-  example:
-  - ironically, he ended up losing money under his own plan
-  ili: i20764
-  members:
-  - ironically
-  partOfSpeech: r
 00384582-r:
   definition:
   - in an irrelevant manner
@@ -25759,15 +13279,6 @@
   ili: i20765
   members:
   - irrelevantly
-  partOfSpeech: r
-00384736-r:
-  definition:
-  - in an irretrievable manner
-  example:
-  - it is irretrievably lost
-  ili: i20766
-  members:
-  - irretrievably
   partOfSpeech: r
 00384850-r:
   definition:
@@ -25900,26 +13411,6 @@
   members:
   - injudiciously
   partOfSpeech: r
-00386914-r:
-  definition:
-  - in a keen or penetrating way
-  example:
-  - he was keenly aware of his own shortcomings
-  - she pitied her sister acutely
-  - acutely aware
-  ili: i21654
-  members:
-  - keenly
-  - acutely
-  partOfSpeech: r
-00387120-r:
-  definition:
-  - in a very humorous manner
-  ili: i20782
-  members:
-  - killingly
-  - sidesplittingly
-  partOfSpeech: r
 00387237-r:
   definition:
   - in a laborious manner
@@ -25948,16 +13439,6 @@
   members:
   - lamely
   partOfSpeech: r
-00387726-r:
-  definition:
-  - toward land
-  example:
-  - landward, miles of rough grass marshes melt into low uplands
-  ili: i20786
-  members:
-  - landward
-  - landwards
-  partOfSpeech: r
 00387954-r:
   definition:
   - in a languid and lethargic manner
@@ -25985,13 +13466,6 @@
   members:
   - large
   partOfSpeech: r
-00388297-r:
-  definition:
-  - at a distance, wide of something (as of a mark)
-  ili: i20791
-  members:
-  - large
-  partOfSpeech: r
 00388378-r:
   definition:
   - in a lascivious manner
@@ -25999,40 +13473,6 @@
   members:
   - lasciviously
   - salaciously
-  partOfSpeech: r
-00388491-r:
-  definition:
-  - in a lateral direction or location
-  domain_topic:
-  - 06067070-n
-  example:
-  - the body is spindle-shaped and only slightly compressed laterally
-  ili: i20793
-  members:
-  - laterally
-  partOfSpeech: r
-00388669-r:
-  definition:
-  - to or by or from the side
-  example:
-  - such women carry in their heads kinship knowledge of six generations depth and
-    extending laterally among consanguineal kin as far as the grandchildren of second
-    cousin
-  ili: i20794
-  members:
-  - laterally
-  partOfSpeech: r
-00388921-r:
-  definition:
-  - so as to arouse or deserve laughter
-  example:
-  - her income was laughably small, but she managed to live well
-  ili: i20795
-  members:
-  - laughably
-  - ridiculously
-  - ludicrously
-  - preposterously
   partOfSpeech: r
 00389158-r:
   definition:
@@ -26045,13 +13485,6 @@
   - laxly
   - leniently
   partOfSpeech: r
-00389359-r:
-  definition:
-  - armed and prepared for fighting
-  ili: i20797
-  members:
-  - under arms
-  partOfSpeech: r
 00389429-r:
   definition:
   - in a slow and lazy manner
@@ -26060,26 +13493,6 @@
   ili: i20798
   members:
   - lazily
-  partOfSpeech: r
-00389570-r:
-  definition:
-  - toward or on the left; also used figuratively
-  example:
-  - he looked right and left
-  - the political party has moved left
-  ili: i20799
-  members:
-  - left
-  partOfSpeech: r
-00389732-r:
-  definition:
-  - toward or on the right; also used figuratively
-  example:
-  - he looked right and left
-  - the party has moved right
-  ili: i20800
-  members:
-  - right
   partOfSpeech: r
 00389887-r:
   definition:
@@ -26110,15 +13523,6 @@
   - lengthwise
   - longwise
   - longways
-  - longitudinally
-  partOfSpeech: r
-00390283-r:
-  definition:
-  - across time
-  example:
-  - We studied the development of the children longitudinally
-  ili: i20804
-  members:
   - longitudinally
   partOfSpeech: r
 00390398-r:
@@ -26215,16 +13619,6 @@
   - lukewarmly
   - tepidly
   partOfSpeech: r
-00391862-r:
-  definition:
-  - in a manner marked by complexity and richness of detail
-  example:
-  - this suave, culture-loving and luxuriantly good-looking M.P. represents the car-workers
-    of Coventry
-  ili: i20814
-  members:
-  - luxuriantly
-  partOfSpeech: r
 00392051-r:
   definition:
   - extremely abundant in growth or production
@@ -26233,24 +13627,6 @@
   ili: i20815
   members:
   - luxuriantly
-  partOfSpeech: r
-00392194-r:
-  definition:
-  - so as to be manageable
-  example:
-  - this house is manageably small
-  ili: i20816
-  members:
-  - manageably
-  partOfSpeech: r
-00392325-r:
-  definition:
-  - so as to be unmanageable
-  example:
-  - ‘This house is unmanageably large,’ she complained
-  ili: i20817
-  members:
-  - unmanageably
   partOfSpeech: r
 00392480-r:
   definition:
@@ -26262,14 +13638,6 @@
   members:
   - manfully
   - manly
-  partOfSpeech: r
-00392720-r:
-  definition:
-  - without qualities thought to befit a man
-  ili: i20819
-  members:
-  - unmanfully
-  - unmanly
   partOfSpeech: r
 00392845-r:
   definition:
@@ -26307,13 +13675,6 @@
   members:
   - lightsomely
   - trippingly
-  partOfSpeech: r
-00393380-r:
-  definition:
-  - with regard to or concerning limnology
-  ili: i20824
-  members:
-  - limnologically
   partOfSpeech: r
 00393479-r:
   definition:
@@ -26401,24 +13762,6 @@
   members:
   - logarithmically
   partOfSpeech: r
-00394594-r:
-  definition:
-  - for more time
-  example:
-  - can I stay bit longer?
-  ili: i20835
-  members:
-  - longer
-  partOfSpeech: r
-00394686-r:
-  definition:
-  - for the most time
-  example:
-  - she stayed longest
-  ili: i20836
-  members:
-  - longest
-  partOfSpeech: r
 00394779-r:
   definition:
   - in a chatty loquacious manner
@@ -26431,24 +13774,6 @@
   - garrulously
   - talkatively
   - talkily
-  partOfSpeech: r
-00395053-r:
-  definition:
-  - in a low position; near the ground
-  example:
-  - the branches hung low
-  ili: i20838
-  members:
-  - low
-  partOfSpeech: r
-00395144-r:
-  definition:
-  - in the lowest position; nearest the ground
-  example:
-  - the branch with the big peaches on it hung lowest
-  ili: i20839
-  members:
-  - lowest
   partOfSpeech: r
 00395274-r:
   definition:
@@ -26468,17 +13793,6 @@
   members:
   - luridly
   partOfSpeech: r
-00395592-r:
-  definition:
-  - so as to produce a delightful taste
-  example:
-  - I bought some more of these deliciously sweet peaches
-  ili: i20842
-  members:
-  - lusciously
-  - deliciously
-  - scrumptiously
-  partOfSpeech: r
 00395807-r:
   definition:
   - in a lustful manner
@@ -26496,15 +13810,6 @@
   ili: i20844
   members:
   - lyrically
-  partOfSpeech: r
-00396055-r:
-  definition:
-  - in a magnanimous manner
-  example:
-  - magnanimously, he forgave all those who had harmed him
-  ili: i20845
-  members:
-  - magnanimously
   partOfSpeech: r
 00396196-r:
   definition:
@@ -26557,13 +13862,6 @@
   members:
   - malignly
   partOfSpeech: r
-00396942-r:
-  definition:
-  - in a managerial manner
-  ili: i20852
-  members:
-  - managerially
-  partOfSpeech: r
 00397023-r:
   definition:
   - in a mangy manner
@@ -26586,24 +13884,6 @@
   ili: i20855
   members:
   - manipulatively
-  partOfSpeech: r
-00397334-r:
-  definition:
-  - in a masochistic manner
-  example:
-  - masochistically he insisted on an even greater workload
-  ili: i20856
-  members:
-  - masochistically
-  partOfSpeech: r
-00397478-r:
-  definition:
-  - to a massive degree or in a massive manner
-  example:
-  - tonight the haddock were shoaling massively in three hundred fathoms
-  ili: i20857
-  members:
-  - massively
   partOfSpeech: r
 00397648-r:
   definition:
@@ -26642,48 +13922,6 @@
   members:
   - mawkishly
   - drippily
-  partOfSpeech: r
-00398267-r:
-  definition:
-  - to a maximal degree
-  example:
-  - the cells maximally responsive to lines in this orientation will fire
-  ili: i20862
-  members:
-  - maximally
-  partOfSpeech: r
-00398433-r:
-  definition:
-  - to a minimal degree
-  example:
-  - the cells minimally responsive to lines in this orientation will not fire
-  ili: i20863
-  members:
-  - minimally
-  partOfSpeech: r
-00398603-r:
-  definition:
-  - to a meager degree or in a meager manner
-  example:
-  - these voices are meagerly represented at the conference
-  - the area is slenderly endowed with natural resources
-  ili: i20864
-  members:
-  - meagerly
-  - sparingly
-  - slenderly
-  - meagrely
-  partOfSpeech: r
-00398920-r:
-  definition:
-  - to an ample degree or in an ample manner
-  example:
-  - these voices were amply represented
-  - we benefited richly
-  ili: i20865
-  members:
-  - amply
-  - richly
   partOfSpeech: r
 00399101-r:
   definition:
@@ -26740,24 +13978,6 @@
   members:
   - meanspiritedly
   partOfSpeech: r
-00399919-r:
-  definition:
-  - to an immeasurable degree; beyond measurement
-  example:
-  - the war left him immeasurably fearful of what man can do to man
-  ili: i20872
-  members:
-  - immeasurably
-  partOfSpeech: r
-00400108-r:
-  definition:
-  - to a measurable degree
-  example:
-  - the difference is measurably large
-  ili: i20873
-  members:
-  - measurably
-  partOfSpeech: r
 00400243-r:
   definition:
   - in a mechanistic manner
@@ -26767,15 +13987,6 @@
   ili: i20874
   members:
   - mechanistically
-  partOfSpeech: r
-00400432-r:
-  definition:
-  - in a medial position
-  example:
-  - this consonant always occurs medially
-  ili: i20875
-  members:
-  - medially
   partOfSpeech: r
 00400548-r:
   definition:
@@ -26869,16 +14080,6 @@
   - mendaciously
   - untruthfully
   partOfSpeech: r
-00402102-r:
-  definition:
-  - with truth
-  example:
-  - I told him truthfully that I had just returned from my vacation
-  - he answered the question as truthfully as he could
-  ili: i20886
-  members:
-  - truthfully
-  partOfSpeech: r
 00402308-r:
   definition:
   - in a menial manner
@@ -26945,15 +14146,6 @@
   members:
   - methodologically
   partOfSpeech: r
-00403375-r:
-  definition:
-  - with regard to meter
-  example:
-  - metrically, these poems are matched
-  ili: i20894
-  members:
-  - metrically
-  partOfSpeech: r
 00403491-r:
   definition:
   - in a rhythmic manner
@@ -26981,25 +14173,6 @@
   ili: i20897
   members:
   - mindlessly
-  partOfSpeech: r
-00403940-r:
-  definition:
-  - at or near or toward the center of a ship
-  example:
-  - in the late 19th century, engines were placed in front, amidships, and at the
-    rear
-  ili: i20898
-  members:
-  - amidships
-  - amidship
-  - midships
-  partOfSpeech: r
-00404127-r:
-  definition:
-  - in the middle of the week
-  ili: i20899
-  members:
-  - midweek
   partOfSpeech: r
 00404188-r:
   definition:
@@ -27030,16 +14203,6 @@
   - minutely
   - circumstantially
   partOfSpeech: r
-00404674-r:
-  definition:
-  - in a miraculous manner
-  example:
-  - my hand grasped the gun that was, miraculously, lying on the ground beside my
-    finger tips
-  ili: i20903
-  members:
-  - miraculously
-  partOfSpeech: r
 00404848-r:
   definition:
   - in a miserable manner
@@ -27057,24 +14220,6 @@
   ili: i20905
   members:
   - mistily
-  partOfSpeech: r
-00405085-r:
-  definition:
-  - much
-  domain_topic:
-  - 07034009-n
-  example:
-  - allegro molto
-  ili: i20906
-  members:
-  - molto
-  partOfSpeech: r
-00405159-r:
-  definition:
-  - in a momentous way
-  ili: i20907
-  members:
-  - momentously
   partOfSpeech: r
 00405235-r:
   definition:
@@ -27095,15 +14240,6 @@
   members:
   - moodily
   partOfSpeech: r
-00405577-r:
-  definition:
-  - in a morbid manner or to a morbid degree
-  example:
-  - he was morbidly fascinated by dead bodies
-  ili: i20910
-  members:
-  - morbidly
-  partOfSpeech: r
 00405717-r:
   definition:
   - in a morose manner
@@ -27112,26 +14248,6 @@
   ili: i20911
   members:
   - morosely
-  partOfSpeech: r
-00405821-r:
-  definition:
-  - in a morphological manner; with regard to morphology
-  example:
-  - these two plants are morphologically related
-  ili: i20912
-  members:
-  - morphologically
-  partOfSpeech: r
-00405983-r:
-  definition:
-  - in such a manner that death ensues (also in reference to hatred, jealousy, fear,
-    etc.)
-  example:
-  - a being of whom the forest Indians are said to be mortally afraid, with a hoof
-    shaped like the heel of a bottle
-  ili: i20913
-  members:
-  - mortally
   partOfSpeech: r
 00406221-r:
   definition:
@@ -27169,16 +14285,6 @@
   ili: i20917
   members:
   - mundanely
-  partOfSpeech: r
-00406789-r:
-  definition:
-  - in a worldly manner
-  example:
-  - terrestrially changeable
-  ili: i20918
-  members:
-  - mundanely
-  - terrestrially
   partOfSpeech: r
 00406926-r:
   definition:
@@ -27236,27 +14342,6 @@
   - mutually
   - reciprocally
   partOfSpeech: r
-00407778-r:
-  definition:
-  - (often followed by ‘for’) in exchange or in reciprocation
-  example:
-  - gave up our seats on the plane and in return received several hundred dollars
-    and seats on the next plane out
-  - we get many benefits in return for our taxes
-  ili: i20925
-  members:
-  - in return
-  - reciprocally
-  partOfSpeech: r
-00408067-r:
-  definition:
-  - in a naive manner
-  example:
-  - he believed, naively, that she would leave him her money
-  ili: i20926
-  members:
-  - naively
-  partOfSpeech: r
 00408198-r:
   definition:
   - without clothing
@@ -27276,26 +14361,6 @@
   members:
   - nakedly
   partOfSpeech: r
-00408548-r:
-  definition:
-  - in a narrow-minded manner
-  example:
-  - narrow-mindedly, the authorities closed down the cafe where teenagers used to
-    hang out
-  ili: i20929
-  members:
-  - narrow-mindedly
-  - small-mindedly
-  partOfSpeech: r
-00408778-r:
-  definition:
-  - in a broad-minded manner
-  example:
-  - the authorities broad-mindedly permitted the opening of a center for teenagers
-  ili: i20930
-  members:
-  - broad-mindedly
-  partOfSpeech: r
 00408963-r:
   definition:
   - in a nasty ill-tempered manner
@@ -27305,19 +14370,6 @@
   members:
   - nastily
   - meanly
-  partOfSpeech: r
-00409125-r:
-  definition:
-  - extending throughout an entire nation
-  example:
-  - nationally advertised
-  - it was broadcast nationwide
-  ili: i20932
-  members:
-  - nationally
-  - nationwide
-  - across the nation
-  - across the country
   partOfSpeech: r
 00409329-r:
   definition:
@@ -27336,71 +14388,6 @@
   ili: i20934
   members:
   - jauntily
-  partOfSpeech: r
-00409589-r:
-  definition:
-  - not this merely but also; not only so but
-  example:
-  - each of us is peculiar, nay, in a sense unique
-  ili: i20935
-  members:
-  - nay
-  partOfSpeech: r
-00409712-r:
-  definition:
-  - (comparative of ‘near’ or ‘close’) within a shorter distance
-  example:
-  - come closer, my dear!
-  - they drew nearer
-  - getting nearer to the true explanation
-  exemplifies:
-  - 06333686-n
-  ili: i20936
-  members:
-  - nearer
-  - nigher
-  - closer
-  partOfSpeech: r
-00409931-r:
-  definition:
-  - (superlative of ‘near’ or ‘close’) within the shortest distance
-  example:
-  - that was the time he came nearest to death
-  exemplifies:
-  - 06706615-n
-  ili: i20937
-  members:
-  - nearest
-  - nighest
-  - closest
-  partOfSpeech: r
-00410115-r:
-  definition:
-  - in an essential manner
-  example:
-  - such expenses are necessarily incurred
-  ili: i20938
-  members:
-  - necessarily
-  - needfully
-  partOfSpeech: r
-00410285-r:
-  definition:
-  - as a highly likely consequence
-  example:
-  - we are necessarily bound for federalism in Europe
-  ili: i20939
-  members:
-  - necessarily
-  partOfSpeech: r
-00410408-r:
-  definition:
-  - in an unnecessary manner
-  example:
-  - they were unnecessarily rude
-  ili: i20940
-  members:
-  - unnecessarily
   partOfSpeech: r
 00410542-r:
   definition:
@@ -27466,66 +14453,6 @@
   members:
   - nervously
   partOfSpeech: r
-00411507-r:
-  definition:
-  - at no time hereafter
-  example:
-  - source: E.A. Poe
-    text: Quoth the raven, nevermore!
-  ili: i20948
-  members:
-  - nevermore
-  - never again
-  partOfSpeech: r
-00411619-r:
-  definition:
-  - near in time or place or relationship
-  example:
-  - as the wedding day drew near
-  - stood near the door
-  - don't shoot until they come near
-  - getting near to the true explanation
-  - her mother is always near
-  - The end draws nigh
-  - the bullet didn't come close
-  - don't get too close to the fire
-  ili: i20949
-  members:
-  - near
-  - nigh
-  - close
-  partOfSpeech: r
-00411953-r:
-  definition:
-  - very close
-  example:
-  - without my reading glasses I can hardly see things close up
-  - even firing at close range he missed
-  ili: i20950
-  members:
-  - close up
-  - at close range
-  partOfSpeech: r
-00412120-r:
-  definition:
-  - at the end of each day
-  example:
-  - she checks on her roses nightly
-  ili: i20951
-  members:
-  - nightly
-  - every night
-  partOfSpeech: r
-00412227-r:
-  definition:
-  - by a factor of nine
-  example:
-  - my investment has increased ninefold
-  ili: i20952
-  members:
-  - ninefold
-  - nine times
-  partOfSpeech: r
 00412336-r:
   definition:
   - in a noble manner
@@ -27534,24 +14461,6 @@
   ili: i20953
   members:
   - nobly
-  partOfSpeech: r
-00412430-r:
-  definition:
-  - in no manner; in no way
-  example:
-  - We could nohow make out his handwriting
-  ili: i20954
-  members:
-  - nohow
-  partOfSpeech: r
-00412530-r:
-  definition:
-  - without stopping
-  example:
-  - we are flying nonstop from New York to Tokyo
-  ili: i20955
-  members:
-  - nonstop
   partOfSpeech: r
 00412630-r:
   definition:
@@ -27563,36 +14472,6 @@
   members:
   - nostalgically
   partOfSpeech: r
-00412791-r:
-  definition:
-  - to a notorious degree
-  example:
-  - European emigres, who notoriously used to repair to the British Museum to write
-    seditious pamphlets
-  ili: i20957
-  members:
-  - notoriously
-  partOfSpeech: r
-00412955-r:
-  definition:
-  - with regard to nutrition
-  example:
-  - nutritionally, her new diet is suicide
-  ili: i20958
-  members:
-  - nutritionally
-  partOfSpeech: r
-00413081-r:
-  definition:
-  - in number; with regard to numbers
-  example:
-  - in ten years' time the Oxbridge mathematicians, scientists, and engineers will
-    not be much more significant numerically than the Oxbridge medical schools are
-    now
-  ili: i20959
-  members:
-  - numerically
-  partOfSpeech: r
 00413337-r:
   definition:
   - in a numb manner; without feeling
@@ -27603,50 +14482,6 @@
   - numbly
   - insensibly
   partOfSpeech: r
-00413480-r:
-  definition:
-  - in no manner
-  example:
-  - they are nowise different
-  ili: i20961
-  members:
-  - nowise
-  - to no degree
-  partOfSpeech: r
-00413571-r:
-  definition:
-  - to, toward, or in the northeast
-  ili: i20962
-  members:
-  - northeast
-  - north-east
-  - nor'-east
-  partOfSpeech: r
-00413665-r:
-  definition:
-  - to, toward, or in the northwest
-  ili: i20963
-  members:
-  - northwest
-  - north-west
-  - nor'-west
-  partOfSpeech: r
-00413759-r:
-  definition:
-  - to, toward, or in the north-northeast
-  ili: i20964
-  members:
-  - north-northeast
-  - nor'-nor'-east
-  partOfSpeech: r
-00413857-r:
-  definition:
-  - to, toward, or in the north-northwest
-  ili: i20965
-  members:
-  - north-northwest
-  - nor'-nor'-west
-  partOfSpeech: r
 00413955-r:
   definition:
   - with objectivity
@@ -27655,24 +14490,6 @@
   ili: i20966
   members:
   - objectively
-  partOfSpeech: r
-00414088-r:
-  definition:
-  - in a subjective way
-  example:
-  - you cannot look at these facts subjectively
-  ili: i20967
-  members:
-  - subjectively
-  partOfSpeech: r
-00414231-r:
-  definition:
-  - to an obscene degree
-  example:
-  - this man is obscenely rich
-  ili: i20968
-  members:
-  - obscenely
   partOfSpeech: r
 00414319-r:
   definition:
@@ -27740,20 +14557,6 @@
   - obstructively
   - hinderingly
   partOfSpeech: r
-00415483-r:
-  definition:
-  - illegally in advance of the ball or puck
-  ili: i20976
-  members:
-  - offside
-  partOfSpeech: r
-00415559-r:
-  definition:
-  - in an onerous manner
-  ili: i20977
-  members:
-  - onerously
-  partOfSpeech: r
 00415635-r:
   definition:
   - in an opaque manner
@@ -27763,40 +14566,12 @@
   members:
   - opaquely
   partOfSpeech: r
-00415752-r:
-  definition:
-  - in respect to operation
-  example:
-  - reported the machine operationally satisfactory
-  - a well-trained staff that is operationally adequate
-  ili: i20979
-  members:
-  - operationally
-  partOfSpeech: r
-00415941-r:
-  definition:
-  - in a heavy and oppressive way
-  example:
-  - it was oppressively hot in the office
-  ili: i20980
-  members:
-  - oppressively
-  partOfSpeech: r
 00416070-r:
   definition:
   - in an optimal and most desirable way
   ili: i20981
   members:
   - optimally
-  partOfSpeech: r
-00416162-r:
-  definition:
-  - with optimism; in an optimistic manner
-  example:
-  - ‘We have a good chance of winning,’ he exclaimed optimistically
-  ili: i20982
-  members:
-  - optimistically
   partOfSpeech: r
 00416346-r:
   definition:
@@ -27834,15 +14609,6 @@
   members:
   - sumptuously
   - opulently
-  partOfSpeech: r
-00416968-r:
-  definition:
-  - with regard to organization
-  example:
-  - organizationally, the conference was a disaster!
-  ili: i20987
-  members:
-  - organizationally
   partOfSpeech: r
 00417110-r:
   definition:
@@ -27886,45 +14652,6 @@
   members:
   - overbearingly
   partOfSpeech: r
-00417776-r:
-  definition:
-  - on or to the other side of a page
-  example:
-  - data tabulated overleaf
-  ili: i20993
-  members:
-  - overleaf
-  partOfSpeech: r
-00417873-r:
-  definition:
-  - more than necessary
-  example:
-  - she eats too much
-  - let's not blame them overmuch
-  ili: i20994
-  members:
-  - overmuch
-  - too much
-  partOfSpeech: r
-00417994-r:
-  definition:
-  - beyond or across the sea
-  example:
-  - He lived overseas for many years
-  ili: i20995
-  members:
-  - oversea
-  - overseas
-  partOfSpeech: r
-00418101-r:
-  definition:
-  - over the side of a boat
-  example:
-  - Willie eased himself overside into the sea
-  ili: i20996
-  members:
-  - overside
-  partOfSpeech: r
 00418207-r:
   definition:
   - in an owlish manner
@@ -27960,15 +14687,6 @@
   members:
   - palatably
   partOfSpeech: r
-00418765-r:
-  definition:
-  - in an unpalatable way
-  example:
-  - The vegetables looked unpalatably wilted
-  ili: i21001
-  members:
-  - unpalatably
-  partOfSpeech: r
 00418906-r:
   definition:
   - in a pale manner; without physical or emotional color
@@ -27977,17 +14695,6 @@
   ili: i21002
   members:
   - palely
-  partOfSpeech: r
-00419049-r:
-  definition:
-  - in a manner lacking interest or vitality
-  example:
-  - a palely entertaining show
-  ili: i21003
-  members:
-  - pallidly
-  - palely
-  - dimly
   partOfSpeech: r
 00419209-r:
   definition:
@@ -28023,16 +14730,6 @@
   members:
   - parochially
   partOfSpeech: r
-00419697-r:
-  definition:
-  - so as to pass a given point
-  example:
-  - every hour a train goes past
-  ili: i21008
-  members:
-  - by
-  - past
-  partOfSpeech: r
 00419794-r:
   definition:
   - in spots
@@ -28049,16 +14746,6 @@
   members:
   - paternally
   partOfSpeech: r
-00419987-r:
-  definition:
-  - arousing scornful pity
-  example:
-  - they had pathetically little money
-  - it was pathetically bad
-  ili: i21011
-  members:
-  - pathetically
-  partOfSpeech: r
 00420133-r:
   definition:
   - in a manner arousing sympathy and compassion
@@ -28068,24 +14755,6 @@
   members:
   - pathetically
   - pitiably
-  partOfSpeech: r
-00420302-r:
-  definition:
-  - in a patriotic manner
-  example:
-  - patriotically, he buys only U.S.-made products
-  ili: i21013
-  members:
-  - patriotically
-  partOfSpeech: r
-00420451-r:
-  definition:
-  - in an unpatriotic manner
-  example:
-  - unpatriotically he contrived a way of avoiding military service
-  ili: i21014
-  members:
-  - unpatriotically
   partOfSpeech: r
 00420622-r:
   definition:
@@ -28097,24 +14766,6 @@
   members:
   - peaceably
   - pacifically
-  partOfSpeech: r
-00420895-r:
-  definition:
-  - in a pedantic manner
-  example:
-  - these interpretations are called ‘schemas’ or, more pedantically, ‘schemata’
-  ili: i21016
-  members:
-  - pedantically
-  partOfSpeech: r
-00421054-r:
-  definition:
-  - in a peevish manner
-  ili: i21017
-  members:
-  - peevishly
-  - querulously
-  - fractiously
   partOfSpeech: r
 00421193-r:
   definition:
@@ -28160,27 +14811,6 @@
   members:
   - perceptively
   partOfSpeech: r
-00421786-r:
-  definition:
-  - with regard to perception
-  example:
-  - this task is perceptually very difficult
-  ili: i21023
-  members:
-  - perceptually
-  partOfSpeech: r
-00421914-r:
-  definition:
-  - through chance
-  example:
-  - To sleep, perchance to dream …
-  exemplifies:
-  - 07087487-n
-  ili: i21024
-  members:
-  - perchance
-  - by chance
-  partOfSpeech: r
 00422032-r:
   definition:
   - in a perfidious manner
@@ -28198,15 +14828,6 @@
   ili: i21026
   members:
   - perkily
-  partOfSpeech: r
-00422293-r:
-  definition:
-  - in a perpendicular manner
-  example:
-  - this red line runs perpendicularly to the green line
-  ili: i21027
-  members:
-  - perpendicularly
   partOfSpeech: r
 00422436-r:
   definition:
@@ -28269,39 +14890,12 @@
   members:
   - pettily
   partOfSpeech: r
-00423382-r:
-  definition:
-  - with regard to pharmacology
-  example:
-  - pharmacologically, this plant could have important applications
-  ili: i21035
-  members:
-  - pharmacologically
-  partOfSpeech: r
-00423540-r:
-  definition:
-  - to a phenomenal degree
-  example:
-  - his reaction was phenomenally quick
-  ili: i21036
-  members:
-  - phenomenally
-  partOfSpeech: r
 00423660-r:
   definition:
   - in a philanthropic manner
   ili: i21037
   members:
   - philanthropically
-  partOfSpeech: r
-00423749-r:
-  definition:
-  - in a philatelic manner
-  example:
-  - the Post Office honors great Americans philatelically
-  ili: i21038
-  members:
-  - philatelically
   partOfSpeech: r
 00423889-r:
   definition:
@@ -28334,28 +14928,6 @@
   - bit by bit
   - in stages
   partOfSpeech: r
-00424346-r:
-  definition:
-  - extremely and sharply
-  example:
-  - it was bitterly cold
-  - bitter cold
-  ili: i21042
-  members:
-  - piercingly
-  - bitterly
-  - bitingly
-  - bitter
-  partOfSpeech: r
-00424530-r:
-  definition:
-  - in a piggish manner
-  example:
-  - piggishly, he took two pieces of cake
-  ili: i21043
-  members:
-  - piggishly
-  partOfSpeech: r
 00424646-r:
   definition:
   - having a pinnate shape
@@ -28364,16 +14936,6 @@
   ili: i21044
   members:
   - pinnately
-  partOfSpeech: r
-00424753-r:
-  definition:
-  - (used of heat) extremely
-  example:
-  - the casserole was piping hot
-  ili: i21045
-  members:
-  - piping
-  - steaming
   partOfSpeech: r
 00424855-r:
   definition:
@@ -28421,16 +14983,6 @@
   members:
   - point-blank
   partOfSpeech: r
-00425509-r:
-  definition:
-  - after death
-  example:
-  - these piano pieces were published posthumously
-  - he was honored posthumously
-  ili: i21051
-  members:
-  - posthumously
-  partOfSpeech: r
 00425660-r:
   definition:
   - extremely fast; as fast as possible
@@ -28452,34 +15004,6 @@
   ili: i21053
   members:
   - rallentando
-  partOfSpeech: r
-00425915-r:
-  definition:
-  - to a recognizable degree
-  example:
-  - he was recognizably slimmer now
-  ili: i21054
-  members:
-  - recognizably
-  partOfSpeech: r
-00426051-r:
-  definition:
-  - beyond recognition; in an unrecognizable manner
-  example:
-  - he had unrecognizably aged
-  ili: i21055
-  members:
-  - unrecognizably
-  - unrecognisable
-  partOfSpeech: r
-00426224-r:
-  definition:
-  - with regret (used in polite formulas)
-  example:
-  - I must regretfully decline your kind invitation
-  ili: i21056
-  members:
-  - regretfully
   partOfSpeech: r
 00426370-r:
   definition:
@@ -28531,15 +15055,6 @@
   - pithily
   - sententiously
   partOfSpeech: r
-00426998-r:
-  definition:
-  - to a pitiful degree
-  example:
-  - wages were pitifully low, particularly the wages of women
-  ili: i21062
-  members:
-  - pitifully
-  partOfSpeech: r
 00427134-r:
   definition:
   - in a placating manner
@@ -28548,17 +15063,6 @@
   ili: i21063
   members:
   - placatingly
-  partOfSpeech: r
-00427241-r:
-  definition:
-  - in a pernicious or annoying manner
-  example:
-  - it's so plaguey cold!
-  ili: i21064
-  members:
-  - plaguey
-  - plaguy
-  - plaguily
   partOfSpeech: r
 00427364-r:
   definition:
@@ -28578,24 +15082,6 @@
   ili: i21066
   members:
   - playfully
-  partOfSpeech: r
-00427673-r:
-  definition:
-  - in a pleasing manner
-  example:
-  - the room was pleasingly large
-  ili: i21067
-  members:
-  - pleasingly
-  partOfSpeech: r
-00427783-r:
-  definition:
-  - in a plenary manner
-  example:
-  - an empire destined to enter the Commonwealth plenarily
-  ili: i21068
-  members:
-  - plenarily
   partOfSpeech: r
 00427916-r:
   definition:
@@ -28639,15 +15125,6 @@
   members:
   - pneumatically
   partOfSpeech: r
-00428539-r:
-  definition:
-  - in a pointless manner
-  example:
-  - he spent his life in pointlessly tiresome drudgery
-  ili: i21073
-  members:
-  - pointlessly
-  partOfSpeech: r
 00428672-r:
   definition:
   - in a very malevolent manner
@@ -28679,15 +15156,6 @@
   example:
   - he moves ponderously
   ili: i21077
-  members:
-  - ponderously
-  partOfSpeech: r
-00429154-r:
-  definition:
-  - in an uninterestingly ponderous manner
-  example:
-  - the play was staged with ponderously realistic sets
-  ili: i21078
   members:
   - ponderously
   partOfSpeech: r
@@ -28735,17 +15203,6 @@
   - post-free
   - post-paid
   partOfSpeech: r
-00429855-r:
-  definition:
-  - in a manner having a powerful influence
-  example:
-  - Clytemnestra's ghost crying in the night for vengeance remained most potently
-    in the audience's mind
-  ili: i21084
-  members:
-  - potently
-  - powerfully
-  partOfSpeech: r
 00430084-r:
   definition:
   - with a pout or in a pouting manner
@@ -28753,31 +15210,12 @@
   members:
   - poutingly
   partOfSpeech: r
-00430156-r:
-  definition:
-  - in a powerful manner
-  example:
-  - the federal government replaced the powerfully pro-settler Sir Godfrey Huggins
-    with the even tougher and more determined ex-trade unionist
-  ili: i21086
-  members:
-  - powerfully
-  - strongly
-  partOfSpeech: r
 00430404-r:
   definition:
   - in a powerless manner
   ili: i21087
   members:
   - powerlessly
-  partOfSpeech: r
-00430483-r:
-  definition:
-  - in a practicable manner; so as to be feasible
-  ili: i21088
-  members:
-  - practicably
-  - feasibly
   partOfSpeech: r
 00430615-r:
   definition:
@@ -28787,27 +15225,6 @@
   ili: i21089
   members:
   - pragmatically
-  partOfSpeech: r
-00430768-r:
-  definition:
-  - to a preeminent degree; with superiority or distinction above others; in a preeminent
-    manner
-  example:
-  - a wide variety of pre-eminently contemporary scenes
-  ili: i21090
-  members:
-  - pre-eminently
-  - preeminently
-  partOfSpeech: r
-00430990-r:
-  definition:
-  - in a precarious manner
-  example:
-  - being a precariously dominant minority is a difficult position for human nature
-    to cope with
-  ili: i21091
-  members:
-  - precariously
   partOfSpeech: r
 00431283-r:
   definition:
@@ -28837,34 +15254,6 @@
   ili: i21095
   members:
   - precociously
-  partOfSpeech: r
-00431708-r:
-  definition:
-  - in a predictable manner or to a predictable degree
-  example:
-  - predictably, he did not like the news
-  ili: i21096
-  members:
-  - predictably
-  partOfSpeech: r
-00431857-r:
-  definition:
-  - too soon; in a premature manner
-  example:
-  - I spoke prematurely
-  ili: i21097
-  members:
-  - prematurely
-  - untimely
-  partOfSpeech: r
-00431998-r:
-  definition:
-  - (of childbirth) before the end of the normal period of gestation
-  example:
-  - the child was born prematurely
-  ili: i21098
-  members:
-  - prematurely
   partOfSpeech: r
 00432154-r:
   definition:
@@ -28900,15 +15289,6 @@
   members:
   - pressingly
   partOfSpeech: r
-00432676-r:
-  definition:
-  - in a presumptuous manner
-  example:
-  - he presumptuously overstepped the doctor's orders
-  ili: i21103
-  members:
-  - presumptuously
-  partOfSpeech: r
 00432814-r:
   definition:
   - in a pretentious manner
@@ -28926,16 +15306,6 @@
   ili: i21105
   members:
   - unpretentiously
-  partOfSpeech: r
-00433131-r:
-  definition:
-  - in a supernatural manner
-  example:
-  - she was preternaturally beautiful
-  ili: i21106
-  members:
-  - preternaturally
-  - supernaturally
   partOfSpeech: r
 00433289-r:
   definition:
@@ -28974,15 +15344,6 @@
   members:
   - primitively
   partOfSpeech: r
-00433834-r:
-  definition:
-  - with reference to the origin or beginning
-  ili: i21111
-  members:
-  - primitively
-  - originally
-  - in the beginning
-  partOfSpeech: r
 00433947-r:
   definition:
   - by the use of probability theory
@@ -28991,13 +15352,6 @@
   ili: i21112
   members:
   - probabilistically
-  partOfSpeech: r
-00434111-r:
-  definition:
-  - in such a way as to pose a problem
-  ili: i21113
-  members:
-  - problematically
   partOfSpeech: r
 00434207-r:
   definition:
@@ -29009,25 +15363,6 @@
   members:
   - warmly
   - warm
-  partOfSpeech: r
-00434339-r:
-  definition:
-  - to a wasteful manner or to a wasteful degree
-  example:
-  - we are still prodigally rich compared to others
-  ili: i21115
-  members:
-  - wastefully
-  - prodigally
-  partOfSpeech: r
-00434522-r:
-  definition:
-  - to a prodigious degree
-  example:
-  - the prices of farms rose prodigiously
-  ili: i21116
-  members:
-  - prodigiously
   partOfSpeech: r
 00434644-r:
   definition:
@@ -29064,15 +15399,6 @@
   - profitlessly
   - unprofitably
   - gainlessly
-  partOfSpeech: r
-00435140-r:
-  definition:
-  - to a prohibitive degree
-  example:
-  - it is prohibitively expensive
-  ili: i21121
-  members:
-  - prohibitively
   partOfSpeech: r
 00435256-r:
   definition:
@@ -29112,30 +15438,12 @@
   members:
   - prosily
   partOfSpeech: r
-00435802-r:
-  definition:
-  - in the manner of something that has become a byword
-  example:
-  - this proverbially bitter plant, wormwood
-  ili: i21126
-  members:
-  - proverbially
-  partOfSpeech: r
 00435956-r:
   definition:
   - in a providential manner; as determined by providence
   example:
   - his providentially destined role
   ili: i21127
-  members:
-  - providentially
-  partOfSpeech: r
-00436106-r:
-  definition:
-  - in a fortunately providential manner
-  example:
-  - providentially the weather remained good
-  ili: i21128
   members:
   - providentially
   partOfSpeech: r
@@ -29174,25 +15482,6 @@
   ili: i21132
   members:
   - pryingly
-  partOfSpeech: r
-00436814-r:
-  definition:
-  - with regard to psychology
-  example:
-  - war that caught them in its toils either psychologically or physically
-  - the event was very damaging to the child psychologically
-  ili: i21133
-  members:
-  - psychologically
-  partOfSpeech: r
-00437035-r:
-  definition:
-  - in terms of psychology
-  example:
-  - classify poetry psychologically
-  ili: i21134
-  members:
-  - psychologically
   partOfSpeech: r
 00437154-r:
   definition:
@@ -29235,13 +15524,6 @@
   ili: i21139
   members:
   - punily
-  partOfSpeech: r
-00437765-r:
-  definition:
-  - in a punishing manner
-  ili: i21140
-  members:
-  - punishingly
   partOfSpeech: r
 00437844-r:
   definition:
@@ -29289,26 +15571,6 @@
   members:
   - quaintly
   partOfSpeech: r
-00438569-r:
-  definition:
-  - in a qualitative manner
-  example:
-  - this discoloration qualitatively suggests that the substance is low in inorganic
-    iron
-  ili: i21146
-  members:
-  - qualitatively
-  partOfSpeech: r
-00438741-r:
-  definition:
-  - in three month intervals
-  example:
-  - interest is compounded quarterly
-  ili: i21147
-  members:
-  - quarterly
-  - every quarter
-  partOfSpeech: r
 00438873-r:
   definition:
   - in diagonally opposed quarters of an escutcheon
@@ -29349,17 +15611,6 @@
   - oddly
   - funnily
   partOfSpeech: r
-00439469-r:
-  definition:
-  - without question
-  example:
-  - Fred Winter is unquestionably the jockey to follow
-  - they hired unimpeachably first-rate faculty members
-  ili: i21152
-  members:
-  - unquestionably
-  - unimpeachably
-  partOfSpeech: r
 00439689-r:
   definition:
   - in a questionable and dubious manner
@@ -29390,16 +15641,6 @@
   - restfully
   - quietly
   partOfSpeech: r
-00440193-r:
-  definition:
-  - in a quixotic manner
-  example:
-  - sent to jail for two years, he has quixotically refused to clear himself by betraying
-    his colleagues
-  ili: i21156
-  members:
-  - quixotically
-  partOfSpeech: r
 00440376-r:
   definition:
   - in a racy manner
@@ -29408,15 +15649,6 @@
   ili: i21157
   members:
   - racily
-  partOfSpeech: r
-00440475-r:
-  definition:
-  - in a radial manner
-  example:
-  - an imaginative dispersal of the pews radially from the central focus of the pulpit
-  ili: i21158
-  members:
-  - radially
   partOfSpeech: r
 00440634-r:
   definition:
@@ -29474,25 +15706,6 @@
   members:
   - rapaciously
   partOfSpeech: r
-00441365-r:
-  definition:
-  - in a raving manner
-  example:
-  - raving mad
-  ili: i21165
-  members:
-  - raving
-  - ravingly
-  partOfSpeech: r
-00441443-r:
-  definition:
-  - in a ravishing manner or to a ravishing degree
-  example:
-  - she was ravishingly beautiful
-  ili: i21166
-  members:
-  - ravishingly
-  partOfSpeech: r
 00441580-r:
   definition:
   - in a reassuring manner
@@ -29525,25 +15738,6 @@
   members:
   - reflectively
   partOfSpeech: r
-00442014-r:
-  definition:
-  - in a pleasantly novel manner
-  example:
-  - she was refreshingly free from shyness
-  ili: i21171
-  members:
-  - refreshingly
-  partOfSpeech: r
-00442143-r:
-  definition:
-  - in a manner that relieves fatigue and restores vitality
-  example:
-  - the air was refreshingly cool
-  ili: i21172
-  members:
-  - refreshingly
-  - refreshfully
-  partOfSpeech: r
 00442305-r:
   definition:
   - in a regal manner
@@ -29569,25 +15763,6 @@
   members:
   - reminiscently
   partOfSpeech: r
-00442638-r:
-  definition:
-  - to a remote degree
-  example:
-  - it is remotely possible
-  ili: i21176
-  members:
-  - remotely
-  partOfSpeech: r
-00442738-r:
-  definition:
-  - in a remote manner
-  example:
-  - when the measured speech of the chorus passes over into song the tones are, remotely
-    but unmistakably, those taught by the orthodox liturgy
-  ili: i21177
-  members:
-  - remotely
-  partOfSpeech: r
 00442936-r:
   definition:
   - in a repellent manner
@@ -29607,40 +15782,12 @@
   members:
   - repetitively
   partOfSpeech: r
-00443214-r:
-  definition:
-  - by repute; according to general belief
-  example:
-  - fish with reputedly poisonous flesh
-  ili: i21180
-  members:
-  - reputedly
-  partOfSpeech: r
-00443329-r:
-  definition:
-  - with resentment; in a resentful manner
-  example:
-  - the best doctors would stay resentfully out of the national service, refusing
-    to become the minions of a Minister
-  ili: i21181
-  members:
-  - resentfully
-  partOfSpeech: r
 00443542-r:
   definition:
   - with reserve; in a reserved manner
   ili: i21182
   members:
   - reservedly
-  partOfSpeech: r
-00443633-r:
-  definition:
-  - with resignation and acceptance; in a resigned manner
-  example:
-  - resignedly, I telegraphed back that it was all right with me if he insisted
-  ili: i21183
-  members:
-  - resignedly
   partOfSpeech: r
 00443804-r:
   definition:
@@ -29673,16 +15820,6 @@
   ili: i21187
   members:
   - respectably
-  partOfSpeech: r
-00444277-r:
-  definition:
-  - to a tolerably worthy extent
-  example:
-  - he did respectably well for his age
-  ili: i21188
-  members:
-  - respectably
-  - creditably
   partOfSpeech: r
 00444433-r:
   definition:
@@ -29727,15 +15864,6 @@
   members:
   - reticently
   partOfSpeech: r
-00444990-r:
-  definition:
-  - in a manner contemplative of past events
-  example:
-  - retrospectively, he seems like a great artist
-  ili: i21194
-  members:
-  - retrospectively
-  partOfSpeech: r
 00445141-r:
   definition:
   - in a vindictive, revengeful manner
@@ -29773,16 +15901,6 @@
   members:
   - rhetorically
   partOfSpeech: r
-00445743-r:
-  definition:
-  - positively
-  example:
-  - source: Charles Dickens
-    text: a regular right-down bad 'un
-  ili: i21199
-  members:
-  - right-down
-  partOfSpeech: r
 00445841-r:
   definition:
   - in a righteous manner
@@ -29810,15 +15928,6 @@
   members:
   - riskily
   partOfSpeech: r
-00446217-r:
-  definition:
-  - extremely (of drunkness)
-  example:
-  - roaring drunk
-  ili: i21203
-  members:
-  - roaring
-  partOfSpeech: r
 00446279-r:
   definition:
   - in a robust manner
@@ -29834,15 +15943,6 @@
   example:
   - he winked at her roguishly
   ili: i21205
-  members:
-  - roguishly
-  partOfSpeech: r
-00446492-r:
-  definition:
-  - like a dishonest rogue
-  example:
-  - he roguishly intended to keep the money
-  ili: i21206
   members:
   - roguishly
   partOfSpeech: r
@@ -29903,15 +16003,6 @@
   members:
   - rowdily
   - raucously
-  partOfSpeech: r
-00447534-r:
-  definition:
-  - in a ruinous manner or to a ruinous degree
-  example:
-  - ruinously high wages
-  ili: i21213
-  members:
-  - ruinously
   partOfSpeech: r
 00447656-r:
   definition:
@@ -29981,24 +16072,6 @@
   members:
   - schematically
   partOfSpeech: r
-00448735-r:
-  definition:
-  - capable of causing burns
-  example:
-  - it was scorching hot
-  ili: i21221
-  members:
-  - scorching
-  partOfSpeech: r
-00448839-r:
-  definition:
-  - funny to the point where screams of laughter are excited
-  example:
-  - screamingly funny
-  ili: i21222
-  members:
-  - screamingly
-  partOfSpeech: r
 00448938-r:
   definition:
   - in a scurrilous manner
@@ -30017,33 +16090,6 @@
   ili: i21224
   members:
   - searchingly
-  partOfSpeech: r
-00449290-r:
-  definition:
-  - depending on the season
-  example:
-  - prices are seasonally adjusted
-  ili: i21225
-  members:
-  - seasonally
-  partOfSpeech: r
-00449404-r:
-  definition:
-  - in the direction of the coast
-  ili: i21226
-  members:
-  - coastward
-  partOfSpeech: r
-00449471-r:
-  definition:
-  - in the direction of the sea
-  example:
-  - the sailor looked seaward
-  ili: i21227
-  members:
-  - seaward
-  - seawards
-  - asea
   partOfSpeech: r
 00449581-r:
   definition:
@@ -30118,22 +16164,6 @@
   members:
   - unselfconsciously
   partOfSpeech: r
-00450666-r:
-  definition:
-  - in a self-evident manner
-  ili: i21236
-  members:
-  - self-evidently
-  partOfSpeech: r
-00450751-r:
-  definition:
-  - in a sensational manner
-  example:
-  - in the summer of 1958 the pianist had a sensationally triumphant return
-  ili: i21237
-  members:
-  - sensationally
-  partOfSpeech: r
 00450909-r:
   definition:
   - in a meaningless and purposeless manner
@@ -30182,15 +16212,6 @@
   members:
   - sentimentally
   partOfSpeech: r
-00451658-r:
-  definition:
-  - in an unsentimental manner
-  example:
-  - unsentimentally, she threw out her dead son's toys
-  ili: i21243
-  members:
-  - unsentimentally
-  partOfSpeech: r
 00451818-r:
   definition:
   - with possibility of separation or individuation
@@ -30217,24 +16238,6 @@
   ili: i21246
   members:
   - serenely
-  partOfSpeech: r
-00452275-r:
-  definition:
-  - seven times
-  example:
-  - the population of this village increased sevenfold in the past 100 years
-  ili: i21247
-  members:
-  - sevenfold
-  partOfSpeech: r
-00452400-r:
-  definition:
-  - in the seventh place
-  example:
-  - seventhly, you have no right to cancel the lease in mid-year
-  ili: i21248
-  members:
-  - seventhly
   partOfSpeech: r
 00452540-r:
   definition:
@@ -30359,25 +16362,6 @@
   members:
   - shiftily
   partOfSpeech: r
-00454221-r:
-  definition:
-  - so as to shock the feelings
-  example:
-  - One day, she lost her temper, completely, suddenly and, even to herself, shockingly
-  - Suddenly, shockingly, the clergyman's son was a desperado.
-  ili: i21263
-  members:
-  - shockingly
-  partOfSpeech: r
-00454436-r:
-  definition:
-  - to a shocking degree
-  example:
-  - teachers were shockingly underpaid
-  ili: i21264
-  members:
-  - shockingly
-  partOfSpeech: r
 00454522-r:
   definition:
   - very badly
@@ -30412,15 +16396,6 @@
   example:
   - She took him up short before he could continue
   ili: i21267
-  members:
-  - short
-  partOfSpeech: r
-00454943-r:
-  definition:
-  - at some point or distance before a goal is reached
-  example:
-  - he fell short of our expectations
-  ili: i21268
   members:
   - short
   partOfSpeech: r
@@ -30484,35 +16459,6 @@
   - sideways
   - obliquely
   partOfSpeech: r
-00455853-r:
-  definition:
-  - with the side toward someone or something
-  example:
-  - source: Nathaniel Hawthorne
-    text: seated sidelong to the window
-  ili: i21275
-  members:
-  - sidelong
-  partOfSpeech: r
-00455985-r:
-  definition:
-  - on the side
-  example:
-  - the plow lay sidelong on the ground
-  ili: i21276
-  members:
-  - sidelong
-  partOfSpeech: r
-00456072-r:
-  definition:
-  - toward one side
-  example:
-  - turn the figure sideward
-  ili: i21277
-  members:
-  - sideward
-  - sidewards
-  partOfSpeech: r
 00456164-r:
   definition:
   - in a lateral direction
@@ -30537,29 +16483,6 @@
   - sideway
   - sideways
   - sidewise
-  partOfSpeech: r
-00456477-r:
-  definition:
-  - with one side forward or to the front
-  example:
-  - turned sideways to show the profile
-  - crabs seeming to walk sidewise
-  ili: i21280
-  members:
-  - sideways
-  - sideway
-  - sidewise
-  partOfSpeech: r
-00456645-r:
-  definition:
-  - in a signal manner
-  example:
-  - signally inappropriate methods
-  ili: i21281
-  members:
-  - signally
-  - unmistakably
-  - remarkably
   partOfSpeech: r
 00456780-r:
   definition:
@@ -30607,37 +16530,6 @@
   members:
   - single-mindedly
   partOfSpeech: r
-00457366-r:
-  definition:
-  - in a singular manner or to a singular degree
-  example:
-  - Lord T. was considered singularly licentious even for the courts of Russia and
-    Portugal; he acquired three wives and fourteen children during his Portuguese
-    embassy alone
-  ili: i21287
-  members:
-  - singularly
-  partOfSpeech: r
-00457641-r:
-  definition:
-  - by a factor of six
-  example:
-  - the population of this town increased sixfold when gold was found in the surrounding
-    hills
-  ili: i21288
-  members:
-  - sixfold
-  - six times
-  partOfSpeech: r
-00457801-r:
-  definition:
-  - in the sixth place
-  example:
-  - sixthly, we cannot afford a vacation
-  ili: i21289
-  members:
-  - sixthly
-  partOfSpeech: r
 00457913-r:
   definition:
   - in a sketchy incomplete manner
@@ -30669,16 +16561,6 @@
   - skimpily
   - scantily
   partOfSpeech: r
-00458383-r:
-  definition:
-  - in a sparse way
-  example:
-  - sparsely inhabited
-  - his beard grew sparsely
-  ili: i21347
-  members:
-  - sparsely
-  partOfSpeech: r
 00458502-r:
   definition:
   - in a skittish manner
@@ -30687,37 +16569,6 @@
   ili: i21293
   members:
   - skittishly
-  partOfSpeech: r
-00458618-r:
-  definition:
-  - to a very high level
-  example:
-  - prices have gone sky-high
-  - garbage was piled sky-high
-  - the men were flung sky-high by the explosion
-  ili: i21294
-  members:
-  - sky-high
-  partOfSpeech: r
-00458782-r:
-  definition:
-  - in a lavish or enthusiastic manner
-  example:
-  - he extolled her virtues sky-high
-  ili: i21295
-  members:
-  - sky-high
-  - enthusiastically
-  partOfSpeech: r
-00458908-r:
-  definition:
-  - (with verb ‘to blow’) destroyed completely; blown apart or to pieces
-  example:
-  - they blew the bridge sky-high
-  - the committee blew the thesis sky-high
-  ili: i21296
-  members:
-  - sky-high
   partOfSpeech: r
 00459088-r:
   definition:
@@ -30762,15 +16613,6 @@
   - slam-bang
   - slap-bang
   partOfSpeech: r
-00459726-r:
-  definition:
-  - with heedless speed
-  example:
-  - yachts ran slap-bang into the convoy at 15 knots an hour
-  ili: i21302
-  members:
-  - slam-bang
-  partOfSpeech: r
 00459843-r:
   definition:
   - in a careless or reckless manner
@@ -30780,15 +16622,6 @@
   members:
   - slapdash
   - slam-bang
-  partOfSpeech: r
-00459960-r:
-  definition:
-  - directly or immediately
-  example:
-  - it hit slap-bang in the middle
-  ili: i21304
-  members:
-  - slap-bang
   partOfSpeech: r
 00460055-r:
   definition:
@@ -30969,15 +16802,6 @@
   members:
   - sobbingly
   partOfSpeech: r
-00462737-r:
-  definition:
-  - in a sociable manner
-  example:
-  - sociably, the new neighbors invited everyone on the block for coffee
-  ili: i21324
-  members:
-  - sociably
-  partOfSpeech: r
 00462902-r:
   definition:
   - in an unsociable manner
@@ -30986,15 +16810,6 @@
   ili: i21325
   members:
   - unsociably
-  partOfSpeech: r
-00463045-r:
-  definition:
-  - with regard to sociology
-  example:
-  - sociologically speaking, this is an interesting phenomenon
-  ili: i21326
-  members:
-  - sociologically
   partOfSpeech: r
 00463192-r:
   definition:
@@ -31033,18 +16848,6 @@
   members:
   - soothingly
   partOfSpeech: r
-00463703-r:
-  definition:
-  - extremely wet
-  example:
-  - dripping wet
-  - soaking wet
-  ili: i21331
-  members:
-  - soaking
-  - sopping
-  - dripping
-  partOfSpeech: r
 00463804-r:
   definition:
   - in a sordid or squalid way
@@ -31052,16 +16855,6 @@
   members:
   - sordidly
   - squalidly
-  partOfSpeech: r
-00463915-r:
-  definition:
-  - to a great extent
-  example:
-  - I missed him sorely
-  - we were sorely taxed to keep up with them
-  ili: i21333
-  members:
-  - sorely
   partOfSpeech: r
 00464053-r:
   definition:
@@ -31086,40 +16879,6 @@
   ili: i21336
   members:
   - sottishly
-  partOfSpeech: r
-00464314-r:
-  definition:
-  - to, toward, or in the southeast
-  ili: i21337
-  members:
-  - southeast
-  - south-east
-  - sou'-east
-  partOfSpeech: r
-00464408-r:
-  definition:
-  - to, toward, or in the southwest
-  ili: i21338
-  members:
-  - southwest
-  - south-west
-  - sou'west
-  partOfSpeech: r
-00464501-r:
-  definition:
-  - to, toward, or in the south southeast
-  ili: i21339
-  members:
-  - south-southeast
-  - sou'-sou'-east
-  partOfSpeech: r
-00464599-r:
-  definition:
-  - to, toward, or in the south southwest
-  ili: i21340
-  members:
-  - south-southwest
-  - sou'-sou'-west
   partOfSpeech: r
 00464697-r:
   definition:
@@ -31149,26 +16908,6 @@
   ili: i21343
   members:
   - sourly
-  partOfSpeech: r
-00465157-r:
-  definition:
-  - from the south
-  example:
-  - a wind blew southerly
-  ili: i21344
-  members:
-  - southerly
-  partOfSpeech: r
-00465252-r:
-  definition:
-  - toward the south
-  example:
-  - the ship turned southerly
-  ili: i21345
-  members:
-  - southerly
-  - southward
-  - southwards
   partOfSpeech: r
 00465378-r:
   definition:
@@ -31232,13 +16971,6 @@
   members:
   - sportingly
   partOfSpeech: r
-00466293-r:
-  definition:
-  - in an unsportsmanlike manner
-  ili: i21355
-  members:
-  - unsportingly
-  partOfSpeech: r
 00466398-r:
   definition:
   - without suspicions
@@ -31247,15 +16979,6 @@
   ili: i21356
   members:
   - unsuspectingly
-  partOfSpeech: r
-00466561-r:
-  definition:
-  - in a spotless manner
-  example:
-  - spotlessly clean
-  ili: i21357
-  members:
-  - spotlessly
   partOfSpeech: r
 00466658-r:
   definition:
@@ -31294,34 +17017,6 @@
   - stagily
   - theatrically
   partOfSpeech: r
-00467231-r:
-  definition:
-  - in a standoffish manner
-  example:
-  - standoffishly, he declined the invitation to the office party
-  ili: i21362
-  members:
-  - standoffishly
-  partOfSpeech: r
-00467379-r:
-  definition:
-  - to the fullest degree
-  example:
-  - stark mad
-  - mouth stark open
-  ili: i21363
-  members:
-  - stark
-  partOfSpeech: r
-00467456-r:
-  definition:
-  - in a blunt manner
-  example:
-  - in starkly realistic terms
-  ili: i21364
-  members:
-  - starkly
-  partOfSpeech: r
 00467557-r:
   definition:
   - in sharp outline or contrast
@@ -31330,33 +17025,6 @@
   ili: i21365
   members:
   - starkly
-  partOfSpeech: r
-00467685-r:
-  definition:
-  - in a stark manner
-  example:
-  - He was starkly unable to achieve coherence
-  ili: i21366
-  members:
-  - starkly
-  partOfSpeech: r
-00467802-r:
-  definition:
-  - in a startling manner
-  example:
-  - a startlingly modern voice
-  ili: i21367
-  members:
-  - startlingly
-  partOfSpeech: r
-00467911-r:
-  definition:
-  - according to statute
-  example:
-  - placed statutorily under the council's supervision
-  ili: i21368
-  members:
-  - statutorily
   partOfSpeech: r
 00468043-r:
   definition:
@@ -31402,16 +17070,6 @@
   members:
   - stickily
   - viscidly
-  partOfSpeech: r
-00468690-r:
-  definition:
-  - to a great degree
-  example:
-  - bored stiff
-  - frightened stiff
-  ili: i21374
-  members:
-  - stiff
   partOfSpeech: r
 00468768-r:
   definition:
@@ -31464,82 +17122,6 @@
   - still
   - stock-still
   partOfSpeech: r
-00469534-r:
-  definition:
-  - in a direct course
-  example:
-  - plunged straightway to the rocks below
-  ili: i21380
-  members:
-  - straightway
-  partOfSpeech: r
-00469634-r:
-  definition:
-  - at once
-  example:
-  - straightway the clouds began to scatter
-  ili: i21381
-  members:
-  - straightway
-  partOfSpeech: r
-00469724-r:
-  definition:
-  - near that place
-  example:
-  - he stayed in London or thereabouts for several weeks
-  ili: i21382
-  members:
-  - thereabout
-  - thereabouts
-  partOfSpeech: r
-00469848-r:
-  definition:
-  - near that time or date
-  example:
-  - come at noon or thereabouts
-  ili: i21383
-  members:
-  - thereabout
-  - thereabouts
-  partOfSpeech: r
-00469954-r:
-  definition:
-  - in the following part of a given matter, as in a document or speech
-  ili: i21384
-  members:
-  - thereinafter
-  partOfSpeech: r
-00470062-r:
-  definition:
-  - of or concerning this or that
-  example:
-  - a problem and the solution thereof
-  ili: i21385
-  members:
-  - thereof
-  partOfSpeech: r
-00470165-r:
-  definition:
-  - on that
-  example:
-  - text and commentary thereon
-  ili: i21386
-  members:
-  - thereon
-  - on it
-  - on that
-  partOfSpeech: r
-00470257-r:
-  definition:
-  - to that
-  example:
-  - with all the appurtenances fitting thereto
-  ili: i21387
-  members:
-  - thereto
-  - to it
-  - to that
-  partOfSpeech: r
 00470364-r:
   definition:
   - with that or this or it
@@ -31549,16 +17131,6 @@
   ili: i21389
   members:
   - therewith
-  partOfSpeech: r
-00470504-r:
-  definition:
-  - together with all that; besides
-  example:
-  - source: Shakespeare
-    text: thy slanders I forgive; and therewithal remit thy other forfeits
-  ili: i21390
-  members:
-  - therewithal
   partOfSpeech: r
 00470656-r:
   definition:
@@ -31586,15 +17158,6 @@
   ili: i21393
   members:
   - stonily
-  partOfSpeech: r
-00470985-r:
-  definition:
-  - with regard to strategy
-  example:
-  - strategically important decisions
-  ili: i21394
-  members:
-  - strategically
   partOfSpeech: r
 00471105-r:
   definition:
@@ -31626,15 +17189,6 @@
   - stuffily
   - stodgily
   partOfSpeech: r
-00471530-r:
-  definition:
-  - to a stupendous degree
-  example:
-  - stupendously ignorant people
-  ili: i21398
-  members:
-  - stupendously
-  partOfSpeech: r
 00471643-r:
   definition:
   - in a sturdy manner
@@ -31653,17 +17207,6 @@
   members:
   - stylishly
   partOfSpeech: r
-00471848-r:
-  also:
-  - 91001531-r
-  definition:
-  - in a rhetorically stylistic manner
-  example:
-  - stylistically complex
-  ili: i21401
-  members:
-  - stylistically
-  partOfSpeech: r
 00471967-r:
   definition:
   - with suavity; in a suave manner
@@ -31681,16 +17224,6 @@
   ili: i21403
   members:
   - sublimely
-  partOfSpeech: r
-00472327-r:
-  definition:
-  - in a subtle manner
-  example:
-  - late nineteenth-century French opera at its most beautiful, subtly romantic with
-    a twilight melancholy
-  ili: i21404
-  members:
-  - subtly
   partOfSpeech: r
 00472504-r:
   definition:
@@ -31728,30 +17261,12 @@
   members:
   - summarily
   partOfSpeech: r
-00473095-r:
-  definition:
-  - in a superfluous manner
-  example:
-  - superfluously, he added his silly comments to the discussion
-  ili: i21409
-  members:
-  - superfluously
-  partOfSpeech: r
 00473242-r:
   definition:
   - to a superlative degree
   ili: i21410
   members:
   - superlatively
-  partOfSpeech: r
-00473325-r:
-  definition:
-  - in a superstitious manner
-  example:
-  - superstitiously he refused to travel on Friday the 13th
-  ili: i21411
-  members:
-  - superstitiously
   partOfSpeech: r
 00473471-r:
   definition:
@@ -31780,19 +17295,6 @@
   members:
   - surreptitiously
   - sneakily
-  partOfSpeech: r
-00473918-r:
-  definition:
-  - to an extraordinary degree
-  example:
-  - she was a surpassingly beautiful woman
-  - source: Walker Percy
-    text: I will mention only one particular aspect of the current mess because …
-      this one is surely something new and passing strange
-  ili: i21415
-  members:
-  - surpassingly
-  - passing
   partOfSpeech: r
 00474199-r:
   definition:
@@ -31874,15 +17376,6 @@
   ili: i21423
   members:
   - tactlessly
-  partOfSpeech: r
-00475679-r:
-  definition:
-  - with regard to tactics
-  example:
-  - the tactically useful province is still firmly in the rebels' hands
-  ili: i21424
-  members:
-  - tactically
   partOfSpeech: r
 00475829-r:
   definition:
@@ -32033,14 +17526,6 @@
   members:
   - tenderly
   partOfSpeech: r
-00478108-r:
-  definition:
-  - (in enumerating something, such as topics or points of discussion) in the tenth
-    place
-  ili: i21441
-  members:
-  - tenthly
-  partOfSpeech: r
 00478247-r:
   definition:
   - in an ill-natured and tetchy manner
@@ -32050,24 +17535,6 @@
   members:
   - tetchily
   partOfSpeech: r
-00478378-r:
-  definition:
-  - in a theological manner
-  example:
-  - he dealt with the problem of evil theologically, not philosophically
-  ili: i21443
-  members:
-  - theologically
-  partOfSpeech: r
-00478533-r:
-  definition:
-  - as regards theology
-  example:
-  - the candidate was found theologically sound
-  ili: i21444
-  members:
-  - theologically
-  partOfSpeech: r
 00478659-r:
   definition:
   - by thermostat; in a thermostatic manner
@@ -32076,35 +17543,6 @@
   ili: i21445
   members:
   - thermostatically
-  partOfSpeech: r
-00478811-r:
-  definition:
-  - by a factor of three
-  example:
-  - our rent increased threefold in the past five years
-  ili: i21446
-  members:
-  - threefold
-  - three times
-  partOfSpeech: r
-00478938-r:
-  definition:
-  - according to tradition; in a traditional manner
-  example:
-  - traditionally, we eat fried foods on Hanukah
-  ili: i21447
-  members:
-  - traditionally
-  partOfSpeech: r
-00479093-r:
-  definition:
-  - in quick succession
-  example:
-  - misfortunes come fast and thick
-  ili: i21448
-  members:
-  - thick
-  - thickly
   partOfSpeech: r
 00479191-r:
   definition:
@@ -32202,33 +17640,6 @@
   members:
   - thriftlessly
   partOfSpeech: r
-00480765-r:
-  definition:
-  - over the whole distance
-  example:
-  - this bus goes through to New York
-  ili: i21459
-  members:
-  - through
-  partOfSpeech: r
-00480861-r:
-  definition:
-  - in diameter
-  example:
-  - this cylinder measures 15 inches through
-  ili: i21460
-  members:
-  - through
-  partOfSpeech: r
-00480952-r:
-  definition:
-  - from beginning to end
-  example:
-  - read this book through
-  ili: i21461
-  members:
-  - through
-  partOfSpeech: r
 00481035-r:
   definition:
   - to completion
@@ -32246,15 +17657,6 @@
   - timorously
   - trepidly
   partOfSpeech: r
-00481239-r:
-  definition:
-  - to the highest extent
-  example:
-  - the shoes fit me tip-top
-  ili: i21464
-  members:
-  - tip-top
-  partOfSpeech: r
 00481324-r:
   definition:
   - on tiptoe or as if on tiptoe
@@ -32264,13 +17666,6 @@
   members:
   - tiptoe
   partOfSpeech: r
-00481406-r:
-  definition:
-  - the next day, the day after, following the present day
-  ili: i21466
-  members:
-  - tomorrow
-  partOfSpeech: r
 00481497-r:
   definition:
   - in a monotone
@@ -32279,16 +17674,6 @@
   ili: i21467
   members:
   - tonelessly
-  partOfSpeech: r
-00481601-r:
-  definition:
-  - with regard to topography
-  example:
-  - the geological environment is the primary factor in determining the character
-    of a country not only topographically but historically
-  ili: i21468
-  members:
-  - topographically
   partOfSpeech: r
 00481824-r:
   definition:
@@ -32331,16 +17716,6 @@
   members:
   - transcendentally
   partOfSpeech: r
-00482326-r:
-  definition:
-  - for a very short time
-  example:
-  - these three pions may actually be joined together transiently as a compound particle
-    during the interchange process
-  ili: i21474
-  members:
-  - transiently
-  partOfSpeech: r
 00482524-r:
   definition:
   - as a transitional step or in a transitional manner
@@ -32348,29 +17723,12 @@
   members:
   - transitionally
   partOfSpeech: r
-00482635-r:
-  definition:
-  - for a very brief time
-  ili: i21476
-  members:
-  - transitorily
-  partOfSpeech: r
 00482715-r:
   definition:
   - so as to allow the passage of light
   example:
   - the red brilliance of the claret shines transparently in our glasses
   ili: i21477
-  members:
-  - transparently
-  partOfSpeech: r
-00482882-r:
-  definition:
-  - so as to be easily understood or seen through
-  example:
-  - his transparently lucid prose
-  - his transparently deceitful behavior
-  ili: i21478
   members:
   - transparently
   partOfSpeech: r
@@ -32419,15 +17777,6 @@
   members:
   - trivially
   partOfSpeech: r
-00483659-r:
-  definition:
-  - in a tropical manner
-  example:
-  - it was tropically hot in the greenhouse
-  ili: i21484
-  members:
-  - tropically
-  partOfSpeech: r
 00483779-r:
   definition:
   - in a defiantly truculent manner
@@ -32474,39 +17823,6 @@
   members:
   - tutorially
   partOfSpeech: r
-00484504-r:
-  definition:
-  - by a factor of two
-  example:
-  - the price increased twofold last year
-  ili: i21490
-  members:
-  - twofold
-  - two times
-  partOfSpeech: r
-00484611-r:
-  definition:
-  - in a typographic way
-  ili: i21491
-  members:
-  - typographically
-  partOfSpeech: r
-00484693-r:
-  definition:
-  - beyond the scope or in excess of legal power or authority
-  ili: i21492
-  members:
-  - ultra vires
-  partOfSpeech: r
-00484790-r:
-  definition:
-  - in an unaccountable manner
-  example:
-  - in the book, a tycoon unaccountably becomes the hero's friend
-  ili: i21493
-  members:
-  - unaccountably
-  partOfSpeech: r
 00484941-r:
   definition:
   - in an unalterable and unchangeable manner
@@ -32519,18 +17835,6 @@
   - unassailably
   - immutably
   partOfSpeech: r
-00485173-r:
-  definition:
-  - in an unarguable and undisputed manner
-  example:
-  - you write as if this fact, whilst inarguably forever condemning me to the ranks
-    of Bohemianism, nevertheless earned for me the right of entry into any company
-  ili: i21495
-  members:
-  - unarguably
-  - undisputedly
-  - inarguably
-  partOfSpeech: r
 00485492-r:
   definition:
   - in an unassuming manner
@@ -32539,16 +17843,6 @@
   ili: i21496
   members:
   - unassumingly
-  partOfSpeech: r
-00485623-r:
-  definition:
-  - in an unattainable manner or to an unattainable degree
-  example:
-  - this house is unattainably expensive
-  ili: i21497
-  members:
-  - unattainably
-  - unachievably
   partOfSpeech: r
 00485809-r:
   definition:
@@ -32571,25 +17865,6 @@
   members:
   - unawares
   partOfSpeech: r
-00486125-r:
-  definition:
-  - to an unbearable degree
-  example:
-  - it was unbearably hot in the room
-  ili: i21500
-  members:
-  - unbearably
-  partOfSpeech: r
-00486260-r:
-  definition:
-  - without someone's knowledge
-  example:
-  - unbeknownst to me, she made all the arrangements
-  ili: i21501
-  members:
-  - unbeknown
-  - unbeknownst
-  partOfSpeech: r
 00486391-r:
   definition:
   - without blushing
@@ -32600,15 +17875,6 @@
   members:
   - unblushingly
   partOfSpeech: r
-00486558-r:
-  definition:
-  - in an uncanny manner
-  example:
-  - uncannily human robots
-  ili: i21503
-  members:
-  - uncannily
-  partOfSpeech: r
 00486660-r:
   definition:
   - showing lack of certainty
@@ -32617,25 +17883,6 @@
   ili: i21504
   members:
   - uncertainly
-  partOfSpeech: r
-00486768-r:
-  definition:
-  - in an unchivalrous and ungallant manner
-  example:
-  - unchivalrously, the husbands who had to provide such innocent indulgences eventually
-    began to count the costs
-  ili: i21505
-  members:
-  - unchivalrously
-  partOfSpeech: r
-00486999-r:
-  definition:
-  - exceptionally
-  example:
-  - a common remedy is uncommonly difficult to find
-  ili: i21506
-  members:
-  - uncommonly
   partOfSpeech: r
 00487120-r:
   definition:
@@ -32688,15 +17935,6 @@
   members:
   - uncontrollably
   partOfSpeech: r
-00487818-r:
-  definition:
-  - in an uncouth manner
-  example:
-  - uncouthly, he told stories that made everybody at the table wince
-  ili: i21513
-  members:
-  - uncouthly
-  partOfSpeech: r
 00487963-r:
   definition:
   - in an unctuous manner
@@ -32705,88 +17943,6 @@
   - unctuously
   - smarmily
   - fulsomely
-  partOfSpeech: r
-00488100-r:
-  definition:
-  - to an undeniable degree or in an undeniable manner
-  example:
-  - she is undeniably the most gifted student in the class
-  ili: i21515
-  members:
-  - undeniably
-  partOfSpeech: r
-00488265-r:
-  definition:
-  - further down
-  example:
-  - see under for further discussion
-  ili: i21516
-  members:
-  - under
-  - below
-  partOfSpeech: r
-00488355-r:
-  definition:
-  - down below
-  example:
-  - get under quickly!
-  ili: i21517
-  members:
-  - under
-  partOfSpeech: r
-00488421-r:
-  definition:
-  - below the horizon
-  example:
-  - the sun went under
-  ili: i21518
-  members:
-  - under
-  partOfSpeech: r
-00488494-r:
-  definition:
-  - below some quantity or limit
-  example:
-  - fifty dollars or under
-  ili: i21519
-  members:
-  - under
-  partOfSpeech: r
-00488582-r:
-  definition:
-  - in or into a state of subordination or subjugation
-  example:
-  - we must keep our disappointment under
-  ili: i21520
-  members:
-  - under
-  partOfSpeech: r
-00488707-r:
-  definition:
-  - down to defeat, death, or ruin
-  example:
-  - their competitors went under
-  ili: i21521
-  members:
-  - under
-  partOfSpeech: r
-00488803-r:
-  definition:
-  - into unconsciousness
-  example:
-  - this will put the patient under
-  ili: i21522
-  members:
-  - under
-  partOfSpeech: r
-00488892-r:
-  definition:
-  - through a range downward
-  example:
-  - children six and under will be admitted free
-  ili: i21523
-  members:
-  - under
   partOfSpeech: r
 00488998-r:
   definition:
@@ -32797,24 +17953,6 @@
   members:
   - underarm
   - underhand
-  partOfSpeech: r
-00489115-r:
-  definition:
-  - beneath the surface of the earth
-  example:
-  - water flowing underground
-  ili: i21525
-  members:
-  - underground
-  partOfSpeech: r
-00489216-r:
-  definition:
-  - in or into hiding or secret operation
-  example:
-  - the organization was driven underground
-  ili: i21526
-  members:
-  - underground
   partOfSpeech: r
 00489336-r:
   definition:
@@ -32829,34 +17967,6 @@
   members:
   - underhandedly
   - underhand
-  partOfSpeech: r
-00489606-r:
-  definition:
-  - under or below an object or a surface; at a lower place or level; directly beneath
-  example:
-  - we could see the original painting underneath
-  - a house with a good foundation underneath
-  ili: i21528
-  members:
-  - underneath
-  partOfSpeech: r
-00489821-r:
-  definition:
-  - on the lower or downward side; on the underside of
-  example:
-  - a chest of drawers all scratched underneath
-  ili: i21529
-  members:
-  - underneath
-  partOfSpeech: r
-00489957-r:
-  definition:
-  - to an undue degree
-  example:
-  - she was unduly pessimistic about her future
-  ili: i21530
-  members:
-  - unduly
   partOfSpeech: r
 00490075-r:
   definition:
@@ -32884,14 +17994,6 @@
   ili: i21533
   members:
   - grammatically
-  partOfSpeech: r
-00490485-r:
-  definition:
-  - to an unimaginable extent
-  ili: i21534
-  members:
-  - unimaginably
-  - unthinkably
   partOfSpeech: r
 00490601-r:
   definition:
@@ -32929,22 +18031,6 @@
   members:
   - precedentedly
   partOfSpeech: r
-00491178-r:
-  definition:
-  - in an unprecedented manner
-  ili: i21539
-  members:
-  - unprecedentedly
-  partOfSpeech: r
-00491284-r:
-  definition:
-  - without reservation
-  example:
-  - I can unreservedly recommend this restaurant!
-  ili: i21540
-  members:
-  - unreservedly
-  partOfSpeech: r
 00491393-r:
   definition:
   - in an unrestrained manner
@@ -32977,15 +18063,6 @@
   members:
   - unswervingly
   partOfSpeech: r
-00491868-r:
-  definition:
-  - in a constant and steadfast manner
-  example:
-  - an unswervingly loyal man
-  ili: i21545
-  members:
-  - unswervingly
-  partOfSpeech: r
 00491990-r:
   definition:
   - in a untrue manner
@@ -32996,68 +18073,12 @@
   members:
   - untruly
   partOfSpeech: r
-00492170-r:
-  definition:
-  - in an unwarrantable manner or to an unwarranted degree
-  example:
-  - in this painting, the relationship of the upper part of the body to the lower
-    is uneasy and the right thigh seems unwarrantably stressed
-  ili: i21547
-  members:
-  - unwarrantably
-  partOfSpeech: r
 00492424-r:
   definition:
   - in an unworthy manner
   ili: i21548
   members:
   - unworthily
-  partOfSpeech: r
-00492502-r:
-  definition:
-  - to or in the interior of a country or region
-  example:
-  - they live upcountry
-  ili: i21549
-  members:
-  - up-country
-  - upcountry
-  partOfSpeech: r
-00492608-r:
-  definition:
-  - upward on a hill or incline
-  example:
-  - this street lay uphill
-  ili: i21550
-  members:
-  - uphill
-  partOfSpeech: r
-00492696-r:
-  definition:
-  - against difficulties
-  example:
-  - she was talking uphill
-  ili: i21551
-  members:
-  - uphill
-  partOfSpeech: r
-00492777-r:
-  definition:
-  - in or into the highest position
-  example:
-  - the blade turned uppermost
-  ili: i21552
-  members:
-  - uppermost
-  partOfSpeech: r
-00492876-r:
-  definition:
-  - in or into the most prominent position, as in the mind
-  example:
-  - say what comes uppermost
-  ili: i21553
-  members:
-  - uppermost
   partOfSpeech: r
 00492996-r:
   definition:
@@ -33165,15 +18186,6 @@
   members:
   - vapidly
   partOfSpeech: r
-00494467-r:
-  definition:
-  - with variation; in a variable manner or to a variable degree
-  example:
-  - it will be variably cloudy
-  ili: i21566
-  members:
-  - variably
-  partOfSpeech: r
 00494612-r:
   definition:
   - in a vehement manner
@@ -33194,19 +18206,6 @@
   - windily
   - long-windedly
   - wordily
-  partOfSpeech: r
-00494943-r:
-  definition:
-  - in truth; certainly
-  example:
-  - I verily think so
-  - source: The Bible, Psalms 37:3
-    text: trust in the Lord … and verily thou shalt be fed
-  exemplifies:
-  - 07087487-n
-  ili: i21569
-  members:
-  - verily
   partOfSpeech: r
 00495098-r:
   definition:
@@ -33261,15 +18260,6 @@
   members:
   - vivaciously
   partOfSpeech: r
-00495806-r:
-  definition:
-  - in a shapely and voluptuous manner
-  example:
-  - a voluptuously curved woman
-  ili: i21576
-  members:
-  - voluptuously
-  partOfSpeech: r
 00495930-r:
   definition:
   - in an eagerly voracious manner
@@ -33301,16 +18291,6 @@
   ili: i21580
   members:
   - waggishly
-  partOfSpeech: r
-00496326-r:
-  definition:
-  - up to the waist
-  example:
-  - the water rose waist-high
-  ili: i21581
-  members:
-  - waist-deep
-  - waist-high
   partOfSpeech: r
 00496422-r:
   definition:
@@ -33355,15 +18335,6 @@
   members:
   - weightily
   partOfSpeech: r
-00496954-r:
-  definition:
-  - to an abnormal extent
-  example:
-  - a whacking good story
-  ili: i21587
-  members:
-  - whacking
-  partOfSpeech: r
 00497025-r:
   definition:
   - with a wheeze
@@ -33383,31 +18354,6 @@
   members:
   - wholeheartedly
   partOfSpeech: r
-00497327-r:
-  definition:
-  - in a wholesome manner
-  example:
-  - the papers we found shed some valuable light on this question, wholesomely contradicting
-    all lies
-  ili: i21590
-  members:
-  - wholesomely
-  partOfSpeech: r
-00497507-r:
-  definition:
-  - from what place, source, or cause
-  ili: i21591
-  members:
-  - whence
-  partOfSpeech: r
-00497575-r:
-  definition:
-  - where in the world; location, singular, elective existential pronoun
-  ili: i21592
-  members:
-  - wherever
-  - wheresoever
-  partOfSpeech: r
 00497722-r:
   definition:
   - to or over a great extent or range; far
@@ -33419,47 +18365,6 @@
   members:
   - wide
   - widely
-  partOfSpeech: r
-00497941-r:
-  definition:
-  - with or by a broad space
-  example:
-  - stand with legs wide apart
-  - ran wide around left end
-  ili: i21596
-  members:
-  - wide
-  partOfSpeech: r
-00498056-r:
-  definition:
-  - far from the intended target
-  example:
-  - the arrow went wide of the mark
-  - a bullet went astray and killed a bystander
-  ili: i21597
-  members:
-  - wide
-  - astray
-  partOfSpeech: r
-00498208-r:
-  definition:
-  - to the fullest extent possible
-  example:
-  - open your eyes wide
-  - with the throttle wide open
-  ili: i21598
-  members:
-  - wide
-  partOfSpeech: r
-00498325-r:
-  definition:
-  - in a willful manner
-  example:
-  - she had willfully deceived me
-  ili: i21599
-  members:
-  - willfully
-  - wilfully
   partOfSpeech: r
 00498462-r:
   definition:
@@ -33505,13 +18410,6 @@
   members:
   - wolfishly
   partOfSpeech: r
-00499077-r:
-  definition:
-  - in a manner to cause worry
-  ili: i21605
-  members:
-  - worryingly
-  partOfSpeech: r
 00499160-r:
   definition:
   - in a worried manner
@@ -33553,16 +18451,6 @@
   ili: i21610
   members:
   - wretchedly
-  partOfSpeech: r
-00499758-r:
-  definition:
-  - not only so, but
-  example:
-  - I therein do rejoice, yea, and will rejoice
-  ili: i21611
-  members:
-  - yea
-  - yeah
   partOfSpeech: r
 00499860-r:
   definition:
@@ -33610,43 +18498,6 @@
   members:
   - a la mode
   partOfSpeech: r
-00500491-r:
-  definition:
-  - in the space between decks, on a ship
-  ili: i21617
-  members:
-  - between decks
-  - '''tween decks'
-  partOfSpeech: r
-00500585-r:
-  definition:
-  - in the interval
-  example:
-  - dancing all the dances with little rest between
-  ili: i21618
-  members:
-  - between
-  - betwixt
-  partOfSpeech: r
-00500697-r:
-  definition:
-  - in the higher atmosphere above the earth
-  example:
-  - weather conditions aloft are fine
-  ili: i21619
-  members:
-  - aloft
-  partOfSpeech: r
-00500808-r:
-  definition:
-  - at or to great height; high up in or into the air
-  example:
-  - eagles were soaring aloft
-  - dust is whirled aloft
-  ili: i21620
-  members:
-  - aloft
-  partOfSpeech: r
 00500945-r:
   definition:
   - in an irreproachable and blameless manner
@@ -33663,24 +18514,6 @@
   ili: i21622
   members:
   - bonnily
-  partOfSpeech: r
-00501202-r:
-  definition:
-  - upward
-  example:
-  - the good news sent her spirits aloft
-  ili: i21623
-  members:
-  - aloft
-  partOfSpeech: r
-00501282-r:
-  definition:
-  - at or on or to the masthead or upper rigging of a ship
-  example:
-  - climbed aloft to unfurl the sail
-  ili: i21624
-  members:
-  - aloft
   partOfSpeech: r
 00501406-r:
   definition:
@@ -33798,22 +18631,6 @@
   members:
   - floridly
   partOfSpeech: r
-00502856-r:
-  definition:
-  - for half the price
-  example:
-  - she bought it half-price during the sale
-  ili: i21639
-  members:
-  - half-price
-  partOfSpeech: r
-00502957-r:
-  definition:
-  - in an imminent manner
-  ili: i21640
-  members:
-  - imminently
-  partOfSpeech: r
 00503035-r:
   definition:
   - in an integral manner
@@ -33842,53 +18659,6 @@
   members:
   - shrewishly
   partOfSpeech: r
-00503338-r:
-  definition:
-  - with regard to fundamentals although not concerning details
-  example:
-  - in principle, we agree
-  ili: i21645
-  members:
-  - in principle
-  - in theory
-  - in essence
-  partOfSpeech: r
-00503489-r:
-  definition:
-  - per person; for each person; of each person
-  example:
-  - we are spending $5,000 per capita annually for education in this district
-  ili: i21646
-  members:
-  - per capita
-  partOfSpeech: r
-00503666-r:
-  definition:
-  - in an identifiably distinctive manner
-  example:
-  - the distinctively conservative district of the county
-  ili: i21647
-  members:
-  - distinctively
-  partOfSpeech: r
-00503820-r:
-  definition:
-  - with respect to philosophy
-  example:
-  - the movement is philosophically indebted to Rousseau
-  ili: i21648
-  members:
-  - philosophically
-  partOfSpeech: r
-00503964-r:
-  definition:
-  - so as to disappear or approach zero
-  example:
-  - errors are vanishingly rare
-  ili: i21649
-  members:
-  - vanishingly
-  partOfSpeech: r
 00504070-r:
   definition:
   - so as to inaugurate
@@ -33897,18 +18667,6 @@
   ili: i21650
   members:
   - inaugurally
-  partOfSpeech: r
-00504204-r:
-  definition:
-  - to or toward the inside of
-  example:
-  - come in
-  - smash in the door
-  ili: i21651
-  members:
-  - in
-  - inwards
-  - inward
   partOfSpeech: r
 00504312-r:
   definition:
@@ -33919,15 +18677,6 @@
   members:
   - unquestioningly
   partOfSpeech: r
-00504442-r:
-  definition:
-  - up to that time
-  example:
-  - they had not done any work theretofore
-  ili: i21653
-  members:
-  - theretofore
-  partOfSpeech: r
 00504539-r:
   definition:
   - in a demanding manner
@@ -33936,16 +18685,6 @@
   ili: i21655
   members:
   - demandingly
-  partOfSpeech: r
-00504667-r:
-  definition:
-  - in a manner designed for heavy duty
-  example:
-  - a heavily constructed car
-  - heavily armed
-  ili: i21656
-  members:
-  - heavily
   partOfSpeech: r
 00504802-r:
   definition:
@@ -34056,24 +18795,6 @@
   members:
   - softly
   partOfSpeech: r
-00506499-r:
-  definition:
-  - near or close by
-  example:
-  - he passed immediately behind her
-  ili: i21666
-  members:
-  - immediately
-  partOfSpeech: r
-00506609-r:
-  definition:
-  - bearing an immediate relation
-  example:
-  - this immediately concerns your future
-  ili: i21667
-  members:
-  - immediately
-  partOfSpeech: r
 00506737-r:
   definition:
   - without anyone or anything intervening
@@ -34094,16 +18815,6 @@
   members:
   - second hand
   partOfSpeech: r
-00507076-r:
-  definition:
-  - referring to a quantity
-  example:
-  - the amount was paid in full
-  ili: i21670
-  members:
-  - in full
-  - fully
-  partOfSpeech: r
 00507174-r:
   definition:
   - in an impressively expansive manner
@@ -34122,16 +18833,6 @@
   members:
   - homogeneously
   partOfSpeech: r
-00507466-r:
-  definition:
-  - flying through the air
-  example:
-  - we saw the ducks in flight
-  ili: i21673
-  members:
-  - in flight
-  - on the wing
-  partOfSpeech: r
 00507682-r:
   definition:
   - in an attentive manner
@@ -34142,40 +18843,6 @@
   - close
   - closely
   - tight
-  partOfSpeech: r
-00507808-r:
-  definition:
-  - through inherent nature
-  example:
-  - he was naturally lazy
-  ili: i21676
-  members:
-  - naturally
-  - by nature
-  partOfSpeech: r
-00507906-r:
-  definition:
-  - with reason or justice
-  ili: i21677
-  members:
-  - by rights
-  partOfSpeech: r
-00507966-r:
-  definition:
-  - toward the posterior end of the body
-  ili: i21678
-  members:
-  - caudally
-  - caudal
-  partOfSpeech: r
-00508084-r:
-  definition:
-  - in a causal fashion
-  example:
-  - causally efficacious powers
-  ili: i21679
-  members:
-  - causally
   partOfSpeech: r
 00508189-r:
   definition:
@@ -34231,15 +18898,6 @@
   members:
   - redly
   partOfSpeech: r
-00508875-r:
-  definition:
-  - so as to leave much space or distance between
-  example:
-  - widely separated
-  ili: i21685
-  members:
-  - widely
-  partOfSpeech: r
 00508975-r:
   definition:
   - in an insignificant manner
@@ -34248,15 +18906,6 @@
   ili: i21686
   members:
   - insignificantly
-  partOfSpeech: r
-00509110-r:
-  definition:
-  - with fatal consequences or implications
-  example:
-  - he was fatally ill equipped for the climb
-  ili: i21687
-  members:
-  - fatally
   partOfSpeech: r
 00509248-r:
   definition:
@@ -34275,25 +18924,6 @@
   ili: i21689
   members:
   - desperately
-  partOfSpeech: r
-00509461-r:
-  definition:
-  - before another in time, space, or importance
-  example:
-  - I was here first
-  - let's do this job first
-  ili: i21690
-  members:
-  - first
-  partOfSpeech: r
-00509586-r:
-  definition:
-  - in an outstanding manner or to an outstanding degree
-  example:
-  - she was outstandingly successful in her profession
-  ili: i21691
-  members:
-  - outstandingly
   partOfSpeech: r
 00509752-r:
   definition:
@@ -34332,24 +18962,6 @@
   members:
   - mellowingly
   partOfSpeech: r
-00510249-r:
-  definition:
-  - on the day preceding today
-  example:
-  - yesterday the weather was beautiful
-  ili: i21696
-  members:
-  - yesterday
-  partOfSpeech: r
-00510352-r:
-  definition:
-  - in the recent past; only a short time ago
-  example:
-  - I was not born yesterday!
-  ili: i21697
-  members:
-  - yesterday
-  partOfSpeech: r
 00510460-r:
   definition:
   - in each other's company
@@ -34359,33 +18971,6 @@
   ili: i21698
   members:
   - together
-  partOfSpeech: r
-00510603-r:
-  definition:
-  - behind or in the rear
-  example:
-  - and Jill came tumbling after
-  ili: i21699
-  members:
-  - after
-  partOfSpeech: r
-00510690-r:
-  definition:
-  - comparative of the adverb ‘late’
-  example:
-  - he stayed later than you did
-  ili: i21700
-  members:
-  - later
-  partOfSpeech: r
-00510788-r:
-  definition:
-  - used with question words to convey surprise
-  example:
-  - what on earth are you doing?
-  ili: i21701
-  members:
-  - on earth
   partOfSpeech: r
 00510900-r:
   definition:
@@ -34450,16 +19035,6 @@
   members:
   - quaveringly
   partOfSpeech: r
-00511820-r:
-  definition:
-  - from one place or situation to another
-  example:
-  - we were driven from pillar to post
-  ili: i21709
-  members:
-  - from pillar to post
-  - hither and thither
-  partOfSpeech: r
 00511965-r:
   definition:
   - in a straight line; in a direct course
@@ -34489,45 +19064,6 @@
   members:
   - painlessly
   partOfSpeech: r
-00512379-r:
-  definition:
-  - from a position of superiority or authority
-  example:
-  - father knows best
-  - I know better.
-  ili: i21713
-  members:
-  - better
-  - best
-  partOfSpeech: r
-00512503-r:
-  definition:
-  - in a statistically significant way
-  example:
-  - the two groups differed significantly
-  ili: i21714
-  members:
-  - significantly
-  partOfSpeech: r
-00512638-r:
-  definition:
-  - no longer visible
-  example:
-  - the ship disappeared behind the horizon and passed out of sight
-  ili: i21715
-  members:
-  - out of sight
-  - out of view
-  partOfSpeech: r
-00512777-r:
-  definition:
-  - in a setting where one is or feels inappropriate or incongruous
-  example:
-  - he felt out of place in the lingerie shop
-  ili: i21716
-  members:
-  - out of place
-  partOfSpeech: r
 00512926-r:
   definition:
   - like a baby
@@ -34547,38 +19083,6 @@
   members:
   - soughingly
   partOfSpeech: r
-00513162-r:
-  definition:
-  - happening at the same time
-  ili: i21719
-  members:
-  - coincidentally
-  - coincidently
-  partOfSpeech: r
-00513282-r:
-  definition:
-  - precisely so
-  example:
-  - on the very next page
-  - he expected the very opposite
-  ili: i21720
-  members:
-  - very
-  partOfSpeech: r
-00513385-r:
-  definition:
-  - in a manner dependent on context
-  ili: i21721
-  members:
-  - contextually
-  partOfSpeech: r
-00513476-r:
-  definition:
-  - dependent on a department
-  ili: i21722
-  members:
-  - departmentally
-  partOfSpeech: r
 00513562-r:
   definition:
   - in a polygonal manner
@@ -34592,13 +19096,6 @@
   ili: i21724
   members:
   - regimentally
-  partOfSpeech: r
-00513738-r:
-  definition:
-  - used as a residence
-  ili: i21725
-  members:
-  - residentially
   partOfSpeech: r
 00513817-r:
   definition:
@@ -34649,56 +19146,6 @@
   members:
   - nebulously
   partOfSpeech: r
-00514450-r:
-  definition:
-  - in a northeastward direction
-  example:
-  - the river flows northeastward to the gulf
-  ili: i21732
-  members:
-  - northeastward
-  - northeastwardly
-  partOfSpeech: r
-00514619-r:
-  definition:
-  - in a northwestward direction
-  ili: i21733
-  members:
-  - northwestward
-  - northwestwardly
-  partOfSpeech: r
-00514743-r:
-  definition:
-  - in a southeastward direction
-  example:
-  - the river flows southeastward to the gulf
-  ili: i21734
-  members:
-  - southeastward
-  - southeastwardly
-  partOfSpeech: r
-00514912-r:
-  definition:
-  - in a southwestward direction
-  ili: i21735
-  members:
-  - southwestward
-  - southwestwardly
-  partOfSpeech: r
-00515036-r:
-  definition:
-  - in an abaxial manner
-  ili: i21736
-  members:
-  - abaxially
-  partOfSpeech: r
-00515130-r:
-  definition:
-  - in an adaxial manner
-  ili: i21737
-  members:
-  - adaxially
-  partOfSpeech: r
 00515224-r:
   definition:
   - as an adjective; in an adjectival manner
@@ -34712,24 +19159,6 @@
   ili: i21739
   members:
   - affirmatively
-  partOfSpeech: r
-00515407-r:
-  definition:
-  - in a canonical manner
-  example:
-  - the deacon was canonically inducted
-  ili: i21740
-  members:
-  - canonically
-  partOfSpeech: r
-00515525-r:
-  definition:
-  - with regard to cognition
-  example:
-  - cognitively skillful
-  ili: i21741
-  members:
-  - cognitively
   partOfSpeech: r
 00515631-r:
   definition:
@@ -34796,43 +19225,12 @@
   members:
   - hypnotically
   partOfSpeech: r
-00516364-r:
-  definition:
-  - from the point of view of immunology
-  ili: i21751
-  members:
-  - immunologically
-  partOfSpeech: r
-00516462-r:
-  definition:
-  - in an artificial environment outside the living organism
-  example:
-  - an egg fertilized in vitro
-  ili: i21752
-  members:
-  - in vitro
-  - ex vivo
-  partOfSpeech: r
-00516613-r:
-  definition:
-  - in an irreparable manner or to an irreparable degree
-  ili: i21753
-  members:
-  - irreparably
-  partOfSpeech: r
 00516723-r:
   definition:
   - in an irritating manner
   ili: i21754
   members:
   - irritatingly
-  partOfSpeech: r
-00516805-r:
-  definition:
-  - as ordered by a court
-  ili: i21755
-  members:
-  - judicially
   partOfSpeech: r
 00516883-r:
   definition:
@@ -34842,15 +19240,6 @@
   ili: i21756
   members:
   - logogrammatically
-  partOfSpeech: r
-00517008-r:
-  definition:
-  - within range of a movie or television camera
-  example:
-  - the senator didn't realize that he was speaking on camera
-  ili: i21757
-  members:
-  - on camera
   partOfSpeech: r
 00517151-r:
   definition:
@@ -34875,13 +19264,6 @@
   members:
   - radioactively
   partOfSpeech: r
-00517422-r:
-  definition:
-  - in a recurrent manner
-  ili: i21761
-  members:
-  - recurrently
-  partOfSpeech: r
 00517501-r:
   definition:
   - in a sidearm manner
@@ -34904,14 +19286,6 @@
   ili: i21764
   members:
   - sinusoidally
-  partOfSpeech: r
-00517761-r:
-  definition:
-  - towards outer space
-  ili: i21765
-  members:
-  - spaceward
-  - spacewards
   partOfSpeech: r
 00517831-r:
   definition:
@@ -34947,13 +19321,6 @@
   members:
   - synergistically
   partOfSpeech: r
-00518336-r:
-  definition:
-  - (of group) in a synergistic or cooperative manner
-  ili: i21770
-  members:
-  - synergistically
-  partOfSpeech: r
 00518447-r:
   definition:
   - in a synonymous manner
@@ -34963,44 +19330,12 @@
   members:
   - synonymously
   partOfSpeech: r
-00518567-r:
-  definition:
-  - with regard to taxonomy
-  example:
-  - closely related taxonomically
-  ili: i21772
-  members:
-  - taxonomically
-  partOfSpeech: r
-00518683-r:
-  definition:
-  - from the point of view of topology
-  ili: i21773
-  members:
-  - topologically
-  partOfSpeech: r
 00518777-r:
   definition:
   - in an ulterior manner
   ili: i21774
   members:
   - ulteriorly
-  partOfSpeech: r
-00518855-r:
-  definition:
-  - in a vexatious manner
-  ili: i21775
-  members:
-  - vexatiously
-  partOfSpeech: r
-00518934-r:
-  definition:
-  - extremely thin
-  example:
-  - it was cut wafer-thin
-  ili: i21776
-  members:
-  - wafer-thin
   partOfSpeech: r
 00519025-r:
   definition:
@@ -35021,21 +19356,9 @@
   members:
   - hollowly
   partOfSpeech: r
-00519421-r:
-  definition:
-  - in an incorrigible manner
-  members:
-  - incorrigibly
-  partOfSpeech: r
 00519523-r:
   definition:
   - in the manner of an animal with rabies
-  members:
-  - rabidly
-  partOfSpeech: r
-00519615-r:
-  definition:
-  - in an extreme or fanatical manner
   members:
   - rabidly
   partOfSpeech: r
@@ -35045,35 +19368,11 @@
   members:
   - insufferably
   partOfSpeech: r
-00519841-r:
-  definition:
-  - to an insufferable degree
-  example:
-  - it was insufferably hot in the room
-  members:
-  - insufferably
-  - unsufferably
-  partOfSpeech: r
 00520033-r:
   definition:
   - in a voluminous manner
   members:
   - voluminously
-  partOfSpeech: r
-81276284-r:
-  definition:
-  - through a computer or a computer network
-  example:
-  - source: UD_English-GUM Corpus
-    text: People were encouraged to submit their designs online at www.flag.govt.nz
-      and suggest what the flag should mean on www.standfor.co.nz.
-  - source: UD_English-GUM Corpus
-    text: Images of the boy wearing a NASA T-shirt and handcuffed by the police were
-      quickly posted and reposted online.
-  - source: UD_English-GUM Corpus
-    text: They should be available at your local home improvement store or online.
-  members:
-  - online
   partOfSpeech: r
 81484980-r:
   definition:
@@ -35094,28 +19393,3 @@
   - dead
   - short
   partOfSpeech: r
-90003183-r:
-  definition:
-  - reacting to a stupid but cute action
-  members:
-  - derp
-  partOfSpeech: r
-  source: Colloquial WordNet
-91000331-r:
-  also:
-  - 00193186-r
-  definition:
-  - In other words, as a result
-  members:
-  - so yeah
-  partOfSpeech: r
-  source: Colloquial WordNet
-91001531-r:
-  also:
-  - 00471848-r
-  definition:
-  - regarding the tone
-  members:
-  - tonally
-  partOfSpeech: r
-  source: Colloquial WordNet

--- a/src/yaml/adv.spaker_oriented.yaml
+++ b/src/yaml/adv.spaker_oriented.yaml
@@ -1,0 +1,9 @@
+91000331-r:
+  also:
+  - 00193186-r
+  definition:
+  - In other words, as a result
+  members:
+  - so yeah
+  partOfSpeech: r
+  source: Colloquial WordNet

--- a/src/yaml/adv.spatial.yaml
+++ b/src/yaml/adv.spatial.yaml
@@ -1,0 +1,3457 @@
+00025699-r:
+  definition:
+  - at or in or to any place
+  example:
+  - you can find this food anywhere
+  exemplifies:
+  - 07089193-n
+  ili: i18288
+  members:
+  - anywhere
+  - anyplace
+  partOfSpeech: r
+00025873-r:
+  definition:
+  - not anywhere; in or at or to no place
+  example:
+  - I am going nowhere
+  ili: i18289
+  members:
+  - nowhere
+  partOfSpeech: r
+00025968-r:
+  definition:
+  - in or at or to some place
+  example:
+  - she must be somewhere
+  exemplifies:
+  - 07089193-n
+  ili: i18290
+  members:
+  - somewhere
+  - someplace
+  partOfSpeech: r
+00026137-r:
+  definition:
+  - 'to or in any or all places; pronoun, location; quantifier: universal'
+  example:
+  - You find fast food stores everywhere
+  - people everywhere are becoming aware of the problem
+  - he carried a gun everywhere he went
+  - looked all over for a suitable gift
+  exemplifies:
+  - 07089193-n
+  ili: i18291
+  members:
+  - everywhere
+  - everyplace
+  - all over
+  partOfSpeech: r
+00026470-r:
+  definition:
+  - everywhere
+  example:
+  - searched high and low
+  ili: i18292
+  members:
+  - high and low
+  partOfSpeech: r
+00030035-r:
+  definition:
+  - to or at a greater distance in time or space (‘farther’ is used more frequently
+    than ‘further’ in this physical sense)
+  example:
+  - farther north
+  - moved farther away
+  - farther down the corridor
+  - the practice may go back still farther to the Druids
+  - went only three miles further
+  - further in the future
+  ili: i18310
+  members:
+  - farther
+  - further
+  partOfSpeech: r
+00033624-r:
+  definition:
+  - under the terms of this agreement
+  ili: i18329
+  members:
+  - hereunder
+  partOfSpeech: r
+00034695-r:
+  definition:
+  - at a short distance
+  example:
+  - the hem fell shortly below her knees
+  ili: i18338
+  members:
+  - shortly
+  partOfSpeech: r
+00038270-r:
+  definition:
+  - in a difficult or vulnerable position
+  example:
+  - he resigned and left me in the lurch
+  exemplifies:
+  - 07169038-n
+  ili: i18360
+  members:
+  - in the lurch
+  partOfSpeech: r
+00038782-r:
+  definition:
+  - in the uterus
+  example:
+  - the child was infected in utero from the mother
+  ili: i18363
+  members:
+  - in utero
+  partOfSpeech: r
+00038883-r:
+  definition:
+  - in a vacuum
+  ili: i18364
+  members:
+  - in vacuo
+  partOfSpeech: r
+00041294-r:
+  definition:
+  - so as not to obstruct or hinder
+  example:
+  - put that box out of the way so that no one trips on it
+  ili: i18377
+  members:
+  - out of the way
+  partOfSpeech: r
+00041426-r:
+  definition:
+  - murdered
+  example:
+  - the mob boss wanted his rival out of the way
+  ili: i18378
+  members:
+  - out of the way
+  partOfSpeech: r
+00041525-r:
+  definition:
+  - in a remote location or at a distance from the usual route
+  ili: i18379
+  members:
+  - out of the way
+  partOfSpeech: r
+00041626-r:
+  definition:
+  - improper; amiss
+  ili: i18380
+  members:
+  - out of the way
+  partOfSpeech: r
+00041802-r:
+  definition:
+  - not along the usual route
+  example:
+  - in order to experience something different, you need to go off the beaten path
+  members:
+  - off the beaten track
+  - off the beaten path
+  partOfSpeech: r
+00043931-r:
+  definition:
+  - from this place
+  example:
+  - get thee hence!
+  exemplifies:
+  - 07087487-n
+  ili: i18393
+  members:
+  - hence
+  partOfSpeech: r
+00044018-r:
+  definition:
+  - from that place or from there
+  example:
+  - proceeded thence directly to college
+  - flew to Helsinki and thence to Moscow
+  - roads that lead therefrom
+  ili: i18394
+  members:
+  - thence
+  - therefrom
+  partOfSpeech: r
+00044204-r:
+  definition:
+  - from that circumstance or source
+  example:
+  - source: W.V.Quine
+    text: atomic formulas and all compounds thence constructible
+  - a natural conclusion follows thence
+  - public interest and a policy deriving therefrom
+  - typhus fever results therefrom
+  ili: i18395
+  members:
+  - thence
+  - therefrom
+  - thereof
+  partOfSpeech: r
+00045286-r:
+  definition:
+  - directly facing each other
+  example:
+  - the two photographs lay face-to-face on the table
+  - lived all their lives in houses face-to-face across the street
+  - they sat opposite at the table
+  ili: i18401
+  members:
+  - face-to-face
+  - face to face
+  - opposite
+  partOfSpeech: r
+00045532-r:
+  definition:
+  - face-to-face with; literally ‘face to face’
+  example:
+  - they sat vis-a-vis at the table
+  - I found myself vis-a-vis a burly policeman
+  ili: i18402
+  members:
+  - vis-a-vis
+  partOfSpeech: r
+00046144-r:
+  definition:
+  - farther along in space or time or degree
+  example:
+  - through the valley and beyond
+  - to the eighth grade but not beyond
+  - will be influential in the 1990s and beyond
+  ili: i18406
+  members:
+  - beyond
+  partOfSpeech: r
+00046337-r:
+  definition:
+  - on the farther side from the observer
+  example:
+  - a pond with a hayfield beyond
+  ili: i18407
+  members:
+  - beyond
+  partOfSpeech: r
+00052386-r:
+  definition:
+  - without deviation
+  example:
+  - the path leads directly to the lake
+  - went direct to the office
+  ili: i18442
+  members:
+  - directly
+  - straight
+  - direct
+  partOfSpeech: r
+00052690-r:
+  definition:
+  - directly or exactly; straight
+  example:
+  - went due North
+  ili: i18444
+  members:
+  - due
+  partOfSpeech: r
+00067181-r:
+  definition:
+  - at or in the front
+  example:
+  - I see the lights of a town ahead
+  - the road ahead is foggy
+  - staring straight ahead
+  - we couldn't see over the heads of the people in front
+  - with the cross of Jesus marching on before
+  ili: i18544
+  members:
+  - ahead
+  - in front
+  - before
+  partOfSpeech: r
+00067665-r:
+  definition:
+  - in a forward direction
+  example:
+  - go ahead
+  - the train moved ahead slowly
+  - the boat lurched ahead
+  - moved onward into the forest
+  - they went slowly forward in the mud
+  ili: i18546
+  members:
+  - ahead
+  - onward
+  - onwards
+  - forward
+  - forwards
+  - forrader
+  partOfSpeech: r
+00067913-r:
+  definition:
+  - leading or ahead in a competition
+  example:
+  - the horse was three lengths ahead going into the home stretch
+  - ahead by two pawns
+  - our candidate is in the lead in the polls
+  - way out front in the race
+  - the advertising campaign put them out front in sales
+  ili: i18547
+  members:
+  - ahead
+  - out front
+  - in the lead
+  partOfSpeech: r
+00068470-r:
+  definition:
+  - to a more advanced or advantageous position
+  example:
+  - a young man sure to get ahead
+  - pushing talented students ahead
+  ili: i18549
+  members:
+  - ahead
+  partOfSpeech: r
+00068768-r:
+  definition:
+  - with a forward motion
+  example:
+  - we drove along admiring the view
+  - the horse trotted along at a steady pace
+  - the circus traveled on to the next city
+  - move along
+  - march on
+  ili: i18551
+  members:
+  - along
+  - 'on'
+  partOfSpeech: r
+00069564-r:
+  definition:
+  - in line with a length or direction (often followed by ‘by’ or ‘beside’)
+  example:
+  - pass the word along
+  - ran along beside me
+  - cottages along by the river
+  ili: i18555
+  members:
+  - along
+  partOfSpeech: r
+00069872-r:
+  definition:
+  - in a state required for something to function or be effective
+  example:
+  - turn the lights on
+  - get a load on
+  ili: i18557
+  members:
+  - 'on'
+  partOfSpeech: r
+00071450-r:
+  definition:
+  - in circumference
+  example:
+  - the trunk is ten feet around
+  - the pond is two miles around
+  ili: i18566
+  members:
+  - around
+  partOfSpeech: r
+00071565-r:
+  definition:
+  - in the area or vicinity
+  example:
+  - a few spectators standing about
+  - hanging around
+  - waited around for the next flight
+  ili: i18567
+  members:
+  - about
+  - around
+  partOfSpeech: r
+00071721-r:
+  definition:
+  - not far away in relative terms
+  example:
+  - she works nearby
+  - the planets orbiting nearby are Venus and Mars
+  ili: i18568
+  members:
+  - nearby
+  partOfSpeech: r
+00072001-r:
+  definition:
+  - by a circular or circuitous route
+  example:
+  - He came all the way around the base
+  - the road goes around the pond
+  ili: i18570
+  members:
+  - around
+  partOfSpeech: r
+00072240-r:
+  definition:
+  - all around or on all sides
+  example:
+  - dirty clothes lying around (or about)
+  - let's look about for help
+  - There were trees growing all around
+  - she looked around her
+  ili: i18572
+  members:
+  - about
+  - around
+  partOfSpeech: r
+00072443-r:
+  definition:
+  - to a particular destination either specified or understood
+  example:
+  - she came around to see me
+  - I invited them around for supper
+  ili: i18573
+  members:
+  - around
+  partOfSpeech: r
+00072601-r:
+  definition:
+  - in or to a reversed position or direction
+  example:
+  - about face
+  - suddenly she turned around
+  ili: i18574
+  members:
+  - about
+  - around
+  partOfSpeech: r
+00072729-r:
+  definition:
+  - used of movement to or among many different places or in no particular direction
+  example:
+  - wandering about with no place to go
+  - people were rushing about
+  - news gets around (or about)
+  - traveled around in Asia
+  - he needs advice from someone who's been around
+  - she sleeps around
+  ili: i18575
+  members:
+  - about
+  - around
+  partOfSpeech: r
+00073049-r:
+  definition:
+  - in or to various places; first this place and then that; location pronoun
+  example:
+  - he worked here and there but never for long in one town
+  - we drove here and there in the darkness
+  ili: i18576
+  members:
+  - here and there
+  partOfSpeech: r
+00074673-r:
+  definition:
+  - at or to or toward the back or rear
+  example:
+  - he moved back
+  - tripped when he stepped backward
+  - she looked rearward out the window of the car
+  ili: i18585
+  members:
+  - back
+  - backward
+  - backwards
+  - rearward
+  - rearwards
+  partOfSpeech: r
+00074907-r:
+  definition:
+  - at or to or toward the front; forward
+  example:
+  - he faced forward
+  - step forward
+  - she practiced sewing backward as well as frontward on her new sewing machine
+  exemplifies:
+  - 07170369-n
+  ili: i18586
+  members:
+  - forward
+  - forwards
+  - frontward
+  - frontwards
+  - forrad
+  - forrard
+  partOfSpeech: r
+00075230-r:
+  definition:
+  - in repayment or retaliation
+  example:
+  - we paid back everything we had borrowed
+  - he hit me and I hit him back
+  - I was kept in after school for talking back to the teacher
+  ili: i18587
+  members:
+  - back
+  partOfSpeech: r
+00075427-r:
+  definition:
+  - in or to or toward a former location
+  example:
+  - she went back to her parents' house
+  ili: i18588
+  members:
+  - back
+  partOfSpeech: r
+00075535-r:
+  definition:
+  - in or to or toward an original condition
+  example:
+  - he went back to sleep
+  ili: i18589
+  members:
+  - back
+  partOfSpeech: r
+00076005-r:
+  definition:
+  - having the wind against the forward side of the sails
+  example:
+  - the ship came up into the wind with all yards aback
+  ili: i18593
+  members:
+  - aback
+  partOfSpeech: r
+00076147-r:
+  definition:
+  - at right angles to the length of a ship or airplane
+  ili: i18594
+  members:
+  - abeam
+  partOfSpeech: r
+00076778-r:
+  definition:
+  - moving backward and forward along a given course
+  example:
+  - he walked up and down the locker room
+  - all up and down the Eastern seaboard
+  ili: i18597
+  members:
+  - up and down
+  partOfSpeech: r
+00077086-r:
+  definition:
+  - with respect to an axis
+  example:
+  - the jet was directed axially toward the cathode
+  ili: i18599
+  members:
+  - axially
+  partOfSpeech: r
+00080132-r:
+  definition:
+  - (in writing) at a later place
+  example:
+  - see below
+  - vide infra
+  ili: i19938
+  members:
+  - below
+  - infra
+  partOfSpeech: r
+00080266-r:
+  definition:
+  - (in writing) at an earlier place
+  example:
+  - see above
+  ili: i18622
+  members:
+  - above
+  - supra
+  partOfSpeech: r
+00080389-r:
+  definition:
+  - in or to a place that is lower
+  ili: i18623
+  members:
+  - below
+  - at a lower place
+  - to a lower place
+  - beneath
+  partOfSpeech: r
+00080519-r:
+  definition:
+  - in or to a place that is higher
+  ili: i18624
+  members:
+  - above
+  - higher up
+  - in a higher place
+  - to a higher place
+  partOfSpeech: r
+00082658-r:
+  definition:
+  - at or in an indicated (usually distant) place (‘yon’ is archaic and dialectal)
+  example:
+  - the house yonder
+  - source: Calder Willingham
+    text: scattered here and yon
+  ili: i18638
+  members:
+  - yonder
+  - yon
+  partOfSpeech: r
+00083430-r:
+  definition:
+  - in a dorsal location or direction
+  ili: i18645
+  members:
+  - dorsally
+  partOfSpeech: r
+00083653-r:
+  definition:
+  - in a ventral location or direction
+  ili: i18647
+  members:
+  - ventrally
+  partOfSpeech: r
+00085352-r:
+  definition:
+  - in or to another place
+  example:
+  - he went elsewhere
+  - look elsewhere for the answer
+  ili: i18658
+  members:
+  - elsewhere
+  partOfSpeech: r
+00087937-r:
+  definition:
+  - in the same plane
+  example:
+  - set it flush with the top of the table
+  ili: i18677
+  members:
+  - flush
+  partOfSpeech: r
+00092809-r:
+  definition:
+  - very near or close in space or time
+  example:
+  - it stands hard by the railroad tracks
+  - they were hard on his heels
+  - a strike followed hard upon the plant's opening
+  ili: i18712
+  members:
+  - hard
+  partOfSpeech: r
+00094168-r:
+  definition:
+  - with respect to the cortex
+  example:
+  - cortically induced arousal
+  ili: i18721
+  members:
+  - cortically
+  partOfSpeech: r
+00094281-r:
+  definition:
+  - in a focal manner
+  example:
+  - the submucosa was focally infiltrated
+  ili: i18722
+  members:
+  - focally
+  partOfSpeech: r
+00094530-r:
+  definition:
+  - into the skin
+  ili: i18724
+  members:
+  - intradermally
+  partOfSpeech: r
+00094603-r:
+  definition:
+  - in an intramuscular way
+  example:
+  - administer the drug intramuscularly
+  ili: i18725
+  members:
+  - intramuscularly
+  partOfSpeech: r
+00094946-r:
+  definition:
+  - on a floor below
+  example:
+  - the tenants live downstairs
+  ili: i18727
+  members:
+  - downstairs
+  - down the stairs
+  - on a lower floor
+  - below
+  partOfSpeech: r
+00095095-r:
+  definition:
+  - on a floor above
+  example:
+  - they lived upstairs
+  ili: i18728
+  members:
+  - upstairs
+  - up the stairs
+  - on a higher floor
+  partOfSpeech: r
+00095225-r:
+  definition:
+  - with respect to the mind
+  example:
+  - she's a bit weak upstairs
+  ili: i18729
+  members:
+  - upstairs
+  partOfSpeech: r
+00095315-r:
+  definition:
+  - with the wind; in the direction the wind is blowing
+  example:
+  - they flew downwind
+  ili: i18730
+  members:
+  - downwind
+  partOfSpeech: r
+00095443-r:
+  definition:
+  - in the direction opposite to the direction the wind is blowing
+  example:
+  - they flew upwind
+  ili: i18731
+  members:
+  - upwind
+  - against the wind
+  - into the wind
+  partOfSpeech: r
+00095613-r:
+  definition:
+  - toward the wind
+  example:
+  - they were sailing windward
+  ili: i18732
+  members:
+  - windward
+  - downwind
+  partOfSpeech: r
+00095742-r:
+  definition:
+  - away from the wind
+  example:
+  - they were sailing leeward
+  ili: i18733
+  members:
+  - leeward
+  - upwind
+  partOfSpeech: r
+00095870-r:
+  definition:
+  - spatially or metaphorically from a higher to a lower level or position
+  example:
+  - don't fall down
+  - rode the lift up and skied down
+  - prices plunged downward
+  ili: i18734
+  members:
+  - down
+  - downwards
+  - downward
+  - downwardly
+  partOfSpeech: r
+00096162-r:
+  definition:
+  - away from a more central or a more northerly place
+  example:
+  - was sent down to work at the regional office
+  - worked down on the farm
+  - came down for the wedding
+  - flew down to Florida
+  ili: i18735
+  members:
+  - down
+  partOfSpeech: r
+00096391-r:
+  definition:
+  - paid in cash at time of purchase
+  example:
+  - put ten dollars down on the necklace
+  ili: i18736
+  members:
+  - down
+  partOfSpeech: r
+00096496-r:
+  definition:
+  - in an inactive or inoperative state
+  example:
+  - the factory went down during the strike
+  - the computer went down again
+  ili: i18737
+  members:
+  - down
+  partOfSpeech: r
+00096782-r:
+  definition:
+  - from an earlier time
+  example:
+  - the story was passed down from father to son
+  ili: i18739
+  members:
+  - down
+  partOfSpeech: r
+00096883-r:
+  definition:
+  - spatially or metaphorically from a lower to a higher position
+  example:
+  - look up!
+  - the music surged up
+  - the fragments flew upwards
+  - prices soared upwards
+  - upwardly mobile
+  ili: i18740
+  members:
+  - up
+  - upwards
+  - upward
+  - upwardly
+  partOfSpeech: r
+00097310-r:
+  definition:
+  - to a more central or a more northerly place
+  example:
+  - was transferred up to headquarters
+  - up to Canada for a vacation
+  ili: i18742
+  members:
+  - up
+  partOfSpeech: r
+00097471-r:
+  definition:
+  - nearer to the speaker
+  example:
+  - he walked up and grabbed my lapels
+  ili: i18743
+  members:
+  - up
+  partOfSpeech: r
+00097658-r:
+  definition:
+  - toward the source or against the current
+  ili: i18745
+  members:
+  - upriver
+  - upstream
+  partOfSpeech: r
+00097781-r:
+  definition:
+  - away from the source or with the current
+  ili: i18746
+  members:
+  - downriver
+  - downstream
+  partOfSpeech: r
+00097908-r:
+  definition:
+  - in the direction of the defending team's end of the playing field
+  domain_topic:
+  - 00524569-n
+  example:
+  - he caught the ball and ran downfield 15 yards
+  ili: i18747
+  members:
+  - downfield
+  partOfSpeech: r
+00098390-r:
+  definition:
+  - at or to or in the direction of one's home or family
+  example:
+  - He stays home on weekends
+  - after the game the children brought friends home for supper
+  - I'll be home tomorrow
+  - came riding home in style
+  - I hope you will come home for Christmas
+  - I'll take her home
+  - don't forget to write home
+  ili: i18751
+  members:
+  - home
+  partOfSpeech: r
+00098716-r:
+  definition:
+  - at, to, or toward the place where you reside
+  example:
+  - he worked at home
+  ili: i18752
+  members:
+  - at home
+  partOfSpeech: r
+00098817-r:
+  definition:
+  - on the home team's field
+  domain_topic:
+  - 00524569-n
+  example:
+  - they played at home last night
+  ili: i18753
+  members:
+  - at home
+  partOfSpeech: r
+00098930-r:
+  definition:
+  - to the fullest extent; to the heart
+  example:
+  - drove the nail home
+  - drove his point home
+  - his comments hit home
+  ili: i18754
+  members:
+  - home
+  partOfSpeech: r
+00099070-r:
+  definition:
+  - on or to the point aimed at
+  example:
+  - the arrow struck home
+  ili: i18755
+  members:
+  - home
+  partOfSpeech: r
+00099155-r:
+  definition:
+  - toward home
+  example:
+  - fought his way homeward through the deep snow
+  ili: i18756
+  members:
+  - homeward
+  - homewards
+  partOfSpeech: r
+00101433-r:
+  definition:
+  - (old-fashioned) at or from or to a great distance; far
+  example:
+  - we traveled afar
+  - we could see the ship afar off
+  - the Magi came from afar
+  ili: i18770
+  members:
+  - afar
+  partOfSpeech: r
+00101601-r:
+  definition:
+  - at or to or from a great distance in space
+  example:
+  - he traveled far
+  - strayed far from home
+  - sat far away from each other
+  ili: i18771
+  members:
+  - far
+  partOfSpeech: r
+00102579-r:
+  definition:
+  - over great areas or distances; everywhere
+  example:
+  - he traveled far and wide
+  - the news spread far and wide
+  - people came from far and near
+  - searched for the child far and near
+  ili: i18777
+  members:
+  - far and wide
+  - far and near
+  partOfSpeech: r
+00104448-r:
+  definition:
+  - out into view
+  example:
+  - came forth from the crowd
+  - put my ideas forth
+  ili: i18791
+  members:
+  - forth
+  partOfSpeech: r
+00104690-r:
+  definition:
+  - to or in a foreign country
+  example:
+  - they had never travelled abroad
+  ili: i18793
+  members:
+  - abroad
+  partOfSpeech: r
+00109134-r:
+  definition:
+  - in this general vicinity
+  example:
+  - the people are friendly hereabouts
+  ili: i18822
+  members:
+  - hereabout
+  - hereabouts
+  partOfSpeech: r
+00109247-r:
+  definition:
+  - in or at this place; where the speaker or writer is
+  example:
+  - I work here
+  - turn here
+  - radio waves received here on Earth
+  ili: i18823
+  members:
+  - here
+  partOfSpeech: r
+00109415-r:
+  definition:
+  - to this place (especially toward the speaker)
+  example:
+  - come here, please
+  ili: i18824
+  members:
+  - here
+  - hither
+  partOfSpeech: r
+00109541-r:
+  definition:
+  - in this circumstance or respect or on this point or detail
+  example:
+  - what do we have here?
+  - here I must disagree
+  ili: i18825
+  members:
+  - here
+  partOfSpeech: r
+00109681-r:
+  definition:
+  - in this place or thing or document
+  example:
+  - I shall discuss the question herein
+  ili: i18826
+  members:
+  - herein
+  partOfSpeech: r
+00109789-r:
+  definition:
+  - at this time; now
+  example:
+  - we'll adjourn here for lunch and discuss the remaining issues this afternoon
+  ili: i18827
+  members:
+  - here
+  partOfSpeech: r
+00109919-r:
+  definition:
+  - in or at that place or location
+  example:
+  - they have lived there for years
+  - it's not there
+  - that man there
+  ili: i18828
+  members:
+  - there
+  partOfSpeech: r
+00110073-r:
+  definition:
+  - to or toward that place; away from the speaker
+  example:
+  - go there around noon!
+  ili: i18829
+  members:
+  - there
+  - thither
+  partOfSpeech: r
+00111276-r:
+  definition:
+  - within a building
+  example:
+  - in winter we play inside
+  ili: i18838
+  members:
+  - inside
+  - indoors
+  partOfSpeech: r
+00111402-r:
+  definition:
+  - outside a building
+  example:
+  - in summer we play outside
+  ili: i18839
+  members:
+  - outside
+  - outdoors
+  - out of doors
+  - alfresco
+  partOfSpeech: r
+00111558-r:
+  definition:
+  - on the inside
+  example:
+  - inside, the car is a mess
+  ili: i18840
+  members:
+  - inside
+  - within
+  partOfSpeech: r
+00111662-r:
+  definition:
+  - on the outside
+  example:
+  - outside, the box is black
+  ili: i18841
+  members:
+  - outside
+  partOfSpeech: r
+00113022-r:
+  definition:
+  - worldwide
+  example:
+  - She is internationally known
+  - this is globally significant
+  ili: i18976
+  members:
+  - internationally
+  - globally
+  partOfSpeech: r
+00115657-r:
+  definition:
+  - in or near or toward a center or according to a central role or function
+  example:
+  - The theater is centrally located
+  ili: i18868
+  members:
+  - centrally
+  partOfSpeech: r
+00128418-r:
+  definition:
+  - to a land environment
+  example:
+  - terrestrially adapted
+  ili: i18964
+  members:
+  - terrestrially
+  partOfSpeech: r
+00131326-r:
+  definition:
+  - with regard to space
+  example:
+  - spatially limited
+  ili: i18991
+  members:
+  - spatially
+  partOfSpeech: r
+00134031-r:
+  definition:
+  - in the viscera
+  example:
+  - he is bleeding viscerally
+  ili: i19014
+  members:
+  - viscerally
+  partOfSpeech: r
+00134131-r:
+  definition:
+  - in the brain
+  example:
+  - bleeding cerebrally
+  ili: i19015
+  members:
+  - cerebrally
+  partOfSpeech: r
+00136124-r:
+  definition:
+  - by a particular locality
+  example:
+  - it was locally decided
+  ili: i19033
+  members:
+  - locally
+  partOfSpeech: r
+00136228-r:
+  definition:
+  - to a restricted area of the body
+  example:
+  - apply this medicine topically
+  ili: i19034
+  members:
+  - locally
+  - topically
+  partOfSpeech: r
+00136377-r:
+  definition:
+  - in a regional manner
+  example:
+  - regionally governed
+  ili: i19035
+  members:
+  - regionally
+  partOfSpeech: r
+00136477-r:
+  definition:
+  - with regard to a nation taken as a whole
+  example:
+  - a nationally uniform culture
+  ili: i19036
+  members:
+  - nationally
+  partOfSpeech: r
+00136898-r:
+  definition:
+  - below the skin
+  example:
+  - inject subcutaneously
+  ili: i19040
+  members:
+  - subcutaneously
+  partOfSpeech: r
+00137187-r:
+  definition:
+  - in the spine
+  example:
+  - spinally administered
+  ili: i19043
+  members:
+  - spinally
+  partOfSpeech: r
+00139983-r:
+  definition:
+  - towards the shore from the water
+  example:
+  - we invited them ashore
+  ili: i19064
+  members:
+  - ashore
+  partOfSpeech: r
+00141083-r:
+  definition:
+  - away from shore; away from land
+  example:
+  - cruising three miles offshore
+  ili: i19070
+  members:
+  - offshore
+  partOfSpeech: r
+00141202-r:
+  definition:
+  - on or toward the land
+  example:
+  - they were living onshore
+  ili: i19071
+  members:
+  - onshore
+  partOfSpeech: r
+00144584-r:
+  definition:
+  - in a rural manner
+  ili: i19101
+  members:
+  - rurally
+  partOfSpeech: r
+00149387-r:
+  definition:
+  - under control
+  example:
+  - the riots were in hand
+  ili: i19136
+  members:
+  - in hand
+  partOfSpeech: r
+00151409-r:
+  definition:
+  - an interjection expressing agreement; Yes, you are indeed correct
+  ili: i19147
+  members:
+  - right
+  - right on
+  partOfSpeech: r
+00151882-r:
+  definition:
+  - while absent; although absent
+  example:
+  - he was sentenced in absentia
+  ili: i19151
+  members:
+  - in absentia
+  partOfSpeech: r
+00152713-r:
+  definition:
+  - in an advantageous position
+  example:
+  - she's ahead of the game
+  ili: i19158
+  members:
+  - ahead of the game
+  partOfSpeech: r
+00154056-r:
+  definition:
+  - by the shortest and most direct route
+  example:
+  - it's 10 miles as the crow flies
+  ili: i19170
+  members:
+  - as the crow flies
+  partOfSpeech: r
+00158237-r:
+  definition:
+  - exactly ahead or in front
+  example:
+  - the laboratory is dead ahead
+  ili: i19202
+  members:
+  - dead ahead
+  partOfSpeech: r
+00160030-r:
+  definition:
+  - to be won or lost; at risk
+  example:
+  - perhaps a million dollars are at stake
+  ili: i19214
+  members:
+  - at stake
+  partOfSpeech: r
+00160135-r:
+  definition:
+  - in question or at issue
+  example:
+  - there is more at stake than your modesty
+  ili: i19215
+  members:
+  - at stake
+  partOfSpeech: r
+00163131-r:
+  definition:
+  - in a manner accessible to or observable by the public; openly
+  example:
+  - she admitted publicly to being a communist
+  ili: i19236
+  members:
+  - publicly
+  - publically
+  - in public
+  partOfSpeech: r
+00164679-r:
+  definition:
+  - in close proximity
+  example:
+  - the houses were jumbled together cheek by jowl
+  ili: i19245
+  members:
+  - cheek by jowl
+  partOfSpeech: r
+00166891-r:
+  definition:
+  - one behind another in a line or queue
+  example:
+  - they waited in line for the tickets
+  ili: i19261
+  members:
+  - in line
+  partOfSpeech: r
+00168205-r:
+  definition:
+  - on everybody's mind
+  example:
+  - Christmas was in the air
+  ili: i19272
+  members:
+  - in the air
+  - in everyone's thoughts
+  partOfSpeech: r
+00170857-r:
+  definition:
+  - on hands and knees
+  example:
+  - he got down on all fours to play with his grandson
+  ili: i19290
+  members:
+  - on all fours
+  partOfSpeech: r
+00172276-r:
+  definition:
+  - at the place in question; there
+  example:
+  - they were on the spot when it happened
+  - it had to be decided by the man on the spot
+  ili: i19301
+  members:
+  - on the spot
+  partOfSpeech: r
+00172436-r:
+  definition:
+  - in a difficult situation
+  example:
+  - that question really put him on the spot
+  ili: i19302
+  members:
+  - on the spot
+  partOfSpeech: r
+00172731-r:
+  definition:
+  - on a route to some place
+  example:
+  - help is on the way
+  - we saw him on the way to California
+  ili: i19304
+  members:
+  - on the way
+  - en route
+  partOfSpeech: r
+00172975-r:
+  definition:
+  - without warning
+  example:
+  - your cousin arrived out of thin air
+  ili: i19306
+  members:
+  - out of thin air
+  - out of nothing
+  - from nowhere
+  partOfSpeech: r
+00174207-r:
+  definition:
+  - toward the mouth or oral region
+  ili: i19317
+  members:
+  - orad
+  partOfSpeech: r
+00174307-r:
+  definition:
+  - away from the mouth or oral region
+  ili: i19318
+  members:
+  - aborad
+  partOfSpeech: r
+00174563-r:
+  definition:
+  - from on board a vessel into the water
+  example:
+  - they dropped their garbage overboard
+  ili: i19320
+  members:
+  - overboard
+  partOfSpeech: r
+00174678-r:
+  definition:
+  - in or toward the northern parts of a state
+  example:
+  - he lives upstate New York
+  ili: i19321
+  members:
+  - upstate
+  partOfSpeech: r
+00177739-r:
+  definition:
+  - far from the center
+  domain_topic:
+  - 06067070-n
+  example:
+  - the bronchus is situated distally
+  ili: i19343
+  members:
+  - distally
+  partOfSpeech: r
+00182561-r:
+  definition:
+  - separated or at a distance in place or position or time
+  example:
+  - These towns are many miles apart
+  - stood with his legs apart
+  - born two years apart
+  ili: i19379
+  members:
+  - apart
+  partOfSpeech: r
+00182739-r:
+  definition:
+  - one from the other
+  example:
+  - people can't tell the twins apart
+  ili: i19380
+  members:
+  - apart
+  partOfSpeech: r
+00183162-r:
+  definition:
+  - in a place across an ocean
+  ili: i19384
+  members:
+  - overseas
+  - abroad
+  partOfSpeech: r
+00183580-r:
+  definition:
+  - in the living organism
+  example:
+  - studies conducted in vivo
+  ili: i19387
+  members:
+  - in vivo
+  partOfSpeech: r
+00189276-r:
+  definition:
+  - toward or in the upper part of town
+  ili: i19427
+  members:
+  - uptown
+  partOfSpeech: r
+00189364-r:
+  definition:
+  - toward or in the lower or central part of town
+  ili: i19428
+  members:
+  - downtown
+  partOfSpeech: r
+00194904-r:
+  definition:
+  - no longer on or in contact or attached
+  example:
+  - clean off the dirt
+  - he shaved off his mustache
+  ili: i19470
+  members:
+  - 'off'
+  partOfSpeech: r
+00199469-r:
+  definition:
+  - over the entire area
+  example:
+  - the wallpaper was covered all over with flowers
+  - she ached all over
+  - everything was dusted over with a fine layer of soot
+  ili: i19506
+  members:
+  - all over
+  - over
+  partOfSpeech: r
+00204147-r:
+  definition:
+  - by means of aircraft
+  example:
+  - the survey was carried out aerially
+  ili: i19537
+  members:
+  - aerially
+  partOfSpeech: r
+00207713-r:
+  definition:
+  - away from the right path or direction
+  example:
+  - he was led astray
+  ili: i19564
+  members:
+  - astray
+  partOfSpeech: r
+00221121-r:
+  definition:
+  - in an inverted manner
+  example:
+  - the box was lying on the floor upside down
+  ili: i19650
+  members:
+  - upside down
+  partOfSpeech: r
+00223465-r:
+  definition:
+  - in or to or toward the rear
+  example:
+  - he followed behind
+  - seen from behind, the house is more imposing than it is from the front
+  - the final runners were far behind
+  ili: i19666
+  members:
+  - behind
+  partOfSpeech: r
+00223660-r:
+  definition:
+  - remaining in a place or condition that has been left or departed from
+  example:
+  - when he died he left much unfinished work behind
+  - left a large family behind
+  - the children left their books behind
+  - he took off with a squeal of tires and left the other cars far behind
+  ili: i19667
+  members:
+  - behind
+  partOfSpeech: r
+00223959-r:
+  definition:
+  - in debt
+  example:
+  - he fell behind with his mortgage payments
+  - a month behind in the rent
+  - a company that has been run behindhand for years
+  - in arrears with their utility bills
+  ili: i19668
+  members:
+  - behind
+  - behindhand
+  - in arrears
+  partOfSpeech: r
+00224193-r:
+  definition:
+  - in or into an inferior position
+  example:
+  - fell behind in his studies
+  - their business was lagging behind in the competition for customers
+  ili: i19669
+  members:
+  - behind
+  partOfSpeech: r
+00228167-r:
+  definition:
+  - at or to a point across intervening space etc.
+  example:
+  - come over and see us some time
+  - over there
+  ili: i19697
+  members:
+  - over
+  partOfSpeech: r
+00228294-r:
+  definition:
+  - throughout an area
+  example:
+  - he is known the world over
+  ili: i19698
+  members:
+  - over
+  partOfSpeech: r
+00228375-r:
+  definition:
+  - beyond the top or upper surface or edge; forward from an upright position
+  example:
+  - a roof that hangs over
+  ili: i19699
+  members:
+  - over
+  partOfSpeech: r
+00230832-r:
+  definition:
+  - in bed
+  ili: i19717
+  members:
+  - abed
+  partOfSpeech: r
+00231947-r:
+  definition:
+  - with respect to the outside
+  example:
+  - outwardly, the figure is smooth
+  ili: i19725
+  members:
+  - outwardly
+  - externally
+  partOfSpeech: r
+00234593-r:
+  definition:
+  - away from home
+  example:
+  - they went out last night
+  ili: i19745
+  members:
+  - out
+  partOfSpeech: r
+00234667-r:
+  definition:
+  - from a particular thing or place or position (‘forth’ is obsolete)
+  example:
+  - ran away from the lion
+  - wanted to get away from there
+  - sent the children away to boarding school
+  - the teacher waved the children away from the dead animal
+  - went off to school
+  - they drove off
+  - go forth and preach
+  exemplifies:
+  - 07087487-n
+  ili: i19746
+  members:
+  - away
+  - 'off'
+  - forth
+  partOfSpeech: r
+00235026-r:
+  definition:
+  - from one's possession
+  example:
+  - he gave out money to the poor
+  - gave away the tickets
+  ili: i19747
+  members:
+  - away
+  - out
+  partOfSpeech: r
+00235144-r:
+  definition:
+  - moving or appearing to move away from a place, especially one that is enclosed
+    or hidden
+  example:
+  - the cat came out from under the bed
+  ili: i19748
+  members:
+  - out
+  partOfSpeech: r
+00235417-r:
+  definition:
+  - in reserve; not for immediate use
+  example:
+  - started setting aside money to buy a car
+  - put something by for her old age
+  - has a nest egg tucked away for a rainy day
+  ili: i19750
+  members:
+  - aside
+  - by
+  - away
+  partOfSpeech: r
+00235622-r:
+  definition:
+  - on or to one side
+  example:
+  - step aside
+  - stood aside to let him pass
+  - threw the book aside
+  - put her sewing aside when he entered
+  ili: i19751
+  members:
+  - aside
+  partOfSpeech: r
+00235782-r:
+  definition:
+  - out of the way (especially away from one's thoughts)
+  example:
+  - brush the objections aside
+  - pushed all doubts away
+  ili: i19752
+  members:
+  - aside
+  - away
+  partOfSpeech: r
+00235931-r:
+  definition:
+  - placed or kept separate and distinct as for a purpose
+  example:
+  - had a feeling of being set apart
+  - quality sets it apart
+  - a day set aside for relaxing
+  ili: i19753
+  members:
+  - aside
+  - apart
+  partOfSpeech: r
+00236119-r:
+  definition:
+  - away from another or others
+  example:
+  - they grew apart over the years
+  - kept apart from the group out of shyness
+  - decided to live apart
+  ili: i19754
+  members:
+  - apart
+  partOfSpeech: r
+00236283-r:
+  definition:
+  - out of existence
+  example:
+  - the music faded away
+  - source: H.E.Scudder
+    text: tried to explain away the affair of the letter
+  - idled the hours away
+  - her fingernails were worn away
+  ili: i19755
+  members:
+  - away
+  partOfSpeech: r
+00236681-r:
+  definition:
+  - in a different direction
+  example:
+  - turn aside
+  - turn away one's face
+  - glanced away
+  ili: i19757
+  members:
+  - away
+  - aside
+  partOfSpeech: r
+00236800-r:
+  definition:
+  - in or into a proper place (especially for storage or safekeeping)
+  example:
+  - put the toys away
+  - her jewels are locked away in a safe
+  - filed the letter away
+  ili: i19758
+  members:
+  - away
+  partOfSpeech: r
+00236984-r:
+  definition:
+  - at a distance in space or time
+  example:
+  - the boat was 5 miles off (or away)
+  - the party is still 2 weeks off (or away)
+  - away back in the 18th century
+  ili: i19759
+  members:
+  - 'off'
+  - away
+  partOfSpeech: r
+00237168-r:
+  definition:
+  - so as to be removed or gotten rid of
+  example:
+  - cleared the mess away
+  - the rotted wood had to be cut away
+  ili: i19760
+  members:
+  - away
+  partOfSpeech: r
+00241809-r:
+  definition:
+  - at or in or to the adjacent residence
+  example:
+  - the criminal had been living next door all this time
+  ili: i19794
+  members:
+  - next door
+  - in the adjacent house
+  - in the adjacent apartment
+  partOfSpeech: r
+00242166-r:
+  definition:
+  - (formal) in or into that thing or place
+  example:
+  - they can read therein what our plans are
+  exemplifies:
+  - 01206545-n
+  ili: i19798
+  members:
+  - therein
+  - in this
+  - in that
+  partOfSpeech: r
+00245397-r:
+  definition:
+  - in a southern direction
+  example:
+  - we moved south
+  ili: i19820
+  members:
+  - south
+  - to the south
+  - in the south
+  partOfSpeech: r
+00245502-r:
+  definition:
+  - in a northern direction
+  example:
+  - they earn more up north
+  - Let's go north!
+  ili: i19821
+  members:
+  - north
+  - northerly
+  - northwards
+  - northward
+  partOfSpeech: r
+00246377-r:
+  definition:
+  - under the feet
+  example:
+  - trampled the beans underfoot
+  - green grass growing underfoot
+  ili: i19828
+  members:
+  - underfoot
+  partOfSpeech: r
+00246494-r:
+  definition:
+  - in the way and hindering progress
+  example:
+  - a house with children and pets and toys always underfoot
+  ili: i19829
+  members:
+  - underfoot
+  partOfSpeech: r
+00248151-r:
+  definition:
+  - as written or printed
+  example:
+  - this is exactly what the composer had set down on paper
+  ili: i19842
+  members:
+  - on paper
+  - in writing
+  partOfSpeech: r
+00250643-r:
+  definition:
+  - on or from the inside
+  example:
+  - an internally controlled environment
+  ili: i19859
+  members:
+  - internally
+  partOfSpeech: r
+00250779-r:
+  definition:
+  - on or from the outside
+  example:
+  - the candidate needs to be externally evaluated
+  ili: i19860
+  members:
+  - externally
+  partOfSpeech: r
+00250926-r:
+  definition:
+  - above the head; over the head
+  example:
+  - bring the legs together overhead
+  ili: i19861
+  members:
+  - overhead
+  partOfSpeech: r
+00251028-r:
+  definition:
+  - at some distance
+  example:
+  - keep someone at arm's length
+  ili: i19862
+  members:
+  - at arm's length
+  partOfSpeech: r
+00251120-r:
+  definition:
+  - above your head; in the sky
+  example:
+  - planes were flying overhead
+  ili: i19863
+  members:
+  - overhead
+  partOfSpeech: r
+00251215-r:
+  definition:
+  - on first or second or third base
+  domain_topic:
+  - 00472688-n
+  example:
+  - Their second homer with Bob Allison aboard
+  ili: i19864
+  members:
+  - aboard
+  partOfSpeech: r
+00251347-r:
+  definition:
+  - on a ship, train, plane or other vehicle
+  ili: i19865
+  members:
+  - aboard
+  - on board
+  partOfSpeech: r
+00251433-r:
+  definition:
+  - part of a group
+  example:
+  - Bill's been aboard for three years now
+  ili: i19866
+  members:
+  - aboard
+  partOfSpeech: r
+00251525-r:
+  definition:
+  - side by side
+  example:
+  - anchored close aboard another ship
+  ili: i19867
+  members:
+  - aboard
+  - alongside
+  partOfSpeech: r
+00252367-r:
+  definition:
+  - in between
+  example:
+  - two houses with a tree between
+  ili: i19874
+  members:
+  - between
+  - '''tween'
+  partOfSpeech: r
+00253874-r:
+  definition:
+  - in a casual way at home
+  example:
+  - we'll have dinner en famille
+  ili: i19888
+  members:
+  - en famille
+  partOfSpeech: r
+00255539-r:
+  definition:
+  - in a direction opposite to the direction in which the hands of a clock move
+  example:
+  - please move counterclockwise in a circle!
+  ili: i19901
+  members:
+  - counterclockwise
+  - anticlockwise
+  partOfSpeech: r
+00255849-r:
+  definition:
+  - in the direction that the hands of a clock move
+  example:
+  - please move clockwise in a circle
+  ili: i19903
+  members:
+  - clockwise
+  partOfSpeech: r
+00256094-r:
+  definition:
+  - prominently forward
+  example:
+  - he put his best foot foremost
+  ili: i19905
+  members:
+  - foremost
+  - first
+  partOfSpeech: r
+00256895-r:
+  definition:
+  - at half the distance; at the middle
+  example:
+  - he was halfway down the ladder when he fell
+  ili: i19912
+  members:
+  - halfway
+  - midway
+  partOfSpeech: r
+00257456-r:
+  definition:
+  - in the same place (used when citing a reference)
+  ili: i19917
+  members:
+  - ibid.
+  - ib.
+  - ibidem
+  partOfSpeech: r
+00257669-r:
+  definition:
+  - in the original or natural place or site
+  example:
+  - carcinoma in situ
+  - the archeologists left the pottery in place
+  ili: i19919
+  members:
+  - in situ
+  - in place
+  partOfSpeech: r
+00257824-r:
+  definition:
+  - in position
+  members:
+  - in situ
+  partOfSpeech: r
+00258633-r:
+  definition:
+  - used to refer to cited works
+  ili: i19927
+  members:
+  - passim
+  - throughout
+  partOfSpeech: r
+00259792-r:
+  definition:
+  - towards or into the interior of a region
+  example:
+  - the town is five miles inland
+  ili: i19939
+  members:
+  - inland
+  partOfSpeech: r
+00259900-r:
+  definition:
+  - toward the shore
+  example:
+  - we swam two miles inshore
+  ili: i19940
+  members:
+  - inshore
+  partOfSpeech: r
+00259981-r:
+  definition:
+  - toward the center or interior
+  example:
+  - move the needle further inwards!
+  ili: i19941
+  members:
+  - inward
+  - inwards
+  partOfSpeech: r
+00260109-r:
+  definition:
+  - toward the outside
+  example:
+  - move the needle further outward!
+  ili: i19942
+  members:
+  - outward
+  - outwards
+  partOfSpeech: r
+00260228-r:
+  definition:
+  - up to the knees
+  example:
+  - we were standing knee-deep in the water
+  ili: i19943
+  members:
+  - knee-deep
+  - knee-high
+  partOfSpeech: r
+00260336-r:
+  definition:
+  - up to the breast
+  example:
+  - we were standing breast-high in the water
+  ili: i19944
+  members:
+  - breast-deep
+  - breast-high
+  partOfSpeech: r
+00260735-r:
+  definition:
+  - the middle or central part or point
+  example:
+  - in the midst of the forest
+  - could he walk out in the midst of his piece?
+  ili: i19948
+  members:
+  - midmost
+  - in the midst
+  partOfSpeech: r
+00261005-r:
+  definition:
+  - not in public
+  example:
+  - the deal was done offstage
+  ili: i19950
+  members:
+  - offstage
+  partOfSpeech: r
+00261085-r:
+  definition:
+  - behind the scenes; not on stage
+  example:
+  - the actors were waiting offstage
+  ili: i19951
+  members:
+  - offstage
+  partOfSpeech: r
+00261207-r:
+  definition:
+  - on the stage
+  example:
+  - it was time for her to go onstage
+  ili: i19952
+  members:
+  - onstage
+  partOfSpeech: r
+00262350-r:
+  definition:
+  - toward the sky
+  example:
+  - look skywards!
+  ili: i19963
+  members:
+  - skyward
+  - skywards
+  partOfSpeech: r
+00262429-r:
+  definition:
+  - in a specified area or place
+  example:
+  - you shouldn't be up here
+  ili: i19964
+  members:
+  - up here
+  - over here
+  partOfSpeech: r
+00264278-r:
+  definition:
+  - off the subject; beyond the point at issue
+  example:
+  - such digressions can lead us too far afield
+  ili: i19978
+  members:
+  - afield
+  partOfSpeech: r
+00264402-r:
+  definition:
+  - in or into a field (especially a field of battle)
+  example:
+  - the armies were afield, challenging the enemy's advance
+  - unlawful to carry hunting rifles afield until the season opens
+  ili: i19979
+  members:
+  - afield
+  partOfSpeech: r
+00264611-r:
+  definition:
+  - far away from home or one's usual surroundings
+  example:
+  - source: R.A.Hall
+    text: looking afield for new lands to conquer
+  ili: i19980
+  members:
+  - afield
+  - abroad
+  partOfSpeech: r
+00265458-r:
+  definition:
+  - at or toward the rear of the stage
+  domain_topic:
+  - 07019235-n
+  example:
+  - the dancers were directed to move upstage
+  ili: i19985
+  members:
+  - upstage
+  partOfSpeech: r
+00265610-r:
+  definition:
+  - at or toward the front of the stage
+  domain_topic:
+  - 07019235-n
+  example:
+  - the actors moved further and further downstage
+  ili: i19986
+  members:
+  - downstage
+  partOfSpeech: r
+00267010-r:
+  definition:
+  - in an anterior direction
+  ili: i19996
+  members:
+  - anteriorly
+  partOfSpeech: r
+00268988-r:
+  definition:
+  - off course, wandering aimlessly
+  example:
+  - there was a search for beauty that had somehow gone adrift
+  ili: i20009
+  members:
+  - adrift
+  partOfSpeech: r
+00269134-r:
+  definition:
+  - floating freely; not anchored
+  example:
+  - the boat was set adrift
+  ili: i20010
+  members:
+  - adrift
+  partOfSpeech: r
+00271442-r:
+  definition:
+  - with the bottom lodged on the ground
+  example:
+  - he ran the ship aground
+  ili: i20027
+  members:
+  - aground
+  partOfSpeech: r
+00271649-r:
+  definition:
+  - on or toward the lee
+  example:
+  - put the helm alee
+  ili: i20029
+  members:
+  - alee
+  partOfSpeech: r
+00274275-r:
+  definition:
+  - transversely
+  example:
+  - the marble slabs were cut across
+  ili: i20048
+  members:
+  - across
+  - crosswise
+  - crossways
+  partOfSpeech: r
+00274382-r:
+  definition:
+  - to the opposite side
+  example:
+  - the football field was 300 feet across
+  ili: i20049
+  members:
+  - across
+  partOfSpeech: r
+00274669-r:
+  definition:
+  - at or near or toward the middle
+  ili: i20052
+  members:
+  - amidship
+  partOfSpeech: r
+00276465-r:
+  definition:
+  - into a sleeping state
+  example:
+  - he fell asleep
+  ili: i20066
+  members:
+  - asleep
+  partOfSpeech: r
+00276631-r:
+  definition:
+  - (of a ship or an airplane) behind
+  domain_topic:
+  - 04201332-n
+  - 02694015-n
+  example:
+  - we dropped her astern on the end of a seven-inch manilla, and she laid comfortably
+    on the ebb tide
+  ili: i20068
+  members:
+  - astern
+  partOfSpeech: r
+00276839-r:
+  definition:
+  - at or near or toward the stern of a ship or tail of an airplane
+  example:
+  - stow the luggage aft
+  - ships with square sails sail fairly efficiently with the wind abaft
+  - the captain looked astern to see what the fuss was about
+  ili: i20069
+  members:
+  - aft
+  - abaft
+  - astern
+  partOfSpeech: r
+00277124-r:
+  definition:
+  - near or toward the bow of a ship or cockpit of a plane
+  example:
+  - the captain went fore (or forward) to check the instruments
+  ili: i20070
+  members:
+  - fore
+  - forward
+  partOfSpeech: r
+00277302-r:
+  definition:
+  - stern foremost or backward
+  example:
+  - the steamer went astern at half speed
+  ili: i20071
+  members:
+  - astern
+  partOfSpeech: r
+00277404-r:
+  definition:
+  - with one leg on each side
+  example:
+  - she sat astride the chair
+  ili: i20072
+  members:
+  - astride
+  - astraddle
+  partOfSpeech: r
+00277506-r:
+  definition:
+  - with the legs stretched far apart
+  ili: i20073
+  members:
+  - astride
+  partOfSpeech: r
+00277575-r:
+  definition:
+  - at right angles to the center line of a ship
+  ili: i20074
+  members:
+  - athwart
+  partOfSpeech: r
+00277655-r:
+  definition:
+  - on, to, or at the top
+  ili: i20075
+  members:
+  - atop
+  partOfSpeech: r
+00278159-r:
+  definition:
+  - in or to a backstage area of a theater
+  example:
+  - costumes were changed backstage
+  ili: i20079
+  members:
+  - backstage
+  partOfSpeech: r
+00278270-r:
+  definition:
+  - out of view of the public; behind the scenes
+  example:
+  - Working backstage to gain political support for his proposal
+  - many private deals were made backstage at the convention
+  ili: i20080
+  members:
+  - backstage
+  partOfSpeech: r
+00282316-r:
+  definition:
+  - very happily
+  example:
+  - we were floating on air at the news
+  ili: i20109
+  members:
+  - on air
+  partOfSpeech: r
+00287481-r:
+  definition:
+  - by way of, or along the coast
+  example:
+  - we were travelling coastwise
+  ili: i20142
+  members:
+  - coastwise
+  partOfSpeech: r
+00292166-r:
+  definition:
+  - by means of cytoplasm
+  ili: i20173
+  members:
+  - cytoplasmically
+  partOfSpeech: r
+00294730-r:
+  definition:
+  - across the countryside
+  example:
+  - the river runs cross-country
+  - the road runs cross-country
+  ili: i20193
+  members:
+  - cross-country
+  partOfSpeech: r
+00294857-r:
+  definition:
+  - not following tracks or roads
+  example:
+  - they liked to race cross-country
+  ili: i20194
+  members:
+  - cross-country
+  partOfSpeech: r
+00295138-r:
+  definition:
+  - across a town or city
+  example:
+  - he traveled crosstown
+  ili: i20196
+  members:
+  - crosstown
+  partOfSpeech: r
+00307076-r:
+  definition:
+  - to a great distance
+  example:
+  - penetrated deep into enemy territory
+  - went deep into the woods
+  ili: i20267
+  members:
+  - deep
+  partOfSpeech: r
+00312113-r:
+  definition:
+  - in a diagonal manner
+  example:
+  - she lives diagonally across the street from us
+  ili: i20299
+  members:
+  - diagonally
+  partOfSpeech: r
+00323816-r:
+  definition:
+  - toward the bottom of a hill
+  example:
+  - running downhill, he gained a lot of speed
+  ili: i20366
+  members:
+  - downhill
+  partOfSpeech: r
+00325179-r:
+  definition:
+  - to, toward, or in the east
+  example:
+  - we travelled east for several miles
+  - located east of Rome
+  ili: i20376
+  members:
+  - east
+  partOfSpeech: r
+00325301-r:
+  definition:
+  - to, toward, or in the west
+  example:
+  - we moved west to Arizona
+  - situated west of Boston
+  ili: i20377
+  members:
+  - west
+  partOfSpeech: r
+00325415-r:
+  definition:
+  - toward the west
+  example:
+  - they traveled westward toward the setting sun
+  ili: i20378
+  members:
+  - westward
+  - westwards
+  partOfSpeech: r
+00325528-r:
+  definition:
+  - toward the east
+  example:
+  - they migrated eastward to Sweden
+  ili: i20379
+  members:
+  - eastward
+  - eastwards
+  partOfSpeech: r
+00325628-r:
+  definition:
+  - from the east
+  example:
+  - the winds blew easterly all night
+  ili: i20380
+  members:
+  - easterly
+  partOfSpeech: r
+00325751-r:
+  definition:
+  - from the west
+  example:
+  - the wind blew westerly
+  ili: i20381
+  members:
+  - westerly
+  partOfSpeech: r
+00325863-r:
+  definition:
+  - in a westward direction
+  example:
+  - source: Daniel Defoe
+    text: we began to steer away westerly
+  ili: i20382
+  members:
+  - westerly
+  partOfSpeech: r
+00330385-r:
+  definition:
+  - with the end forward or toward the observer
+  example:
+  - houses built endways
+  ili: i20410
+  members:
+  - endways
+  - endwise
+  - end on
+  partOfSpeech: r
+00357305-r:
+  definition:
+  - toward heaven
+  example:
+  - he pointed heavenward
+  ili: i20591
+  members:
+  - heavenward
+  - heavenwards
+  - heavenwardly
+  partOfSpeech: r
+00357947-r:
+  definition:
+  - in the preceding part of the current text
+  ili: i20595
+  members:
+  - hereinbefore
+  partOfSpeech: r
+00358029-r:
+  definition:
+  - of or concerning this
+  example:
+  - the twigs hereof are physic
+  ili: i20596
+  members:
+  - hereof
+  partOfSpeech: r
+00358116-r:
+  definition:
+  - to this writing or document
+  example:
+  - the charts hereto attached
+  ili: i20597
+  members:
+  - hereto
+  partOfSpeech: r
+00358753-r:
+  definition:
+  - at a great altitude
+  example:
+  - he climbed high on the ladder
+  ili: i20602
+  members:
+  - high
+  - high up
+  partOfSpeech: r
+00358848-r:
+  definition:
+  - far up toward the source
+  example:
+  - he lives high up the river
+  ili: i20603
+  members:
+  - high
+  partOfSpeech: r
+00359047-r:
+  definition:
+  - in a rich manner
+  example:
+  - he lives high
+  ili: i20605
+  members:
+  - high
+  - richly
+  - luxuriously
+  partOfSpeech: r
+00359910-r:
+  definition:
+  - in rotation or succession
+  example:
+  - turn about is fair play
+  ili: i20611
+  members:
+  - about
+  partOfSpeech: r
+00360138-r:
+  definition:
+  - in a horizontal direction
+  example:
+  - a gallery quite often is added to make use of space vertically as well as horizontally
+  ili: i20613
+  members:
+  - horizontally
+  partOfSpeech: r
+00360312-r:
+  definition:
+  - in a vertical direction
+  example:
+  - a gallery quite often is added to make use of space vertically as well as horizontally
+  ili: i20614
+  members:
+  - vertically
+  partOfSpeech: r
+00387726-r:
+  definition:
+  - toward land
+  example:
+  - landward, miles of rough grass marshes melt into low uplands
+  ili: i20786
+  members:
+  - landward
+  - landwards
+  partOfSpeech: r
+00388491-r:
+  definition:
+  - in a lateral direction or location
+  domain_topic:
+  - 06067070-n
+  example:
+  - the body is spindle-shaped and only slightly compressed laterally
+  ili: i20793
+  members:
+  - laterally
+  partOfSpeech: r
+00388669-r:
+  definition:
+  - to or by or from the side
+  example:
+  - such women carry in their heads kinship knowledge of six generations depth and
+    extending laterally among consanguineal kin as far as the grandchildren of second
+    cousin
+  ili: i20794
+  members:
+  - laterally
+  partOfSpeech: r
+00389359-r:
+  definition:
+  - armed and prepared for fighting
+  ili: i20797
+  members:
+  - under arms
+  partOfSpeech: r
+00389570-r:
+  definition:
+  - toward or on the left; also used figuratively
+  example:
+  - he looked right and left
+  - the political party has moved left
+  ili: i20799
+  members:
+  - left
+  partOfSpeech: r
+00389732-r:
+  definition:
+  - toward or on the right; also used figuratively
+  example:
+  - he looked right and left
+  - the party has moved right
+  ili: i20800
+  members:
+  - right
+  partOfSpeech: r
+00395053-r:
+  definition:
+  - in a low position; near the ground
+  example:
+  - the branches hung low
+  ili: i20838
+  members:
+  - low
+  partOfSpeech: r
+00395144-r:
+  definition:
+  - in the lowest position; nearest the ground
+  example:
+  - the branch with the big peaches on it hung lowest
+  ili: i20839
+  members:
+  - lowest
+  partOfSpeech: r
+00400432-r:
+  definition:
+  - in a medial position
+  example:
+  - this consonant always occurs medially
+  ili: i20875
+  members:
+  - medially
+  partOfSpeech: r
+00403940-r:
+  definition:
+  - at or near or toward the center of a ship
+  example:
+  - in the late 19th century, engines were placed in front, amidships, and at the
+    rear
+  ili: i20898
+  members:
+  - amidships
+  - amidship
+  - midships
+  partOfSpeech: r
+00409125-r:
+  definition:
+  - extending throughout an entire nation
+  example:
+  - nationally advertised
+  - it was broadcast nationwide
+  ili: i20932
+  members:
+  - nationally
+  - nationwide
+  - across the nation
+  - across the country
+  partOfSpeech: r
+00409712-r:
+  definition:
+  - (comparative of ‘near’ or ‘close’) within a shorter distance
+  example:
+  - come closer, my dear!
+  - they drew nearer
+  - getting nearer to the true explanation
+  exemplifies:
+  - 06333686-n
+  ili: i20936
+  members:
+  - nearer
+  - nigher
+  - closer
+  partOfSpeech: r
+00411953-r:
+  definition:
+  - very close
+  example:
+  - without my reading glasses I can hardly see things close up
+  - even firing at close range he missed
+  ili: i20950
+  members:
+  - close up
+  - at close range
+  partOfSpeech: r
+00413571-r:
+  definition:
+  - to, toward, or in the northeast
+  ili: i20962
+  members:
+  - northeast
+  - north-east
+  - nor'-east
+  partOfSpeech: r
+00413665-r:
+  definition:
+  - to, toward, or in the northwest
+  ili: i20963
+  members:
+  - northwest
+  - north-west
+  - nor'-west
+  partOfSpeech: r
+00413759-r:
+  definition:
+  - to, toward, or in the north-northeast
+  ili: i20964
+  members:
+  - north-northeast
+  - nor'-nor'-east
+  partOfSpeech: r
+00413857-r:
+  definition:
+  - to, toward, or in the north-northwest
+  ili: i20965
+  members:
+  - north-northwest
+  - nor'-nor'-west
+  partOfSpeech: r
+00415483-r:
+  definition:
+  - illegally in advance of the ball or puck
+  ili: i20976
+  members:
+  - offside
+  partOfSpeech: r
+00417776-r:
+  definition:
+  - on or to the other side of a page
+  example:
+  - data tabulated overleaf
+  ili: i20993
+  members:
+  - overleaf
+  partOfSpeech: r
+00417994-r:
+  definition:
+  - beyond or across the sea
+  example:
+  - He lived overseas for many years
+  ili: i20995
+  members:
+  - oversea
+  - overseas
+  partOfSpeech: r
+00418101-r:
+  definition:
+  - over the side of a boat
+  example:
+  - Willie eased himself overside into the sea
+  ili: i20996
+  members:
+  - overside
+  partOfSpeech: r
+00419697-r:
+  definition:
+  - so as to pass a given point
+  example:
+  - every hour a train goes past
+  ili: i21008
+  members:
+  - by
+  - past
+  partOfSpeech: r
+00422293-r:
+  definition:
+  - in a perpendicular manner
+  example:
+  - this red line runs perpendicularly to the green line
+  ili: i21027
+  members:
+  - perpendicularly
+  partOfSpeech: r
+00440475-r:
+  definition:
+  - in a radial manner
+  example:
+  - an imaginative dispersal of the pews radially from the central focus of the pulpit
+  ili: i21158
+  members:
+  - radially
+  partOfSpeech: r
+00449404-r:
+  definition:
+  - in the direction of the coast
+  ili: i21226
+  members:
+  - coastward
+  partOfSpeech: r
+00449471-r:
+  definition:
+  - in the direction of the sea
+  example:
+  - the sailor looked seaward
+  ili: i21227
+  members:
+  - seaward
+  - seawards
+  - asea
+  partOfSpeech: r
+00455853-r:
+  definition:
+  - with the side toward someone or something
+  example:
+  - source: Nathaniel Hawthorne
+    text: seated sidelong to the window
+  ili: i21275
+  members:
+  - sidelong
+  partOfSpeech: r
+00455985-r:
+  definition:
+  - on the side
+  example:
+  - the plow lay sidelong on the ground
+  ili: i21276
+  members:
+  - sidelong
+  partOfSpeech: r
+00456072-r:
+  definition:
+  - toward one side
+  example:
+  - turn the figure sideward
+  ili: i21277
+  members:
+  - sideward
+  - sidewards
+  partOfSpeech: r
+00456477-r:
+  definition:
+  - with one side forward or to the front
+  example:
+  - turned sideways to show the profile
+  - crabs seeming to walk sidewise
+  ili: i21280
+  members:
+  - sideways
+  - sideway
+  - sidewise
+  partOfSpeech: r
+00459960-r:
+  definition:
+  - directly or immediately
+  example:
+  - it hit slap-bang in the middle
+  ili: i21304
+  members:
+  - slap-bang
+  partOfSpeech: r
+00464314-r:
+  definition:
+  - to, toward, or in the southeast
+  ili: i21337
+  members:
+  - southeast
+  - south-east
+  - sou'-east
+  partOfSpeech: r
+00464408-r:
+  definition:
+  - to, toward, or in the southwest
+  ili: i21338
+  members:
+  - southwest
+  - south-west
+  - sou'west
+  partOfSpeech: r
+00464501-r:
+  definition:
+  - to, toward, or in the south southeast
+  ili: i21339
+  members:
+  - south-southeast
+  - sou'-sou'-east
+  partOfSpeech: r
+00464599-r:
+  definition:
+  - to, toward, or in the south southwest
+  ili: i21340
+  members:
+  - south-southwest
+  - sou'-sou'-west
+  partOfSpeech: r
+00465157-r:
+  definition:
+  - from the south
+  example:
+  - a wind blew southerly
+  ili: i21344
+  members:
+  - southerly
+  partOfSpeech: r
+00465252-r:
+  definition:
+  - toward the south
+  example:
+  - the ship turned southerly
+  ili: i21345
+  members:
+  - southerly
+  - southward
+  - southwards
+  partOfSpeech: r
+00469724-r:
+  definition:
+  - near that place
+  example:
+  - he stayed in London or thereabouts for several weeks
+  ili: i21382
+  members:
+  - thereabout
+  - thereabouts
+  partOfSpeech: r
+00470165-r:
+  definition:
+  - on that
+  example:
+  - text and commentary thereon
+  ili: i21386
+  members:
+  - thereon
+  - on it
+  - on that
+  partOfSpeech: r
+00470257-r:
+  definition:
+  - to that
+  example:
+  - with all the appurtenances fitting thereto
+  ili: i21387
+  members:
+  - thereto
+  - to it
+  - to that
+  partOfSpeech: r
+00480765-r:
+  definition:
+  - over the whole distance
+  example:
+  - this bus goes through to New York
+  ili: i21459
+  members:
+  - through
+  partOfSpeech: r
+00480861-r:
+  definition:
+  - in diameter
+  example:
+  - this cylinder measures 15 inches through
+  ili: i21460
+  members:
+  - through
+  partOfSpeech: r
+00488265-r:
+  definition:
+  - further down
+  example:
+  - see under for further discussion
+  ili: i21516
+  members:
+  - under
+  - below
+  partOfSpeech: r
+00488355-r:
+  definition:
+  - down below
+  example:
+  - get under quickly!
+  ili: i21517
+  members:
+  - under
+  partOfSpeech: r
+00488421-r:
+  definition:
+  - below the horizon
+  example:
+  - the sun went under
+  ili: i21518
+  members:
+  - under
+  partOfSpeech: r
+00488582-r:
+  definition:
+  - in or into a state of subordination or subjugation
+  example:
+  - we must keep our disappointment under
+  ili: i21520
+  members:
+  - under
+  partOfSpeech: r
+00488707-r:
+  definition:
+  - down to defeat, death, or ruin
+  example:
+  - their competitors went under
+  ili: i21521
+  members:
+  - under
+  partOfSpeech: r
+00488803-r:
+  definition:
+  - into unconsciousness
+  example:
+  - this will put the patient under
+  ili: i21522
+  members:
+  - under
+  partOfSpeech: r
+00488892-r:
+  definition:
+  - through a range downward
+  example:
+  - children six and under will be admitted free
+  ili: i21523
+  members:
+  - under
+  partOfSpeech: r
+00489115-r:
+  definition:
+  - beneath the surface of the earth
+  example:
+  - water flowing underground
+  ili: i21525
+  members:
+  - underground
+  partOfSpeech: r
+00489216-r:
+  definition:
+  - in or into hiding or secret operation
+  example:
+  - the organization was driven underground
+  ili: i21526
+  members:
+  - underground
+  partOfSpeech: r
+00489606-r:
+  definition:
+  - under or below an object or a surface; at a lower place or level; directly beneath
+  example:
+  - we could see the original painting underneath
+  - a house with a good foundation underneath
+  ili: i21528
+  members:
+  - underneath
+  partOfSpeech: r
+00489821-r:
+  definition:
+  - on the lower or downward side; on the underside of
+  example:
+  - a chest of drawers all scratched underneath
+  ili: i21529
+  members:
+  - underneath
+  partOfSpeech: r
+00492502-r:
+  definition:
+  - to or in the interior of a country or region
+  example:
+  - they live upcountry
+  ili: i21549
+  members:
+  - up-country
+  - upcountry
+  partOfSpeech: r
+00492608-r:
+  definition:
+  - upward on a hill or incline
+  example:
+  - this street lay uphill
+  ili: i21550
+  members:
+  - uphill
+  partOfSpeech: r
+00492696-r:
+  definition:
+  - against difficulties
+  example:
+  - she was talking uphill
+  ili: i21551
+  members:
+  - uphill
+  partOfSpeech: r
+00492777-r:
+  definition:
+  - in or into the highest position
+  example:
+  - the blade turned uppermost
+  ili: i21552
+  members:
+  - uppermost
+  partOfSpeech: r
+00492876-r:
+  definition:
+  - in or into the most prominent position, as in the mind
+  example:
+  - say what comes uppermost
+  ili: i21553
+  members:
+  - uppermost
+  partOfSpeech: r
+00497507-r:
+  definition:
+  - from what place, source, or cause
+  ili: i21591
+  members:
+  - whence
+  partOfSpeech: r
+00497575-r:
+  definition:
+  - where in the world; location, singular, elective existential pronoun
+  ili: i21592
+  members:
+  - wherever
+  - wheresoever
+  partOfSpeech: r
+00498056-r:
+  definition:
+  - far from the intended target
+  example:
+  - the arrow went wide of the mark
+  - a bullet went astray and killed a bystander
+  ili: i21597
+  members:
+  - wide
+  - astray
+  partOfSpeech: r
+00500491-r:
+  definition:
+  - in the space between decks, on a ship
+  ili: i21617
+  members:
+  - between decks
+  - '''tween decks'
+  partOfSpeech: r
+00500585-r:
+  definition:
+  - in the interval
+  example:
+  - dancing all the dances with little rest between
+  ili: i21618
+  members:
+  - between
+  - betwixt
+  partOfSpeech: r
+00500697-r:
+  definition:
+  - in the higher atmosphere above the earth
+  example:
+  - weather conditions aloft are fine
+  ili: i21619
+  members:
+  - aloft
+  partOfSpeech: r
+00500808-r:
+  definition:
+  - at or to great height; high up in or into the air
+  example:
+  - eagles were soaring aloft
+  - dust is whirled aloft
+  ili: i21620
+  members:
+  - aloft
+  partOfSpeech: r
+00501202-r:
+  definition:
+  - upward
+  example:
+  - the good news sent her spirits aloft
+  ili: i21623
+  members:
+  - aloft
+  partOfSpeech: r
+00501282-r:
+  definition:
+  - at or on or to the masthead or upper rigging of a ship
+  example:
+  - climbed aloft to unfurl the sail
+  ili: i21624
+  members:
+  - aloft
+  partOfSpeech: r
+00504204-r:
+  definition:
+  - to or toward the inside of
+  example:
+  - come in
+  - smash in the door
+  ili: i21651
+  members:
+  - in
+  - inwards
+  - inward
+  partOfSpeech: r
+00506499-r:
+  definition:
+  - near or close by
+  example:
+  - he passed immediately behind her
+  ili: i21666
+  members:
+  - immediately
+  partOfSpeech: r
+00507466-r:
+  definition:
+  - flying through the air
+  example:
+  - we saw the ducks in flight
+  ili: i21673
+  members:
+  - in flight
+  - on the wing
+  partOfSpeech: r
+00507966-r:
+  definition:
+  - toward the posterior end of the body
+  ili: i21678
+  members:
+  - caudally
+  - caudal
+  partOfSpeech: r
+00510603-r:
+  definition:
+  - behind or in the rear
+  example:
+  - and Jill came tumbling after
+  ili: i21699
+  members:
+  - after
+  partOfSpeech: r
+00511820-r:
+  definition:
+  - from one place or situation to another
+  example:
+  - we were driven from pillar to post
+  ili: i21709
+  members:
+  - from pillar to post
+  - hither and thither
+  partOfSpeech: r
+00512638-r:
+  definition:
+  - no longer visible
+  example:
+  - the ship disappeared behind the horizon and passed out of sight
+  ili: i21715
+  members:
+  - out of sight
+  - out of view
+  partOfSpeech: r
+00514450-r:
+  definition:
+  - in a northeastward direction
+  example:
+  - the river flows northeastward to the gulf
+  ili: i21732
+  members:
+  - northeastward
+  - northeastwardly
+  partOfSpeech: r
+00514619-r:
+  definition:
+  - in a northwestward direction
+  ili: i21733
+  members:
+  - northwestward
+  - northwestwardly
+  partOfSpeech: r
+00514743-r:
+  definition:
+  - in a southeastward direction
+  example:
+  - the river flows southeastward to the gulf
+  ili: i21734
+  members:
+  - southeastward
+  - southeastwardly
+  partOfSpeech: r
+00514912-r:
+  definition:
+  - in a southwestward direction
+  ili: i21735
+  members:
+  - southwestward
+  - southwestwardly
+  partOfSpeech: r
+00515036-r:
+  definition:
+  - in an abaxial manner
+  ili: i21736
+  members:
+  - abaxially
+  partOfSpeech: r
+00515130-r:
+  definition:
+  - in an adaxial manner
+  ili: i21737
+  members:
+  - adaxially
+  partOfSpeech: r
+00516462-r:
+  definition:
+  - in an artificial environment outside the living organism
+  example:
+  - an egg fertilized in vitro
+  ili: i21752
+  members:
+  - in vitro
+  - ex vivo
+  partOfSpeech: r
+00517008-r:
+  definition:
+  - within range of a movie or television camera
+  example:
+  - the senator didn't realize that he was speaking on camera
+  ili: i21757
+  members:
+  - on camera
+  partOfSpeech: r
+00517761-r:
+  definition:
+  - towards outer space
+  ili: i21765
+  members:
+  - spaceward
+  - spacewards
+  partOfSpeech: r
+81276284-r:
+  definition:
+  - through a computer or a computer network
+  example:
+  - source: UD_English-GUM Corpus
+    text: People were encouraged to submit their designs online at www.flag.govt.nz
+      and suggest what the flag should mean on www.standfor.co.nz.
+  - source: UD_English-GUM Corpus
+    text: Images of the boy wearing a NASA T-shirt and handcuffed by the police were
+      quickly posted and reposted online.
+  - source: UD_English-GUM Corpus
+    text: They should be available at your local home improvement store or online.
+  members:
+  - online
+  partOfSpeech: r

--- a/src/yaml/adv.speaker_oriented.yaml
+++ b/src/yaml/adv.speaker_oriented.yaml
@@ -1,0 +1,1571 @@
+00003761-r:
+  definition:
+  - in an annoying manner or to an annoying degree
+  ili: i18167
+  members:
+  - annoyingly
+  partOfSpeech: r
+00004152-r:
+  definition:
+  - in a blessed manner
+  ili: i18169
+  members:
+  - blessedly
+  partOfSpeech: r
+00005724-r:
+  definition:
+  - as can be shown by argument
+  example:
+  - she is arguably the best
+  ili: i18181
+  members:
+  - arguably
+  partOfSpeech: r
+00010428-r:
+  definition:
+  - used in polite request
+  example:
+  - please pay attention
+  ili: i18204
+  members:
+  - please
+  partOfSpeech: r
+00012993-r:
+  definition:
+  - indicating high probability; in all likelihood
+  example:
+  - I might well do it
+  - a mistake that could easily have ended in disaster
+  - you may well need your umbrella
+  - he could equally well be trying to deceive us
+  ili: i18217
+  members:
+  - well
+  - easily
+  partOfSpeech: r
+00023622-r:
+  definition:
+  - in a paradoxical manner
+  example:
+  - paradoxically, ice ages seem to occur when the sun gets hotter
+  ili: i18273
+  members:
+  - paradoxically
+  partOfSpeech: r
+00024715-r:
+  definition:
+  - used to express refusal or denial or disagreement etc. or especially to emphasize
+    a negative statement
+  example:
+  - no, you are wrong
+  ili: i18282
+  members:
+  - 'no'
+  partOfSpeech: r
+00026794-r:
+  definition:
+  - for some unspecified reason
+  example:
+  - It doesn't seem fair somehow
+  - he had me dead to rights but somehow I got away with it
+  ili: i18294
+  members:
+  - somehow
+  partOfSpeech: r
+00026948-r:
+  definition:
+  - used to indicate that a statement explains or supports a previous statement
+  example:
+  - Anyhow, he is dead now
+  - I think they're asleep; anyhow, they're quiet
+  - I don't know what happened to it; anyway, it's gone
+  - anyway, there is another factor to consider
+  - I don't know how it started; in any case, there was a brief scuffle
+  - in any event, the government faced a serious protest
+  - but at any rate he got a knighthood for it
+  ili: i18295
+  members:
+  - anyhow
+  - anyway
+  - anyways
+  - in any case
+  - at any rate
+  - in any event
+  partOfSpeech: r
+00029433-r:
+  definition:
+  - making an additional point; anyway
+  example:
+  - I don't want to go to a restaurant; besides, we can't afford it
+  - she couldn't shelter behind him all the time and in any case he wasn't always
+    with her
+  ili: i18307
+  members:
+  - besides
+  - in any case
+  partOfSpeech: r
+00029763-r:
+  definition:
+  - denoting additional information
+  example:
+  - computer chess games are getting cheaper all the time; furthermore, their quality
+    is improving
+  - the cellar was dark; moreover, mice nested there
+  - what is more, there's no sign of a change
+  ili: i18309
+  members:
+  - furthermore
+  - moreover
+  - what is more
+  - in addition
+  partOfSpeech: r
+00035878-r:
+  definition:
+  - in a manner differing from the usual or expected
+  example:
+  - had a curiously husky voice
+  - he's behaving rather peculiarly
+  ili: i18349
+  members:
+  - inexplicably
+  - curiously
+  - oddly
+  - peculiarly
+  partOfSpeech: r
+00037864-r:
+  definition:
+  - (used as an interjection) an expression of surprise or skepticism or irony etc.
+  example:
+  - Wants to marry the butler? Indeed!
+  exemplifies:
+  - 07120931-n
+  ili: i18358
+  members:
+  - indeed
+  partOfSpeech: r
+00038035-r:
+  definition:
+  - in truth (often tends to intensify)
+  example:
+  - they said the car would break down and indeed it did
+  - it is very cold indeed
+  - was indeed grateful
+  - indeed, the rain may still come
+  - he did so do it!
+  ili: i18359
+  members:
+  - indeed
+  - so
+  partOfSpeech: r
+00038407-r:
+  definition:
+  - in fact (used as intensifiers or sentence modifiers)
+  example:
+  - in truth, moral decay hastened the decline of the Roman Empire
+  - really, you shouldn't have done it
+  - a truly awful book
+  exemplifies:
+  - 06332047-n
+  ili: i18361
+  members:
+  - in truth
+  - really
+  - truly
+  partOfSpeech: r
+00038658-r:
+  definition:
+  - an archaic word originally meaning ‘in truth’ but now usually used to express
+    disbelief
+  ili: i18362
+  members:
+  - forsooth
+  partOfSpeech: r
+00039019-r:
+  definition:
+  - as might be expected
+  example:
+  - naturally, the lawyer sent us a huge bill
+  ili: i18366
+  members:
+  - naturally
+  - of course
+  - course
+  partOfSpeech: r
+00039161-r:
+  definition:
+  - in a manner at variance with what is natural or normal
+  example:
+  - The early Church not unnaturally adopted the position that failure to see the
+    messianic character of his work was really caused by the people's own blindness
+  ili: i18367
+  members:
+  - unnaturally
+  partOfSpeech: r
+00039452-r:
+  definition:
+  - without doubt or question
+  example:
+  - they were clearly lost
+  - history has clearly shown the folly of that policy
+  ili: i18368
+  members:
+  - clearly
+  partOfSpeech: r
+00039730-r:
+  definition:
+  - unmistakably (‘plain’ is often used informally for ‘plainly’)
+  example:
+  - the answer is obviously wrong
+  - she was in bed and evidently in great pain
+  - he was manifestly too important to leave off the guest list
+  - it is all patently nonsense
+  - she has apparently been living here for some time
+  - I thought he owned the property, but apparently not
+  - You are plainly wrong
+  - he is plain stubborn
+  exemplifies:
+  - 07089193-n
+  ili: i18370
+  members:
+  - obviously
+  - evidently
+  - manifestly
+  - patently
+  - apparently
+  - plainly
+  - plain
+  partOfSpeech: r
+00040353-r:
+  definition:
+  - from appearances alone
+  example:
+  - irrigation often produces bumper crops from apparently desert land
+  - the child is seemingly healthy but the doctor is concerned
+  - source: Thomas Hardy
+    text: had been ostensibly frank as to his purpose while really concealing it
+  - on the face of it the problem seems minor
+  ili: i18371
+  members:
+  - apparently
+  - seemingly
+  - ostensibly
+  - on the face of it
+  partOfSpeech: r
+00041131-r:
+  definition:
+  - in a way that was not expected
+  example:
+  - her brother showed up at the wedding out of the blue
+  ili: i18375
+  members:
+  - unexpectedly
+  - out of the blue
+  partOfSpeech: r
+00042664-r:
+  definition:
+  - by good fortune
+  example:
+  - fortunately the weather was good
+  ili: i18386
+  members:
+  - fortunately
+  - fortuitously
+  - luckily
+  - as luck would have it
+  partOfSpeech: r
+00042894-r:
+  definition:
+  - in an unexpectedly lucky way
+  example:
+  - happily he was not injured
+  ili: i18387
+  members:
+  - happily
+  partOfSpeech: r
+00043024-r:
+  definition:
+  - in an unfortunate way
+  example:
+  - sadly he died before he could see his grandchild
+  ili: i18388
+  members:
+  - sadly
+  - unhappily
+  partOfSpeech: r
+00043179-r:
+  definition:
+  - by bad luck
+  example:
+  - unfortunately it rained all day
+  - alas, I cannot stay
+  ili: i18389
+  members:
+  - unfortunately
+  - unluckily
+  - regrettably
+  - alas
+  partOfSpeech: r
+00043413-r:
+  definition:
+  - (used to introduce a logical conclusion) from that fact or reason or as a result
+  example:
+  - therefore X must be true
+  - the eggs were fresh and hence satisfactory
+  - we were young and thence optimistic
+  - it is late and thus we must go
+  - the witness is biased and so cannot be trusted
+  ili: i18390
+  members:
+  - therefore
+  - hence
+  - thence
+  - thus
+  - so
+  partOfSpeech: r
+00043757-r:
+  definition:
+  - (used as a sentence connector) therefore or consequently
+  ili: i18391
+  members:
+  - ergo
+  partOfSpeech: r
+00050427-r:
+  definition:
+  - interjection of rebuke
+  ili: i18430
+  members:
+  - now now
+  partOfSpeech: r
+00053542-r:
+  definition:
+  - an expression of agreement normally occurring at the beginning of a sentence
+  ili: i18450
+  members:
+  - very well
+  - fine
+  - alright
+  - all right
+  - OK
+  partOfSpeech: r
+00053690-r:
+  definition:
+  - without doubt (used to reinforce an assertion)
+  example:
+  - it's expensive all right
+  ili: i18451
+  members:
+  - all right
+  - alright
+  partOfSpeech: r
+00054490-r:
+  definition:
+  - by reasonable assumption
+  example:
+  - presumably, he missed the train
+  ili: i18456
+  members:
+  - presumably
+  - presumptively
+  partOfSpeech: r
+00057454-r:
+  definition:
+  - definitely or certainly
+  example:
+  - Visit us by all means
+  exemplifies:
+  - 07089193-n
+  ili: i18478
+  members:
+  - by all means
+  partOfSpeech: r
+00060570-r:
+  definition:
+  - in actuality or reality or fact
+  example:
+  - she is effectively his wife
+  - in effect, they had no choice
+  ili: i18499
+  members:
+  - effectively
+  - in effect
+  partOfSpeech: r
+00060735-r:
+  definition:
+  - in reality or fact
+  example:
+  - the result was, de facto, a one-party system
+  ili: i18500
+  members:
+  - de facto
+  partOfSpeech: r
+00063395-r:
+  definition:
+  - (sentence connectors) because of the reason given
+  example:
+  - consequently, he didn't do it
+  - continued to have severe headaches and accordingly returned to the doctor
+  ili: i18516
+  members:
+  - consequently
+  - accordingly
+  partOfSpeech: r
+00079373-r:
+  definition:
+  - without doubt; certainly
+  example:
+  - it's undoubtedly very beautiful
+  ili: i18615
+  members:
+  - undoubtedly
+  - doubtless
+  - doubtlessly
+  partOfSpeech: r
+00093820-r:
+  definition:
+  - in an unfortunate or deplorable manner
+  example:
+  - he was sadly neglected
+  - it was woefully inadequate
+  ili: i18719
+  members:
+  - deplorably
+  - lamentably
+  - sadly
+  - woefully
+  partOfSpeech: r
+00103431-r:
+  definition:
+  - in the second place
+  example:
+  - second, we must consider the economy
+  ili: i18783
+  members:
+  - second
+  - secondly
+  partOfSpeech: r
+00106462-r:
+  definition:
+  - under the best of conditions
+  example:
+  - at best we'll lose only the money
+  ili: i18805
+  members:
+  - at best
+  - at the best
+  partOfSpeech: r
+00112012-r:
+  definition:
+  - (intensifier before a figurative expression) without exaggeration
+  example:
+  - our eyes were literally pinned to TV during the Gulf War
+  exemplifies:
+  - 06332047-n
+  ili: i18844
+  members:
+  - literally
+  partOfSpeech: r
+00115217-r:
+  definition:
+  - in an official role
+  example:
+  - officially, he is in charge
+  - officially responsible
+  ili: i18865
+  members:
+  - officially
+  partOfSpeech: r
+00116461-r:
+  definition:
+  - more readily or willingly
+  example:
+  - clean it well, preferably with warm water
+  - I'd rather be in Philadelphia
+  - I'd sooner die than give up
+  ili: i18873
+  members:
+  - preferably
+  - sooner
+  - rather
+  partOfSpeech: r
+00132870-r:
+  definition:
+  - as a person
+  example:
+  - he is personally repulsive
+  ili: i19004
+  members:
+  - personally
+  partOfSpeech: r
+00133132-r:
+  definition:
+  - concerning the speaker
+  example:
+  - personally, I find him stupid
+  ili: i19006
+  members:
+  - personally
+  partOfSpeech: r
+00139421-r:
+  definition:
+  - with considerable certainty; without much doubt
+  example:
+  - He is probably out of the country
+  - in all likelihood we are headed for war
+  ili: i19060
+  members:
+  - probably
+  - likely
+  - in all likelihood
+  - in all probability
+  - belike
+  partOfSpeech: r
+00145758-r:
+  definition:
+  - definitely or positively (‘sure’ is sometimes used informally for ‘surely’)
+  example:
+  - the results are surely encouraging
+  - she certainly is a hard worker
+  - it's going to be a good day for sure
+  - they are coming, for certain
+  - they thought he had been killed sure enough
+  - he'll win sure as shooting
+  - they sure smell good
+  - sure he'll come
+  exemplifies:
+  - 07089193-n
+  ili: i19112
+  members:
+  - surely
+  - certainly
+  - sure
+  - for sure
+  - for certain
+  - sure enough
+  - sure as shooting
+  partOfSpeech: r
+00146264-r:
+  definition:
+  - in a surprising manner
+  example:
+  - he was surprisingly friendly
+  ili: i19113
+  members:
+  - surprisingly
+  partOfSpeech: r
+00149927-r:
+  definition:
+  - in reality or actuality
+  example:
+  - in fact, it was a wonder anyone survived
+  - painters who are in fact anything but unsophisticated
+  - as a matter of fact, he is several inches taller than his father
+  ili: i19140
+  members:
+  - in fact
+  - in point of fact
+  - as a matter of fact
+  partOfSpeech: r
+00150196-r:
+  definition:
+  - used to imply that one would expect the fact to be the opposite of that stated;
+    surprisingly
+  example:
+  - you may actually be doing the right thing by walking out
+  - she actually spoke Latin
+  - they thought they made the rules but in reality they were only puppets
+  - people who seem stand-offish are in reality often simply nervous
+  ili: i19141
+  members:
+  - actually
+  - in reality
+  partOfSpeech: r
+00150568-r:
+  definition:
+  - in actual fact
+  example:
+  - to be nominally but not actually independent
+  - no one actually saw the shark
+  - large meteorites actually come from the asteroid belt
+  - properly speaking, they are not husband and wife
+  ili: i19142
+  members:
+  - actually
+  - really
+  - properly speaking
+  - strictly speaking
+  - to be precise
+  partOfSpeech: r
+00150802-r:
+  definition:
+  - as a sentence modifier to add slight emphasis; as a modifier to add slight emphasis
+  example:
+  - actually, we all help clear up after a meal
+  - actually, I haven't seen the film
+  - I'm not all that surprised actually
+  - she hasn't proved to be too satisfactory, actually
+  ili: i19143
+  members:
+  - actually
+  partOfSpeech: r
+00151061-r:
+  definition:
+  - at present
+  example:
+  - the transmission screen shows the picture that is actually on the air
+  ili: i19144
+  members:
+  - actually
+  partOfSpeech: r
+00151192-r:
+  definition:
+  - admittedly
+  example:
+  - to be sure, he is no Einstein
+  ili: i19145
+  members:
+  - to be sure
+  - without doubt
+  - no doubt
+  partOfSpeech: r
+00151301-r:
+  definition:
+  - as supposed or expected
+  example:
+  - sure enough, he asked her for money again
+  ili: i19146
+  members:
+  - sure enough
+  partOfSpeech: r
+00152207-r:
+  definition:
+  - emphasizes something to be considered
+  example:
+  - after all, she is your boss, so invite her
+  - he is, after all, our president
+  ili: i19154
+  members:
+  - after all
+  partOfSpeech: r
+00152813-r:
+  definition:
+  - with everything considered (and neglecting details)
+  example:
+  - altogether, I'm sorry it happened
+  - all in all, it's not so bad
+  ili: i19159
+  members:
+  - all in all
+  - on the whole
+  - altogether
+  - tout ensemble
+  partOfSpeech: r
+00153834-r:
+  definition:
+  - as if it were really so
+  example:
+  - she lives here, as it were
+  ili: i19168
+  members:
+  - as it were
+  - so to speak
+  partOfSpeech: r
+00153940-r:
+  definition:
+  - in a manner of speaking
+  example:
+  - the feeling is, as we say, quite dead
+  ili: i19169
+  members:
+  - as we say
+  - so to speak
+  partOfSpeech: r
+00155440-r:
+  definition:
+  - according to what has been alleged
+  example:
+  - he was on trial for allegedly murdering his wife
+  ili: i19181
+  members:
+  - allegedly
+  partOfSpeech: r
+00155582-r:
+  definition:
+  - believed or reputed to be the case
+  ili: i19182
+  members:
+  - purportedly
+  - supposedly
+  partOfSpeech: r
+00156754-r:
+  definition:
+  - usually; as a rule
+  example:
+  - by and large it doesn't rain much here
+  ili: i19191
+  members:
+  - by and large
+  - generally
+  - more often than not
+  - mostly
+  partOfSpeech: r
+00157363-r:
+  definition:
+  - introducing a different topic
+  example:
+  - incidentally, I won't go to the party
+  ili: i19196
+  members:
+  - by the way
+  - by the bye
+  - incidentally
+  - apropos
+  partOfSpeech: r
+00160239-r:
+  definition:
+  - as an example
+  example:
+  - take ribbon snakes, for example
+  ili: i19216
+  members:
+  - for example
+  - for instance
+  - e.g.
+  partOfSpeech: r
+00161285-r:
+  definition:
+  - written formula for ending a letter
+  ili: i19224
+  members:
+  - sincerely
+  - sincerely yours
+  partOfSpeech: r
+00169954-r:
+  definition:
+  - used ironically to indicate the opposite of what is stated
+  example:
+  - says he'll help me? Like hell he will!
+  ili: i19284
+  members:
+  - like hell
+  - like fun
+  partOfSpeech: r
+00171282-r:
+  definition:
+  - by hypothesis
+  ili: i19294
+  members:
+  - hypothetically
+  partOfSpeech: r
+00174073-r:
+  definition:
+  - because of prevailing conditions
+  example:
+  - under the circumstances I cannot buy the house
+  ili: i19316
+  members:
+  - under the circumstances
+  partOfSpeech: r
+00180819-r:
+  definition:
+  - otherwise stated
+  example:
+  - in other words, we are broke
+  ili: i19366
+  members:
+  - in other words
+  - put differently
+  partOfSpeech: r
+00181163-r:
+  definition:
+  - without any necessity
+  example:
+  - this marathon would exhaust him unnecessarily
+  ili: i19369
+  members:
+  - unnecessarily
+  partOfSpeech: r
+00185770-r:
+  definition:
+  - as acknowledged
+  example:
+  - true, she is the smartest in her class
+  ili: i19401
+  members:
+  - 'true'
+  - admittedly
+  - avowedly
+  - confessedly
+  partOfSpeech: r
+00189465-r:
+  definition:
+  - especially fortunate
+  example:
+  - best of all, we don't have any homework!
+  ili: i19429
+  members:
+  - best of all
+  partOfSpeech: r
+00189569-r:
+  definition:
+  - it would be sensible
+  example:
+  - you'd best stay at home
+  ili: i19430
+  members:
+  - best
+  partOfSpeech: r
+00190790-r:
+  definition:
+  - with pretense or intention to deceive
+  example:
+  - is only professedly poor
+  ili: i19440
+  members:
+  - professedly
+  partOfSpeech: r
+00191723-r:
+  definition:
+  - by some means not understood by the speaker
+  example:
+  - God knows how he did it, but he did climbed that steep wall
+  ili: i19447
+  members:
+  - God knows how
+  partOfSpeech: r
+00193186-r:
+  also:
+  - 91000331-r
+  definition:
+  - a figure of speech used as a way to provide further information, or to be more
+    specific or exact about something
+  ili: i19457
+  members:
+  - i.e.
+  - ie
+  - id est
+  partOfSpeech: r
+00195469-r:
+  definition:
+  - within the realm of possibility
+  example:
+  - the weather may conceivably change
+  ili: i19475
+  members:
+  - conceivably
+  partOfSpeech: r
+00196820-r:
+  definition:
+  - in an ideal manner
+  example:
+  - ideally, this will remove all problems
+  ili: i19487
+  members:
+  - ideally
+  partOfSpeech: r
+00201311-r:
+  definition:
+  - let us be thankful that
+  example:
+  - thankfully he didn't come to the party
+  ili: i19518
+  members:
+  - thankfully
+  partOfSpeech: r
+00201575-r:
+  definition:
+  - it is hoped
+  example:
+  - hopefully the weather will be fine on Sunday
+  ili: i19520
+  members:
+  - hopefully
+  partOfSpeech: r
+00202356-r:
+  definition:
+  - according to reports or other information
+  example:
+  - she was reportedly his mistress for many years
+  ili: i19525
+  members:
+  - reportedly
+  partOfSpeech: r
+00206553-r:
+  definition:
+  - in accordance with moral or social standards
+  example:
+  - that serves him right
+  - do right by him
+  ili: i19555
+  members:
+  - justly
+  - right
+  partOfSpeech: r
+00206702-r:
+  definition:
+  - with honesty
+  example:
+  - he was rightly considered the greatest singer of his time
+  ili: i19556
+  members:
+  - rightly
+  - justly
+  - justifiedly
+  partOfSpeech: r
+00213360-r:
+  definition:
+  - without possibility of mistake
+  example:
+  - this watercolor is unmistakably a synthesis of nature
+  ili: i19603
+  members:
+  - unmistakably
+  partOfSpeech: r
+00214599-r:
+  definition:
+  - in an amazing manner; to everyone's surprise
+  example:
+  - amazingly, he finished medical school in three years
+  ili: i19612
+  members:
+  - amazingly
+  - surprisingly
+  - astonishingly
+  partOfSpeech: r
+00216059-r:
+  definition:
+  - in an interesting manner
+  example:
+  - source: Time
+    text: when he ceases to be just interestingly neurotic and … gets locked up
+  ili: i19620
+  members:
+  - interestingly
+  partOfSpeech: r
+00219478-r:
+  definition:
+  - in a rueful manner
+  example:
+  - ‘I made a big mistake,’ he said ruefully
+  ili: i19640
+  members:
+  - ruefully
+  - contritely
+  - remorsefully
+  partOfSpeech: r
+00224480-r:
+  definition:
+  - by right
+  example:
+  - baseball rightfully is the nation's pastime
+  ili: i19671
+  members:
+  - rightfully
+  - truly
+  partOfSpeech: r
+00238709-r:
+  definition:
+  - in a tragic manner; with tragic consequences
+  example:
+  - the adventure ended tragically
+  - tragically, she contracted AIDS
+  ili: i19773
+  members:
+  - tragically
+  partOfSpeech: r
+00240942-r:
+  definition:
+  - with modesty; in a modest manner
+  example:
+  - the dissertation was entitled, modestly, ‘Remarks about a play by Shakespeare’
+  ili: i19789
+  members:
+  - modestly
+  partOfSpeech: r
+00255756-r:
+  definition:
+  - in a counterintuitive manner
+  ili: i19902
+  members:
+  - counterintuitively
+  partOfSpeech: r
+00257094-r:
+  definition:
+  - (formal) by means of this
+  example:
+  - I hereby declare you man and wife
+  exemplifies:
+  - 01206545-n
+  ili: i19914
+  members:
+  - hereby
+  - herewith
+  partOfSpeech: r
+00257990-r:
+  definition:
+  - by the fact itself
+  example:
+  - ipso facto, her innocence was established
+  ili: i19921
+  members:
+  - ipso facto
+  partOfSpeech: r
+00261520-r:
+  definition:
+  - by necessity; by force of circumstance
+  ili: i19955
+  members:
+  - perforce
+  partOfSpeech: r
+00268242-r:
+  definition:
+  - without a doubt
+  example:
+  - the grammar schools were assuredly not intended for the gentry alone
+  ili: i20004
+  members:
+  - assuredly
+  partOfSpeech: r
+00278639-r:
+  definition:
+  - in a bald manner
+  example:
+  - this book is, to put it baldly, an uneven work.
+  ili: i20082
+  members:
+  - baldly
+  partOfSpeech: r
+00295773-r:
+  definition:
+  - as a consequence
+  example:
+  - he had good reason to be grateful for the opportunities which they had made available
+    to him and which consequently led to the good position he now held
+  ili: i20199
+  members:
+  - consequently
+  - therefore
+  partOfSpeech: r
+00296016-r:
+  definition:
+  - having the result that
+  ili: i20200
+  members:
+  - consequentially
+  partOfSpeech: r
+00297139-r:
+  definition:
+  - not easy to believe
+  example:
+  - incredibly, she survived the crash
+  ili: i20206
+  members:
+  - incredibly
+  - improbably
+  - implausibly
+  - unbelievably
+  partOfSpeech: r
+00301501-r:
+  definition:
+  - by chance
+  example:
+  - perhaps she will call tomorrow
+  - we may possibly run into them at the concert
+  - it may peradventure be thought that there never was such a time
+  ili: i20231
+  members:
+  - possibly
+  - perchance
+  - perhaps
+  - maybe
+  - mayhap
+  - peradventure
+  partOfSpeech: r
+00301868-r:
+  definition:
+  - to a degree possible of achievement or by possible means
+  example:
+  - they can't possibly get here in time for the funeral?
+  ili: i20232
+  members:
+  - possibly
+  partOfSpeech: r
+00302263-r:
+  definition:
+  - with a possibility of becoming actual
+  example:
+  - he is potentially dangerous
+  - potentially useful
+  ili: i20234
+  members:
+  - potentially
+  partOfSpeech: r
+00302867-r:
+  definition:
+  - as deserved
+  example:
+  - he chalked up two goals which deservedly gave Bolton their second victory of the
+    season
+  ili: i20238
+  members:
+  - deservedly
+  partOfSpeech: r
+00303026-r:
+  definition:
+  - in an unmerited manner
+  example:
+  - the team chalked up another victory, the last one quite undeservedly, in my opinion
+  ili: i20239
+  members:
+  - undeservedly
+  partOfSpeech: r
+00304163-r:
+  definition:
+  - not involving any controversy
+  ili: i20246
+  members:
+  - uncontroversially
+  partOfSpeech: r
+00309952-r:
+  definition:
+  - in an obvious and provable manner
+  example:
+  - his documentary sources are demonstrably wrong
+  ili: i20285
+  members:
+  - demonstrably
+  - provably
+  - incontrovertibly
+  partOfSpeech: r
+00314318-r:
+  definition:
+  - in a disappointing manner
+  example:
+  - the discoverer of argon, Sir William Ramsay, looked disappointingly ordinary
+  ili: i20311
+  members:
+  - disappointingly
+  partOfSpeech: r
+00316228-r:
+  definition:
+  - (used as intensives reflecting the speaker's attitude) it is sincerely the case
+    that
+  example:
+  - honestly, I don't believe it
+  - candidly, I think she doesn't have a conscience
+  - frankly, my dear, I don't give a damn
+  exemplifies:
+  - 06332047-n
+  ili: i20320
+  members:
+  - honestly
+  - candidly
+  - frankly
+  partOfSpeech: r
+00320668-r:
+  definition:
+  - in a respectful manner
+  example:
+  - might I respectfully suggest to the Town Council that they should adopt a policy
+    of masterly inactivity?
+  ili: i20345
+  members:
+  - respectfully
+  partOfSpeech: r
+00341590-r:
+  definition:
+  - in the fifth place
+  example:
+  - fifthly, we must adhere to the rules set by the local government
+  ili: i20478
+  members:
+  - fifthly
+  partOfSpeech: r
+00341730-r:
+  definition:
+  - in a figurative sense
+  example:
+  - figuratively speaking, …
+  ili: i20479
+  members:
+  - figuratively
+  partOfSpeech: r
+00355281-r:
+  definition:
+  - by accident
+  example:
+  - betrayed by a word haply overheard
+  ili: i20575
+  members:
+  - haply
+  - by chance
+  - by luck
+  partOfSpeech: r
+00365540-r:
+  definition:
+  - according to logical reasoning
+  example:
+  - logically, you should now do the same to him
+  ili: i20647
+  members:
+  - logically
+  partOfSpeech: r
+00368189-r:
+  definition:
+  - as yourself
+  example:
+  - speaking personally, I would not want to go
+  ili: i20664
+  members:
+  - personally
+  partOfSpeech: r
+00369664-r:
+  definition:
+  - in an important way or to an important degree
+  example:
+  - more importantly, Weber held that the manifold meaning attached to the event by
+    the social scientist could alter his definition of the concrete event itself
+  ili: i20673
+  members:
+  - importantly
+  - significantly
+  partOfSpeech: r
+00370459-r:
+  definition:
+  - just as it should be
+  example:
+  - ‘Precisely, my lord,’ he said
+  ili: i20677
+  members:
+  - precisely
+  - exactly
+  - on the nose
+  - on the dot
+  - on the button
+  partOfSpeech: r
+00372716-r:
+  definition:
+  - in a manner tending to attract attention
+  example:
+  - there have been plenty of general declarations about willingness to meet and talk,
+    but conspicuously no mention of time and place
+  ili: i20691
+  members:
+  - conspicuously
+  partOfSpeech: r
+00384453-r:
+  definition:
+  - contrary to plan or expectation
+  example:
+  - ironically, he ended up losing money under his own plan
+  ili: i20764
+  members:
+  - ironically
+  partOfSpeech: r
+00402102-r:
+  definition:
+  - with truth
+  example:
+  - I told him truthfully that I had just returned from my vacation
+  - he answered the question as truthfully as he could
+  ili: i20886
+  members:
+  - truthfully
+  partOfSpeech: r
+00404674-r:
+  definition:
+  - in a miraculous manner
+  example:
+  - my hand grasped the gun that was, miraculously, lying on the ground beside my
+    finger tips
+  ili: i20903
+  members:
+  - miraculously
+  partOfSpeech: r
+00410115-r:
+  definition:
+  - in an essential manner
+  example:
+  - such expenses are necessarily incurred
+  ili: i20938
+  members:
+  - necessarily
+  - needfully
+  partOfSpeech: r
+00410285-r:
+  definition:
+  - as a highly likely consequence
+  example:
+  - we are necessarily bound for federalism in Europe
+  ili: i20939
+  members:
+  - necessarily
+  partOfSpeech: r
+00412791-r:
+  definition:
+  - to a notorious degree
+  example:
+  - European emigres, who notoriously used to repair to the British Museum to write
+    seditious pamphlets
+  ili: i20957
+  members:
+  - notoriously
+  partOfSpeech: r
+00420895-r:
+  definition:
+  - in a pedantic manner
+  example:
+  - these interpretations are called ‘schemas’ or, more pedantically, ‘schemata’
+  ili: i21016
+  members:
+  - pedantically
+  partOfSpeech: r
+00421914-r:
+  definition:
+  - through chance
+  example:
+  - To sleep, perchance to dream …
+  exemplifies:
+  - 07087487-n
+  ili: i21024
+  members:
+  - perchance
+  - by chance
+  partOfSpeech: r
+00426224-r:
+  definition:
+  - with regret (used in polite formulas)
+  example:
+  - I must regretfully decline your kind invitation
+  ili: i21056
+  members:
+  - regretfully
+  partOfSpeech: r
+00430483-r:
+  definition:
+  - in a practicable manner; so as to be feasible
+  ili: i21088
+  members:
+  - practicably
+  - feasibly
+  partOfSpeech: r
+00431708-r:
+  definition:
+  - in a predictable manner or to a predictable degree
+  example:
+  - predictably, he did not like the news
+  ili: i21096
+  members:
+  - predictably
+  partOfSpeech: r
+00434111-r:
+  definition:
+  - in such a way as to pose a problem
+  ili: i21113
+  members:
+  - problematically
+  partOfSpeech: r
+00435802-r:
+  definition:
+  - in the manner of something that has become a byword
+  example:
+  - this proverbially bitter plant, wormwood
+  ili: i21126
+  members:
+  - proverbially
+  partOfSpeech: r
+00436106-r:
+  definition:
+  - in a fortunately providential manner
+  example:
+  - providentially the weather remained good
+  ili: i21128
+  members:
+  - providentially
+  partOfSpeech: r
+00439469-r:
+  definition:
+  - without question
+  example:
+  - Fred Winter is unquestionably the jockey to follow
+  - they hired unimpeachably first-rate faculty members
+  ili: i21152
+  members:
+  - unquestionably
+  - unimpeachably
+  partOfSpeech: r
+00442014-r:
+  definition:
+  - in a pleasantly novel manner
+  example:
+  - she was refreshingly free from shyness
+  ili: i21171
+  members:
+  - refreshingly
+  partOfSpeech: r
+00442143-r:
+  definition:
+  - in a manner that relieves fatigue and restores vitality
+  example:
+  - the air was refreshingly cool
+  ili: i21172
+  members:
+  - refreshingly
+  - refreshfully
+  partOfSpeech: r
+00443214-r:
+  definition:
+  - by repute; according to general belief
+  example:
+  - fish with reputedly poisonous flesh
+  ili: i21180
+  members:
+  - reputedly
+  partOfSpeech: r
+00443633-r:
+  definition:
+  - with resignation and acceptance; in a resigned manner
+  example:
+  - resignedly, I telegraphed back that it was all right with me if he insisted
+  ili: i21183
+  members:
+  - resignedly
+  partOfSpeech: r
+00450666-r:
+  definition:
+  - in a self-evident manner
+  ili: i21236
+  members:
+  - self-evidently
+  partOfSpeech: r
+00452400-r:
+  definition:
+  - in the seventh place
+  example:
+  - seventhly, you have no right to cancel the lease in mid-year
+  ili: i21248
+  members:
+  - seventhly
+  partOfSpeech: r
+00457801-r:
+  definition:
+  - in the sixth place
+  example:
+  - sixthly, we cannot afford a vacation
+  ili: i21289
+  members:
+  - sixthly
+  partOfSpeech: r
+00484790-r:
+  definition:
+  - in an unaccountable manner
+  example:
+  - in the book, a tycoon unaccountably becomes the hero's friend
+  ili: i21493
+  members:
+  - unaccountably
+  partOfSpeech: r
+00485173-r:
+  definition:
+  - in an unarguable and undisputed manner
+  example:
+  - you write as if this fact, whilst inarguably forever condemning me to the ranks
+    of Bohemianism, nevertheless earned for me the right of entry into any company
+  ili: i21495
+  members:
+  - unarguably
+  - undisputedly
+  - inarguably
+  partOfSpeech: r
+00486260-r:
+  definition:
+  - without someone's knowledge
+  example:
+  - unbeknownst to me, she made all the arrangements
+  ili: i21501
+  members:
+  - unbeknown
+  - unbeknownst
+  partOfSpeech: r
+00488100-r:
+  definition:
+  - to an undeniable degree or in an undeniable manner
+  example:
+  - she is undeniably the most gifted student in the class
+  ili: i21515
+  members:
+  - undeniably
+  partOfSpeech: r
+00491284-r:
+  definition:
+  - without reservation
+  example:
+  - I can unreservedly recommend this restaurant!
+  ili: i21540
+  members:
+  - unreservedly
+  partOfSpeech: r
+00494943-r:
+  definition:
+  - in truth; certainly
+  example:
+  - I verily think so
+  - source: The Bible, Psalms 37:3
+    text: trust in the Lord … and verily thou shalt be fed
+  exemplifies:
+  - 07087487-n
+  ili: i21569
+  members:
+  - verily
+  partOfSpeech: r
+00499758-r:
+  definition:
+  - not only so, but
+  example:
+  - I therein do rejoice, yea, and will rejoice
+  ili: i21611
+  members:
+  - yea
+  - yeah
+  partOfSpeech: r
+00507906-r:
+  definition:
+  - with reason or justice
+  ili: i21677
+  members:
+  - by rights
+  partOfSpeech: r
+00510788-r:
+  definition:
+  - used with question words to convey surprise
+  example:
+  - what on earth are you doing?
+  ili: i21701
+  members:
+  - on earth
+  partOfSpeech: r
+00512379-r:
+  definition:
+  - from a position of superiority or authority
+  example:
+  - father knows best
+  - I know better.
+  ili: i21713
+  members:
+  - better
+  - best
+  partOfSpeech: r
+00513162-r:
+  definition:
+  - happening at the same time
+  ili: i21719
+  members:
+  - coincidentally
+  - coincidently
+  partOfSpeech: r
+00518855-r:
+  definition:
+  - in a vexatious manner
+  ili: i21775
+  members:
+  - vexatiously
+  partOfSpeech: r

--- a/src/yaml/adv.subject_oriented.yaml
+++ b/src/yaml/adv.subject_oriented.yaml
@@ -1,0 +1,695 @@
+00015344-r:
+  definition:
+  - with prudence or propriety
+  example:
+  - You would do well to say nothing more
+  - could not well refuse
+  ili: i18228
+  members:
+  - well
+  partOfSpeech: r
+00041684-r:
+  definition:
+  - extraordinary; unusual
+  example:
+  - such erratic behavior was out of the way for him
+  ili: i18381
+  members:
+  - out of the way
+  partOfSpeech: r
+00080795-r:
+  definition:
+  - in a manner deserving contempt
+  ili: i18626
+  members:
+  - contemptibly
+  partOfSpeech: r
+00091747-r:
+  definition:
+  - with reluctance
+  ili: i18704
+  members:
+  - reluctantly
+  partOfSpeech: r
+00107831-r:
+  definition:
+  - in the usual manner
+  example:
+  - as usual, she arrived late
+  ili: i18814
+  members:
+  - as usual
+  partOfSpeech: r
+00116998-r:
+  definition:
+  - in a self-indulgent manner
+  ili: i18877
+  members:
+  - self-indulgently
+  partOfSpeech: r
+00123514-r:
+  definition:
+  - in an undemocratic manner
+  example:
+  - undemocratically, he made all the important decisions without his colleagues
+  ili: i18922
+  members:
+  - undemocratically
+  partOfSpeech: r
+00129052-r:
+  definition:
+  - in a typical manner
+  example:
+  - Tom was typically hostile
+  ili: i18970
+  members:
+  - typically
+  partOfSpeech: r
+00129174-r:
+  definition:
+  - in a manner that is not typical
+  example:
+  - she was atypically quiet
+  ili: i18971
+  members:
+  - atypically
+  - untypically
+  partOfSpeech: r
+00174412-r:
+  definition:
+  - in a courageous manner
+  example:
+  - bravely he went into the burning house
+  ili: i19319
+  members:
+  - bravely
+  - courageously
+  partOfSpeech: r
+00176830-r:
+  definition:
+  - in a stupid manner
+  example:
+  - he had stupidly bought a one way ticket
+  ili: i19337
+  members:
+  - stupidly
+  - doltishly
+  partOfSpeech: r
+00184261-r:
+  definition:
+  - in a considerate manner
+  example:
+  - they considerately withdrew
+  ili: i19392
+  members:
+  - considerately
+  partOfSpeech: r
+00184393-r:
+  definition:
+  - without consideration; in an inconsiderate manner
+  example:
+  - inconsiderately, he asked to be invited for dinner
+  ili: i19393
+  members:
+  - inconsiderately
+  partOfSpeech: r
+00196934-r:
+  definition:
+  - in a mistaken or erroneous manner
+  example:
+  - he mistakenly believed it
+  ili: i19488
+  members:
+  - mistakenly
+  - erroneously
+  partOfSpeech: r
+00200274-r:
+  definition:
+  - in a stubborn unregenerate manner
+  example:
+  - she remained stubbornly in the same position
+  ili: i19511
+  members:
+  - stubbornly
+  - pig-headedly
+  - obdurately
+  - mulishly
+  - obstinately
+  - cussedly
+  partOfSpeech: r
+00200566-r:
+  definition:
+  - in a wrongheaded manner
+  ili: i19512
+  members:
+  - wrongheadedly
+  partOfSpeech: r
+00202999-r:
+  definition:
+  - in a wise manner
+  example:
+  - she acted wisely when she invited her parents
+  ili: i19530
+  members:
+  - wisely
+  - sagely
+  partOfSpeech: r
+00218268-r:
+  definition:
+  - showing consideration and thoughtfulness
+  example:
+  - he had thoughtfully brought with him some food to share
+  ili: i19633
+  members:
+  - thoughtfully
+  partOfSpeech: r
+00220366-r:
+  definition:
+  - in an admirable manner
+  example:
+  - the children's responses were admirably normal
+  ili: i19646
+  members:
+  - admirably
+  - laudably
+  - praiseworthily
+  - commendable
+  partOfSpeech: r
+00233351-r:
+  definition:
+  - in accommodation
+  example:
+  - obligingly, he lowered his voice
+  ili: i19735
+  members:
+  - obligingly
+  - accommodatingly
+  partOfSpeech: r
+00240256-r:
+  definition:
+  - in a callous way
+  example:
+  - he callously exploited their feelings
+  ili: i19784
+  members:
+  - callously
+  - unfeelingly
+  partOfSpeech: r
+00240401-r:
+  definition:
+  - with good reason
+  example:
+  - he is justifiably bitter
+  ili: i19785
+  members:
+  - justifiably
+  partOfSpeech: r
+00240521-r:
+  definition:
+  - without any excuse
+  example:
+  - he is unjustifiably harsh on her
+  ili: i19786
+  members:
+  - unjustifiably
+  - inexcusably
+  partOfSpeech: r
+00249046-r:
+  definition:
+  - in characteristic manner
+  example:
+  - he arrived characteristically late
+  ili: i19849
+  members:
+  - characteristically
+  partOfSpeech: r
+00249191-r:
+  definition:
+  - in uncharacteristic manner
+  example:
+  - he was uncharacteristically cool
+  ili: i19850
+  members:
+  - uncharacteristically
+  partOfSpeech: r
+00249728-r:
+  definition:
+  - in a prophetic manner
+  example:
+  - he prophetically anticipated the disaster
+  ili: i19854
+  members:
+  - prophetically
+  partOfSpeech: r
+00267447-r:
+  definition:
+  - in an arrogant manner
+  example:
+  - in the old days she had been harsh and stiff; afraid of her husband and yet arrogantly
+    proud that she had a husband strong and fierce enough to make her afraid
+  ili: i19999
+  members:
+  - arrogantly
+  partOfSpeech: r
+00272405-r:
+  definition:
+  - in an altruistic manner
+  example:
+  - he acted selflessly when he helped the old lady in distress
+  ili: i20035
+  members:
+  - altruistically
+  - selflessly
+  partOfSpeech: r
+00272901-r:
+  definition:
+  - in an ungrateful manner
+  ili: i20038
+  members:
+  - ungratefully
+  - unappreciatively
+  partOfSpeech: r
+00285748-r:
+  definition:
+  - in a brash cheeky manner
+  example:
+  - brashly, she asked for a rebate
+  ili: i20130
+  members:
+  - cheekily
+  - nervily
+  - brashly
+  partOfSpeech: r
+00289255-r:
+  definition:
+  - in a self-satisfied manner
+  example:
+  - he complacently lived out his life as a village school teacher
+  ili: i20154
+  members:
+  - complacently
+  partOfSpeech: r
+00295240-r:
+  definition:
+  - in an subtle, cunning manner
+  example:
+  - he craftily arranged to be there when the decision was announced
+  - had ever circumstances conspired so cunningly?
+  ili: i20197
+  members:
+  - craftily
+  - cunningly
+  - foxily
+  - knavishly
+  - slyly
+  - trickily
+  - artfully
+  partOfSpeech: r
+00305811-r:
+  definition:
+  - in an adventurous manner
+  example:
+  - daringly, he set out on a camping trip in East Africa
+  ili: i20257
+  members:
+  - daringly
+  partOfSpeech: r
+00306669-r:
+  definition:
+  - in a willing manner
+  example:
+  - I willingly accept
+  ili: i20264
+  members:
+  - willingly
+  - volitionally
+  partOfSpeech: r
+00316567-r:
+  definition:
+  - in a hypocritical manner
+  example:
+  - he behaved hypocritically by praying piously when people were watching
+  ili: i20321
+  members:
+  - hypocritically
+  partOfSpeech: r
+00316988-r:
+  definition:
+  - in a disingenuous manner
+  example:
+  - disingenuously, he asked leading questions about his opponent's work
+  ili: i20324
+  members:
+  - disingenuously
+  - artfully
+  partOfSpeech: r
+00334820-r:
+  definition:
+  - in an excusable manner or to an excusable degree
+  example:
+  - he was excusably late
+  ili: i20437
+  members:
+  - excusably
+  - forgivably
+  - pardonably
+  partOfSpeech: r
+00340873-r:
+  definition:
+  - without compassionate feelings
+  example:
+  - unfeelingly, she required her maid to work on Christmas Day
+  ili: i20474
+  members:
+  - unfeelingly
+  partOfSpeech: r
+00353559-r:
+  definition:
+  - in a grudging manner
+  example:
+  - he grudgingly agreed to have a drink in a hotel close by
+  ili: i20563
+  members:
+  - grudgingly
+  partOfSpeech: r
+00356577-r:
+  definition:
+  - in an unadvised manner
+  ili: i20585
+  members:
+  - unadvisedly
+  partOfSpeech: r
+00366712-r:
+  definition:
+  - in an impenitent manner
+  example:
+  - he repeated his position unrepentantly
+  ili: i20655
+  members:
+  - impenitently
+  - unrepentantly
+  partOfSpeech: r
+00370928-r:
+  definition:
+  - in a provident manner
+  example:
+  - providently, he had saved up some money for emergencies
+  ili: i20680
+  members:
+  - providently
+  partOfSpeech: r
+00371084-r:
+  definition:
+  - in a prudent manner
+  example:
+  - I had allotted my own bedroom for necking, prudently removing both the bed and
+    the key, and taken both myself and my typewriter into my son's bedroom.
+  ili: i20681
+  members:
+  - prudently
+  - providentially
+  partOfSpeech: r
+00371348-r:
+  definition:
+  - in an imprudent manner
+  example:
+  - imprudently, he downed tools and ran home to make his wife happy
+  ili: i20682
+  members:
+  - imprudently
+  partOfSpeech: r
+00374744-r:
+  definition:
+  - without discretion or wisdom or self-restraint
+  example:
+  - she inquired indiscreetly after the state of his health
+  ili: i20702
+  members:
+  - indiscreetly
+  partOfSpeech: r
+00377757-r:
+  definition:
+  - in a not unlawful manner
+  example:
+  - he claimed to have purchased the contraband innocently
+  ili: i20719
+  members:
+  - innocently
+  partOfSpeech: r
+00392720-r:
+  definition:
+  - without qualities thought to befit a man
+  ili: i20819
+  members:
+  - unmanfully
+  - unmanly
+  partOfSpeech: r
+00396055-r:
+  definition:
+  - in a magnanimous manner
+  example:
+  - magnanimously, he forgave all those who had harmed him
+  ili: i20845
+  members:
+  - magnanimously
+  partOfSpeech: r
+00397334-r:
+  definition:
+  - in a masochistic manner
+  example:
+  - masochistically he insisted on an even greater workload
+  ili: i20856
+  members:
+  - masochistically
+  partOfSpeech: r
+00408067-r:
+  definition:
+  - in a naive manner
+  example:
+  - he believed, naively, that she would leave him her money
+  ili: i20926
+  members:
+  - naively
+  partOfSpeech: r
+00408548-r:
+  definition:
+  - in a narrow-minded manner
+  example:
+  - narrow-mindedly, the authorities closed down the cafe where teenagers used to
+    hang out
+  ili: i20929
+  members:
+  - narrow-mindedly
+  - small-mindedly
+  partOfSpeech: r
+00408778-r:
+  definition:
+  - in a broad-minded manner
+  example:
+  - the authorities broad-mindedly permitted the opening of a center for teenagers
+  ili: i20930
+  members:
+  - broad-mindedly
+  partOfSpeech: r
+00410408-r:
+  definition:
+  - in an unnecessary manner
+  example:
+  - they were unnecessarily rude
+  ili: i20940
+  members:
+  - unnecessarily
+  partOfSpeech: r
+00416162-r:
+  definition:
+  - with optimism; in an optimistic manner
+  example:
+  - ‘We have a good chance of winning,’ he exclaimed optimistically
+  ili: i20982
+  members:
+  - optimistically
+  partOfSpeech: r
+00420302-r:
+  definition:
+  - in a patriotic manner
+  example:
+  - patriotically, he buys only U.S.-made products
+  ili: i21013
+  members:
+  - patriotically
+  partOfSpeech: r
+00420451-r:
+  definition:
+  - in an unpatriotic manner
+  example:
+  - unpatriotically he contrived a way of avoiding military service
+  ili: i21014
+  members:
+  - unpatriotically
+  partOfSpeech: r
+00421054-r:
+  definition:
+  - in a peevish manner
+  ili: i21017
+  members:
+  - peevishly
+  - querulously
+  - fractiously
+  partOfSpeech: r
+00424530-r:
+  definition:
+  - in a piggish manner
+  example:
+  - piggishly, he took two pieces of cake
+  ili: i21043
+  members:
+  - piggishly
+  partOfSpeech: r
+00432676-r:
+  definition:
+  - in a presumptuous manner
+  example:
+  - he presumptuously overstepped the doctor's orders
+  ili: i21103
+  members:
+  - presumptuously
+  partOfSpeech: r
+00440193-r:
+  definition:
+  - in a quixotic manner
+  example:
+  - sent to jail for two years, he has quixotically refused to clear himself by betraying
+    his colleagues
+  ili: i21156
+  members:
+  - quixotically
+  partOfSpeech: r
+00443329-r:
+  definition:
+  - with resentment; in a resentful manner
+  example:
+  - the best doctors would stay resentfully out of the national service, refusing
+    to become the minions of a Minister
+  ili: i21181
+  members:
+  - resentfully
+  partOfSpeech: r
+00446492-r:
+  definition:
+  - like a dishonest rogue
+  example:
+  - he roguishly intended to keep the money
+  ili: i21206
+  members:
+  - roguishly
+  partOfSpeech: r
+00451658-r:
+  definition:
+  - in an unsentimental manner
+  example:
+  - unsentimentally, she threw out her dead son's toys
+  ili: i21243
+  members:
+  - unsentimentally
+  partOfSpeech: r
+00454221-r:
+  definition:
+  - so as to shock the feelings
+  example:
+  - One day, she lost her temper, completely, suddenly and, even to herself, shockingly
+  - Suddenly, shockingly, the clergyman's son was a desperado.
+  ili: i21263
+  members:
+  - shockingly
+  partOfSpeech: r
+00462737-r:
+  definition:
+  - in a sociable manner
+  example:
+  - sociably, the new neighbors invited everyone on the block for coffee
+  ili: i21324
+  members:
+  - sociably
+  partOfSpeech: r
+00466293-r:
+  definition:
+  - in an unsportsmanlike manner
+  ili: i21355
+  members:
+  - unsportingly
+  partOfSpeech: r
+00467231-r:
+  definition:
+  - in a standoffish manner
+  example:
+  - standoffishly, he declined the invitation to the office party
+  ili: i21362
+  members:
+  - standoffishly
+  partOfSpeech: r
+00473095-r:
+  definition:
+  - in a superfluous manner
+  example:
+  - superfluously, he added his silly comments to the discussion
+  ili: i21409
+  members:
+  - superfluously
+  partOfSpeech: r
+00473325-r:
+  definition:
+  - in a superstitious manner
+  example:
+  - superstitiously he refused to travel on Friday the 13th
+  ili: i21411
+  members:
+  - superstitiously
+  partOfSpeech: r
+00486768-r:
+  definition:
+  - in an unchivalrous and ungallant manner
+  example:
+  - unchivalrously, the husbands who had to provide such innocent indulgences eventually
+    began to count the costs
+  ili: i21505
+  members:
+  - unchivalrously
+  partOfSpeech: r
+00487818-r:
+  definition:
+  - in an uncouth manner
+  example:
+  - uncouthly, he told stories that made everybody at the table wince
+  ili: i21513
+  members:
+  - uncouthly
+  partOfSpeech: r
+00498325-r:
+  definition:
+  - in a willful manner
+  example:
+  - she had willfully deceived me
+  ili: i21599
+  members:
+  - willfully
+  - wilfully
+  partOfSpeech: r
+00507808-r:
+  definition:
+  - through inherent nature
+  example:
+  - he was naturally lazy
+  ili: i21676
+  members:
+  - naturally
+  - by nature
+  partOfSpeech: r
+00512777-r:
+  definition:
+  - in a setting where one is or feels inappropriate or incongruous
+  example:
+  - he felt out of place in the lingerie shop
+  ili: i21716
+  members:
+  - out of place
+  partOfSpeech: r

--- a/src/yaml/adv.temporal.yaml
+++ b/src/yaml/adv.temporal.yaml
@@ -1,0 +1,1984 @@
+00001885-r:
+  definition:
+  - in the Christian era; used before dates after the supposed year Christ was born
+  example:
+  - in AD 200
+  ili: i18158
+  members:
+  - AD
+  - A.D.
+  - anno Domini
+  partOfSpeech: r
+00002029-r:
+  definition:
+  - of the period coinciding with the Christian era; preferred by some writers who
+    are not Christians
+  example:
+  - in 200 CE
+  ili: i18159
+  members:
+  - CE
+  - C.E.
+  - Common Era
+  partOfSpeech: r
+00002190-r:
+  definition:
+  - before the Christian era; used following dates before the supposed year Christ
+    was born
+  example:
+  - in 200 BC
+  ili: i18160
+  members:
+  - BC
+  - B.C.
+  - before Christ
+  partOfSpeech: r
+00002344-r:
+  definition:
+  - of the period before the Common Era; preferred by some writers who are not Christians
+  example:
+  - in 200 BCE
+  ili: i18161
+  members:
+  - BCE
+  - B.C.E.
+  partOfSpeech: r
+00003175-r:
+  definition:
+  - exactly at this moment or the moment described
+  example:
+  - we've just finished painting the walls, so don't touch them
+  ili: i18164
+  members:
+  - just
+  partOfSpeech: r
+00005591-r:
+  definition:
+  - in ancient times; long ago
+  example:
+  - a concern with what may have happened anciently
+  ili: i18180
+  members:
+  - anciently
+  partOfSpeech: r
+00007414-r:
+  definition:
+  - (of quantities) imprecise but fairly close to correct
+  example:
+  - lasted approximately an hour
+  - in just about a minute
+  - he's about 30 years old
+  - I've had about all I can stand
+  - we meet about once a month
+  - some forty people came
+  - weighs around a hundred pounds
+  - roughly $3,000
+  - holds 3 gallons, more or less
+  - 20 or so people were at the party
+  ili: i18193
+  members:
+  - approximately
+  - about
+  - close to
+  - just about
+  - some
+  - roughly
+  - more or less
+  - around
+  - or so
+  partOfSpeech: r
+00020597-r:
+  definition:
+  - in a consecutive manner
+  example:
+  - he was consecutively ill, then well, then ill again
+  ili: i18258
+  members:
+  - consecutively
+  partOfSpeech: r
+00022156-r:
+  definition:
+  - at some indefinite or unstated time
+  example:
+  - let's get together sometime
+  - everything has to end sometime
+  - It was to be printed sometime later
+  ili: i18265
+  members:
+  - sometime
+  partOfSpeech: r
+00022855-r:
+  definition:
+  - of the distant or comparatively distant past
+  example:
+  - We met once long ago
+  - they long ago forsook their nomadic life
+  - left for work long ago
+  - he has long since given up mountain climbing
+  - This name has long since been forgotten
+  - ‘lang syne’ is Scottish
+  ili: i18268
+  members:
+  - long ago
+  - long since
+  - lang syne
+  - langsyne
+  partOfSpeech: r
+00028191-r:
+  definition:
+  - up to the present time
+  example:
+  - I have yet to see the results
+  - details are yet to be worked out
+  ili: i18299
+  members:
+  - yet
+  partOfSpeech: r
+00028314-r:
+  definition:
+  - used in negative statement to describe a situation that has existed up to this
+    point or up to the present time
+  example:
+  - So far he hasn't called
+  - the sun isn't up yet
+  ili: i18300
+  members:
+  - so far
+  - thus far
+  - up to now
+  - hitherto
+  - heretofore
+  - as yet
+  - yet
+  - til now
+  - until now
+  - till now
+  partOfSpeech: r
+00028594-r:
+  definition:
+  - used after a superlative
+  example:
+  - this is the best so far
+  - the largest drug bust yet
+  ili: i18301
+  members:
+  - so far
+  - yet
+  partOfSpeech: r
+00031700-r:
+  definition:
+  - with reference to action or condition; without change, interruption, or cessation
+  example:
+  - it's still warm outside
+  - will you still love me when we're old and grey?
+  ili: i18316
+  members:
+  - still
+  partOfSpeech: r
+00031911-r:
+  definition:
+  - not now
+  example:
+  - she is no more
+  ili: i18317
+  members:
+  - no longer
+  - no more
+  partOfSpeech: r
+00032002-r:
+  definition:
+  - at the present or from now on; usually used with a negative
+  example:
+  - Alice doesn't live here anymore
+  - the children promised not to quarrel any more
+  ili: i18318
+  members:
+  - anymore
+  - any longer
+  partOfSpeech: r
+00032194-r:
+  definition:
+  - prior to a specified or implied time
+  example:
+  - she has already graduated
+  ili: i18319
+  members:
+  - already
+  partOfSpeech: r
+00033250-r:
+  definition:
+  - from this time forth; from now on
+  example:
+  - henceforth she will be known as Mrs. Smith
+  ili: i18326
+  members:
+  - henceforth
+  - henceforward
+  partOfSpeech: r
+00033383-r:
+  definition:
+  - following this in time or order or place; after this
+  example:
+  - hereafter you will no longer receive an allowance
+  ili: i18327
+  members:
+  - hereafter
+  partOfSpeech: r
+00033526-r:
+  definition:
+  - in a future life or state
+  example:
+  - hope to win salvation hereafter
+  ili: i18328
+  members:
+  - hereafter
+  partOfSpeech: r
+00033695-r:
+  definition:
+  - only a moment ago
+  example:
+  - he has just arrived
+  - the sun just now came out
+  ili: i18330
+  members:
+  - just
+  - just now
+  partOfSpeech: r
+00034196-r:
+  definition:
+  - (old-fashioned or informal) in a little while
+  example:
+  - see you anon
+  exemplifies:
+  - 07089193-n
+  ili: i18334
+  members:
+  - anon
+  partOfSpeech: r
+00034309-r:
+  definition:
+  - in the near future
+  example:
+  - the doctor will soon be here
+  - the book will appear shortly
+  - she will arrive presently
+  - we should have news before long
+  ili: i18335
+  members:
+  - soon
+  - shortly
+  - presently
+  - before long
+  partOfSpeech: r
+00034524-r:
+  definition:
+  - as soon as possible
+  ili: i18336
+  members:
+  - ASAP
+  partOfSpeech: r
+00034576-r:
+  definition:
+  - for a short time
+  example:
+  - he was at the airport shortly before she was expected to arrive
+  - she visited him briefly
+  - was briefly associated with IBM
+  ili: i18337
+  members:
+  - shortly
+  - briefly
+  partOfSpeech: r
+00034790-r:
+  definition:
+  - at any moment
+  example:
+  - she will be with you momently
+  ili: i18339
+  members:
+  - momentarily
+  - momently
+  partOfSpeech: r
+00035028-r:
+  definition:
+  - with the least delay
+  example:
+  - the soonest I can arrive is 3 P.M.
+  ili: i18341
+  members:
+  - soonest
+  - earliest
+  partOfSpeech: r
+00043846-r:
+  definition:
+  - from this time
+  example:
+  - a year hence it will be forgotten
+  ili: i18392
+  members:
+  - hence
+  partOfSpeech: r
+00048179-r:
+  definition:
+  - within an indefinite time or at an unspecified future time
+  example:
+  - he longed for the flowers that were yet to show themselves
+  - sooner or later you will have to face the facts
+  - in time they came to accept the harsh reality
+  ili: i18419
+  members:
+  - yet
+  - in time
+  partOfSpeech: r
+00048441-r:
+  definition:
+  - as the end result of a succession or process
+  example:
+  - ultimately he had to give in
+  - at long last the winter was over
+  ili: i18420
+  members:
+  - ultimately
+  - finally
+  - in the end
+  - at last
+  - at long last
+  partOfSpeech: r
+00048676-r:
+  definition:
+  - after an unspecified period of time or an especially long delay
+  ili: i18421
+  members:
+  - finally
+  - eventually
+  partOfSpeech: r
+00048806-r:
+  definition:
+  - at this time or period; now
+  example:
+  - he is presently our ambassador to the United Nations
+  - currently they live in Connecticut
+  ili: i18422
+  members:
+  - presently
+  - currently
+  partOfSpeech: r
+00049013-r:
+  definition:
+  - in these times
+  example:
+  - source: Nancy Mitford
+    text: it is solely by their language that the upper classes nowadays are distinguished
+  - we now rarely see horse-drawn vehicles on city streets
+  - today almost every home has television
+  ili: i18423
+  members:
+  - nowadays
+  - now
+  - today
+  partOfSpeech: r
+00049277-r:
+  definition:
+  - without delay or hesitation; with no time intervening
+  example:
+  - he answered immediately
+  - found an answer straightaway
+  - an official accused of dishonesty should be suspended forthwith
+  - Come here now!
+  ili: i18424
+  members:
+  - immediately
+  - instantly
+  - straightaway
+  - straight off
+  - directly
+  - now
+  - right away
+  - at once
+  - forthwith
+  - like a shot
+  partOfSpeech: r
+00049640-r:
+  definition:
+  - used to preface a command or reproof or request
+  example:
+  - now hear this!
+  - now pay attention
+  ili: i18425
+  members:
+  - now
+  partOfSpeech: r
+00049758-r:
+  definition:
+  - at the present moment
+  example:
+  - goods now on sale
+  - the now-aging dictator
+  - they are now abroad
+  - he is busy at present writing a new novel
+  - it could happen any time now
+  ili: i18426
+  members:
+  - now
+  - at present
+  partOfSpeech: r
+00049971-r:
+  definition:
+  - in the historical present; at this point in the narration of a series of past
+    events
+  example:
+  - President Kennedy now calls in the National Guard
+  - Washington now decides to cross the Delaware
+  - the ship is now listing to port
+  ili: i18427
+  members:
+  - now
+  partOfSpeech: r
+00050223-r:
+  definition:
+  - in the immediate past
+  example:
+  - told me just now
+  ili: i18428
+  members:
+  - now
+  partOfSpeech: r
+00050296-r:
+  definition:
+  - (prefatory or transitional) indicates a change of subject or activity
+  example:
+  - Now the next problem is …
+  ili: i18429
+  members:
+  - now
+  partOfSpeech: r
+00054750-r:
+  definition:
+  - at the time or occasion immediately following
+  example:
+  - next the doctor examined his back
+  ili: i18458
+  members:
+  - next
+  partOfSpeech: r
+00054865-r:
+  definition:
+  - temporarily
+  example:
+  - we'll stop for the time being
+  ili: i18459
+  members:
+  - for the moment
+  - for the time being
+  partOfSpeech: r
+00061170-r:
+  definition:
+  - at an earlier time or formerly
+  example:
+  - she had previously lived in Chicago
+  - he was previously president of a bank
+  - better than anything previously proposed
+  - a previously unquestioned attitude
+  - antecedently arranged
+  ili: i18503
+  members:
+  - previously
+  - antecedently
+  partOfSpeech: r
+00061477-r:
+  definition:
+  - earlier in time; previously
+  example:
+  - I had known her before
+  - as I said before
+  - he called me the day before but your call had come even earlier
+  - her parents had died four years earlier
+  - I mentioned that problem earlier
+  ili: i18504
+  members:
+  - earlier
+  - before
+  partOfSpeech: r
+00061741-r:
+  definition:
+  - happening at a time subsequent to a reference time
+  example:
+  - he apologized subsequently
+  - he's going to the store but he'll be back here later
+  - it didn't happen until afterward
+  - two hours after that
+  ili: i18505
+  members:
+  - subsequently
+  - later
+  - afterwards
+  - afterward
+  - after
+  - later on
+  partOfSpeech: r
+00065346-r:
+  definition:
+  - during the intervening time
+  example:
+  - meanwhile I will not think about the problem
+  - meantime he was attentive to his other interests
+  - in the meantime the police were notified
+  ili: i18530
+  members:
+  - meanwhile
+  - meantime
+  - in the meantime
+  partOfSpeech: r
+00065584-r:
+  definition:
+  - at the same time but in another place
+  example:
+  - meanwhile, back at the ranch …
+  ili: i18531
+  members:
+  - meanwhile
+  partOfSpeech: r
+00065975-r:
+  definition:
+  - in a lengthy or prolix manner
+  example:
+  - the argument went on lengthily
+  - she talked at length about the problem
+  ili: i18535
+  members:
+  - lengthily
+  - at length
+  partOfSpeech: r
+00066148-r:
+  definition:
+  - most recently
+  example:
+  - I saw him last in London
+  ili: i18536
+  members:
+  - last
+  partOfSpeech: r
+00066222-r:
+  definition:
+  - the item at the end
+  example:
+  - last, I'll discuss family values
+  ili: i18537
+  members:
+  - last
+  - lastly
+  - in conclusion
+  - finally
+  partOfSpeech: r
+00066500-r:
+  definition:
+  - in an enduring or permanent manner
+  ili: i18539
+  members:
+  - lastingly
+  partOfSpeech: r
+00067445-r:
+  definition:
+  - ahead of time; in anticipation
+  example:
+  - when you pay ahead (or in advance) you receive a discount
+  - We like to plan ahead
+  - should have made reservations beforehand
+  ili: i18545
+  members:
+  - ahead
+  - in advance
+  - beforehand
+  partOfSpeech: r
+00068223-r:
+  definition:
+  - to a different or a more advanced time (meaning advanced either toward the present
+    or toward the future)
+  example:
+  - moved the appointment ahead from Tuesday to Monday
+  - pushed the deadline ahead from Tuesday to Wednesday
+  ili: i18548
+  members:
+  - ahead
+  partOfSpeech: r
+00068615-r:
+  definition:
+  - all the time or over a period of time
+  example:
+  - She had known all along
+  - the hope had been there all along
+  ili: i18550
+  members:
+  - all along
+  - right along
+  partOfSpeech: r
+00069746-r:
+  definition:
+  - indicates continuity or persistence or concentration
+  example:
+  - his spirit lives on
+  - shall I read on?
+  ili: i18556
+  members:
+  - 'on'
+  partOfSpeech: r
+00071856-r:
+  definition:
+  - from beginning to end; throughout
+  example:
+  - It rains all year round on Skye
+  - frigid weather the year around
+  ili: i18569
+  members:
+  - round
+  - around
+  partOfSpeech: r
+00074361-r:
+  definition:
+  - in the past
+  example:
+  - long ago
+  - sixty years ago my grandfather came to the U.S.
+  ili: i18583
+  members:
+  - ago
+  partOfSpeech: r
+00074467-r:
+  definition:
+  - in or to or toward a past time
+  example:
+  - set the clocks back an hour
+  - never look back
+  - lovers of the past looking fondly backward
+  ili: i18584
+  members:
+  - back
+  - backward
+  partOfSpeech: r
+00075708-r:
+  definition:
+  - toward the future; forward in time
+  example:
+  - I like to look ahead in imagination to what the future may bring
+  - I look forward to seeing you
+  ili: i18591
+  members:
+  - ahead
+  - forward
+  partOfSpeech: r
+00079765-r:
+  definition:
+  - during the night of the present day
+  example:
+  - drop by tonight
+  ili: i18618
+  members:
+  - tonight
+  - this evening
+  - this night
+  partOfSpeech: r
+00088030-r:
+  definition:
+  - for a limitless time
+  example:
+  - no one can live forever
+  - source: P.P.Bliss
+    text: brightly beams our Father's mercy from his lighthouse evermore
+  ili: i18678
+  members:
+  - everlastingly
+  - eternally
+  - forever
+  - evermore
+  partOfSpeech: r
+00088265-r:
+  definition:
+  - to infinity; without or seemingly without limit
+  example:
+  - talked on and on ad infinitum
+  ili: i18679
+  members:
+  - ad infinitum
+  partOfSpeech: r
+00088404-r:
+  definition:
+  - for a long time without essential change
+  example:
+  - he is permanently disabled
+  ili: i18680
+  members:
+  - permanently
+  - for good
+  partOfSpeech: r
+00088561-r:
+  definition:
+  - for an indefinitely long time
+  example:
+  - bequeathed to the nation in perpetuity
+  ili: i18681
+  members:
+  - in perpetuity
+  partOfSpeech: r
+00088674-r:
+  definition:
+  - for life
+  example:
+  - desire happiness in perpetuity
+  - an annuity paid in perpetuity
+  ili: i18682
+  members:
+  - in perpetuity
+  partOfSpeech: r
+00088791-r:
+  definition:
+  - for a limited time only; not permanently
+  example:
+  - he will work here temporarily
+  - he was brought out of retirement temporarily
+  - a power failure temporarily darkened the town
+  ili: i18683
+  members:
+  - temporarily
+  partOfSpeech: r
+00089037-r:
+  definition:
+  - for an intervening time; temporarily
+  example:
+  - elected to serve ad interim
+  ili: i18684
+  members:
+  - ad interim
+  partOfSpeech: r
+00089265-r:
+  definition:
+  - temporarily and conditionally
+  example:
+  - they have agreed provisionally
+  - was appointed provisionally
+  ili: i18686
+  members:
+  - provisionally
+  partOfSpeech: r
+00089564-r:
+  definition:
+  - for a very long or seemingly endless time
+  example:
+  - she took forever to write the paper
+  - we had to wait forever and a day
+  exemplifies:
+  - 07089193-n
+  ili: i18688
+  members:
+  - forever
+  - forever and a day
+  partOfSpeech: r
+00093364-r:
+  definition:
+  - for an instant or moment
+  example:
+  - we paused momentarily before proceeding
+  - a cardinal perched momently on the dogwood branch
+  ili: i18716
+  members:
+  - momentarily
+  - momently
+  partOfSpeech: r
+00097186-r:
+  definition:
+  - to a later time
+  example:
+  - they moved the meeting date up
+  - from childhood upward
+  ili: i18741
+  members:
+  - up
+  - upwards
+  - upward
+  partOfSpeech: r
+00100632-r:
+  definition:
+  - before the usual time or the time expected
+  example:
+  - she graduated early
+  - the house was completed ahead of time
+  ili: i18765
+  members:
+  - early
+  - ahead of time
+  - too soon
+  partOfSpeech: r
+00100817-r:
+  definition:
+  - later than usual or than expected
+  example:
+  - the train arrived late
+  - we awoke late
+  - the children came late to school
+  - notice came so tardily that we almost missed the deadline
+  - I belatedly wished her a happy birthday
+  ili: i18766
+  members:
+  - late
+  - belatedly
+  - tardily
+  partOfSpeech: r
+00101142-r:
+  definition:
+  - in good time
+  example:
+  - he awoke betimes that morning
+  ili: i18767
+  members:
+  - early
+  - betimes
+  partOfSpeech: r
+00101231-r:
+  definition:
+  - during an early stage
+  example:
+  - early on in her career
+  ili: i18768
+  members:
+  - early on
+  - early
+  partOfSpeech: r
+00103286-r:
+  definition:
+  - before anything else
+  example:
+  - first we must consider the garter snake
+  ili: i18782
+  members:
+  - first
+  - firstly
+  - foremost
+  - first of all
+  - first off
+  partOfSpeech: r
+00103637-r:
+  definition:
+  - from first to last
+  example:
+  - the play was excellent end-to-end
+  ili: i18785
+  members:
+  - throughout
+  - end-to-end
+  partOfSpeech: r
+00103744-r:
+  definition:
+  - at the beginning
+  example:
+  - at first he didn't notice anything strange
+  ili: i18786
+  members:
+  - initially
+  - ab initio
+  - at first
+  partOfSpeech: r
+00103874-r:
+  definition:
+  - on first seeing (someone or something); immediately
+  example:
+  - it was love at first sight
+  ili: i18787
+  members:
+  - at first sight
+  - at first glance
+  partOfSpeech: r
+00104016-r:
+  definition:
+  - after an initial impression, which later proves incorrect
+  members:
+  - at first sight
+  - at first glance
+  partOfSpeech: r
+00104134-r:
+  definition:
+  - as a first impression
+  example:
+  - at first blush the offer seemed attractive
+  ili: i18788
+  members:
+  - at first blush
+  - when first seen
+  partOfSpeech: r
+00104262-r:
+  definition:
+  - the initial time
+  example:
+  - when Felix first saw a garter snake
+  ili: i18789
+  members:
+  - first
+  partOfSpeech: r
+00104546-r:
+  definition:
+  - forward in time or order or degree
+  example:
+  - from that time forth
+  - from the sixth century onward
+  ili: i18792
+  members:
+  - forth
+  - forward
+  - onward
+  partOfSpeech: r
+00105849-r:
+  definition:
+  - immediately
+  example:
+  - she called right after dinner
+  ili: i18800
+  members:
+  - right
+  partOfSpeech: r
+00105927-r:
+  definition:
+  - at a particular time in the past
+  example:
+  - just then the bugle sounded
+  ili: i18801
+  members:
+  - just then
+  partOfSpeech: r
+00106154-r:
+  definition:
+  - at once (usually modifies an undesirable occurrence)
+  example:
+  - he promptly forgot the address
+  ili: i18803
+  members:
+  - promptly
+  - right away
+  partOfSpeech: r
+00106290-r:
+  definition:
+  - with little or no delay
+  example:
+  - the rescue squad arrived promptly
+  - come here, quick!
+  ili: i18804
+  members:
+  - promptly
+  - quickly
+  - quick
+  partOfSpeech: r
+00108184-r:
+  definition:
+  - in the recent past
+  example:
+  - he was in Paris recently
+  - lately the rules have been enforced
+  - as late as yesterday she was fine
+  - feeling better of late
+  - the spelling was first affected, but latterly the meaning also
+  ili: i18816
+  members:
+  - recently
+  - late
+  - lately
+  - of late
+  - latterly
+  partOfSpeech: r
+00113522-r:
+  definition:
+  - very recently
+  example:
+  - they are newly married
+  - newly raised objections
+  - a newly arranged hairdo
+  - grass new washed by the rain
+  - a freshly cleaned floor
+  - we are fresh out of tomatoes
+  ili: i18853
+  members:
+  - newly
+  - freshly
+  - fresh
+  - new
+  partOfSpeech: r
+00118527-r:
+  definition:
+  - subsequently or soon afterward (often used as sentence connectors)
+  example:
+  - then he left
+  - go left first, then right
+  - first came lightning, then thunder
+  - we watched the late movie and then went to bed
+  - and so home and to bed
+  ili: i18890
+  members:
+  - then
+  - so
+  - and so
+  partOfSpeech: r
+00118799-r:
+  definition:
+  - at that time
+  example:
+  - I was young then
+  - prices were lower back then
+  - science as it was then taught
+  ili: i18891
+  members:
+  - then
+  partOfSpeech: r
+00119765-r:
+  definition:
+  - on one occasion
+  example:
+  - once I ran into her
+  ili: i18897
+  members:
+  - once
+  - one time
+  - in one case
+  partOfSpeech: r
+00119861-r:
+  definition:
+  - at a previous time
+  example:
+  - at one time he loved her
+  - her erstwhile writing
+  - she was a dancer once
+  ili: i18898
+  members:
+  - once
+  - formerly
+  - at one time
+  - erstwhile
+  - erst
+  partOfSpeech: r
+00120252-r:
+  definition:
+  - immediately following or undeservedly benefiting from
+  example:
+  - the CEO resigned on the coattails of the scandal
+  - he was elected on his predecessor's coattails
+  ili: i18901
+  members:
+  - on the coattails
+  - on one's coattails
+  partOfSpeech: r
+00120979-r:
+  definition:
+  - at the same instant
+  example:
+  - they spoke simultaneously
+  ili: i18905
+  members:
+  - simultaneously
+  - at the same time
+  partOfSpeech: r
+00121107-r:
+  definition:
+  - overlapping in duration
+  example:
+  - concurrently with the conference an exhibition of things associated with Rutherford
+    was held
+  - going to school and holding a job at the same time
+  ili: i18906
+  members:
+  - concurrently
+  - at the same time
+  partOfSpeech: r
+00130452-r:
+  definition:
+  - with respect to longitude
+  example:
+  - longitudinally measured
+  ili: i18983
+  members:
+  - longitudinally
+  partOfSpeech: r
+00138162-r:
+  definition:
+  - after the operation
+  example:
+  - remove postoperatively
+  ili: i19052
+  members:
+  - postoperatively
+  partOfSpeech: r
+00141918-r:
+  definition:
+  - in a slowly developing and long lasting manner
+  example:
+  - chronically ill persons
+  ili: i19076
+  members:
+  - chronically
+  partOfSpeech: r
+00142067-r:
+  definition:
+  - in a habitual and longstanding manner
+  example:
+  - smoking chronically
+  ili: i19077
+  members:
+  - chronically
+  - inveterate
+  partOfSpeech: r
+00144491-r:
+  definition:
+  - at night
+  example:
+  - nocturnally active bird
+  ili: i19100
+  members:
+  - nocturnally
+  partOfSpeech: r
+00145441-r:
+  definition:
+  - for a brief period
+  example:
+  - sit down and stay awhile
+  - they settled awhile in Virginia before moving West
+  - the baby was quiet for a while
+  ili: i19110
+  members:
+  - awhile
+  - for a while
+  partOfSpeech: r
+00147317-r:
+  definition:
+  - from that time on
+  example:
+  - thereafter he never called again
+  ili: i19121
+  members:
+  - thereafter
+  - thenceforth
+  partOfSpeech: r
+00147423-r:
+  definition:
+  - at any time
+  example:
+  - did you ever smoke?
+  - the best con man of all time
+  ili: i19122
+  members:
+  - ever
+  - of all time
+  partOfSpeech: r
+00152484-r:
+  definition:
+  - not during regular hours
+  example:
+  - he often worked after hours
+  ili: i19156
+  members:
+  - after hours
+  partOfSpeech: r
+00153015-r:
+  definition:
+  - suddenly
+  example:
+  - all at once, he started shouting
+  ili: i19160
+  members:
+  - all of a sudden
+  - all at once
+  partOfSpeech: r
+00153617-r:
+  definition:
+  - endlessly
+  example:
+  - she worked around the clock
+  ili: i19166
+  members:
+  - around the clock
+  - for 24 hours
+  - round the clock
+  partOfSpeech: r
+00155858-r:
+  definition:
+  - in an manner suggesting originality
+  ili: i19184
+  members:
+  - originally
+  partOfSpeech: r
+00156621-r:
+  definition:
+  - at some eventual time in the future
+  example:
+  - By and by he'll understand
+  - I'll see you later
+  ili: i19190
+  members:
+  - by and by
+  - later
+  partOfSpeech: r
+00161376-r:
+  definition:
+  - since long ago
+  example:
+  - she knows him from way back
+  ili: i19225
+  members:
+  - from way back
+  - since a long time ago
+  partOfSpeech: r
+00165958-r:
+  definition:
+  - if there happens to be need
+  example:
+  - in case of trouble call 911
+  - I have money, just in case
+  ili: i19255
+  members:
+  - in case
+  - just in case
+  partOfSpeech: r
+00166484-r:
+  definition:
+  - at the appropriate time
+  example:
+  - we'll get to this question in due course
+  ili: i19258
+  members:
+  - in due course
+  - in due season
+  - in good time
+  - in due time
+  - when the time comes
+  partOfSpeech: r
+00167121-r:
+  definition:
+  - in a relatively short time
+  example:
+  - she finished the assignment in no time
+  ili: i19263
+  members:
+  - in no time
+  - very fast
+  partOfSpeech: r
+00167240-r:
+  definition:
+  - for an extended time or at a distant time
+  example:
+  - a promotion long overdue
+  - something long hoped for
+  - his name has long been forgotten
+  - talked all night long
+  - how long will you be gone?
+  - arrived long before he was expected
+  - it is long after your bedtime
+  ili: i19264
+  members:
+  - long
+  partOfSpeech: r
+00167533-r:
+  definition:
+  - for an extended distance
+  ili: i19265
+  members:
+  - long
+  partOfSpeech: r
+00168316-r:
+  definition:
+  - before now
+  example:
+  - why didn't you tell me in the first place?
+  ili: i19273
+  members:
+  - in the first place
+  - earlier
+  - in the beginning
+  - to begin with
+  - originally
+  partOfSpeech: r
+00168477-r:
+  definition:
+  - eventually or after a lengthy period of time
+  example:
+  - she will succeed in the end
+  ili: i19274
+  members:
+  - in the end
+  partOfSpeech: r
+00168591-r:
+  definition:
+  - at the last possible moment
+  example:
+  - she was saved in the nick of time
+  ili: i19275
+  members:
+  - in the nick of time
+  - just in time
+  partOfSpeech: r
+00168839-r:
+  definition:
+  - without being tardy
+  example:
+  - we made it to the party in time
+  ili: i19277
+  members:
+  - in time
+  - soon enough
+  partOfSpeech: r
+00172124-r:
+  definition:
+  - without delay or immediately
+  example:
+  - we hired her on the spot
+  - thought they were going to shoot us down on the spot
+  ili: i19300
+  members:
+  - on the spot
+  partOfSpeech: r
+00172866-r:
+  definition:
+  - at the expected or proper time
+  example:
+  - she always arrives on time
+  ili: i19305
+  members:
+  - on time
+  - punctually
+  partOfSpeech: r
+00173583-r:
+  definition:
+  - prior to the present time
+  example:
+  - no suspect has been found to date
+  ili: i19311
+  members:
+  - up to now
+  - to date
+  partOfSpeech: r
+00179304-r:
+  definition:
+  - gradually and progressively
+  example:
+  - his health weakened day by day
+  ili: i19354
+  members:
+  - day by day
+  - daily
+  partOfSpeech: r
+00179602-r:
+  definition:
+  - weekly
+  example:
+  - week by week, the betrayal gnawed at his heart
+  ili: i19357
+  members:
+  - week by week
+  partOfSpeech: r
+00179699-r:
+  definition:
+  - for an indefinite number of months
+  example:
+  - month by month, the betrayal gnawed at his heart
+  ili: i19358
+  members:
+  - month by month
+  partOfSpeech: r
+00182828-r:
+  definition:
+  - as soon as
+  example:
+  - once we are home, we can rest
+  ili: i19381
+  members:
+  - once
+  partOfSpeech: r
+00182904-r:
+  definition:
+  - according to need (physicians use PRN in writing prescriptions)
+  example:
+  - add water as needed
+  ili: i19382
+  members:
+  - as needed
+  - as required
+  - pro re nata
+  - PRN
+  partOfSpeech: r
+00190913-r:
+  definition:
+  - some unspecified time in the future
+  example:
+  - someday you will understand my actions
+  ili: i19441
+  members:
+  - someday
+  partOfSpeech: r
+00198594-r:
+  definition:
+  - according to the clock
+  example:
+  - it's three o'clock in Tokyo now
+  ili: i19499
+  members:
+  - o'clock
+  partOfSpeech: r
+00205211-r:
+  definition:
+  - to an indefinite extent; for an indefinite time
+  example:
+  - this could go on indefinitely
+  ili: i19545
+  members:
+  - indefinitely
+  partOfSpeech: r
+00208693-r:
+  definition:
+  - on this day as distinct from yesterday or tomorrow
+  example:
+  - I can't meet with you today
+  ili: i19571
+  members:
+  - today
+  partOfSpeech: r
+00214164-r:
+  definition:
+  - after the fact
+  example:
+  - he will get paid retroactively
+  ili: i19608
+  members:
+  - retroactively
+  partOfSpeech: r
+00224359-r:
+  definition:
+  - showing a time that is earlier than the actual time
+  example:
+  - the clock is almost an hour slow
+  - my watch is running behind
+  ili: i19670
+  members:
+  - behind
+  - slow
+  partOfSpeech: r
+00228075-r:
+  definition:
+  - throughout a period of time
+  example:
+  - stay over the weekend
+  ili: i19696
+  members:
+  - over
+  - o'er
+  partOfSpeech: r
+00229434-r:
+  definition:
+  - in a perennial manner; repeatedly
+  example:
+  - We want to know what is perennially new about the world
+  ili: i19707
+  members:
+  - perennially
+  partOfSpeech: r
+00229584-r:
+  definition:
+  - everlastingly; for all time
+  example:
+  - source: Stuart Chase
+    text: rays … streaming perpetually from the sun
+  ili: i19708
+  members:
+  - perpetually
+  partOfSpeech: r
+00240685-r:
+  definition:
+  - in motion; set in motion
+  example:
+  - the ship got under way
+  ili: i19787
+  members:
+  - under way
+  partOfSpeech: r
+00245801-r:
+  definition:
+  - during or for the length of one night
+  example:
+  - the fish marinates overnight
+  ili: i19823
+  members:
+  - overnight
+  partOfSpeech: r
+00245908-r:
+  definition:
+  - happening in a short time or with great speed
+  example:
+  - these solutions cannot be found overnight!
+  ili: i19824
+  members:
+  - overnight
+  partOfSpeech: r
+00251832-r:
+  definition:
+  - in an enduring manner
+  example:
+  - Roman culture was enduringly fertilized
+  ili: i19870
+  members:
+  - enduringly
+  partOfSpeech: r
+00252773-r:
+  definition:
+  - before 12 noon
+  domain_topic:
+  - 06975340-n
+  example:
+  - let's meet at 11 A.M.
+  ili: i19878
+  members:
+  - ante meridiem
+  - A.M.
+  - a.m.
+  - am
+  - AM
+  partOfSpeech: r
+00252877-r:
+  definition:
+  - between noon and midnight
+  domain_topic:
+  - 06975340-n
+  example:
+  - let's meet at 8 P.M.
+  ili: i19879
+  members:
+  - post meridiem
+  - P.M.
+  - p.m.
+  - pm
+  - PM
+  partOfSpeech: r
+00254098-r:
+  definition:
+  - for the standard number of hours
+  example:
+  - she works full-time
+  ili: i19890
+  members:
+  - full-time
+  partOfSpeech: r
+00258709-r:
+  definition:
+  - for the time being; temporarily
+  example:
+  - source: J.W.Krutch
+    text: accepting pro tem that hypothesis consistent with the facts
+  ili: i19928
+  members:
+  - pro tem
+  - pro tempore
+  partOfSpeech: r
+00258865-r:
+  definition:
+  - without a date fixed (as of an adjournment)
+  ili: i19929
+  members:
+  - sine die
+  partOfSpeech: r
+00260528-r:
+  definition:
+  - comparatives of ‘soon’ or ‘early’
+  example:
+  - Come a little sooner, if you can
+  - came earlier than I expected
+  ili: i19946
+  members:
+  - sooner
+  - earlier
+  partOfSpeech: r
+00260674-r:
+  definition:
+  - at the point of death
+  ili: i19947
+  members:
+  - in extremis
+  partOfSpeech: r
+00261310-r:
+  definition:
+  - overtime without extra compensation
+  example:
+  - she often has to work off-the-clock
+  ili: i19953
+  members:
+  - off-the-clock
+  partOfSpeech: r
+00261426-r:
+  definition:
+  - beyond the regular time
+  example:
+  - she often has to work overtime
+  ili: i19954
+  members:
+  - overtime
+  partOfSpeech: r
+00261595-r:
+  definition:
+  - as fast as possible; with all possible haste
+  example:
+  - send it to me post-haste
+  ili: i19956
+  members:
+  - post-haste
+  partOfSpeech: r
+00275183-r:
+  definition:
+  - at an opportune time
+  example:
+  - your letter arrived apropos
+  ili: i20056
+  members:
+  - seasonably
+  - timely
+  - well-timed
+  - apropos
+  partOfSpeech: r
+00275323-r:
+  definition:
+  - in accordance with the season
+  example:
+  - it was seasonably cold
+  ili: i20057
+  members:
+  - seasonably
+  partOfSpeech: r
+00284664-r:
+  definition:
+  - all the time; seemingly without stopping
+  example:
+  - a theological student with whom I argued interminably
+  - her nagging went on endlessly
+  ili: i20123
+  members:
+  - interminably
+  - endlessly
+  partOfSpeech: r
+00296490-r:
+  definition:
+  - during the same period of time
+  example:
+  - contemporaneously, or possibly a little later, there developed a great Sumerian
+    civilisation
+  ili: i20203
+  members:
+  - contemporaneously
+  partOfSpeech: r
+00306173-r:
+  definition:
+  - during the entire day
+  example:
+  - light pours daylong into the parlor
+  ili: i20260
+  members:
+  - daylong
+  - all day long
+  partOfSpeech: r
+00307214-r:
+  definition:
+  - to an advanced time
+  example:
+  - deep into the night
+  - talked late into the evening
+  ili: i20268
+  members:
+  - deep
+  - late
+  partOfSpeech: r
+00307328-r:
+  definition:
+  - at an advanced age or stage
+  example:
+  - she married late
+  - undertook the project late in her career
+  ili: i20269
+  members:
+  - late
+  partOfSpeech: r
+00334320-r:
+  definition:
+  - at any future time; in the future
+  example:
+  - lead a blameless life evermore
+  ili: i20434
+  members:
+  - evermore
+  - forevermore
+  partOfSpeech: r
+00346567-r:
+  definition:
+  - in the fourth place
+  example:
+  - fourthly, you must pay the rent on the first of the month
+  ili: i20515
+  members:
+  - fourthly
+  - fourth
+  partOfSpeech: r
+00357692-r:
+  definition:
+  - in a subsequent part of this document or statement or matter etc.
+  example:
+  - the landlord demises unto the tenant the premises hereinafter called the demised
+    premises
+  - the terms specified hereunder
+  ili: i20594
+  members:
+  - hereinafter
+  - hereafter
+  - hereunder
+  partOfSpeech: r
+00358208-r:
+  definition:
+  - immediately after this
+  example:
+  - hereupon, the passengers stumbled aboard
+  ili: i20598
+  members:
+  - hereupon
+  partOfSpeech: r
+00378096-r:
+  definition:
+  - conveniently
+  example:
+  - he arrived rather opportunely just when we needed a new butler
+  ili: i20721
+  members:
+  - opportunely
+  partOfSpeech: r
+00390283-r:
+  definition:
+  - across time
+  example:
+  - We studied the development of the children longitudinally
+  ili: i20804
+  members:
+  - longitudinally
+  partOfSpeech: r
+00394594-r:
+  definition:
+  - for more time
+  example:
+  - can I stay bit longer?
+  ili: i20835
+  members:
+  - longer
+  partOfSpeech: r
+00394686-r:
+  definition:
+  - for the most time
+  example:
+  - she stayed longest
+  ili: i20836
+  members:
+  - longest
+  partOfSpeech: r
+00404127-r:
+  definition:
+  - in the middle of the week
+  ili: i20899
+  members:
+  - midweek
+  partOfSpeech: r
+00411619-r:
+  definition:
+  - near in time or place or relationship
+  example:
+  - as the wedding day drew near
+  - stood near the door
+  - don't shoot until they come near
+  - getting near to the true explanation
+  - her mother is always near
+  - The end draws nigh
+  - the bullet didn't come close
+  - don't get too close to the fire
+  ili: i20949
+  members:
+  - near
+  - nigh
+  - close
+  partOfSpeech: r
+00412530-r:
+  definition:
+  - without stopping
+  example:
+  - we are flying nonstop from New York to Tokyo
+  ili: i20955
+  members:
+  - nonstop
+  partOfSpeech: r
+00425509-r:
+  definition:
+  - after death
+  example:
+  - these piano pieces were published posthumously
+  - he was honored posthumously
+  ili: i21051
+  members:
+  - posthumously
+  partOfSpeech: r
+00431857-r:
+  definition:
+  - too soon; in a premature manner
+  example:
+  - I spoke prematurely
+  ili: i21097
+  members:
+  - prematurely
+  - untimely
+  partOfSpeech: r
+00431998-r:
+  definition:
+  - (of childbirth) before the end of the normal period of gestation
+  example:
+  - the child was born prematurely
+  ili: i21098
+  members:
+  - prematurely
+  partOfSpeech: r
+00433834-r:
+  definition:
+  - with reference to the origin or beginning
+  ili: i21111
+  members:
+  - primitively
+  - originally
+  - in the beginning
+  partOfSpeech: r
+00444990-r:
+  definition:
+  - in a manner contemplative of past events
+  example:
+  - retrospectively, he seems like a great artist
+  ili: i21194
+  members:
+  - retrospectively
+  partOfSpeech: r
+00449290-r:
+  definition:
+  - depending on the season
+  example:
+  - prices are seasonally adjusted
+  ili: i21225
+  members:
+  - seasonally
+  partOfSpeech: r
+00469534-r:
+  definition:
+  - in a direct course
+  example:
+  - plunged straightway to the rocks below
+  ili: i21380
+  members:
+  - straightway
+  partOfSpeech: r
+00469634-r:
+  definition:
+  - at once
+  example:
+  - straightway the clouds began to scatter
+  ili: i21381
+  members:
+  - straightway
+  partOfSpeech: r
+00469848-r:
+  definition:
+  - near that time or date
+  example:
+  - come at noon or thereabouts
+  ili: i21383
+  members:
+  - thereabout
+  - thereabouts
+  partOfSpeech: r
+00469954-r:
+  definition:
+  - in the following part of a given matter, as in a document or speech
+  ili: i21384
+  members:
+  - thereinafter
+  partOfSpeech: r
+00481406-r:
+  definition:
+  - the next day, the day after, following the present day
+  ili: i21466
+  members:
+  - tomorrow
+  partOfSpeech: r
+00482326-r:
+  definition:
+  - for a very short time
+  example:
+  - these three pions may actually be joined together transiently as a compound particle
+    during the interchange process
+  ili: i21474
+  members:
+  - transiently
+  partOfSpeech: r
+00482635-r:
+  definition:
+  - for a very brief time
+  ili: i21476
+  members:
+  - transitorily
+  partOfSpeech: r
+00502957-r:
+  definition:
+  - in an imminent manner
+  ili: i21640
+  members:
+  - imminently
+  partOfSpeech: r
+00504442-r:
+  definition:
+  - up to that time
+  example:
+  - they had not done any work theretofore
+  ili: i21653
+  members:
+  - theretofore
+  partOfSpeech: r
+00506609-r:
+  definition:
+  - bearing an immediate relation
+  example:
+  - this immediately concerns your future
+  ili: i21667
+  members:
+  - immediately
+  partOfSpeech: r
+00509461-r:
+  definition:
+  - before another in time, space, or importance
+  example:
+  - I was here first
+  - let's do this job first
+  ili: i21690
+  members:
+  - first
+  partOfSpeech: r
+00510249-r:
+  definition:
+  - on the day preceding today
+  example:
+  - yesterday the weather was beautiful
+  ili: i21696
+  members:
+  - yesterday
+  partOfSpeech: r
+00510352-r:
+  definition:
+  - in the recent past; only a short time ago
+  example:
+  - I was not born yesterday!
+  ili: i21697
+  members:
+  - yesterday
+  partOfSpeech: r
+00510690-r:
+  definition:
+  - comparative of the adverb ‘late’
+  example:
+  - he stayed later than you did
+  ili: i21700
+  members:
+  - later
+  partOfSpeech: r


### PR DESCRIPTION
target #1233 to update the taxonomy for adverbs

- [ ] missing new lexnames for new adverb supersense, e.g., hereafter%4:02:01:: -> hereafter%4:49:01:: (adv.all -> adv.temporal) in entries.*.yaml