### PR TITLE
Add reviewed Wikidata links for location synsets

### DIFF
--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -46652,7 +46652,6 @@
   mero_part:
   - 03905846-n
   partOfSpeech: n
-  wikidata: Q1107656
 03422781-n:
   definition:
   - a hose used for watering a lawn or garden

--- a/src/yaml/noun.artifact.yaml
+++ b/src/yaml/noun.artifact.yaml
@@ -4107,6 +4107,7 @@
   - arena
   - scene of action
   partOfSpeech: n
+  wikidata: Q641226
 02739650-n:
   definition:
   - a theater arranged with seats around at least three sides of the stage
@@ -17547,6 +17548,7 @@
   - camp
   - summer camp
   partOfSpeech: n
+  wikidata: Q2984259
 02949268-n:
   definition:
   - shelter for persons displaced by war or political oppression or for religious
@@ -46638,6 +46640,7 @@
   members:
   - garden
   partOfSpeech: n
+  wikidata: Q1107656
 03422659-n:
   definition:
   - a yard or lawn adjoining a house
@@ -46649,6 +46652,7 @@
   mero_part:
   - 03905846-n
   partOfSpeech: n
+  wikidata: Q1107656
 03422781-n:
   definition:
   - a hose used for watering a lawn or garden
@@ -49663,6 +49667,9 @@
   - orchard
   - plantation
   partOfSpeech: n
+  wikidata:
+  - Q1510380
+  - Q236371
 03468985-n:
   definition:
   - minimal clothing worn by stripteasers; a narrow strip of fabric that covers the
@@ -59363,6 +59370,7 @@
   - vegetable garden
   - vegetable patch
   partOfSpeech: n
+  wikidata: Q624114
 03625809-n:
   definition:
   - an unattached counter in a kitchen that permits access from all sides
@@ -80559,6 +80567,7 @@
   - 04245234-n
   - 04378861-n
   partOfSpeech: n
+  wikidata: Q11875349
 03970107-n:
   definition:
   - plaything consisting of a small model of a house that children can play inside
@@ -89427,6 +89436,7 @@
   mero_part:
   - 04116565-n
   partOfSpeech: n
