### PR TITLE
Make 'hint' a hyponym of 'suggest, intimate' (fixes #1364)

### DIFF
--- a/src/yaml/entries-s.yaml
+++ b/src/yaml/entries-s.yaml
@@ -121906,22 +121906,6 @@ suggest:
       subcat:
       - vtai
       synset: 00876925-v
-    - agent:
-      - 'suggester%1:18:00::'
-      derivation:
-      - suggestible%5:00:00:susceptible:00
-      - 'suggestion%1:10:00::'
-      - 'suggester%1:18:00::'
-      event:
-      - 'suggestion%1:10:00::'
-      id: 'suggest%2:32:04::'
-      sent:
-      - They suggest that there was a traffic accident
-      subcat:
-      - via
-      - via-pp
-      - via-that
-      synset: 00929401-v
     - derivation:
       - suggestible%5:00:00:susceptible:00
       - suggestive%5:00:00:revealing:00
@@ -121945,7 +121929,6 @@ suggester:
   n:
     sense:
     - derivation:
-      - 'suggest%2:32:04::'
       - 'suggest%2:32:00::'
       id: 'suggester%1:18:00::'
       synset: 10692890-n
@@ -121960,7 +121943,6 @@ suggestible:
   a:
     sense:
     - derivation:
-      - 'suggest%2:32:04::'
       - 'suggest%2:32:02::'
       - 'suggest%2:32:00::'
       - 'suggestibility%1:26:00::'
@@ -121977,7 +121959,6 @@ suggestion:
     - id: 'suggestion%1:09:00::'
       synset: 05924749-n
     - derivation:
-      - 'suggest%2:32:04::'
       - 'suggest%2:32:00::'
       id: 'suggestion%1:10:00::'
       synset: 07177331-n

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -10171,11 +10171,10 @@
   definition:
   - drop a hint; intimate by a hint
   hypernym:
-  - 00930591-v
+  - 00932768-v
   ili: i26247
   members:
   - hint
-  - suggest
   partOfSpeech: v
 00929682-v:
   definition:


### PR DESCRIPTION
## Summary
- Changes the hypernym of `hint` (00929401-v) from `convey` (00930591-v) to `suggest, intimate` (00932768-v), making hinting a specific kind of suggesting.
- Removes `suggest` as a member/lemma of 00929401-v, since that sense is now redundant with 00932768-v (`suggest, intimate`).

Fixes #1364

## Test plan
- [x] `python scripts/validate.py` passes with no validity issues
- [x] `./ewe word hint` confirms 00929401-v now has hypernym `suggest, intimate` and members `hint` only