### PR TITLE
Fix Crataegus oxy(a)cantha synset

### DIFF
--- a/src/deprecations.csv
+++ b/src/deprecations.csv
@@ -252,3 +252,4 @@
 "ewn-01852317-n","i45064","ewn-01852107-n","i45063","Incorrect definition; shelduck is not female sheldrake (#1192)"
 "ewn-01078146-s","i5895","ewn-01077510-a","i5895","Duplicate (#1310)"
 "ewn-07001985-n","i73372","ewn-07001806-n","i73371","Merged with Canaanitic language, indistinct senses (#1371)"
+"ewn-12649340-n","i103245","ewn-12648511-n","i103242","Split into Crataegus oxyacantha (duplicate, #1376) and Pyracantha coccinea (evergreen thorn, #1376)"

--- a/src/yaml/entries-c.yaml
+++ b/src/yaml/entries-c.yaml
@@ -9162,7 +9162,7 @@ Crataegus oxyacantha:
   n:
     sense:
     - id: 'crataegus_oxyacantha%1:20:00::'
-      synset: 12649340-n
+      synset: 12648511-n
 Crataegus oxycantha:
   n:
     sense:

--- a/src/yaml/entries-e.yaml
+++ b/src/yaml/entries-e.yaml
@@ -32775,8 +32775,8 @@ evergreen plant:
 evergreen thorn:
   n:
     sense:
-    - id: 'evergreen_thorn%1:20:00::'
-      synset: 12649340-n
+    - id: 'evergreen_thorn%1:20:01::'
+      synset: 88088503-n
 evergreen winterberry:
   n:
     sense:

--- a/src/yaml/entries-p.yaml
+++ b/src/yaml/entries-p.yaml
@@ -7283,6 +7283,11 @@ Pyracantha:
     sense:
     - id: 'pyracantha%1:20:00::'
       synset: 12671990-n
+Pyracantha coccinea:
+  n:
+    sense:
+    - id: 'pyracantha_coccinea%1:20:00::'
+      synset: 88088503-n
 Pyrausta nubilalis:
   n:
     sense:

--- a/src/yaml/entries-r.yaml
+++ b/src/yaml/entries-r.yaml
@@ -18718,6 +18718,11 @@ red fire:
     sense:
     - id: 'red_fire%1:27:00::'
       synset: 14719345-n
+red firethorn:
+  n:
+    sense:
+    - id: 'red_firethorn%1:20:00::'
+      synset: 88088503-n
 red flag:
   n:
     sense:

--- a/src/yaml/entries-s.yaml
+++ b/src/yaml/entries-s.yaml
@@ -19020,6 +19020,11 @@ scarlet fever:
     sense:
     - id: 'scarlet_fever%1:26:00::'
       synset: 14147552-n
+scarlet firethorn:
+  n:
+    sense:
+    - id: 'scarlet_firethorn%1:20:00::'
+      synset: 88088503-n
 scarlet fritillary:
   n:
     sense:

--- a/src/yaml/noun.plant.yaml
+++ b/src/yaml/noun.plant.yaml
@@ -42848,6 +42848,7 @@
   - may
   - Crataegus laevigata
   - Crataegus oxycantha
+  - Crataegus oxyacantha
   partOfSpeech: n
   wikidata: Q159553
 12648821-n:
@@ -42879,17 +42880,6 @@
   - Crataegus coccinea mollis
   partOfSpeech: n
   wikidata: Q2671022
-12649340-n:
-  definition:
-  - evergreen hawthorn of southeastern Europe
-  hypernym:
-  - 12647114-n
-  ili: i103245
-  members:
-  - evergreen thorn
-  - Crataegus oxyacantha
-  partOfSpeech: n
-  wikidata: Q3780432
 12649466-n:
   definition:
   - American red-fruited hawthorn with dense corymbs of pink-red flowers
@@ -67285,6 +67275,19 @@
   members:
   - quinoa
   partOfSpeech: n
+88088503-n:
+  definition:
+  - an evergreen or deciduous thorny shrub of southern Europe with clusters of white
+    flowers followed by red or orange berries
+  hypernym:
+  - 12671990-n
+  members:
+  - scarlet firethorn
+  - red firethorn
+  - evergreen thorn
+  - Pyracantha coccinea
+  partOfSpeech: n
+  wikidata: Q159269
 88952530-n:
   definition:
   - a mushroom containing psilocybin taken as a hallucinogenic drug


### PR DESCRIPTION
## Summary
- `Crataegus oxyacantha` is a rejected/ambiguous botanical name historically applied to several hawthorn species, including the one already in `12648511-n` (whitethorn, English hawthorn, may, Crataegus laevigata) - which already carries the misspelled variant `Crataegus oxycantha`. Added the correctly-spelled synonym there too.
- `evergreen thorn` (previously paired with `Crataegus oxyacantha` in `12649340-n`) actually refers to *Pyracantha coccinea* (scarlet/red firethorn), not any *Crataegus* species. Added a new synset for it under the `Pyracantha` genus synset (`12671990-n`), with the Wikidata link (Q159269) suggested in the issue.
- Deleted `12649340-n`, now split between the two synsets above, with a deprecation record.

Closes #1376

## Test plan
- [x] `python scripts/from_yaml.py` regenerates `wn.xml` with no warnings/errors
- [x] `python3 scripts/validate.py` reports "No validity issues"

🤖 Generated with [Claude Code](https://claude.com/claude-code)