### PR TITLE
Remove Wikidata property links and validate QID format

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -185,6 +185,8 @@ valid_sense_id = re.compile(
 
 valid_synset_id = re.compile("^oewn-[0-9]{8}-[nvars]$")
 
+valid_wikidata = re.compile("^Q[1-9][0-9]*$")
+
 
 def is_valid_id(xml_id):
     return bool(valid_id.match(xml_id))
@@ -445,7 +447,10 @@ def main():
         if synset.wikidata:
             ss_wikidatas = synset.wikidata if isinstance(synset.wikidata, list) else [synset.wikidata]
             for wikidata in ss_wikidatas:
-                if wikidata in wikidatas and wikidata not in WIKIDATA_DUPLICATION_EXCEPTIONS:
+                if not valid_wikidata.match(wikidata):
+                    print(f"ERROR: Invalid Wikidata ID {wikidata} for {synset.id}")
+                    errors += 1
+                elif wikidata in wikidatas and wikidata not in WIKIDATA_DUPLICATION_EXCEPTIONS:
                     print(f"ERROR: QID {wikidata} is duplicated")
                     errors += 1
                 else:

--- a/src/yaml/noun.person.yaml
+++ b/src/yaml/noun.person.yaml
@@ -18911,7 +18911,6 @@
   - candidate
   - nominee
   partOfSpeech: n
-  wikidata: P2453
 09909393-n:
   definition:
   - someone living temporarily in a tent or lodge for recreation
@@ -61147,7 +61146,6 @@
   members:
   - secretary general
   partOfSpeech: n
-  wikidata: P3975
 10593401-n:
   definition:
   - a member of a sect

--- a/src/yaml/noun.time.yaml
+++ b/src/yaml/noun.time.yaml
@@ -2542,7 +2542,6 @@
   - feast day
   - fete day
   partOfSpeech: n
-  wikidata: P841
 15186919-n:
   definition:
   - a major Jewish festival beginning on the eve of the 15th of Tishri and commemorating


### PR DESCRIPTION
## Summary
- Removed three synset `wikidata` links that pointed to Wikidata properties (`Pxxx`) instead of items (`Qxxx`)
- Added a validation check in `scripts/validate.py` that flags any `wikidata` value not matching `^Q[1-9][0-9]*$`

Fixes #1373

## Test plan
- [x] `uv run python scripts/validate.py` reports "No validity issues"