+  wikidata: Q291177
 04116796-n:
   definition:
   - a Scandinavian style of carved or painted decoration (as on furniture or walls
@@ -91038,6 +91048,7 @@
   members:
   - sanctuary
   partOfSpeech: n
+  wikidata: Q29553
 04140872-n:
   definition:
   - a shoe consisting of a sole fastened by straps to the foot

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -5680,7 +5680,6 @@
   - place
   - piazza
   partOfSpeech: n
-  wikidata: Q174782
 08637524-n:
   definition:
   - an area where tollbooths are located

--- a/src/yaml/noun.location.yaml
+++ b/src/yaml/noun.location.yaml
@@ -229,6 +229,7 @@
   - territory
   - soil
   partOfSpeech: n
+  wikidata: Q4835091
 08510715-n:
   definition:
   - the path of a rocket or projectile or aircraft through the air
@@ -521,6 +522,7 @@
   - colony
   - dependency
   partOfSpeech: n
+  wikidata: Q133156
 08517107-n:
   definition:
   - a British colony controlled by the British Crown, represented by a governor
@@ -531,6 +533,7 @@
   - Crown colony
   - royal colony
   partOfSpeech: n
+  wikidata: Q1351282
 08517241-n:
   definition:
   - (plural) the deepest and most remote part
@@ -740,6 +743,7 @@
   - heath
   - heathland
   partOfSpeech: n
+  wikidata: Q27590
 08522039-n:
   definition:
   - a large wilderness area
@@ -820,6 +824,7 @@
   - 08591221-n
   - 08666233-n
   partOfSpeech: n
+  wikidata: Q4895508
 08524276-n:
   definition:
   - a region in which explosives mines have been placed
@@ -1351,6 +1356,7 @@
   - pitch
   - soccer field
   partOfSpeech: n
+  wikidata: Q8524
 08534045-n:
   definition:
   - a geographic region serving as the principal source of grain
@@ -2044,6 +2050,7 @@
   - clearing
   - glade
   partOfSpeech: n
+  wikidata: Q4358873
 08559172-n:
   definition:
   - the smallest administrative district of several European countries
@@ -2471,6 +2478,7 @@
   - excavation
   - archeological site
   partOfSpeech: n
+  wikidata: Q839954
 08567939-n:
   definition:
   - the jurisdiction or office of an abbot
@@ -3098,6 +3106,7 @@
   - midden
   - kitchen midden
   partOfSpeech: n
+  wikidata: Q1152199
 08578322-n:
   definition:
   - the range within which a voice can be heard
@@ -3456,6 +3465,7 @@
   mero_part:
   - 08513344-n
   partOfSpeech: n
+  wikidata: Q1776205
 08587011-n:
   definition:
   - a rural area where farming is practiced
@@ -3466,6 +3476,7 @@
   - farmland
   - farming area
   partOfSpeech: n
+  wikidata: Q3395383
 08587120-n:
   definition:
   - (geology) line determined by the intersection of a geological fault and the earth's
@@ -3501,6 +3512,7 @@
   members:
   - field
   partOfSpeech: n
+  wikidata: Q188869
 08587771-n:
   definition:
   - the area that a weapon or group of weapons can cover effectively with gun fire
@@ -3540,6 +3552,7 @@
   - hayfield
   - meadow
   partOfSpeech: n
+  wikidata: Q7777019
 08588287-n:
   definition:
   - a piece of land prepared for playing a game
@@ -3701,6 +3714,7 @@
   - polar zone
   - polar region
   partOfSpeech: n
+  wikidata: Q60670
 08591019-n:
   definition:
   - the side that is forward or prominent
@@ -3931,6 +3945,7 @@
   - habitat
   - home ground
   partOfSpeech: n
+  wikidata: Q52105
 08598331-n:
   definition:
   - the native habitat or home of an animal or plant
@@ -4033,6 +4048,7 @@
   members:
   - hemisphere
   partOfSpeech: n
+  wikidata: Q399984
 08600819-n:
   definition:
   - the line formed by the lower edge of a skirt or coat
@@ -4945,6 +4961,7 @@
   members:
   - grassland
   partOfSpeech: n
+  wikidata: Q1006733
 08616124-n:
   definition:
   - a place that attracts many visitors
@@ -5079,6 +5096,7 @@
   members:
   - national park
   partOfSpeech: n
+  wikidata: Q46169
 08627580-n:
   definition:
   - the side of something that is toward the wind
@@ -5329,6 +5347,7 @@
   members:
   - fairground
   partOfSpeech: n
+  wikidata: Q2948561
 08632321-n:
   definition:
   - the place at a fair or carnival where sideshows and similar amusements are located
@@ -5369,6 +5388,7 @@
   - park
   - parkland
   partOfSpeech: n
+  wikidata: Q22698
 08632949-n:
   definition:
   - a piece of open land for recreational use in an urban area
@@ -5383,6 +5403,7 @@
   - common
   - green
   partOfSpeech: n
+  wikidata: Q22652
 08633213-n:
   definition:
   - a lot where cars are parked
@@ -5395,6 +5416,7 @@
   - park
   - parking area
   partOfSpeech: n
+  wikidata: Q6501349
 08633385-n:
   definition:
   - a space where an automobile can be parked
@@ -5431,6 +5453,7 @@
   - lea
   - ley
   partOfSpeech: n
+  wikidata: Q30121
 08633886-n:
   definition:
   - an established line of travel or access
@@ -5642,6 +5665,7 @@
   - public square
   - square
   partOfSpeech: n
+  wikidata: Q174782
 08637370-n:
   definition:
   - a public square with room for pedestrians
@@ -5656,6 +5680,7 @@
   - place
   - piazza
   partOfSpeech: n
+  wikidata: Q174782
 08637524-n:
   definition:
   - an area where tollbooths are located
@@ -6003,6 +6028,7 @@
   mero_part:
   - 08690135-n
   partOfSpeech: n
+  wikidata: Q15284
 08644097-n:
   definition:
   - a planned urban community created in a rural or undeveloped area and designed
@@ -6789,6 +6815,7 @@
   members:
   - countryside
   partOfSpeech: n
+  wikidata: Q175185
 08662679-n:
   definition:
   - an uncultivated region covered with scrub vegetation
@@ -6972,6 +6999,7 @@
   - churchyard
   - God's acre
   partOfSpeech: n
+  wikidata: Q2749813
 08665032-n:
   definition:
   - a place that is scoured (especially by running water)
@@ -7225,6 +7253,7 @@
   - site
   - land site
   partOfSpeech: n
+  wikidata: Q11499678
 08669310-n:
   definition:
   - the outline of objects seen against the sky
@@ -7735,6 +7764,7 @@
   members:
   - theme park
   partOfSpeech: n
+  wikidata: Q2416723
 08680789-n:
   definition:
   - the limit of a nation's territorial waters
@@ -7860,6 +7890,7 @@
   mero_part:
   - 08558693-n
   partOfSpeech: n
+  wikidata: Q3957
 08688906-n:
   definition:
   - colloquial American term for a town
@@ -7931,6 +7962,7 @@
   members:
   - market town
   partOfSpeech: n
+  wikidata: Q18511725
 08689937-n:
   definition:
   - an administrative division of a county
@@ -7962,6 +7994,7 @@
   members:
   - settlement
   partOfSpeech: n
+  wikidata: Q486972
 08690476-n:
   definition:
   - a settlement smaller than a town
@@ -7972,6 +8005,7 @@
   - village
   - hamlet
   partOfSpeech: n
+  wikidata: Q532
 08690777-n:
   definition:
   - a native malay village
@@ -8033,6 +8067,7 @@
   - subtropics
   - semitropics
   partOfSpeech: n
+  wikidata: Q16305538
 08692202-n:
   definition:
   - a tract of land containing explosive mines
@@ -8042,6 +8077,7 @@
   members:
   - mine field
   partOfSpeech: n
+  wikidata: Q1936555
 08692301-n:
   definition:
   - a piece of ground having specific characteristics or military potential
@@ -8194,6 +8230,7 @@
   - veld
   - veldt
   partOfSpeech: n
+  wikidata: Q1433901
 08695263-n:
   definition:
   - 'in law: the jurisdiction where a trial will be held'
@@ -8460,6 +8497,7 @@
   - western hemisphere
   - occident
   partOfSpeech: n
+  wikidata: Q181982
 08701024-n:
   definition:
   - a field planted with wheat
@@ -8839,6 +8877,7 @@
   members:
   - national capital
   partOfSpeech: n
+  wikidata: Q108178728
 08713012-n:
   definition:
   - the capital city of a province
@@ -8849,6 +8888,7 @@
   members:
   - provincial capital
   partOfSpeech: n
+  wikidata: Q137640468
 08713353-n:
   definition:
   - the capital city of a political subdivision of a country
@@ -8859,6 +8899,7 @@
   members:
   - state capital
   partOfSpeech: n
+  wikidata: Q11271835
 08714745-n:
   definition:
   - any one of the countries occupying the European continent
@@ -9063,6 +9104,7 @@
   members:
   - French region
   partOfSpeech: n
+  wikidata: Q36784
 08984793-n:
   definition:
   - one of the several states constituting Malaysia
@@ -9100,6 +9142,7 @@
   - Baltic state
   - Baltic republic
   partOfSpeech: n
+  wikidata: Q39731
 09054666-n:
   definition:
   - one of the cantons of Switzerland
@@ -9166,6 +9209,7 @@
   - Dar al-Islam
   - House of Islam
   partOfSpeech: n
+  wikidata: Q771468
 09201493-n:
   definition:
   - areas where Muslims are in the minority and are persecuted


### PR DESCRIPTION
## Summary
Applies reviewed Wikidata links from `unlinked_lemma_matches_locations.csv` (manual review, ~2000 candidate lemma/synset matches). 53 synsets received a link:
- 35 from rows ticked `TRUE` in the accept column, using `wikidata_qid`.
- 18 from rows marked `FALSE` where the reviewer supplied a corrected QID in the "actual link" column instead.

## Flags for review

**Skipped - target synset no longer exists (4 rows):** these CSV rows point at proper-noun synsets already removed from OEWN in an earlier cleanup:
- `08520259-n` Barbary Coast → Q501768
- `08765327-n` British West Indies → Q920396
- `09019857-n` Singapore / Republic of Singapore → Q334
- `09146476-n` West Point → Q9219 (actual-link override)

**Already correct, no change needed (6 rows):** these synsets already carried the exact QID the CSV proposes (from an earlier pass) - `08511241-n`, `08522594-n`, `08533808-n`, `08535652-n`, `08536123-n`, `08663422-n`.

**Same Wikidata item linked from two different synsets (please double check these are intentional):**
- `Q1107656` ("garden") linked from both `03422255-n` ("a plot of ground where plants are cultivated") and `03422659-n` ("a yard or lawn adjoining a house") - both rows were independently ticked TRUE.
- `Q174782` ("square") linked from both `08637195-n` ("public square; square" - open area at a street junction) and `08637370-n` ("plaza; place; piazza" - a public square with room for pedestrians) - both rows were independently ticked TRUE.

**Multi-valued link:** `03468764-n` (grove; woodlet; orchard; plantation) got two QIDs (`Q1510380`, `Q236371`) from a semicolon-separated "actual link" override - applied both since the reviewer's column supplied two ids for one synset.

## Test plan
- [x] `validate` via ewe_mcp reports no errors after the change