### PR TITLE
Fix adjective entries mislabeled with 's' part of speech

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -259,6 +259,11 @@ def main():
                 sys.exit(-1)
             print("ERROR: Invalid ID " + entry.id)
             errors += 1
+        if entry.lemma.part_of_speech == PartOfSpeech.ADJECTIVE_SATELLITE:
+            print(
+                "ERROR: Adjective entry should have part of speech 'a', not 's' %s" %
+                entry.id)
+            errors += 1
         for sense in entry.senses:
             synset = wn.synset_by_id(sense.synset)
             if not synset:
@@ -349,6 +354,20 @@ def main():
                         "ERROR: similar not between verb/adjective %s => %s" %
                         (synset.id, sr.target))
                     errors += 1
+                else:
+                    target = wn.synset_by_id(sr.target)
+                    if (synset.part_of_speech == PartOfSpeech.ADJECTIVE and target and
+                            target.part_of_speech != PartOfSpeech.ADJECTIVE_SATELLITE):
+                        print(
+                            "ERROR: adjective synset should only be similar to a satellite synset %s => %s" %
+                            (synset.id, sr.target))
+                        errors += 1
+                    if (synset.part_of_speech == PartOfSpeech.ADJECTIVE_SATELLITE and target and
+                            target.part_of_speech != PartOfSpeech.ADJECTIVE):
+                        print(
+                            "ERROR: satellite synset should be similar to a single adjective synset %s => %s" %
+                            (synset.id, sr.target))
+                        errors += 1
                 similars += 1
                 if similars > 1 and synset.part_of_speech == PartOfSpeech.ADJECTIVE_SATELLITE:
                     print(

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -57640,6 +57640,8 @@
   - 01185568-a
   - 01720680-a
   - 02455719-a
+  - 80529909-a
+  - 82572455-a
   definition:
   - suitable for use as food
   ili: i4556
@@ -57652,8 +57654,6 @@
   - 00832580-s
   - 00832685-s
   - 00832782-s
-  - 80529909-a
-  - 82572455-a
 00832580-s:
   definition:
   - fit to kill, especially for food
@@ -70250,6 +70250,8 @@
   similar:
   - 01012544-a
 01013622-a:
+  also:
+  - 88121161-a
   definition:
   - final or ending
   example:
@@ -70265,7 +70267,6 @@
   - 01013868-s
   - 01014166-s
   - 01014344-s
-  - 88121161-a
 01013868-s:
   definition:
   - occurring at or forming an end or termination
@@ -70311,6 +70312,7 @@
   - 00199739-a
   - 01691099-a
   - 01858102-a
+  - 02207704-a
   definition:
   - preceding all others in time or space or degree
   example:
@@ -70336,7 +70338,6 @@
   - 01016452-s
   - 01016587-s
   - 01016768-s
-  - 02207704-a
 01014989-s:
   definition:
   - representing or constituting an original type after which other similar things
@@ -86646,6 +86647,7 @@
   - 01746545-a
   - 02520937-a
   - 00999867-a
+  - 80644890-a
   definition:
   - characterized by enmity or ill will
   example:
@@ -86666,7 +86668,6 @@
   - 01248878-s
   - 01249022-s
   - 01249262-s
-  - 80644890-a
 01247720-s:
   definition:
   - characteristic of an enemy or one eager to fight
@@ -103273,6 +103274,8 @@
   similar:
   - 01483247-a
 01483493-a:
+  also:
+  - 88306827-a
   definition:
   - having or as if having an identifying mark or a mark as specified; often used
     in combination
@@ -103290,7 +103293,6 @@
   - 01483991-s
   - 01484223-s
   - 01484321-s
-  - 88306827-a
 01483799-s:
   definition:
   - marked with an asterisk
@@ -116139,6 +116141,8 @@
   - unopposable
   partOfSpeech: a
 01667221-a:
+  also:
+  - 83800950-a
   definition:
   - being in opposition or having an opponent
   example:
@@ -116149,7 +116153,6 @@
   partOfSpeech: a
   similar:
   - 01667377-s
-  - 83800950-a
 01667377-s:
   definition:
   - on bad terms
@@ -130659,6 +130662,9 @@
   - productive
   partOfSpeech: a
 01873452-a:
+  also:
+  - 81031470-a
+  - 85788493-a
   definition:
   - tending to consume or use often wastefully
   example:
@@ -130671,8 +130677,6 @@
   partOfSpeech: a
   similar:
   - 01873718-s
-  - 81031470-a
-  - 85788493-a
 01873718-s:
   definition:
   - tending to exploit or make use of
@@ -154514,6 +154518,8 @@
   similar:
   - 02191250-a
 02207704-a:
+  also:
+  - 01014459-a
   definition:
   - being or denoting a numerical order in a series
   example:
@@ -154616,7 +154622,6 @@
   - 02220583-s
   - 02220698-s
   - 02220813-s
-  - 01014459-a
 02209551-s:
   definition:
   - indicating an initial point or origin
@@ -183430,6 +183435,8 @@
   - tribadistic
   partOfSpeech: a
 80529909-a:
+  also:
+  - 00832318-a
   definition:
   - not containing any animal products
   example:
@@ -183441,16 +183448,14 @@
   members:
   - vegan
   partOfSpeech: a
-  similar:
-  - 00832318-a
 80644890-a:
+  also:
+  - 01247284-a
   definition:
   - as a rival in a competition
   members:
   - rival
   partOfSpeech: a
-  similar:
-  - 01247284-a
 80651043-s:
   definition:
   - of the blue-green color that is a primary subtractive color of light
@@ -183460,6 +183465,8 @@
   similar:
   - 00367771-a
 81031470-a:
+  also:
+  - 01873452-a
   definition:
   - involving the removal of substances from the ground
   example:
@@ -183469,8 +183476,6 @@
   members:
   - extractive
   partOfSpeech: a
-  similar:
-  - 01873452-a
 81662907-a:
   definition:
   - having albinism
@@ -183487,6 +183492,8 @@
   - metrosexual
   partOfSpeech: a
 82572455-a:
+  also:
+  - 00832318-a
   definition:
   - not containing meat
   example:
@@ -183496,8 +183503,6 @@
   members:
   - vegetarian
   partOfSpeech: a
-  similar:
-  - 00832318-a
 82841156-s:
   definition:
   - not capable of being decided as following or not following from the axioms of
@@ -183536,6 +183541,8 @@
   similar:
   - 01518910-a
 83800950-a:
+  also:
+  - 01667221-a
   definition:
   - opposed to the establishment
   example:
@@ -183546,8 +183553,6 @@
   - anti-establishment
   - antiestablishment
   partOfSpeech: a
-  similar:
-  - 01667221-a
 83909192-a:
   definition:
   - of or related to cumulous clouds
@@ -183572,6 +183577,8 @@
   similar:
   - 00270855-a
 85788493-a:
+  also:
+  - 01873452-a
   definition:
   - of a capitalist system that prioritizes short-term profit over long-term sustainability
   example:
@@ -183581,8 +183588,6 @@
   members:
   - extractive
   partOfSpeech: a
-  similar:
-  - 01873452-a
 85983944-a:
   definition:
   - performing gestures or possessing qualities or features that suggest a certain
@@ -183637,6 +183642,8 @@
   similar:
   - 00829153-a
 88121161-a:
+  also:
+  - 01013622-a
   definition:
   - limited or coming to an end soon
   example:
@@ -183645,9 +183652,9 @@
   members:
   - numbered
   partOfSpeech: a
-  similar:
-  - 01013622-a
 88306827-a:
+  also:
+  - 01483493-a
   definition:
   - having a number or a series of numbers
   example:
@@ -183656,8 +183663,6 @@
   members:
   - numbered
   partOfSpeech: a
-  similar:
-  - 01483493-a
 88455131-a:
   definition:
   - causing indignation due to hypocrisy

--- a/src/yaml/entries-f.yaml
+++ b/src/yaml/entries-f.yaml
@@ -48364,6 +48364,10 @@ fumitory:
     - id: 'fumitory%1:20:00::'
       synset: 11929996-n
 fun:
+  a:
+    sense:
+    - id: fun%5:00:02:interesting:00
+      synset: 01347192-s
   n:
     pronunciation:
     - value: fʌn
@@ -48378,10 +48382,6 @@ fun:
       synset: 01263236-n
     - id: 'fun%1:07:00::'
       synset: 04656618-n
-  s:
-    sense:
-    - id: fun%5:00:02:interesting:00
-      synset: 01347192-s
 fun run:
   n:
     sense:

--- a/src/yaml/entries-s.yaml
+++ b/src/yaml/entries-s.yaml
@@ -111867,7 +111867,7 @@ street urchin:
     - id: 'street_urchin%1:18:00::'
       synset: 10682391-n
 street-smart:
-  s:
+  a:
     sense:
     - id: street-smart%5:00:00:smart:00
       synset: 00441171-s
@@ -124108,8 +124108,6 @@ sunny:
       - 'sunniness%1:07:01::'
       id: sunny%5:00:00:cheerful:00
       synset: 00365018-s
-  s:
-    sense:
     - id: sunny%5:00:01:light:06
       synset: 85737845-s
 sunny-side up:

--- a/src/yaml/entries-w.yaml
+++ b/src/yaml/entries-w.yaml
@@ -23803,7 +23803,7 @@ wok:
     - id: 'wok%1:06:00::'
       synset: 04604069-n
 woke:
-  s:
+  a:
     sense:
     - id: woke%5:00:00:aware:00
       synset: 86794676-s


### PR DESCRIPTION
## Summary
- `src/yaml/entries-*.yaml` grouping keys for adjectives should always be `a` (the a/s distinction belongs to the synset data, not the entry). Fixes `fun`, `street-smart`, `sunny`, and `woke`, which a tool had introduced/left under the `s` key.
- `scripts/validate.py`: adds checks so this can't silently recur — adjective entries must use `a`, and `similar` relations must respect head/satellite structure (`a` synsets link only to `s` synsets and vice versa, with a satellite linking to exactly one head).
- `src/yaml/adj.all.yaml`: implementing the new check surfaced 9 pre-existing `a`<->`a` `similar` pairs from the UD_GUM import (e.g. eatable/vegan, first/ordinal, hostile/rival). These are converted to `also` relations, which is the established relation for this kind of association elsewhere in the data.

Fixes #1358

## Test plan
- [x] `python3 scripts/validate.py` passes with no errors
- [x] `python3 scripts/from_yaml.py` regenerates `wn.xml` successfully, with the affected entries emitting `partOfSpeech="a"` (e.g. `oewn-street-smart-a`, `oewn-woke-a`) while their synsets remain correctly `partOfSpeech="s"`