### PR TITLE
Add 'break off' synset as hypernym of three indistinct senses

### DIFF
--- a/src/yaml/entries-b.yaml
+++ b/src/yaml/entries-b.yaml
@@ -52325,7 +52325,6 @@ break:
     - also:
       - 'break_up%2:36:00::'
       - 'break_apart%2:36:00::'
-      - 'break_off%2:35:00::'
       - 'break_up%2:35:01::'
       - 'break_down%2:31:00::'
       antonym:
@@ -52549,8 +52548,6 @@ break:
       - vtaa
       synset: 01560428-v
     - also:
-      - 'break_away%2:35:00::'
-      - 'break_off%2:35:01::'
       - 'break_up%2:35:02::'
       - 'break_apart%2:35:00::'
       derivation:
@@ -52693,13 +52690,6 @@ break away:
       - via-pp
       - vii-pp
       synset: 02077161-v
-    - also:
-      - 'break%2:35:00::'
-      id: 'break_away%2:35:00::'
-      subcat:
-      - vii
-      - vii-pp
-      synset: 01262255-v
     - id: 'break_away%2:41:01::'
       subcat:
       - via-pp
@@ -52720,6 +52710,8 @@ break away:
       - via-pp
       - vii
       synset: 02079296-v
+    - id: 'break_away%2:35:02::'
+      synset: 89863093-v
 break bread:
   v:
     sense:
@@ -52917,29 +52909,13 @@ break off:
       - vtai
       - vtii
       synset: 00363458-v
-    - also:
-      - 'break%2:35:00::'
-      id: 'break_off%2:35:01::'
-      subcat:
-      - vii
-      - vii-pp
-      synset: 01262255-v
-    - id: 'break_off%2:35:02::'
-      subcat:
-      - vtai
-      synset: 01301517-v
-    - also:
-      - 'break%2:35:01::'
-      id: 'break_off%2:35:00::'
-      subcat:
-      - vtai
-      - vtii
-      synset: 01262022-v
     - id: 'break_off%2:42:01::'
       subcat:
       - vtai
       - vtii
       synset: 02686624-v
+    - id: 'break_off%2:35:04::'
+      synset: 89863093-v
 break one's back:
   v:
     sense:

--- a/src/yaml/verb.contact.yaml
+++ b/src/yaml/verb.contact.yaml
@@ -3373,12 +3373,12 @@
   - chip a tooth
   hypernym:
   - 01555301-v
+  - 89863093-v
   ili: i27943
   members:
   - chip
   - knap
   - cut off
-  - break off
   partOfSpeech: v
 01262255-v:
   definition:
@@ -3387,13 +3387,12 @@
   - Her tooth chipped
   hypernym:
   - 01560556-v
+  - 89863093-v
   ili: i27944
   members:
   - chip
   - chip off
   - come off
-  - break away
-  - break off
   partOfSpeech: v
 01262515-v:
   definition:
@@ -5896,11 +5895,10 @@
   example:
   - break a branch from a tree
   hypernym:
-  - 01301254-v
+  - 89863093-v
   ili: i28168
   members:
   - break
-  - break off
   - snap off
   partOfSpeech: v
 01301713-v:
@@ -25729,6 +25727,15 @@
   - euthanatize
   - euthanatise
   - mercy kill
+  partOfSpeech: v
+89863093-v:
+  definition:
+  - break off a piece from the whole
+  hypernym:
+  - 01301254-v
+  members:
+  - break off
+  - break away
   partOfSpeech: v
 90000601-v:
   definition:

--- a/src/yaml/verb.contact.yaml
+++ b/src/yaml/verb.contact.yaml
@@ -3367,7 +3367,7 @@
   partOfSpeech: v
 01262022-v:
   definition:
-  - break a small piece off from
+  - break or cut a small piece off something, typically with a sharp blow
   example:
   - chip the glass
   - chip a tooth
@@ -3382,7 +3382,7 @@
   partOfSpeech: v
 01262255-v:
   definition:
-  - break off (a piece from a whole)
+  - lose a small piece from an edge or surface through wear or impact
   example:
   - Her tooth chipped
   hypernym:
@@ -5891,7 +5891,7 @@
   partOfSpeech: v
 01301517-v:
   definition:
-  - break a piece from a whole
+  - break a piece off with a sudden sharp snapping motion
   example:
   - break a branch from a tree
   hypernym:


### PR DESCRIPTION
## Summary

Fixes #1262.

The three synsets for 'break off' were indistinguishable:
- `01262255-v` chip, chip off, come off — "break off (a piece from a whole)"
- `01301517-v` break, snap off — "break a piece from a whole"
- `01262022-v` chip, knap, cut off — "break a small piece off from"

Creates a new synset `break off, break away` with definition "break off a piece from the whole" and hypernym `detach` (`01301254-v`). The three existing synsets become its hyponyms, representing the more specific mechanisms (chipping, snapping, cutting). Removes `break off` and `break away` from the three existing synsets to avoid redundancy.

## Test plan

- [x] `python scripts/validate.py` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)