### PR TITLE
'hayfield'

### DIFF
--- a/src/yaml/entries-h.yaml
+++ b/src/yaml/entries-h.yaml
@@ -13034,6 +13034,11 @@ hay fever:
     sense:
     - id: 'hay_fever%1:26:00::'
       synset: 14557801-n
+hay field:
+  n:
+    sense:
+    - id: 'hay_field%1:15:00::'
+      synset: 80570093-n
 hay-scented:
   n:
     sense:
@@ -13052,8 +13057,8 @@ haycock:
 hayfield:
   n:
     sense:
-    - id: 'hayfield%1:15:00::'
-      synset: 08588163-n
+    - id: 'hayfield%1:15:01::'
+      synset: 80570093-n
 hayfork:
   n:
     sense:

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -3531,13 +3531,11 @@
   partOfSpeech: n
 08588163-n:
   definition:
-  - a piece of land covered or mostly covered with grass; a field where grass or alfalfa
-    are grown to be made into hay
+  - a piece of land covered with grass and wild plants
   hypernym:
   - 08615857-n
   ili: i82023
   members:
-  - hayfield
   - meadow
   partOfSpeech: n
 08588287-n:
@@ -9175,6 +9173,15 @@
   members:
   - Dar al-harb
   - House of War
+  partOfSpeech: n
+80570093-n:
+  definition:
+  - a field where grass grows for hay
+  hypernym:
+  - 08587527-n
+  members:
+  - hayfield
+  - hay field
   partOfSpeech: n
 83586037-n:
   definition:


### PR DESCRIPTION
## Summary
- 'hayfield' was previously merged into the 'meadow' synset (08588163-n), whose definition conflated two distinct concepts ("a piece of land covered ... with grass; a field where grass or alfalfa are grown to be made into hay").
- Shortens 'meadow' to "a piece of land covered with grass and wild plants".
- Adds a new synset for 'hayfield'/'hay field': "a field where grass grows for hay".

Note: the issue proposed `08596880-n` (grainfield) as the new synset's hypernym, but that's specifically for grain crops, and hay isn't a grain. I used `08587527-n` ("field") instead — the same hypernym 'grainfield' itself uses, making 'hayfield' and 'grainfield' siblings rather than putting hayfield under grainfield.

Fixes #1387

## Test plan
- [x] `validate` via ewe_mcp reports no errors after the change