### PR TITLE
Document JSON API in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ The size of the core resources are as follows
 
 The easiest way to explore Open English Wordnet is through the web interface at **<https://en-word.net/>**. You can search for words, browse synsets, and navigate the relation graph without installing anything.
 
+### JSON API
+
+Open English Wordnet also provides a JSON API for programmatic access, documented at **<https://en-word.net/api/docs>**.
+
 ### Python (`wn` library)
 
 [`wn`](https://wn.readthedocs.io/en/latest/) is a Python library for working with wordnets programmatically. Install it with pip:


### PR DESCRIPTION
## Summary
- Adds a "JSON API" subsection to the README's Usage section, linking to the newly published API docs at https://en-word.net/api/docs

Closes #1110

## Test plan
- [x] Verified https://en-word.net/api/docs resolves and is the API documentation page
- [x] Reviewed rendered README section for correct Markdown formatting