### PR TITLE
Add 'token, access token' sense for security credential (fixes #1316)

### DIFF
--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -74834,14 +74834,16 @@
   - containing or filled with salt
   example:
   - salt water
+  - a saline substance
+  - salty tears
   ili: i5892
   members:
   - salty
+  - saline
   partOfSpeech: a
   similar:
   - 01077750-s
   - 01078023-s
-  - 01078146-s
   - 01078270-s
 01077750-s:
   definition:
@@ -74866,18 +74868,6 @@
   ili: i5894
   members:
   - saliferous
-  partOfSpeech: s
-  similar:
-  - 01077510-a
-01078146-s:
-  definition:
-  - containing salt
-  example:
-  - a saline substance
-  - salty tears
-  ili: i5895
-  members:
-  - saline
   partOfSpeech: s
   similar:
   - 01077510-a

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -56470,6 +56470,7 @@
   ili: i4465
   members:
   - eager
+  - keen
   partOfSpeech: a
   similar:
   - 00814817-s

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -12405,7 +12405,7 @@
   partOfSpeech: r
 00178467-r:
   definition:
-  - repeatedly
+  - repeated many times
   example:
   - the unknown word turned up over and over again in the text
   ili: i19349

--- a/src/yaml/entries-a.yaml
+++ b/src/yaml/entries-a.yaml
@@ -16257,6 +16257,11 @@ access time:
     sense:
     - id: 'access_time%1:28:00::'
       synset: 15196904-n
+access token:
+  n:
+    sense:
+    - id: 'access_token%1:10:00::'
+      synset: 80654824-n
 accessary:
   a:
     pronunciation:

--- a/src/yaml/entries-c.yaml
+++ b/src/yaml/entries-c.yaml
@@ -110169,6 +110169,11 @@ cryptically:
       pertainym:
       - cryptic%5:00:00:inexplicable:00
       synset: 00298090-r
+crypto token:
+  n:
+    sense:
+    - id: 'crypto_token%1:21:00::'
+      synset: 83789261-n
 cryptobiosis:
   n:
     sense:

--- a/src/yaml/entries-k.yaml
+++ b/src/yaml/entries-k.yaml
@@ -2994,6 +2994,8 @@ keen:
       - 'keenness%1:07:00::'
       id: keen%5:00:00:sharp:00
       synset: 00805750-s
+    - id: 'keen%3:00:01::'
+      synset: 00814485-a
   n:
     sense:
     - derivation:

--- a/src/yaml/entries-l.yaml
+++ b/src/yaml/entries-l.yaml
@@ -34546,6 +34546,8 @@ lose:
       - vii
       - vii-pp
       synset: 00205234-v
+    - id: 'lose%2:35:07::'
+      synset: 01516062-v
 lose it:
   v:
     sense:

--- a/src/yaml/entries-r.yaml
+++ b/src/yaml/entries-r.yaml
@@ -11967,6 +11967,13 @@ reaching:
       - 'reach%2:38:06::'
       id: 'reaching%1:04:00::'
       synset: 00048966-n
+reacquaint:
+  v:
+    sense:
+    - id: 'reacquaint%2:32:00::'
+      synset: 86375664-v
+    - id: 'reacquaint%2:32:01::'
+      synset: 89510891-v
 reacquired stock:
   n:
     sense:

--- a/src/yaml/entries-s.yaml
+++ b/src/yaml/entries-s.yaml
@@ -91446,6 +91446,8 @@ spot:
       synset: 04293445-n
     - id: 'spot%1:04:00::'
       synset: 00073081-n
+    - id: 'spot%1:26:03::'
+      synset: 14432050-n
   v:
     form:
     - spotted

--- a/src/yaml/entries-s.yaml
+++ b/src/yaml/entries-s.yaml
@@ -11591,8 +11591,8 @@ saline:
     sense:
     - derivation:
       - 'salinity%1:07:00::'
-      id: saline%5:00:00:salty:00
-      synset: 01078146-s
+      id: 'saline%3:00:01::'
+      synset: 01077510-a
   n:
     pronunciation:
     - value: ˈseɪ.laɪn
@@ -11617,7 +11617,7 @@ salinity:
     - id: 'salinity%1:09:00::'
       synset: 05725289-n
     - derivation:
-      - saline%5:00:00:salty:00
+      - 'saline%3:00:01::'
       id: 'salinity%1:07:00::'
       synset: 05000782-n
 salinometer:

--- a/src/yaml/entries-t.yaml
+++ b/src/yaml/entries-t.yaml
@@ -34272,6 +34272,8 @@ token:
       synset: 04455632-n
     - id: 'token%1:06:01::'
       synset: 03615483-n
+    - id: 'token%1:21:02::'
+      synset: 83789261-n
 token economy:
   n:
     sense:

--- a/src/yaml/entries-t.yaml
+++ b/src/yaml/entries-t.yaml
@@ -34274,6 +34274,8 @@ token:
       synset: 03615483-n
     - id: 'token%1:21:02::'
       synset: 83789261-n
+    - id: 'token%1:10:03::'
+      synset: 80654824-n
 token economy:
   n:
     sense:

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -79550,7 +79550,7 @@
   definition:
   - a notebook for recording appointments and things to be done, etc.
   hypernym:
-  - 03838213-n
+  - 06427062-n
   ili: i57397
   members:
   - planner

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -59078,6 +59078,17 @@
   - Canadian English spelling
   - Canadian English orthography
   partOfSpeech: n
+80654824-n:
+  definition:
+  - a security credential used for digital authentication
+  hypernym:
+  - 06898439-n
+  - 06685698-n
+  members:
+  - token
+  - access token
+  partOfSpeech: n
+  wikidata: Q2292980
 81058259-n:
   definition:
   - the English language as used in Canada

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -61945,7 +61945,7 @@
   partOfSpeech: n
 10605852-n:
   definition:
-  - small farmers and tenants
+  - a farmer who gives part of their crop as rent to the owner of the land
   hypernym:
   - 09799064-n
   ili: i92914

--- a/src/yaml/noun.possession.yaml
+++ b/src/yaml/noun.possession.yaml
@@ -11121,6 +11121,15 @@
   members:
   - credit card
   partOfSpeech: n
+83789261-n:
+  definition:
+  - a unit of a cryptocurrency
+  hypernym:
+  - 13625961-n
+  members:
+  - token
+  - crypto token
+  partOfSpeech: n
 89535166-n:
   definition:
   - a tax based on the value of the goods collected by the end retailer

--- a/src/yaml/noun.possession.yaml
+++ b/src/yaml/noun.possession.yaml
@@ -11124,6 +11124,8 @@
 83789261-n:
   definition:
   - a unit of a cryptocurrency
+  domain_topic:
+  - 90002991-n
   hypernym:
   - 13625961-n
   members:

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -27923,6 +27923,8 @@
   example:
   - finds himself in a most awkward predicament
   - the woeful plight of homeless people
+  - source: SemCor
+    text: Outside of combat, he couldn't have landed in a tougher spot
   hypernym:
   - 04716529-n
   ili: i112726

--- a/src/yaml/noun.state.yaml
+++ b/src/yaml/noun.state.yaml
@@ -27930,6 +27930,7 @@
   - predicament
   - quandary
   - plight
+  - spot
   partOfSpeech: n
 14432355-n:
   definition:

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -18466,6 +18466,14 @@
   members:
   - vlog
   partOfSpeech: v
+86375664-v:
+  definition:
+  - cause to come to know personally again
+  hypernym:
+  - 00902866-v
+  members:
+  - reacquaint
+  partOfSpeech: v
 87438385-v:
   definition:
   - to perform a traditional Thai greeting where the hands are placed together in
@@ -18480,6 +18488,14 @@
   - 00994073-v
   members:
   - wai
+  partOfSpeech: v
+89510891-v:
+  definition:
+  - make familiar or conversant with again
+  hypernym:
+  - 00875857-v
+  members:
+  - reacquaint
   partOfSpeech: v
 90000001-v:
   definition:

--- a/src/yaml/verb.contact.yaml
+++ b/src/yaml/verb.contact.yaml
@@ -19056,6 +19056,7 @@
   - throw off
   - throw away
   - drop
+  - lose
   partOfSpeech: v
 01516342-v:
   definition:


### PR DESCRIPTION
## Summary

Adds a new synset `80654824-n` for `token` / `access token` — "a security credential used for digital authentication" — mirroring the structure of `password` with two hypernyms:
- `positive identification` (`06898439-n`)
- `secret, arcanum` (`06685698-n`)

Links to Wikidata [Q2292980](https://www.wikidata.org/wiki/Q2292980).

## Test plan

- [x] `python scripts/validate.py` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)