### PR TITLE
'eitchen midden'

### DIFF
--- a/src/yaml/entries-e.yaml
+++ b/src/yaml/entries-e.yaml
@@ -10611,11 +10611,6 @@ eisteddfod:
     sense:
     - id: 'eisteddfod%1:04:00::'
       synset: 00518287-n
-eitchen midden:
-  n:
-    sense:
-    - id: 'eitchen_midden%1:15:00::'
-      synset: 08578097-n
 either:
   r:
     pronunciation:

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -3094,7 +3094,6 @@
   - 08577564-n
   ili: i81970
   members:
-  - eitchen midden
   - midden
   - kitchen midden
   partOfSpeech: n


### PR DESCRIPTION
## Summary
- Removes the typo lemma 'eitchen midden' from 08578097-n; the correct spelling 'kitchen midden' is already present in the same synset alongside 'midden'.

Fixes #1388

## Test plan
- [x] `validate` via ewe_mcp reports no errors after the change