### PR TITLE
Link languages to Wikidata; fix Kafiri classification; merge Canaanite

### DIFF
--- a/src/deprecations.csv
+++ b/src/deprecations.csv
@@ -251,4 +251,4 @@
 "ewn-00208155-n","i36494","ewn-00208610-n","i36497","Merged with 00208610-n; senses are not distinct (#1207)"
 "ewn-01852317-n","i45064","ewn-01852107-n","i45063","Incorrect definition; shelduck is not female sheldrake (#1192)"
 "ewn-01078146-s","i5895","ewn-01077510-a","i5895","Duplicate (#1310)"
-
+"ewn-07001985-n","i73372","ewn-07001806-n","i73371","Merged with Canaanitic language, indistinct senses (#1371)"

--- a/src/yaml/adj.all.yaml
+++ b/src/yaml/adj.all.yaml
@@ -42736,7 +42736,7 @@
   - of long-established quality; widely recognized as exemplary or typical
   example:
   - a classic car
-  - '‘War and Peace’ is a classic novel'
+  - ‘War and Peace’ is a classic novel
   - classic double-breasted suit
   - the classic struggle between good and evil
   - I woke up with all the classic symptoms of the flu

--- a/src/yaml/adv.all.yaml
+++ b/src/yaml/adv.all.yaml
@@ -9233,7 +9233,7 @@
   definition:
   - in a metonymic manner
   example:
-  - "‘The Pentagon’ is often used metonymically to refer to the Department of Defense"
+  - ‘The Pentagon’ is often used metonymically to refer to the Department of Defense
   ili: i19026
   members:
   - metonymically

--- a/src/yaml/entries-c.yaml
+++ b/src/yaml/entries-c.yaml
@@ -1644,12 +1644,12 @@ Canaanite:
     - id: 'canaanite%1:18:00::'
       synset: 09909959-n
     - id: 'canaanite%1:10:00::'
-      synset: 07001985-n
+      synset: 07001806-n
 Canaanite language:
   n:
     sense:
     - id: 'canaanite_language%1:10:01::'
-      synset: 07001985-n
+      synset: 07001806-n
 Canaanitic:
   n:
     sense:

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -35423,6 +35423,7 @@
   - maternal language
   - first language
   partOfSpeech: n
+  wikidata: Q36870
 06917719-n:
   definition:
   - a language in which different tones distinguish different meanings
@@ -35435,6 +35436,7 @@
   mero_part:
   - 07128440-n
   partOfSpeech: n
+  wikidata: Q191328
 06917917-n:
   definition:
   - a tone language that uses pitch changes
@@ -35462,6 +35464,7 @@
   members:
   - creole
   partOfSpeech: n
+  wikidata: Q33289
 06918289-n:
   definition:
   - a creole language spoken by most Haitians; based on French and various African
@@ -35619,6 +35622,7 @@
   - Arapaho language
   - Arapahoe language
   partOfSpeech: n
+  wikidata: Q56417
 06921177-n:
   definition:
   - the Siouan language spoken by the Biloxi
@@ -35781,6 +35785,7 @@
   - Hidatsa
   - Hidatsa language
   partOfSpeech: n
+  wikidata: Q3135234
 06922815-n:
   definition:
   - a Siouan language spoken by the Hunkpapa
@@ -36308,6 +36313,7 @@
   - Paiute
   - Paiute language
   partOfSpeech: n
+  wikidata: Q3360656
 06927997-n:
   definition:
   - the Shoshonean language spoken by the Utes
@@ -37751,6 +37757,7 @@
   - Himalayish
   - Himalayish language
   partOfSpeech: n
+  wikidata: Q2700231
 06944668-n:
   definition:
   - a non-standard subfamily of the Tibeto-Burman languages including languages spoken
@@ -37862,6 +37869,7 @@
   - Lolo language
   - Yi language
   partOfSpeech: n
+  wikidata: Q34235
 06945799-n:
   definition:
   - Tibeto-Burman languages spoken in northernmost Burma and adjacent China and India
@@ -38514,6 +38522,7 @@
   - Australian language
   - Aboriginal Australian language
   partOfSpeech: n
+  wikidata: Q205143
 06953264-n:
   definition:
   - a language of Australian aborigines, spoken in northeast Queensland
@@ -39639,6 +39648,7 @@
   members:
   - Volgaic
   partOfSpeech: n
+  wikidata: Q900795
 06970027-n:
   definition:
   - the Finnic language spoken by the Cheremis
@@ -40178,6 +40188,7 @@
   - New Latin language
   - Neo-Latin language
   partOfSpeech: n
+  wikidata: Q1248221
 06976693-n:
   definition:
   - the group of languages derived from Latin
@@ -40189,6 +40200,7 @@
   - Romance language
   - Latinian language
   partOfSpeech: n
