### PR TITLE
Merge 'appointment book'/'appointment calendar' into 'planner'

### DIFF
--- a/src/deprecations.csv
+++ b/src/deprecations.csv
@@ -252,3 +252,4 @@
 "ewn-01852317-n","i45064","ewn-01852107-n","i45063","Incorrect definition; shelduck is not female sheldrake (#1192)"
 "ewn-01078146-s","i5895","ewn-01077510-a","i5895","Duplicate (#1310)"
 "ewn-07001985-n","i73372","ewn-07001806-n","i73371","Merged with Canaanitic language, indistinct senses (#1371)"
+"ewn-06427692-n","i70210","ewn-03963061-n","i57397","Duplicate (#1311)"

--- a/src/yaml/entries-a.yaml
+++ b/src/yaml/entries-a.yaml
@@ -56247,13 +56247,13 @@ appointment:
 appointment book:
   n:
     sense:
-    - id: 'appointment_book%1:10:00::'
-      synset: 06427692-n
+    - id: 'appointment_book%1:06:00::'
+      synset: 03963061-n
 appointment calendar:
   n:
     sense:
-    - id: 'appointment_calendar%1:10:00::'
-      synset: 06427692-n
+    - id: 'appointment_calendar%1:06:00::'
+      synset: 03963061-n
 apportion:
   v:
     pronunciation:

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -80131,13 +80131,17 @@
   partOfSpeech: n
 03963061-n:
   definition:
-  - a notebook for recording appointments and things to be done, etc.
+  - a notebook containing a calendar and space for recording appointments and things
+    to be done
   hypernym:
   - 06427062-n
   ili: i57397
   members:
   - planner
+  - appointment book
+  - appointment calendar
   partOfSpeech: n
+  wikidata: Q1136404
 03963198-n:
   definition:
   - buildings for carrying on industrial labor

--- a/src/yaml/noun.communication.yaml
+++ b/src/yaml/noun.communication.yaml
@@ -9126,16 +9126,6 @@
   - copybook
   partOfSpeech: n
   wikidata: Q11244624
-06427692-n:
-  definition:
-  - a book containing a calendar and space to keep a record of appointments
-  hypernym:
-  - 06422547-n
-  ili: i70210
-  members:
-  - appointment book
-  - appointment calendar
-  partOfSpeech: n
 06427849-n:
   definition:
   - a book or pamphlet containing an enumeration of things


### PR DESCRIPTION
## Summary
- Merges `06427692-n` (appointment book, appointment calendar) into `03963061-n` (planner), per Wikidata [Q1136404](https://www.wikidata.org/wiki/Q1136404) "personal organizer" - both described the same physical-notebook-with-calendar concept.
- No lemmas are moved elsewhere, per the discussion on the issue.
- `03963061-n` keeps its existing `notebook` hypernym (already fixed by #1351) and gains a merged definition plus the Wikidata link.
- `06427692-n` is deprecated in favor of `03963061-n` with a deprecation record.

Closes #1311

## Test plan
- [x] `python scripts/from_yaml.py` regenerates `wn.xml` with no warnings/errors
- [x] `python3 scripts/validate.py` reports "No validity issues"
- [x] Confirmed neither merged synset had hyponyms, incoming sense relations, or examples that would be lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)