### PR TITLE
'carnivore' -> 'carnivoran' in mammal synset

### DIFF
--- a/src/yaml/entries-c.yaml
+++ b/src/yaml/entries-c.yaml
@@ -22765,13 +22765,16 @@ carnival:
       synset: 00553716-n
     - id: 'carnival%1:04:01::'
       synset: 00520389-n
+carnivoran:
+  n:
+    sense:
+    - id: 'carnivoran%1:05:00::'
+      synset: 02077948-n
 carnivore:
   n:
     pronunciation:
     - value: ˈkɑːnɪvɔː
     sense:
-    - id: 'carnivore%1:05:00::'
-      synset: 02077948-n
     - id: 'carnivore%1:05:02::'
       synset: 01327072-n
 carnivorous:
@@ -22781,8 +22784,6 @@ carnivorous:
       variety: US
     sense:
     - id: 'carnivorous%3:01:00::'
-      pertainym:
-      - 'carnivore%1:05:00::'
       synset: 02691317-a
     - antonym:
       - 'herbivorous%3:00:00::'
@@ -22795,6 +22796,11 @@ carnivorous bat:
     sense:
     - id: 'carnivorous_bat%1:05:00::'
       synset: 02143958-n
+carnivorous mammal:
+  n:
+    sense:
+    - id: 'carnivorous_mammal%1:05:00::'
+      synset: 02077948-n
 carnivorous plant:
   n:
     sense:

--- a/src/yaml/noun.animal.yaml
+++ b/src/yaml/noun.animal.yaml
@@ -26122,7 +26122,8 @@
   - 01889397-n
   ili: i46310
   members:
-  - carnivore
+  - carnivoran
+  - carnivorous mammal
   partOfSpeech: n
 02078264-n:
   definition:


### PR DESCRIPTION
## Summary
- Not all carnivores are mammals, so the mammal-only synset `02077948-n` ("a terrestrial or aquatic flesh-eating mammal") should not use the lemma 'carnivore', which already denotes the broader any-flesh-eating-animal sense in `01327072-n`.
- Replaces 'carnivore' with 'carnivoran' and 'carnivorous mammal' on `02077948-n`.

Fixes #1378

## Test plan
- [x] `validate` via ewe_mcp reports no errors after the change