### PR TITLE
Merge redundant deportation synsets

### DIFF
--- a/src/deprecations.csv
+++ b/src/deprecations.csv
@@ -231,3 +231,4 @@
 "ewn-88956965-n","","ewn-86306106-n","","Duplicate (#1132)"
 "ewn-87660527-n","","ewn-87148112-n","","Duplicate (#1132)"
 "ewn-00018727-r","i18247","ewn-00017907-r","","Duplicate (#1249)"
+"ewn-00208155-n","i36494","ewn-00208610-n","i36497","Merged with 00208610-n; senses are not distinct (#1207)"

--- a/src/yaml/entries-d.yaml
+++ b/src/yaml/entries-d.yaml
@@ -22923,10 +22923,8 @@ deport:
       - 'deportee%1:18:00::'
     - derivation:
       - 'deportee%1:18:00::'
-      - 'deportation%1:04:01::'
       - 'deportation%1:04:00::'
       event:
-      - 'deportation%1:04:01::'
       - 'deportation%1:04:00::'
       id: 'deport%2:41:00::'
       subcat:
@@ -22950,10 +22948,6 @@ deportation:
       - 'deport%2:41:00::'
       id: 'deportation%1:04:00::'
       synset: 00208610-n
-    - derivation:
-      - 'deport%2:41:00::'
-      id: 'deportation%1:04:01::'
-      synset: 00208155-n
 deportee:
   n:
     pronunciation:

--- a/src/yaml/noun.act.yaml
+++ b/src/yaml/noun.act.yaml
@@ -9963,15 +9963,6 @@
   - expulsion
   - riddance
   partOfSpeech: n
-00208155-n:
-  definition:
-  - the expulsion from a country of an undesirable alien
-  hypernym:
-  - 00207776-n
-  ili: i36494
-  members:
-  - deportation
-  partOfSpeech: n
 00208283-n:
   definition:
   - the act of excluding someone from society by general consent


### PR DESCRIPTION
## Summary

Fixes #1207.

Deletes `00208155-n` ("the expulsion from a country of an undesirable alien") as not meaningfully distinct from `00208610-n` ("the act of expelling a person from their native land"), which already contains `deportation` as a member. Superseded by `00208610-n`.

## Test plan

- [x] `python scripts/validate.py` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)