### PR TITLE
Add adjective sense of 'fun'

### DIFF
--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -93414,6 +93414,7 @@
   ili: i7326
   members:
   - entertaining
+  - fun
   partOfSpeech: s
   similar:
   - 01346766-a

--- a/src/yaml/entries-f.yaml
+++ b/src/yaml/entries-f.yaml
@@ -48380,6 +48380,10 @@ fun:
       synset: 01263236-n
     - id: 'fun%1:07:00::'
       synset: 04656618-n
+  s:
+    sense:
+    - id: fun%5:00:02:interesting:00
+      synset: 01347192-s
 fun run:
   n:
     sense:


### PR DESCRIPTION
## Summary

- Adds `fun` as an adjective satellite to synset `01347192-s` (entertaining, agreeably diverting)
- This covers uses like "a fun game" or "she is fun to be with"

Fixes #1172

## Test plan

- [x] `python scripts/validate.py` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)