### PR TITLE
Align weasel and snake (deceptive person senses) under beguiler (fixes #1312)

### DIFF
--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -63840,7 +63840,7 @@
   exemplifies:
   - 06730109-n
   hypernym:
-  - 09851208-n
+  - 10017621-n
   ili: i93095
   members:
   - snake
@@ -73832,7 +73832,7 @@
   definition:
   - a person who is regarded as treacherous or sneaky
   hypernym:
-  - 09786620-n
+  - 10017621-n
   ili: i94062
   members:
   - weasel


### PR DESCRIPTION
## Summary

- Moves `weasel` (10791658-n) hypernym from `doer` (09786620-n) → `beguiler` (10017621-n)
- Moves `snake / snake in the grass` (10635218-n) hypernym from `bad person` (09851208-n) → `beguiler` (10017621-n)
- `fox` (10042484-n) was already under `beguiler` — no change needed

All three terms ("a shifty/deceptive/treacherous person") now sit at the same level under `deceiver, cheat, cheater, trickster, beguiler, slicker`.

Closes #1312

## Test plan

- [x] `python scripts/validate.py` passes with no issues
- [x] `./ewe word weasel` and `./ewe word snake` confirm correct hypernym

🤖 Generated with [Claude Code](https://claude.com/claude-code)