### PR TITLE
Add verb senses for pshaw, pish, pooh (#1368)

### DIFF
--- a/src/yaml/entries-p.yaml
+++ b/src/yaml/entries-p.yaml
@@ -43161,6 +43161,11 @@ piscivorous:
     sense:
     - id: piscivorous%5:00:00:carnivorous:00
       synset: 00314733-s
+pish:
+  v:
+    sense:
+    - id: 'pish%2:32:00::'
+      synset: 01066084-v
 pisha paysha:
   n:
     sense:
@@ -57519,6 +57524,11 @@ poof:
     sense:
     - id: 'poof%1:18:00::'
       synset: 10095821-n
+pooh:
+  v:
+    sense:
+    - id: 'pooh%2:32:00::'
+      synset: 01066084-v
 pooh-bah:
   n:
     pronunciation:
@@ -84072,6 +84082,11 @@ pseudovariola:
     sense:
     - id: 'pseudovariola%1:26:00::'
       synset: 14148170-n
+pshaw:
+  v:
+    sense:
+    - id: 'pshaw%2:32:00::'
+      synset: 01066084-v
 psi:
   n:
     pronunciation:

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -8112,7 +8112,7 @@
   - stonechat
   - Saxicola torquata
   partOfSpeech: n
-  wikidata: 
+  wikidata:
   - Q1315689
   - Q40658797
 01563576-n:

--- a/src/yaml/verb.communication.yaml
+++ b/src/yaml/verb.communication.yaml
@@ -17874,11 +17874,17 @@
 01066084-v:
   definition:
   - express contempt about
+  example:
+  - source: Margarita's Soul, Ingraham Lovell
+    text: It cannot be pished and pshawed away, by you or me or another
   hypernym:
   - 00942415-v
   ili: i26906
   members:
   - pooh-pooh
+  - pshaw
+  - pish
+  - pooh
   partOfSpeech: v
 01066173-v:
   definition:


### PR DESCRIPTION
## Summary
- Adds 'pshaw', 'pish', and 'pooh' as rare verb entries (meaning to express contempt about something) to the existing `pooh-pooh` synset `01066084-v`
- Adds a supporting example citation from *Margarita's Soul* by Ingraham Lovell

Closes #1368

## Test plan
- [x] `apply_automaton` dry run succeeded with no validation errors
- [x] Real apply succeeded, saved cleanly, verified via `lookup_id` that the synset now has all four members and the example