### PR TITLE
Remove incorrect pair < building hypernym

### DIFF
--- a/src/yaml/noun.group.yaml
+++ b/src/yaml/noun.group.yaml
@@ -2095,7 +2095,6 @@
   - two people considered as a unit
   hypernym:
   - 07991473-n
-  - 07989688-n
   ili: i79228
   members:
   - pair


### PR DESCRIPTION
## Summary

Fixes #1221.

Removes the spurious hypernym relation from `pair` (`07993383-n`, "two people considered as a unit") to `building` (`07989688-n`, "the occupants of a building"). The `gathering/assemblage` hypernym remains intact.

## Test plan

- [x] `python scripts/validate.py` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)