+  wikidata: Q19814
 06976989-n:
   definition:
   - the Romance language spoken in Italy
@@ -40605,6 +40617,7 @@
   - Hindoostani language
   - Hindostani language
   partOfSpeech: n
+  wikidata: Q11051
 06983184-n:
   definition:
   - the Indic language spoken in Bihar (and by some people in Pakistan and Bangladesh)
@@ -40781,14 +40794,16 @@
   wikidata: Q938216
 06985416-n:
   definition:
-  - a Dardic language spoken by the Kafir in northeastern Afghanistan
+  - any of the Nuristani languages, a branch of the Indo-Iranian family spoken by
+    the Kafir in northeastern Afghanistan
   hypernym:
-  - 06984971-n
+  - 06984532-n
   ili: i73258
   members:
   - Kafiri
   - Kafiri language
   partOfSpeech: n
+  wikidata: Q161804
 06985534-n:
   definition:
   - the official state language of Kashmir
@@ -41204,6 +41219,7 @@
   - Arcadic
   - Arcadic dialect
   partOfSpeech: n
+  wikidata: Q499602
 06990728-n:
   definition:
   - the dialect of Ancient Greek spoken in Doris
@@ -41226,6 +41242,7 @@
   - Caucasian
   - Caucasian language
   partOfSpeech: n
+  wikidata: Q169921
 06991082-n:
   definition:
   - a northern Caucasian language spoken by the Chechen
@@ -41831,6 +41848,7 @@
   - Mandage
   - Mandage language
   partOfSpeech: n
+  wikidata: Q3502264
 06997406-n:
   definition:
   - a Chadic language spoken south of Lake Chad, especially in the Far North Region,
@@ -42148,19 +42166,10 @@
   members:
   - Canaanitic
   - Canaanitic language
-  partOfSpeech: n
-  wikidata: Q747547
-07001985-n:
-  definition:
-  - the extinct language of the Semitic people who occupied Canaan before the Israelite
-    conquest
-  hypernym:
-  - 07001806-n
-  ili: i73372
-  members:
   - Canaanite
   - Canaanite language
   partOfSpeech: n
+  wikidata: Q747547
 07002133-n:
   definition:
   - the extinct language of an ancient Semitic people who dominated trade in the ancient
@@ -59308,6 +59317,7 @@
   - Arlêng
   - Arlêng language
   partOfSpeech: n
+  wikidata: Q56591
 86712636-n:
   definition:
   - English orthography used in the UK, Ireland and most of the Commonwealth (characterized
@@ -59379,6 +59389,7 @@
   - Gros Ventre
   - Gros Ventre language
   partOfSpeech: n
+  wikidata: Q56628
 89083071-n:
   definition:
   - a traditional Thai greeting where the hands are placed together in a prayer-like
@@ -59407,6 +59418,7 @@
   - Manipuri
   - Manipuri language
   partOfSpeech: n
+  wikidata: Q33868
 89822606-n:
   definition:
   - a series of letters, numbers or symbols assigned to something for the purpose
@@ -62753,6 +62765,7 @@
   - standard language
   partOfSpeech: n
   source: plWordNet 4.0
+  wikidata: Q399495
 92466500-n:
   definition:
   - an Indo-European language that shows distinctive preservation of the Proto-Indo-European


### PR DESCRIPTION
## Summary

Addresses #1371:

- Adds Wikidata IDs to 21 language/language-family synsets (mother tongue, tone language, creole, Australian languages, Caucasian, standard language, Arapaho, Hidatsa, Paiute, Shoshonean, Himalayish, Karbi, Gros Ventre, Meitei, Neo-Latin, Romance, Hindustani, Arcadic, Kotoko, Lolo/Yi, Volgaic).
- Re-classifies Kafiri (`06985416-n`): it was listed as a Dardic language, but Kafiri is the older name for the Nuristani languages, which Morgenstierne showed form an independent third branch of Indo-Iranian (not a subgroup of Dardic/Indo-Aryan). Hypernym moved from Dardic to Indo-Iranian, definition updated, linked to Wikidata Q161804 (Nuristani).
- Merges the indistinct `Canaanite` sense (`07001985-n`) into `Canaanitic language` (`07001806-n`), per the issue.

Note: the issue's suggested Wikidata ID for "Shoshonean" (Q33811) actually identifies Shoshoni specifically, which is already linked from `06927578-n`. Left `Shoshonean` (`06928089-n`) unlinked rather than assign a wrong/duplicate ID — a correct Wikidata item for the broader "Shoshonean"/Northern Uto-Aztecan grouping wasn't findable.

## Test plan

- [x] `python scripts/validate.py` passes with no issues
- [x] `python scripts/from_yaml.py` generates XML without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)