### PR TITLE
Add adjectival senses for 'positive', 'comparative', 'superlative'

### DIFF
--- a/src/yaml/adj.pert.yaml
+++ b/src/yaml/adj.pert.yaml
@@ -31292,9 +31292,27 @@
   members:
   - asphaltic
   partOfSpeech: a
+80375345-a:
+  definition:
+  - of an adjective in the primary form, not the comparative or superlative form
+  members:
+  - positive
+  partOfSpeech: a
 84185412-a:
   definition:
   - of or relating to Cambridge or Cambridge University
   members:
   - Cantabrigian
+  partOfSpeech: a
+84372218-a:
+  definition:
+  - of an adjective in the form showing greatest degree
+  members:
+  - superlative
+  partOfSpeech: a
+88608554-a:
+  definition:
+  - of an adjective in the form showing comparison
+  members:
+  - comparative
   partOfSpeech: a

--- a/src/yaml/entries-c.yaml
+++ b/src/yaml/entries-c.yaml
@@ -73083,6 +73083,10 @@ comparative:
       - 'compare%2:31:00::'
       id: 'comparative%3:00:00::'
       synset: 00006050-a
+    - id: 'comparative%3:01:01::'
+      pertainym:
+      - 'comparative%1:10:00::'
+      synset: 88608554-a
   n:
     pronunciation:
     - value: kəmˈpæɹ.ə.tɪv

--- a/src/yaml/entries-p.yaml
+++ b/src/yaml/entries-p.yaml
@@ -60016,6 +60016,10 @@ positive:
       - 'positiveness%1:07:00::'
       id: positive%5:00:00:confident:00
       synset: 00340186-s
+    - id: 'positive%3:01:06::'
+      pertainym:
+      - 'positive%1:10:00::'
+      synset: 80375345-a
   n:
     pronunciation:
     - value: ˈpɒzɪ̈tɪv

--- a/src/yaml/entries-s.yaml
+++ b/src/yaml/entries-s.yaml
@@ -125125,6 +125125,10 @@ superlative:
       - 'superlative%1:26:00::'
       id: superlative%5:00:00:superior:02
       synset: 02351683-s
+    - id: 'superlative%3:01:02::'
+      pertainym:
+      - 'superlative%1:10:01::'
+      synset: 84372218-a
   n:
     pronunciation:
     - value: suːˈpɜː.lə.tɪv


### PR DESCRIPTION
## Summary
- We had nominal senses for 'positive', 'comparative', 'superlative' (grammatical degree forms) but no matching adjectival sense (e.g. "the positive form of an adjective").
- Adds three new `adj.pert` synsets, each with a `pertainym` relation to its existing nominal counterpart:
  - 'positive' — "of an adjective in the primary form, not the comparative or superlative form" → pertainym `06333461-n`
  - 'comparative' — "of an adjective in the form showing comparison" → pertainym `06333686-n`
  - 'superlative' — "of an adjective in the form showing greatest degree" → pertainym `06334277-n`

Fixes #1380

## Test plan
- [x] `validate` via ewe_mcp reports no errors after the change