### PR TITLE
Fix five poor species definitions

### DIFF
--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -28460,7 +28460,8 @@
   wikidata: Q188657
 02120298-n:
   definition:
-  - of southern Africa
+  - a carnivorous mammal native to southern Africa, noted for its shaggy dark coat
+    and scavenging habits
   hypernym:
   - 02119787-n
   ili: i46570
@@ -36184,7 +36185,7 @@
   partOfSpeech: n
 02324699-n:
   definition:
-  - of warm coasts from Australia to Asia; used as food especially by Chinese
+  - a species of sea cucumber inhabiting warm coastal waters from Australia to Asia
   hypernym:
   - 02324181-n
   ili: i47755
@@ -36349,7 +36350,8 @@
   partOfSpeech: n
 02328374-n:
   definition:
-  - widely distributed in United States except northwest and far west regions
+  - one of the most common North American rabbit species, widely distributed across
+    the United States except the northwest and far west
   hypernym:
   - 02328018-n
   ili: i47774
@@ -37449,7 +37451,8 @@
   wikidata: Q1767114
 02357273-n:
   definition:
-  - of valleys and mountain meadows of western United States
+  - a species of pocket gopher found in valleys and mountain meadows of the western
+    United States
   hypernym:
   - 02356513-n
   ili: i47939

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -15736,7 +15736,7 @@
   wikidata: Q2702202
 11981569-n:
   definition:
-  - of China
+  - a perennial flowering plant native to China
   hypernym:
   - 11970814-n
   ili: i100085


### PR DESCRIPTION
## Summary

Fixes #1225.

Replaces fragment definitions with complete ones for five species synsets:

| Synset | Old | New |
|--------|-----|-----|
| `11981569-n` Chrysanthemum morifolium | "of China" | "a perennial flowering plant native to China" |
| `02357273-n` Thomomys bottae | "of valleys and mountain meadows of western United States" | "a species of pocket gopher found in valleys and mountain meadows of the western United States" |
| `02324699-n` Holothuria edulis | "of warm coasts from Australia to Asia; used as food especially by Chinese" | "a species of sea cucumber inhabiting warm coastal waters from Australia to Asia" |
| `02328374-n` Sylvilagus floridanus | "widely distributed in United States except northwest and far west regions" | "one of the most common North American rabbit species, widely distributed across the United States except the northwest and far west" |
| `02120298-n` Parahyaena brunnea | "of southern Africa" | "a carnivorous mammal native to southern Africa, noted for its shaggy dark coat and scavenging habits" |

## Test plan

- [x] `python scripts/validate.py` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)