### PR TITLE
'country' vs 'countryside'

### DIFF
--- a/src/deprecations.csv
+++ b/src/deprecations.csv
@@ -252,3 +252,4 @@
 "ewn-01852317-n","i45064","ewn-01852107-n","i45063","Incorrect definition; shelduck is not female sheldrake (#1192)"
 "ewn-01078146-s","i5895","ewn-01077510-a","i5895","Duplicate (#1310)"
 "ewn-07001985-n","i73372","ewn-07001806-n","i73371","Merged with Canaanitic language, indistinct senses (#1371)"
+"ewn-08662608-n","i82392","ewn-08662297-n","i82391","Duplicate of country/rural area (#1386)"

--- a/src/yaml/entries-c.yaml
+++ b/src/yaml/entries-c.yaml
@@ -98792,7 +98792,7 @@ countryside:
     - value: ˈkʌn.tɹiˌsaɪd
     sense:
     - id: 'countryside%1:15:00::'
-      synset: 08662608-n
+      synset: 08662297-n
 countrywide:
   a:
     pronunciation:

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -6777,17 +6777,9 @@
   members:
   - country
   - rural area
+  - countryside
   mero_part:
   - 08633625-n
-  partOfSpeech: n
-08662608-n:
-  definition:
-  - rural regions
-  hypernym:
-  - 08662297-n
-  ili: i82392
-  members:
-  - countryside
   partOfSpeech: n
 08662679-n:
   definition:


### PR DESCRIPTION
## Summary
- 'countryside' (08662608-n, "rural regions") is a hyponym of 'country, rural area' (08662297-n) but the definitions are effectively the same, and the example sentences substitute freely between the two without loss of meaning.
- Deletes the 'countryside' synset with `superseded_by` pointing to 08662297-n, which hands off the lemma to that synset.

Fixes #1386

## Test plan
- [x] `validate` via ewe_mcp reports no errors after the change