### PR TITLE
Add missing senses of 'be' for temporal and come-and-go uses

### DIFF
--- a/src/yaml/entries-b.yaml
+++ b/src/yaml/entries-b.yaml
@@ -17497,6 +17497,10 @@ be:
       subcat:
       - vtii
       synset: 02708368-v
+    - id: 'be%2:30:14::'
+      synset: 00340744-v
+    - id: 'be%2:38:15::'
+      synset: 85478917-v
 be active:
   v:
     sense:

--- a/src/yaml/verb.change.yaml
+++ b/src/yaml/verb.change.yaml
@@ -13346,6 +13346,7 @@
   - fall out
   - come about
   - take place
+  - be
   partOfSpeech: v
 00341496-v:
   definition:

--- a/src/yaml/verb.motion.yaml
+++ b/src/yaml/verb.motion.yaml
@@ -16775,6 +16775,14 @@
   members:
   - drown
   partOfSpeech: v
+85478917-v:
+  definition:
+  - go to and return from a place
+  hypernym:
+  - 01839438-v
+  members:
+  - be
+  partOfSpeech: v
 90003682-v:
   definition:
   - to perform a dance move in which the dancer simultaneously drops the head while


### PR DESCRIPTION
## Summary

- Adds `be` to synset `00340744-v` (happen, occur, take place) to cover the temporal use of 'be', e.g. "The ceremony will be Monday" or "That was forty years ago"
- Creates new synset `85478917-v` with definition "go to and return from a place" and hypernym `01839438-v` (travel, go, move, locomote) to cover the come-and-go use, e.g. "He had been and gone" or "I've been to Paris"

Fixes #1261

## Test plan

- [x] `python scripts/validate.py` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)